### PR TITLE
feat(vitest): support default reporter output parsing

### DIFF
--- a/collector/connector/testlogstotraces/connector_test.go
+++ b/collector/connector/testlogstotraces/connector_test.go
@@ -460,3 +460,274 @@ func TestConnectorMissingResourceAttributes(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, tracesSink.SpanCount(), "should not produce spans when resource attributes are missing")
 }
+
+func TestConnectorMixedRustAndVitestVerbose(t *testing.T) {
+	// When both Rust and Vitest verbose output appear in the same step,
+	// the parser with more tests should win.
+	tracesSink := &consumertest.TracesSink{}
+	set := connectortest.NewNopSettings(metadata.Type)
+
+	c, err := newConnector(set, &Config{}, tracesSink)
+	require.NoError(t, err)
+
+	traceID := pcommon.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	spanID := pcommon.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
+
+	logs := buildTestLogs(
+		[]string{
+			// Rust test output (2 tests)
+			"Running unittests src/lib.rs (target/debug/deps/my_crate-abc123)",
+			"running 2 tests",
+			"test utils::tests::parses_config ... ok <0.010s>",
+			"test utils::tests::handles_empty ... ok <0.005s>",
+			// Vitest verbose output (3 tests) — should win
+			" ✓ src/app.test.ts > App > renders title 5ms",
+			" ✓ src/app.test.ts > App > handles click 3ms",
+			" × src/app.test.ts > App > shows error 2ms",
+		},
+		map[string]any{
+			string(conventions.CICDPipelineRunIDKey): int64(123),
+			semconv.EverrGitHubWorkflowRunRunAttempt: int64(1),
+		},
+		"test-job",
+		1,
+		traceID,
+		spanID,
+	)
+
+	err = c.ConsumeLogs(context.Background(), logs)
+	require.NoError(t, err)
+
+	traces := tracesSink.AllTraces()
+	require.Len(t, traces, 1)
+
+	// Vitest has 3 leaf tests + 1 describe block = 4 spans; Rust has 2 leaf + 1 module = 3 spans.
+	// Vitest wins because vitestCtx.TestCount() > rustCtx.TestCount().
+	scopeSpans := traces[0].ResourceSpans().At(0).ScopeSpans().At(0)
+	assert.Equal(t, "vitest", scopeSpans.Scope().Name(), "Vitest should win when it has more tests")
+
+	// Verify framework attribute
+	spans := scopeSpans.Spans()
+	for i := 0; i < spans.Len(); i++ {
+		fw, ok := spans.At(i).Attributes().Get(semconv.EverrTestFramework)
+		require.True(t, ok)
+		assert.Equal(t, "vitest", fw.Str(), "all spans should be attributed to vitest")
+	}
+}
+
+func TestConnectorMixedRustAndVitestDefaultReporter(t *testing.T) {
+	// When Rust output and Vitest default reporter output appear in the same step,
+	// the parser with more tests should win. Vitest default reporter lines must not
+	// be misattributed to Rust.
+	tracesSink := &consumertest.TracesSink{}
+	set := connectortest.NewNopSettings(metadata.Type)
+
+	c, err := newConnector(set, &Config{}, tracesSink)
+	require.NoError(t, err)
+
+	traceID := pcommon.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	spanID := pcommon.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
+
+	logs := buildTestLogs(
+		[]string{
+			// Vitest default reporter (1 file summary + 2 slow tests = 3 spans)
+			" ✓ src/utils.test.ts (5 tests) 120ms",
+			"    ✓ parses input correctly  2097ms",
+			"    × validates schema  1500ms",
+			// Rust test output (1 test = 1 span)
+			"Running unittests src/lib.rs (target/debug/deps/my_crate-abc123)",
+			"test config::parse ... ok <0.010s>",
+		},
+		map[string]any{
+			string(conventions.CICDPipelineRunIDKey): int64(123),
+			semconv.EverrGitHubWorkflowRunRunAttempt: int64(1),
+		},
+		"test-job",
+		1,
+		traceID,
+		spanID,
+	)
+
+	err = c.ConsumeLogs(context.Background(), logs)
+	require.NoError(t, err)
+
+	traces := tracesSink.AllTraces()
+	require.Len(t, traces, 1)
+
+	// Vitest: 1 file summary + 2 slow tests = 3 spans. Rust: 1 test = 1 span.
+	// Vitest wins.
+	scopeSpans := traces[0].ResourceSpans().At(0).ScopeSpans().At(0)
+	assert.Equal(t, "vitest", scopeSpans.Scope().Name(), "Vitest should win with more tests")
+}
+
+func TestConnectorRustWinsOverVitestDefaultReporter(t *testing.T) {
+	// When Rust has more tests than Vitest default reporter, Rust should win.
+	tracesSink := &consumertest.TracesSink{}
+	set := connectortest.NewNopSettings(metadata.Type)
+
+	c, err := newConnector(set, &Config{}, tracesSink)
+	require.NoError(t, err)
+
+	traceID := pcommon.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	spanID := pcommon.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
+
+	logs := buildTestLogs(
+		[]string{
+			// Vitest default reporter (1 file summary only)
+			" ✓ src/utils.test.ts (5 tests) 120ms",
+			// Rust test output (3 tests)
+			"Running unittests src/lib.rs (target/debug/deps/my_crate-abc123)",
+			"test config::parse ... ok <0.010s>",
+			"test config::validate ... ok <0.020s>",
+			"test config::serialize ... FAILED <0.030s>",
+		},
+		map[string]any{
+			string(conventions.CICDPipelineRunIDKey): int64(123),
+			semconv.EverrGitHubWorkflowRunRunAttempt: int64(1),
+		},
+		"test-job",
+		1,
+		traceID,
+		spanID,
+	)
+
+	err = c.ConsumeLogs(context.Background(), logs)
+	require.NoError(t, err)
+
+	traces := tracesSink.AllTraces()
+	require.Len(t, traces, 1)
+
+	// Rust: 3 leaf tests + 1 module node = 4 spans. Vitest: 1 file summary = 1 span.
+	// Rust wins.
+	scopeSpans := traces[0].ResourceSpans().At(0).ScopeSpans().At(0)
+	assert.Equal(t, "rusttest", scopeSpans.Scope().Name(), "Rust should win with more tests")
+}
+
+func TestConnectorMixedGoAndVitestDefaultReporter(t *testing.T) {
+	// Go test output mixed with Vitest default reporter. Go should win when it has more tests.
+	tracesSink := &consumertest.TracesSink{}
+	set := connectortest.NewNopSettings(metadata.Type)
+
+	c, err := newConnector(set, &Config{}, tracesSink)
+	require.NoError(t, err)
+
+	traceID := pcommon.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	spanID := pcommon.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
+
+	logs := buildTestLogs(
+		[]string{
+			// Go test output (3 tests)
+			"=== RUN   TestFoo",
+			"--- PASS: TestFoo (0.100s)",
+			"=== RUN   TestBar",
+			"--- PASS: TestBar (0.200s)",
+			"=== RUN   TestBaz",
+			"--- FAIL: TestBaz (0.300s)",
+			// Vitest default reporter (1 file summary)
+			" ✓ src/utils.test.ts (5 tests) 120ms",
+		},
+		map[string]any{
+			string(conventions.CICDPipelineRunIDKey): int64(123),
+			semconv.EverrGitHubWorkflowRunRunAttempt: int64(1),
+		},
+		"test-job",
+		1,
+		traceID,
+		spanID,
+	)
+
+	err = c.ConsumeLogs(context.Background(), logs)
+	require.NoError(t, err)
+
+	traces := tracesSink.AllTraces()
+	require.Len(t, traces, 1)
+
+	// Go has 3 tests, Vitest has 1 file summary. Go wins (goCtx >= vitestCtx && goCtx >= rustCtx).
+	spans := traces[0].ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+	fw, ok := spans.At(0).Attributes().Get(semconv.EverrTestFramework)
+	require.True(t, ok)
+	assert.Equal(t, "go", fw.Str(), "Go should win with more tests")
+}
+
+func TestConnectorVitestDefaultReporterNoFalsePositivesFromBuildOutput(t *testing.T) {
+	// Non-test output that contains checkmarks or similar characters should not
+	// produce false positives in the Vitest parser.
+	tracesSink := &consumertest.TracesSink{}
+	set := connectortest.NewNopSettings(metadata.Type)
+
+	c, err := newConnector(set, &Config{}, tracesSink)
+	require.NoError(t, err)
+
+	traceID := pcommon.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	spanID := pcommon.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
+
+	logs := buildTestLogs(
+		[]string{
+			// Common build output that should NOT match any parser
+			"✓ Compiled successfully in 1200ms",
+			"✓ Build complete",
+			"✓ Linting passed",
+			"× ESLint found 2 errors",
+			"✓ Dependencies installed 500ms",
+			"✓ TypeScript check passed 3200ms",
+			"Downloading artifact build-output 42ms",
+			"Step completed with status: success",
+		},
+		map[string]any{
+			string(conventions.CICDPipelineRunIDKey): int64(123),
+			semconv.EverrGitHubWorkflowRunRunAttempt: int64(1),
+		},
+		"build-job",
+		1,
+		traceID,
+		spanID,
+	)
+
+	err = c.ConsumeLogs(context.Background(), logs)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, tracesSink.SpanCount(), "build output with checkmarks should not produce test spans")
+}
+
+func TestConnectorVitestDefaultReporterNotConfusedByRustOutput(t *testing.T) {
+	// Rust test lines must not be parsed as Vitest slow tests.
+	// Rust format: "test name ... ok <0.010s>" — contains no checkmarks and uses "..." separator.
+	// This verifies the Vitest slow test pattern doesn't match Rust output.
+	tracesSink := &consumertest.TracesSink{}
+	set := connectortest.NewNopSettings(metadata.Type)
+
+	c, err := newConnector(set, &Config{}, tracesSink)
+	require.NoError(t, err)
+
+	traceID := pcommon.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	spanID := pcommon.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
+
+	logs := buildTestLogs(
+		[]string{
+			// Only Rust output — Vitest parser should detect 0 tests
+			"Running unittests src/lib.rs (target/debug/deps/my_crate-abc123)",
+			"running 3 tests",
+			"test utils::parse ... ok <0.010s>",
+			"test utils::validate ... ok <0.020s>",
+			"test utils::serialize ... FAILED <0.030s>",
+		},
+		map[string]any{
+			string(conventions.CICDPipelineRunIDKey): int64(123),
+			semconv.EverrGitHubWorkflowRunRunAttempt: int64(1),
+		},
+		"test-job",
+		1,
+		traceID,
+		spanID,
+	)
+
+	err = c.ConsumeLogs(context.Background(), logs)
+	require.NoError(t, err)
+
+	traces := tracesSink.AllTraces()
+	require.Len(t, traces, 1)
+
+	// Must be attributed to Rust, not Vitest
+	scopeSpans := traces[0].ResourceSpans().At(0).ScopeSpans().At(0)
+	assert.Equal(t, "rusttest", scopeSpans.Scope().Name(), "Rust output should be attributed to Rust parser")
+}

