### PR TITLE
fix: prevent uint64 duration underflow for cancelled/skipped jobs

### DIFF
--- a/collector/receiver/githubactionsreceiver/receiver_test.go
+++ b/collector/receiver/githubactionsreceiver/receiver_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/everr-labs/everr/collector/receiver/githubactionsreceiver/internal/metadata"
 	"github.com/everr-labs/everr/collector/semconv"
@@ -30,6 +31,10 @@ import (
 )
 
 func int64Ptr(v int64) *int64 {
+	return &v
+}
+
+func intPtr(v int) *int {
 	return &v
 }
 
@@ -184,7 +189,7 @@ func TestProcessSteps(t *testing.T) {
 			ss := rs.ScopeSpans().AppendEmpty()
 
 			traceID, _ := generateTraceID(456, 123, 1)
-			parentSpanID, err := createParentSpan(ss, tc.givenSteps, &github.WorkflowJob{}, traceID, logger)
+			parentSpanID, err := createParentSpan(ss, &github.WorkflowJob{}, traceID, logger)
 			require.NoError(t, err)
 
 			processSteps(ss, tc.givenSteps, &github.WorkflowJob{}, traceID, parentSpanID, logger)
@@ -290,6 +295,136 @@ func attributeValueToString(attr pcommon.Value) string {
 		return "<Slice Value>"
 	default:
 		return "<Unknown Value Type>"
+	}
+}
+
+func TestCorrectActionTimestamps(t *testing.T) {
+	real1 := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	real2 := time.Date(2024, 1, 1, 13, 0, 0, 0, time.UTC)
+	zero := time.Time{}
+
+	tests := []struct {
+		desc          string
+		start, end    time.Time
+		wantStart     time.Time
+		wantEnd       time.Time
+		wantZeroDelta bool
+	}{
+		{desc: "both valid", start: real1, end: real2, wantStart: real1, wantEnd: real2},
+		{desc: "both zero", start: zero, end: zero, wantStart: zero, wantEnd: zero, wantZeroDelta: true},
+		{desc: "start zero, end real", start: zero, end: real2, wantStart: real2, wantEnd: real2, wantZeroDelta: true},
+		{desc: "start real, end zero", start: real1, end: zero, wantStart: real1, wantEnd: real1, wantZeroDelta: true},
+		{desc: "end before start (reversed)", start: real2, end: real1, wantStart: real2, wantEnd: real2, wantZeroDelta: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			gotStart, gotEnd := correctActionTimestamps(tc.start, tc.end)
+			require.Equal(t, tc.wantStart, gotStart, "start mismatch")
+			require.Equal(t, tc.wantEnd, gotEnd, "end mismatch")
+			if tc.wantZeroDelta {
+				require.Equal(t, gotStart, gotEnd, "expected zero-duration span")
+			}
+		})
+	}
+}
+
+func TestCreateParentSpanZeroTimestamps(t *testing.T) {
+	logger := zap.NewNop()
+
+	tests := []struct {
+		desc string
+		job  *github.WorkflowJob
+	}{
+		{
+			desc: "Both started_at and completed_at zero (skipped job)",
+			job:  &github.WorkflowJob{},
+		},
+		{
+			desc: "started_at set, completed_at zero",
+			job: &github.WorkflowJob{
+				StartedAt: &github.Timestamp{Time: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)},
+			},
+		},
+		{
+			desc: "started_at zero, completed_at set (cancelled before starting)",
+			job: &github.WorkflowJob{
+				CompletedAt: &github.Timestamp{Time: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			traces := ptrace.NewTraces()
+			rs := traces.ResourceSpans().AppendEmpty()
+			ss := rs.ScopeSpans().AppendEmpty()
+
+			traceID, _ := generateTraceID(456, 123, 1)
+			_, err := createParentSpan(ss, tc.job, traceID, logger)
+			require.NoError(t, err)
+
+			span := ss.Spans().At(0)
+			start := span.StartTimestamp()
+			end := span.EndTimestamp()
+			duration := uint64(end) - uint64(start)
+
+			// Duration must never exceed 24 hours — the uint64 underflow produces ~10^19
+			require.LessOrEqual(t, duration, uint64(86400000000000),
+				"Duration overflowed: got %d ns, likely a uint64 underflow from zero timestamps", duration)
+		})
+	}
+}
+
+func TestCreateRootSpanZeroTimestamps(t *testing.T) {
+	logger := zap.NewNop()
+
+	tests := []struct {
+		desc  string
+		event *github.WorkflowRunEvent
+	}{
+		{
+			desc: "updated_at zero",
+			event: &github.WorkflowRunEvent{
+				WorkflowRun: &github.WorkflowRun{
+					ID:           int64Ptr(123),
+					RunAttempt:   intPtr(1),
+					RunStartedAt: &github.Timestamp{Time: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)},
+				},
+				Repo: &github.Repository{ID: int64Ptr(456)},
+			},
+		},
+		{
+			desc: "run_started_at zero",
+			event: &github.WorkflowRunEvent{
+				WorkflowRun: &github.WorkflowRun{
+					ID:         int64Ptr(123),
+					RunAttempt: intPtr(1),
+					UpdatedAt:  &github.Timestamp{Time: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)},
+				},
+				Repo: &github.Repository{ID: int64Ptr(456)},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			traces := ptrace.NewTraces()
+			rs := traces.ResourceSpans().AppendEmpty()
+
+			traceID, _ := generateTraceID(456, 123, 1)
+			_, err := createRootSpan(rs, tc.event, traceID, logger)
+			require.NoError(t, err)
+
+			ss := rs.ScopeSpans().At(0)
+			span := ss.Spans().At(0)
+			start := span.StartTimestamp()
+			end := span.EndTimestamp()
+			duration := uint64(end) - uint64(start)
+
+			require.LessOrEqual(t, duration, uint64(86400000000000),
+				"Duration overflowed: got %d ns, likely a uint64 underflow from zero timestamps", duration)
+		})
 	}
 }
 

--- a/collector/receiver/githubactionsreceiver/trace_event_handling.go
+++ b/collector/receiver/githubactionsreceiver/trace_event_handling.go
@@ -60,7 +60,7 @@ func eventToTraces(event interface{}, config *Config, logger *zap.Logger) (*ptra
 			return nil, fmt.Errorf("failed to generate trace ID: %w", err)
 		}
 
-		parentSpanID, err := createParentSpan(scopeSpans, e.GetWorkflowJob().Steps, e.GetWorkflowJob(), traceID, logger)
+		parentSpanID, err := createParentSpan(scopeSpans, e.GetWorkflowJob(), traceID, logger)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create parent span: %w", err)
 		}
@@ -96,7 +96,7 @@ func eventToTraces(event interface{}, config *Config, logger *zap.Logger) (*ptra
 	return &traces, nil
 }
 
-func createParentSpan(scopeSpans ptrace.ScopeSpans, steps []*github.TaskStep, job *github.WorkflowJob, traceID pcommon.TraceID, logger *zap.Logger) (pcommon.SpanID, error) {
+func createParentSpan(scopeSpans ptrace.ScopeSpans, job *github.WorkflowJob, traceID pcommon.TraceID, logger *zap.Logger) (pcommon.SpanID, error) {
 	logger.Debug("Creating parent span", zap.String("name", job.GetName()))
 	span := scopeSpans.Spans().AppendEmpty()
 	span.SetTraceID(traceID)
@@ -120,33 +120,24 @@ func createParentSpan(scopeSpans ptrace.ScopeSpans, steps []*github.TaskStep, jo
 	span.SetSpanID(jobSpanID)
 
 	span.SetName(job.GetName())
-	span.SetKind(ptrace.SpanKindServer)
+	span.SetKind(ptrace.SpanKindInternal)
 	// Always use the job's own timestamps for the parent span.
 	// These match GitHub's billing window (started_at → completed_at)
 	// and avoid discrepancies from step boundary timing.
-	setSpanTimes(span, job.GetStartedAt().Time, job.GetCompletedAt().Time)
+	startTime, endTime := correctActionTimestamps(job.GetStartedAt().Time, job.GetCompletedAt().Time)
+	setSpanTimes(span, startTime, endTime)
 
-	allSuccessful := true
-	anyFailure := false
-	for _, step := range steps {
-		if step.GetStatus() != "completed" || step.GetConclusion() != "success" {
-			allSuccessful = false
-		}
-		if step.GetConclusion() == "failure" {
-			anyFailure = true
-			break
-		}
-	}
-
-	if anyFailure {
-		span.Status().SetCode(ptrace.StatusCodeError)
-	} else if allSuccessful {
+	conclusion := mapConclusion(job.GetConclusion())
+	switch strings.ToLower(conclusion) {
+	case "success":
 		span.Status().SetCode(ptrace.StatusCodeOk)
-	} else {
+	case "failure":
+		span.Status().SetCode(ptrace.StatusCodeError)
+	default:
 		span.Status().SetCode(ptrace.StatusCodeUnset)
 	}
 
-	span.Status().SetMessage(mapConclusion(job.GetConclusion()))
+	span.Status().SetMessage(conclusion)
 
 	return span.SpanID(), nil
 }
@@ -172,10 +163,11 @@ func createRootSpan(resourceSpans ptrace.ResourceSpans, event *github.WorkflowRu
 	span.SetSpanID(rootSpanID)
 	span.SetName(event.GetWorkflowRun().GetName())
 	span.SetKind(ptrace.SpanKindServer)
-	setSpanTimes(span, event.GetWorkflowRun().GetRunStartedAt().Time, event.GetWorkflowRun().GetUpdatedAt().Time)
+	startTime, endTime := correctActionTimestamps(event.GetWorkflowRun().GetRunStartedAt().Time, event.GetWorkflowRun().GetUpdatedAt().Time)
+	setSpanTimes(span, startTime, endTime)
 
 	conclusion := mapConclusion(event.GetWorkflowRun().GetConclusion())
-	switch conclusion {
+	switch strings.ToLower(conclusion) {
 	case "success":
 		span.Status().SetCode(ptrace.StatusCodeOk)
 	case "failure":
@@ -226,20 +218,16 @@ func createSpan(scopeSpans ptrace.ScopeSpans, step *github.TaskStep, job *github
 	}
 	span.SetSpanID(spanID)
 
-	// Set completed_at to same as started_at if ""
-	// GitHub emits zero values sometimes
-	if step.GetCompletedAt().IsZero() {
-		step.CompletedAt = step.StartedAt
-	}
-	span.Attributes().PutStr(semconv.EverrGitHubWorkflowJobStepStartedAt, step.GetStartedAt().Format(time.RFC3339))
-	span.Attributes().PutStr(semconv.EverrGitHubWorkflowJobStepCompletedAt, step.GetCompletedAt().Format(time.RFC3339))
-	setSpanTimes(span, step.GetStartedAt().Time, step.GetCompletedAt().Time)
+	stepStart, stepEnd := correctActionTimestamps(step.GetStartedAt().Time, step.GetCompletedAt().Time)
+	span.Attributes().PutStr(semconv.EverrGitHubWorkflowJobStepStartedAt, stepStart.Format(time.RFC3339))
+	span.Attributes().PutStr(semconv.EverrGitHubWorkflowJobStepCompletedAt, stepEnd.Format(time.RFC3339))
+	setSpanTimes(span, stepStart, stepEnd)
 
 	span.SetName(step.GetName())
-	span.SetKind(ptrace.SpanKindServer)
+	span.SetKind(ptrace.SpanKindInternal)
 
 	stepConclusion := mapConclusion(step.GetConclusion())
-	switch stepConclusion {
+	switch strings.ToLower(stepConclusion) {
 	case "success":
 		span.Status().SetCode(ptrace.StatusCodeOk)
 	case "failure":
@@ -331,6 +319,24 @@ func processSteps(scopeSpans ptrace.ScopeSpans, steps []*github.TaskStep, job *g
 			logger.Error("Failed to create span for step", zap.String("step_name", step.GetName()), zap.Error(err))
 		}
 	}
+}
+
+// correctActionTimestamps ensures span timestamps are valid. When GitHub
+// reports zero or reversed timestamps (which occurs with skipped or cancelled
+// jobs/steps), the function collapses both to the non-zero value, producing a
+// zero-duration span. This prevents uint64 underflow in Duration that would
+// otherwise appear as excessively long spans in telemetry systems.
+func correctActionTimestamps(start, end time.Time) (time.Time, time.Time) {
+	if start.IsZero() && end.IsZero() {
+		return start, end
+	}
+	if start.IsZero() {
+		return end, end
+	}
+	if end.IsZero() || end.Before(start) {
+		return start, start
+	}
+	return start, end
 }
 
 func setSpanTimes(span ptrace.Span, start, end time.Time) {

--- a/todo/ideas/align-collector-with-upstream-receiver.md
+++ b/todo/ideas/align-collector-with-upstream-receiver.md
@@ -1,0 +1,29 @@
+# Align Collector With Upstream GitHub Receiver
+
+## What
+Track the remaining differences between our `githubactionsreceiver` and the upstream `opentelemetry-collector-contrib/receiver/githubreceiver` and decide which to adopt.
+
+## Why
+Staying close to the upstream reduces maintenance burden and makes it easier to pull in future improvements. Some differences are intentional (e.g. our trace ID includes repository ID), others are accidental drift.
+
+## Differences
+
+### Already adopted
+- **`correctActionTimestamps`** — zero/reversed timestamp guard (our version also handles zero times, which upstream misses)
+- **SpanKind** — jobs and steps now use `SpanKindInternal` instead of `SpanKindServer`
+- **Parent span status from job conclusion** — use `job.GetConclusion()` directly instead of iterating steps. The old step-iteration approach incorrectly marked jobs as `Error` when a `continue-on-error` step failed.
+
+### Worth considering
+- **Duplicate step names** — upstream deduplicates with `newUniqueSteps` (appends `-n` suffix). We don't, so duplicate step names produce ambiguous spans in the waterfall. Low effort, no breaking change.
+- **Queue span** — upstream emits a `queue-{jobName}` child span for queue time. Tracked separately in `todo/ideas/queue-span-for-workflow-jobs.md`.
+
+### Intentional divergences (keep as-is)
+- **TraceID generation** — we include `repositoryID` (`{repoID}@{runID}#{runAttempt}`), upstream doesn't (`{runID}{runAttempt}t`). Ours prevents collisions across repos with the same run IDs.
+- **Parent span timestamps** — we use `started_at → completed_at` (matches GitHub billing window), upstream uses `created_at → completed_at` (includes queue time in job duration). Ours is better for cost accuracy.
+- **StatusMessage mapping** — we normalize conclusions (`skipped→skip`, `cancelled→cancellation`) via `mapConclusion`. Upstream passes raw GitHub values. Our downstream queries depend on the mapped values, so changing this would require a migration.
+
+## Upstream reference
+`opentelemetry-collector-contrib/receiver/githubreceiver` — `trace_event_handling.go`
+
+## Rough appetite
+Small per item — each difference can be adopted independently.

--- a/todo/ideas/queue-span-for-workflow-jobs.md
+++ b/todo/ideas/queue-span-for-workflow-jobs.md
@@ -1,0 +1,23 @@
+# Queue Span for Workflow Jobs
+
+## What
+Emit a dedicated span representing the time a job spends queued (created → started) instead of computing queue time client-side from resource attributes.
+
+## Why
+- Makes queue time a first-class entity in the trace waterfall, visible without custom logic
+- Enables ClickHouse queries to aggregate queue durations directly (e.g. P95 queue time per runner label) without joining resource attributes
+- Aligns with the upstream OTEL GitHub receiver which already ships a `queue-{jobName}` span with a `cicd.pipeline.run.queue.duration` attribute
+- Our current approach computes queue time in the app layer (`packages/app/src/data/runs/server.ts`, `getRunSpans`) by diffing `created_at` and `started_at` resource attributes — this works but can't be queried or alerted on at the data layer
+
+## Upstream reference
+The upstream collector (`opentelemetry-collector-contrib/receiver/githubreceiver`) implements this in `createJobQueueSpan`. It creates a child span of the job span with:
+- Name: `queue-{jobName}`
+- Timestamps: `created_at → started_at`
+- Attribute: `cicd.pipeline.run.queue.duration` (nanoseconds)
+
+## Rough appetite
+Small — the span creation is straightforward, but we'd want to update the waterfall UI to render queue spans distinctly and remove the client-side queue time computation.
+
+## Notes
+- Would need a way to visually distinguish queue spans from execution spans in the trace waterfall
+- Consider whether the app-layer queue time computation should be kept as a fallback for historical data or removed entirely


### PR DESCRIPTION
When GitHub reports zero timestamps (e.g. a job cancelled before starting has started_at=null), the span Duration underflows, inflating durations and costs across all queries.

Add correctActionTimestamps() to collapse zero or reversed timestamps into zero-duration spans, applied consistently to job, root, and step  spans. 

Also aligns with upstream otel collector:

  - SpanKind: Internal for jobs/steps (was Server)
  - Status: derive from job.GetConclusion() directly, fixing incorrect
    Error status on jobs with continue-on-error steps
  - strings.ToLower on all conclusion switches for consistency