--- a/collector/connector/testlogstotraces/vitest/parser.go
+++ b/collector/connector/testlogstotraces/vitest/parser.go
@@ -24,12 +24,24 @@ var (
 	ansiPattern = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 	// pnpm recursive output prefixes each line with "<package> <script>: ".
 	workspaceTestPrefixPattern = regexp.MustCompile(`^\S+\s+\S+:\s+`)
+
+	// Default reporter file summary patterns
+	// Pass: ✓ [project] filepath (N tests) Nms  or  ✓ [project] TS filepath (N tests)
+	fileSummaryPassPattern = regexp.MustCompile(`^[✓✔√]\s+.*?(\S+\.(?:test|spec|test-d)\.(?:ts|tsx|js|jsx|mts|mjs|cts|cjs))\s+\(\d+\s+tests?(?:\s*\|\s*\d+\s+skipped)?\)\s*(?:(\d+)\s*ms)?$`)
+	// Fail: × [project] filepath (N tests | M failed) Nms
+	fileSummaryFailPattern = regexp.MustCompile(`^[×✕✖xX]\s+.*?(\S+\.(?:test|spec|test-d)\.(?:ts|tsx|js|jsx|mts|mjs|cts|cjs))\s+\(\d+\s+tests?(?:\s*\|\s*\d+\s+(?:failed|skipped))*\)\s*(?:(\d+)\s*ms)?$`)
+
+	// Default reporter slow test line (indented, no hierarchy separator, no test count)
+	// Example: "    ✓ server responds with hello world  2097ms"
+	slowTestPassPattern = regexp.MustCompile(`^[✓✔√]\s+(.+?)\s+(\d+)\s*ms$`)
+	slowTestFailPattern = regexp.MustCompile(`^[×✕✖xX]\s+(.+?)\s+(\d+)\s*ms$`)
 )
 
 // Parser processes Vitest verbose output and extracts test information.
 type Parser struct {
-	ctx    *gotest.TestParseContext
-	logger *zap.Logger
+	ctx             *gotest.TestParseContext
+	logger          *zap.Logger
+	lastFileSummary *gotest.TestInfo // tracks current file context for slow test lines
 }
 
 // NewParser creates a new Parser for processing Vitest verbose output.
@@ -70,6 +82,49 @@ func (p *Parser) ProcessLine(line string, timestamp time.Time) {
 		p.addTest(fullName, gotest.TestResultSkip, 0, timestamp)
 		return
 	}
+
+	// Check for default reporter file summary pass: ✓ project filepath (N tests) Nms
+	if matches := fileSummaryPassPattern.FindStringSubmatch(trimmed); matches != nil {
+		filePath := matches[1]
+		var durationMs float64
+		if matches[2] != "" {
+			durationMs, _ = strconv.ParseFloat(matches[2], 64)
+		}
+		p.addFileSummary(filePath, gotest.TestResultPass, durationMs, timestamp)
+		return
+	}
+
+	// Check for default reporter file summary fail: × project filepath (N tests | M failed) Nms
+	if matches := fileSummaryFailPattern.FindStringSubmatch(trimmed); matches != nil {
+		filePath := matches[1]
+		var durationMs float64
+		if matches[2] != "" {
+			durationMs, _ = strconv.ParseFloat(matches[2], 64)
+		}
+		p.addFileSummary(filePath, gotest.TestResultFail, durationMs, timestamp)
+		return
+	}
+
+	// Check for default reporter slow test lines (only if we have a file context)
+	if p.lastFileSummary != nil {
+		if matches := slowTestPassPattern.FindStringSubmatch(trimmed); matches != nil {
+			testName := strings.TrimSpace(matches[1])
+			if !strings.Contains(testName, " > ") {
+				durationMs, _ := strconv.ParseFloat(matches[2], 64)
+				p.addSlowTest(testName, gotest.TestResultPass, durationMs, timestamp)
+				return
+			}
+		}
+
+		if matches := slowTestFailPattern.FindStringSubmatch(trimmed); matches != nil {
+			testName := strings.TrimSpace(matches[1])
+			if !strings.Contains(testName, " > ") {
+				durationMs, _ := strconv.ParseFloat(matches[2], 64)
+				p.addSlowTest(testName, gotest.TestResultFail, durationMs, timestamp)
+				return
+			}
+		}
+	}
 }
 
 func normalizeLine(line string) string {
@@ -77,6 +132,62 @@ func normalizeLine(line string) string {
 	trimmed := strings.TrimSpace(cleaned)
 	normalized := workspaceTestPrefixPattern.ReplaceAllString(trimmed, "")
 	return strings.TrimSpace(normalized)
+}
+
+// addFileSummary creates a suite-level TestInfo for a default reporter file summary line.
+func (p *Parser) addFileSummary(filePath string, result gotest.TestResult, durationMs float64, timestamp time.Time) {
+	duration := time.Duration(durationMs * float64(time.Millisecond))
+
+	test := &gotest.TestInfo{
+		Name:      filePath,
+		Package:   filePath,
+		StartTime: timestamp.Add(-duration),
+		EndTime:   timestamp,
+		Result:    result,
+		Duration:  duration,
+		Output:    make([]string, 0),
+		Subtests:  make([]*gotest.TestInfo, 0),
+	}
+	test.SpanID = gotest.GenerateTestSpanID()
+
+	p.ctx.RootTests = append(p.ctx.RootTests, test)
+	p.lastFileSummary = test
+
+	p.logger.Debug("Parsed vitest file summary",
+		zap.String("file", filePath),
+		zap.String("result", string(result)),
+		zap.Duration("duration", duration),
+	)
+}
+
+// addSlowTest creates a TestInfo for an indented slow-test line in the default reporter,
+// adding it as a child of the most recent file summary.
+func (p *Parser) addSlowTest(testName string, result gotest.TestResult, durationMs float64, timestamp time.Time) {
+	duration := time.Duration(durationMs * float64(time.Millisecond))
+	filePath := p.lastFileSummary.Package
+
+	fullName := filePath + " > " + testName
+
+	test := &gotest.TestInfo{
+		Name:       fullName,
+		Package:    filePath,
+		ParentTest: filePath,
+		StartTime:  timestamp.Add(-duration),
+		EndTime:    timestamp,
+		Result:     result,
+		Duration:   duration,
+		Output:     make([]string, 0),
+		Subtests:   make([]*gotest.TestInfo, 0),
+	}
+	test.SpanID = gotest.GenerateTestSpanID()
+
+	p.lastFileSummary.Subtests = append(p.lastFileSummary.Subtests, test)
+
+	p.logger.Debug("Parsed vitest slow test",
+		zap.String("test", fullName),
+		zap.String("result", string(result)),
+		zap.Duration("duration", duration),
+	)
 }
 
 // addTest creates a TestInfo for a completed Vitest test line.

--- a/collector/connector/testlogstotraces/vitest/parser_test.go
+++ b/collector/connector/testlogstotraces/vitest/parser_test.go
@@ -119,6 +119,99 @@ func TestParseVerboseOutput(t *testing.T) {
 			expectedTests: 0,
 		},
 		{
+			name: "default reporter file summary pass",
+			lines: []string{
+				"✓  my-app  src/tests/permissions.test.ts (106 tests | 3 skipped) 1090ms",
+			},
+			expectedTests:  1,
+			expectedPassed: 1,
+		},
+		{
+			name: "default reporter file summary with project containing parens",
+			lines: []string{
+				"✓  e2e-tests (chrome)  src/createImage.test.ts (2 tests) 164ms",
+			},
+			expectedTests:  1,
+			expectedPassed: 1,
+		},
+		{
+			name: "default reporter file summary fail",
+			lines: []string{
+				"×  my-app  src/tests/sync.test.ts (33 tests | 2 failed) 5027ms",
+			},
+			expectedTests:  1,
+			expectedFailed: 1,
+		},
+		{
+			name: "default reporter type-check file summary (no duration)",
+			lines: []string{
+				"✓  my-lib   TS  src/tools/tests/coMap.test-d.ts (33 tests)",
+			},
+			expectedTests:  1,
+			expectedPassed: 1,
+		},
+		{
+			name: "default reporter single test file",
+			lines: []string{
+				"✓  web-server  tests/integration.test.ts (1 test) 3721ms",
+			},
+			expectedTests:  1,
+			expectedPassed: 1,
+		},
+		{
+			name: "default reporter file summary with ANSI codes",
+			lines: []string{
+				" \x1b[32m✓\x1b[39m \x1b[30m\x1b[42m my-app \x1b[49m\x1b[39m src/tests/permissions.test.ts \x1b[2m(\x1b[22m\x1b[2m106 tests\x1b[22m\x1b[2m)\x1b[22m\x1b[32m 1090\x1b[2mms\x1b[22m\x1b[39m",
+			},
+			expectedTests:  1,
+			expectedPassed: 1,
+		},
+		{
+			name: "default reporter does not match non-test checkmarks",
+			lines: []string{
+				"✓ Starting...",
+				"✓ built in 848ms",
+				"✓ 42 modules transformed.",
+			},
+			expectedTests: 0,
+		},
+		{
+			name: "default reporter file summary with slow tests",
+			lines: []string{
+				"✓  web-server  tests/integration.test.ts (2 tests) 3721ms",
+				"    ✓ server responds with hello world  2097ms",
+				"    ✓ WASM crypto works  1623ms",
+			},
+			expectedTests:  3, // 1 file suite + 2 slow tests
+			expectedPassed: 3,
+		},
+		{
+			name: "default reporter slow test without file context is ignored",
+			lines: []string{
+				"    ✓ some orphan test  500ms",
+			},
+			expectedTests: 0,
+		},
+		{
+			name: "default reporter multiple files with slow tests",
+			lines: []string{
+				"✓  my-app  src/tests/sync.test.ts (33 tests) 5027ms",
+				"    ✓ Node handles disconnection  307ms",
+				"✓  my-app  src/tests/permissions.test.ts (106 tests) 1090ms",
+			},
+			expectedTests:  3, // 2 file suites + 1 slow test
+			expectedPassed: 3,
+		},
+		{
+			name: "default reporter slow test fail",
+			lines: []string{
+				"×  my-app  src/tests/sync.test.ts (33 tests | 1 failed) 5027ms",
+				"    × Node handles disconnection  307ms",
+			},
+			expectedTests:  2,
+			expectedFailed: 2,
+		},
+		{
 			name: "mixed results",
 			lines: []string{
 				" ✓ src/test.ts > group > passes 1ms",
@@ -564,6 +657,115 @@ func TestParseVerboseOutputWithWorkspacePrefix(t *testing.T) {
 			assert.Equal(t, tt.expectedSkipped, skipped, "skipped count mismatch")
 		})
 	}
+}
+
+func TestSpanGenerationDefaultReporter(t *testing.T) {
+	logger := zap.NewNop()
+	traceID := pcommon.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	stepSpanID := pcommon.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
+
+	ctx := gotest.NewParseContext(123, 1, "test-job", 1, traceID, stepSpanID)
+	parser := NewParser(ctx, logger)
+
+	lines := []string{
+		"✓  web-server  tests/integration.test.ts (2 tests) 3721ms",
+		"    ✓ server responds with hello world  2097ms",
+		"    ✓ WASM crypto works  1623ms",
+	}
+
+	baseTime := time.Now()
+	for i, line := range lines {
+		parser.ProcessLine(line, baseTime.Add(time.Duration(i)*time.Millisecond))
+	}
+	parser.Finalize()
+
+	resourceAttrs := pcommon.NewMap()
+	traces := GenerateSpans(ctx, resourceAttrs)
+	require.NotNil(t, traces)
+	assert.Equal(t, 3, traces.SpanCount()) // 1 file suite + 2 slow tests
+
+	resourceSpans := traces.ResourceSpans()
+	require.Equal(t, 1, resourceSpans.Len())
+
+	traceResourceAttrs := resourceSpans.At(0).Resource().Attributes()
+	resourceFramework, ok := traceResourceAttrs.Get(semconv.EverrTestFramework)
+	require.True(t, ok)
+	assert.Equal(t, "vitest", resourceFramework.Str())
+
+	spans := resourceSpans.At(0).ScopeSpans().At(0).Spans()
+	spanMap := make(map[string]ptrace.Span)
+	for i := 0; i < spans.Len(); i++ {
+		span := spans.At(i)
+		spanMap[span.Name()] = span
+	}
+
+	// File suite span
+	fileSuiteSpan, ok := spanMap["tests/integration.test.ts"]
+	require.True(t, ok, "file suite span not found, got: %v", spanNames(spans))
+	assert.Equal(t, stepSpanID, fileSuiteSpan.ParentSpanID())
+
+	isSuite, ok := fileSuiteSpan.Attributes().Get(semconv.EverrTestIsSuite)
+	require.True(t, ok)
+	assert.True(t, isSuite.Bool())
+
+	pkg, ok := fileSuiteSpan.Attributes().Get(semconv.EverrTestPackage)
+	require.True(t, ok)
+	assert.Equal(t, "tests/integration.test.ts", pkg.Str())
+
+	// Slow test spans are children of the file suite
+	slowSpan1, ok := spanMap["server responds with hello world"]
+	require.True(t, ok, "slow test span not found")
+	assert.Equal(t, fileSuiteSpan.SpanID(), slowSpan1.ParentSpanID())
+
+	isSubtest, ok := slowSpan1.Attributes().Get(semconv.EverrTestIsSubtest)
+	require.True(t, ok)
+	assert.True(t, isSubtest.Bool())
+
+	slowSpan2, ok := spanMap["WASM crypto works"]
+	require.True(t, ok, "slow test span not found")
+	assert.Equal(t, fileSuiteSpan.SpanID(), slowSpan2.ParentSpanID())
+}
+
+func TestDefaultReporterSlowTestHierarchy(t *testing.T) {
+	logger := zap.NewNop()
+	ctx := gotest.NewParseContext(123, 1, "test-job", 1, pcommon.TraceID{}, pcommon.SpanID{})
+	parser := NewParser(ctx, logger)
+
+	lines := []string{
+		"✓  web-server  tests/integration.test.ts (2 tests) 3721ms",
+		"    ✓ server responds with hello world  2097ms",
+		"    ✓ WASM crypto works  1623ms",
+	}
+
+	baseTime := time.Now()
+	for i, line := range lines {
+		parser.ProcessLine(line, baseTime.Add(time.Duration(i)*time.Millisecond))
+	}
+	parser.Finalize()
+
+	// Should have 1 root test (file suite)
+	require.Len(t, ctx.RootTests, 1)
+	fileSuite := ctx.RootTests[0]
+	assert.Equal(t, "tests/integration.test.ts", fileSuite.Name)
+	assert.Equal(t, "tests/integration.test.ts", fileSuite.Package)
+	assert.True(t, fileSuite.IsSuite())
+	assert.Equal(t, gotest.TestResultPass, fileSuite.Result)
+
+	// File suite should have 2 slow test children
+	require.Len(t, fileSuite.Subtests, 2)
+
+	child1 := fileSuite.Subtests[0]
+	assert.Equal(t, "tests/integration.test.ts > server responds with hello world", child1.Name)
+	assert.Equal(t, "tests/integration.test.ts", child1.Package)
+	assert.Equal(t, "tests/integration.test.ts", child1.ParentTest)
+	assert.True(t, child1.IsSubtest())
+	assert.Equal(t, gotest.TestResultPass, child1.Result)
+	assert.Equal(t, 2097*time.Millisecond, child1.Duration)
+
+	child2 := fileSuite.Subtests[1]
+	assert.Equal(t, "tests/integration.test.ts > WASM crypto works", child2.Name)
+	assert.Equal(t, "tests/integration.test.ts", child2.Package)
+	assert.Equal(t, gotest.TestResultPass, child2.Result)
 }
 
 func TestSplitTestName(t *testing.T) {

--- a/packages/docs/content/docs/test-analytics/vitest.mdx
+++ b/packages/docs/content/docs/test-analytics/vitest.mdx
@@ -3,11 +3,13 @@ title: Vitest
 description: Set up test analytics for Vitest projects.
 ---
 
-Everr parses verbose Vitest output to track individual test results, detect flaky tests, and analyze failures.
+Everr automatically parses Vitest output to track test results, detect flaky tests, and analyze failures.
 
-## Setup
+## Supported reporters
 
-Run Vitest with the `verbose` reporter so that individual test results are printed:
+### Verbose reporter (recommended)
+
+The verbose reporter prints every individual test result, giving Everr full per-test visibility:
 
 ```bash
 vitest run --reporter=verbose
@@ -23,18 +25,26 @@ export default defineConfig({
 });
 ```
 
-### GitHub Actions workflow example
+### Default reporter
+
+The default reporter (no extra configuration needed) is also supported. Everr parses:
+- **File-level summaries** for every test file (pass/fail status and duration)
+- **Individual slow tests** that Vitest prints below each file summary
+
+Since the default reporter only shows individual results for slow tests, the verbose reporter gives more granular per-test tracking.
+
+## GitHub Actions workflow example
 
 ```yaml
 - name: Run tests
   run: npx vitest run --reporter=verbose
 ```
 
-Everr automatically detects and parses Vitest verbose output from workflow logs.
+Everr automatically detects and parses Vitest output from workflow logs.
 
 ## What gets parsed
 
-The parser recognizes Vitest verbose reporter output patterns (after stripping ANSI color codes):
+### Verbose reporter patterns
 
 | Pattern | Meaning |
 |---------|---------|
@@ -42,9 +52,18 @@ The parser recognizes Vitest verbose reporter output patterns (after stripping A
 | `× filepath > describe > test 15ms` | Test failed |
 | `↓ filepath > describe > test` | Test skipped |
 
+### Default reporter patterns
+
+| Pattern | Meaning |
+|---------|---------|
+| `✓ project filepath (N tests) 42ms` | File passed |
+| `× project filepath (N tests \| M failed) 42ms` | File failed |
+| `    ✓ test name 42ms` | Slow test passed (child of file above) |
+| `    × test name 15ms` | Slow test failed (child of file above) |
+
 ## Describe block hierarchy
 
-Vitest uses the ` > ` separator to represent the test hierarchy: file path, describe blocks, and test name. For example:
+Vitest verbose output uses the ` > ` separator to represent the test hierarchy: file path, describe blocks, and test name. For example:
 
 ```
 ✓ src/utils.test.ts > parseConfig > handles empty input 3ms
@@ -66,6 +85,6 @@ Nested describe blocks are automatically detected. Describe nodes get `everr.tes
 | `everr.test.duration_seconds` | Duration from the test output |
 | `everr.test.framework` | `vitest` |
 | `everr.test.package` | File path (e.g. `src/utils.test.ts`) |
-| `everr.test.is_suite` | `true` for describe blocks that contain child tests |
-| `everr.test.is_subtest` | `true` for tests within describe blocks |
-| `everr.test.parent_test` | Parent describe block name |
+| `everr.test.is_suite` | `true` for describe blocks or file summaries that contain child tests |
+| `everr.test.is_subtest` | `true` for tests within describe blocks or file summaries |
+| `everr.test.parent_test` | Parent describe block or file name |


### PR DESCRIPTION
## Summary

- Add parsing for Vitest's default reporter format (file summaries + indented slow-test lines) alongside the existing verbose reporter support
- File summaries become suite spans; slow tests become child spans of their parent file
- Enables test detection for repos using `vitest run` without `--reporter=verbose`

## Test plan

- [x] File summary parsing: pass, fail, type-check (no duration), project names with parens, ANSI codes
- [x] Slow test parsing: pass/fail, file context gating (orphan lines ignored), multi-file sequences
- [x] Span generation: correct parent-child hierarchy, suite/subtest attributes
- [x] False positive prevention: `✓ Starting...`, `✓ built in 848ms` not matched
- [x] No regressions on existing verbose reporter tests