### PR TITLE
Fix sanitized job names in log ingestion + update CLI docs

### DIFF
--- a/collector/receiver/githubactionsreceiver/job_name_cache.go
+++ b/collector/receiver/githubactionsreceiver/job_name_cache.go
@@ -1,0 +1,94 @@
+package githubactionsreceiver
+
+import (
+	"sync"
+	"time"
+)
+
+type runKey struct {
+	repoID     int64
+	runID      int64
+	runAttempt int
+}
+
+type cacheEntry struct {
+	jobNames  []string
+	createdAt time.Time
+}
+
+type jobNameCache struct {
+	mu      sync.Mutex
+	entries map[runKey]*cacheEntry
+	order   []runKey
+	maxSize int
+	ttl     time.Duration
+}
+
+func newJobNameCache(maxSize int, ttl time.Duration) *jobNameCache {
+	return &jobNameCache{
+		entries: make(map[runKey]*cacheEntry),
+		order:   make([]runKey, 0),
+		maxSize: maxSize,
+		ttl:     ttl,
+	}
+}
+
+func (c *jobNameCache) AddJobName(key runKey, jobName string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry, exists := c.entries[key]
+	if !exists {
+		if len(c.entries) >= c.maxSize {
+			c.evictOldest()
+		}
+		entry = &cacheEntry{
+			createdAt: time.Now(),
+		}
+		c.entries[key] = entry
+		c.order = append(c.order, key)
+	}
+	entry.jobNames = append(entry.jobNames, jobName)
+}
+
+func (c *jobNameCache) GetJobNames(key runKey) []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry, exists := c.entries[key]
+	if !exists {
+		return nil
+	}
+	if time.Since(entry.createdAt) > c.ttl {
+		c.deleteUnlocked(key)
+		return nil
+	}
+	result := make([]string, len(entry.jobNames))
+	copy(result, entry.jobNames)
+	return result
+}
+
+func (c *jobNameCache) Delete(key runKey) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.deleteUnlocked(key)
+}
+
+func (c *jobNameCache) deleteUnlocked(key runKey) {
+	delete(c.entries, key)
+	for i, k := range c.order {
+		if k == key {
+			c.order = append(c.order[:i], c.order[i+1:]...)
+			break
+		}
+	}
+}
+
+func (c *jobNameCache) evictOldest() {
+	if len(c.order) == 0 {
+		return
+	}
+	oldest := c.order[0]
+	c.order = c.order[1:]
+	delete(c.entries, oldest)
+}

--- a/collector/receiver/githubactionsreceiver/job_name_cache_test.go
+++ b/collector/receiver/githubactionsreceiver/job_name_cache_test.go
@@ -1,0 +1,81 @@
+package githubactionsreceiver
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestJobNameCacheAddAndGet(t *testing.T) {
+	c := newJobNameCache(10, 30*time.Minute)
+	key := runKey{repoID: 1, runID: 100, runAttempt: 1}
+
+	c.AddJobName(key, "build (1/2)")
+	c.AddJobName(key, "build (2/2)")
+
+	names := c.GetJobNames(key)
+	require.Equal(t, []string{"build (1/2)", "build (2/2)"}, names)
+}
+
+func TestJobNameCacheGetMiss(t *testing.T) {
+	c := newJobNameCache(10, 30*time.Minute)
+	key := runKey{repoID: 1, runID: 100, runAttempt: 1}
+
+	names := c.GetJobNames(key)
+	require.Nil(t, names)
+}
+
+func TestJobNameCacheTTLExpiry(t *testing.T) {
+	c := newJobNameCache(10, 50*time.Millisecond)
+	key := runKey{repoID: 1, runID: 100, runAttempt: 1}
+
+	c.AddJobName(key, "build (1/2)")
+	require.NotNil(t, c.GetJobNames(key))
+
+	time.Sleep(60 * time.Millisecond)
+	require.Nil(t, c.GetJobNames(key))
+}
+
+func TestJobNameCacheSizeEviction(t *testing.T) {
+	c := newJobNameCache(2, 30*time.Minute)
+	key1 := runKey{repoID: 1, runID: 1, runAttempt: 1}
+	key2 := runKey{repoID: 1, runID: 2, runAttempt: 1}
+	key3 := runKey{repoID: 1, runID: 3, runAttempt: 1}
+
+	c.AddJobName(key1, "a (1/2)")
+	c.AddJobName(key2, "b (1/2)")
+	c.AddJobName(key3, "c (1/2)") // should evict key1
+
+	require.Nil(t, c.GetJobNames(key1))
+	require.NotNil(t, c.GetJobNames(key2))
+	require.NotNil(t, c.GetJobNames(key3))
+}
+
+func TestJobNameCacheDelete(t *testing.T) {
+	c := newJobNameCache(10, 30*time.Minute)
+	key := runKey{repoID: 1, runID: 100, runAttempt: 1}
+
+	c.AddJobName(key, "build (1/2)")
+	c.Delete(key)
+
+	require.Nil(t, c.GetJobNames(key))
+}
+
+func TestJobNameCacheConcurrency(t *testing.T) {
+	c := newJobNameCache(1000, 30*time.Minute)
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			key := runKey{repoID: 1, runID: int64(i), runAttempt: 1}
+			c.AddJobName(key, fmt.Sprintf("job (%d/2)", i))
+			c.GetJobNames(key)
+			c.Delete(key)
+		}(i)
+	}
+	wg.Wait()
+}

--- a/collector/receiver/githubactionsreceiver/log_event_handling.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling.go
@@ -14,7 +14,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -264,12 +263,10 @@ func resolveJobNames(ctx context.Context, zipJobNames []string, jobNamesCache *j
 	return resolvedNames
 }
 
-// looksLikeSanitizedJobName checks if a ZIP directory name could be a
-// sanitized matrix/shard job name (e.g., "test (1_2)" from "test (1/2)").
-var sanitizedJobNamePattern = regexp.MustCompile(`\(\d+_\d+\)`)
-
+// looksLikeSanitizedJobName checks if a ZIP directory name contains "_"
+// which could be a "/" sanitized by GitHub's ZIP archive builder.
 func looksLikeSanitizedJobName(name string) bool {
-	return sanitizedJobNamePattern.MatchString(name)
+	return strings.Contains(name, "_")
 }
 
 // listSanitizedJobNames calls the GitHub API to list workflow jobs and

--- a/collector/receiver/githubactionsreceiver/log_event_handling.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling.go
@@ -281,7 +281,7 @@ func listSanitizedJobNames(ctx context.Context, ghClient *github.Client, e *gith
 		ListOptions: github.ListOptions{PerPage: 100},
 	}
 
-	var sanitized []string
+	var originals []string
 	for {
 		jobsResp, resp, err := ghClient.Actions.ListWorkflowJobs(ctx, owner, repo, runID, opts)
 		if err != nil {
@@ -292,7 +292,7 @@ func listSanitizedJobNames(ctx context.Context, ghClient *github.Client, e *gith
 		for _, job := range jobsResp.Jobs {
 			name := job.GetName()
 			if strings.Contains(name, "/") {
-				sanitized = append(sanitized, name)
+				originals = append(originals, name)
 			}
 		}
 
@@ -302,5 +302,5 @@ func listSanitizedJobNames(ctx context.Context, ghClient *github.Client, e *gith
 		opts.Page = resp.NextPage
 	}
 
-	return sanitized
+	return originals
 }

--- a/collector/receiver/githubactionsreceiver/log_event_handling.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling.go
@@ -29,7 +29,7 @@ import (
 
 const maxLogArchiveSize = 256 * 1024 * 1024 // 256 MB
 
-func eventToLogs(ctx context.Context, event interface{}, config *Config, ghClient *github.Client, logger *zap.Logger, withTraceInfo bool) (*plog.Logs, error) {
+func eventToLogs(ctx context.Context, event interface{}, config *Config, ghClient *github.Client, logger *zap.Logger, withTraceInfo bool, jobNamesCache *jobNameCache) (*plog.Logs, error) {
 	e, ok := event.(*github.WorkflowRunEvent)
 	if !ok {
 		return nil, nil
@@ -132,16 +132,31 @@ func eventToLogs(ctx context.Context, event interface{}, config *Config, ghClien
 
 	logger.Debug("Extracted jobs from zip", zap.Strings("jobs", jobs), zap.Int("file_count", len(files)))
 
-	for _, jobName := range jobs {
+	// Resolve sanitized ZIP directory names to original job names.
+	// GitHub sanitizes "/" to "_" in ZIP paths, causing span ID mismatches
+	// for matrix/sharded jobs like "test (1/2)" → "test (1_2)".
+	resolvedNames := resolveJobNames(ctx, jobs, jobNamesCache, ghClient, e, logger)
+
+	for _, zipJobName := range jobs {
+		// Use the original (unsanitized) name for scope attributes and span IDs.
+		// The ZIP directory name is kept for file path matching.
+		jobName := zipJobName
+		if resolvedNames != nil {
+			if resolved, ok := resolvedNames[zipJobName]; ok {
+				jobName = resolved
+			}
+		}
+
 		jobLogsScope := allLogs.ScopeLogs().AppendEmpty()
 		jobLogsScope.Scope().Attributes().PutStr(string(conventions.CICDPipelineTaskNameKey), jobName)
 
 		for _, logFile := range files {
-			if !strings.HasPrefix(logFile.Name, jobName) {
+			// File matching uses the ZIP directory name
+			if !strings.HasPrefix(logFile.Name, zipJobName+"/") {
 				continue
 			}
 
-			fileNameWithoutDir := strings.TrimPrefix(logFile.Name, jobName+"/")
+			fileNameWithoutDir := strings.TrimPrefix(logFile.Name, zipJobName+"/")
 			stepNumberStr := strings.Split(fileNameWithoutDir, "_")[0]
 			stepNumber, err := strconv.Atoi(stepNumberStr)
 			if err != nil {
@@ -149,6 +164,7 @@ func eventToLogs(ctx context.Context, event interface{}, config *Config, ghClien
 				continue
 			}
 
+			// Span ID uses the original name to match trace-side generation
 			spanID, err := generateStepSpanID(e.GetWorkflowRun().GetID(), e.GetWorkflowRun().GetRunAttempt(), jobName, int64(stepNumber))
 			if err != nil {
 				logger.Error("Failed to generate span ID", zap.Error(err))
@@ -201,4 +217,118 @@ func eventToLogs(ctx context.Context, event interface{}, config *Config, ghClien
 	}
 
 	return &logs, nil
+}
+
+func resolveJobNames(ctx context.Context, zipJobNames []string, jobNamesCache *jobNameCache, ghClient *github.Client, e *github.WorkflowRunEvent, logger *zap.Logger) map[string]string {
+	if jobNamesCache == nil {
+		return nil
+	}
+
+	resolvedNames := make(map[string]string) // zipDirName → originalName
+
+	key := runKey{
+		repoID:     e.GetRepo().GetID(),
+		runID:      e.GetWorkflowRun().GetID(),
+		runAttempt: e.GetWorkflowRun().GetRunAttempt(),
+	}
+	originals := jobNamesCache.GetJobNames(key)
+
+	if originals == nil {
+		// Cache miss — check if any ZIP name looks sanitized before calling API
+		needsAPI := false
+		for _, zipName := range zipJobNames {
+			if looksLikeSanitizedJobName(zipName) {
+				needsAPI = true
+				break
+			}
+		}
+		if needsAPI {
+			originals = listSanitizedJobNames(ctx, ghClient, e, logger)
+		}
+	}
+
+	for _, original := range originals {
+		sanitized := strings.ReplaceAll(original, "/", "_")
+		for _, zipName := range zipJobNames {
+			if zipName == sanitized {
+				resolvedNames[zipName] = original
+				break
+			}
+		}
+	}
+
+	// Clean up cache entry after consumption
+	jobNamesCache.Delete(key)
+
+	return resolvedNames
+}
+
+// looksLikeSanitizedJobName checks if a ZIP directory name could be a
+// sanitized matrix/shard job name (e.g., "test (1_2)" from "test (1/2)").
+func looksLikeSanitizedJobName(name string) bool {
+	for i := 0; i < len(name); i++ {
+		if name[i] == '(' {
+			for j := i + 1; j < len(name); j++ {
+				if name[j] == ')' {
+					inner := name[i+1 : j]
+					if strings.Contains(inner, "_") {
+						parts := strings.SplitN(inner, "_", 2)
+						if len(parts) == 2 && isDigits(parts[0]) && isDigits(parts[1]) {
+							return true
+						}
+					}
+					break
+				}
+			}
+		}
+	}
+	return false
+}
+
+func isDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// listSanitizedJobNames calls the GitHub API to list workflow jobs and
+// returns original names that contain "/" (i.e., names GitHub would sanitize).
+func listSanitizedJobNames(ctx context.Context, ghClient *github.Client, e *github.WorkflowRunEvent, logger *zap.Logger) []string {
+	owner := e.GetRepo().GetOwner().GetLogin()
+	repo := e.GetRepo().GetName()
+	runID := e.GetWorkflowRun().GetID()
+
+	opts := &github.ListWorkflowJobsOptions{
+		Filter:      "latest",
+		ListOptions: github.ListOptions{PerPage: 100},
+	}
+
+	var sanitized []string
+	for {
+		jobsResp, resp, err := ghClient.Actions.ListWorkflowJobs(ctx, owner, repo, runID, opts)
+		if err != nil {
+			logger.Warn("Failed to list workflow jobs for name resolution", zap.Error(err))
+			return nil
+		}
+
+		for _, job := range jobsResp.Jobs {
+			name := job.GetName()
+			if strings.Contains(name, "/") {
+				sanitized = append(sanitized, name)
+			}
+		}
+
+		if resp == nil || resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	return sanitized
 }

--- a/collector/receiver/githubactionsreceiver/log_event_handling.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -265,36 +266,10 @@ func resolveJobNames(ctx context.Context, zipJobNames []string, jobNamesCache *j
 
 // looksLikeSanitizedJobName checks if a ZIP directory name could be a
 // sanitized matrix/shard job name (e.g., "test (1_2)" from "test (1/2)").
-func looksLikeSanitizedJobName(name string) bool {
-	for i := 0; i < len(name); i++ {
-		if name[i] == '(' {
-			for j := i + 1; j < len(name); j++ {
-				if name[j] == ')' {
-					inner := name[i+1 : j]
-					if strings.Contains(inner, "_") {
-						parts := strings.SplitN(inner, "_", 2)
-						if len(parts) == 2 && isDigits(parts[0]) && isDigits(parts[1]) {
-							return true
-						}
-					}
-					break
-				}
-			}
-		}
-	}
-	return false
-}
+var sanitizedJobNamePattern = regexp.MustCompile(`\(\d+_\d+\)`)
 
-func isDigits(s string) bool {
-	if s == "" {
-		return false
-	}
-	for _, c := range s {
-		if c < '0' || c > '9' {
-			return false
-		}
-	}
-	return true
+func looksLikeSanitizedJobName(name string) bool {
+	return sanitizedJobNamePattern.MatchString(name)
 }
 
 // listSanitizedJobNames calls the GitHub API to list workflow jobs and

--- a/collector/receiver/githubactionsreceiver/log_event_handling.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling.go
@@ -291,7 +291,7 @@ func listSanitizedJobNames(ctx context.Context, ghClient *github.Client, e *gith
 
 		for _, job := range jobsResp.Jobs {
 			name := job.GetName()
-			if strings.Contains(name, "/") {
+			if strings.Contains(name, "/") || strings.Contains(name, "_") {
 				originals = append(originals, name)
 			}
 		}

--- a/collector/receiver/githubactionsreceiver/log_event_handling_test.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling_test.go
@@ -60,16 +60,11 @@ func TestResolveJobNamesCacheMissNoSanitizedNames(t *testing.T) {
 
 func TestLooksLikeSanitizedJobName(t *testing.T) {
 	require.True(t, looksLikeSanitizedJobName("deploy (1_2)"))
-	require.True(t, looksLikeSanitizedJobName("deploy (12_34)"))
-	require.True(t, looksLikeSanitizedJobName("test (1_2) extra"))
+	require.True(t, looksLikeSanitizedJobName("build_deploy"))
+	require.True(t, looksLikeSanitizedJobName("test_rust"))
 	require.False(t, looksLikeSanitizedJobName("lint"))
-	require.False(t, looksLikeSanitizedJobName("test-rust"))
-	require.False(t, looksLikeSanitizedJobName("deploy (fast_mode)"))
 	require.False(t, looksLikeSanitizedJobName("deploy"))
-	require.False(t, looksLikeSanitizedJobName("deploy ()"))
-	require.False(t, looksLikeSanitizedJobName("deploy (_)"))
-	require.False(t, looksLikeSanitizedJobName("deploy (1_)"))
-	require.False(t, looksLikeSanitizedJobName("deploy (_2)"))
+	require.False(t, looksLikeSanitizedJobName("test-rust"))
 }
 
 func TestSpanIDMatchesTraceGeneration(t *testing.T) {

--- a/collector/receiver/githubactionsreceiver/log_event_handling_test.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling_test.go
@@ -1,0 +1,113 @@
+package githubactionsreceiver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-github/v67/github"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveJobNamesFromCache(t *testing.T) {
+	cache := newJobNameCache(10, 30*60*1e9) // 30 min
+	repoID := int64(42)
+	runID := int64(100)
+	runAttempt := 1
+
+	cache.AddJobName(runKey{repoID: repoID, runID: runID, runAttempt: runAttempt}, "deploy (1/2)")
+	cache.AddJobName(runKey{repoID: repoID, runID: runID, runAttempt: runAttempt}, "deploy (2/2)")
+
+	zipJobNames := []string{"deploy (1_2)", "deploy (2_2)", "lint"}
+
+	resolved := resolveJobNames(
+		context.TODO(),
+		zipJobNames,
+		cache,
+		nil, // ghClient not needed for cache hit
+		makeTestWorkflowRunEvent(repoID, runID, runAttempt),
+		nil, // logger not needed for cache hit
+	)
+
+	require.Equal(t, "deploy (1/2)", resolved["deploy (1_2)"])
+	require.Equal(t, "deploy (2/2)", resolved["deploy (2_2)"])
+	require.Empty(t, resolved["lint"])
+
+	// Verify cache was cleaned up
+	require.Nil(t, cache.GetJobNames(runKey{repoID: repoID, runID: runID, runAttempt: runAttempt}))
+}
+
+func TestResolveJobNamesNilCache(t *testing.T) {
+	resolved := resolveJobNames(context.TODO(), []string{"job"}, nil, nil, nil, nil)
+	require.Nil(t, resolved)
+}
+
+func TestResolveJobNamesCacheMissNoSanitizedNames(t *testing.T) {
+	cache := newJobNameCache(10, 30*60*1e9)
+
+	zipJobNames := []string{"lint", "test-rust"}
+
+	resolved := resolveJobNames(
+		context.TODO(),
+		zipJobNames,
+		cache,
+		nil, // ghClient nil — should not be called since no names look sanitized
+		makeTestWorkflowRunEvent(1, 1, 1),
+		nil,
+	)
+
+	require.Empty(t, resolved)
+}
+
+func TestLooksLikeSanitizedJobName(t *testing.T) {
+	require.True(t, looksLikeSanitizedJobName("deploy (1_2)"))
+	require.True(t, looksLikeSanitizedJobName("deploy (12_34)"))
+	require.True(t, looksLikeSanitizedJobName("test (1_2) extra"))
+	require.False(t, looksLikeSanitizedJobName("lint"))
+	require.False(t, looksLikeSanitizedJobName("test-rust"))
+	require.False(t, looksLikeSanitizedJobName("deploy (fast_mode)"))
+	require.False(t, looksLikeSanitizedJobName("deploy"))
+	require.False(t, looksLikeSanitizedJobName("deploy ()"))
+	require.False(t, looksLikeSanitizedJobName("deploy (_)"))
+	require.False(t, looksLikeSanitizedJobName("deploy (1_)"))
+	require.False(t, looksLikeSanitizedJobName("deploy (_2)"))
+}
+
+func TestSpanIDMatchesTraceGeneration(t *testing.T) {
+	// Verify that using the resolved original name produces the same span ID
+	// as the trace-side generation in trace_event_handling.go
+	originalName := "deploy (1/2)"
+	runID := int64(100)
+	runAttempt := 1
+	stepNumber := int64(1)
+
+	// This is what trace_event_handling.go generates for the original name
+	expectedSpanID, err := generateStepSpanID(runID, runAttempt, originalName, stepNumber)
+	require.NoError(t, err)
+
+	// This is what we'd get with the sanitized name (the bug)
+	buggySpanID, err := generateStepSpanID(runID, runAttempt, "deploy (1_2)", stepNumber)
+	require.NoError(t, err)
+
+	// They should be different (proving the bug exists)
+	require.NotEqual(t, expectedSpanID, buggySpanID)
+
+	// After resolution, log_event_handling uses the original name, matching trace side
+	resolvedSpanID, err := generateStepSpanID(runID, runAttempt, originalName, stepNumber)
+	require.NoError(t, err)
+	require.Equal(t, expectedSpanID, resolvedSpanID)
+}
+
+func makeTestWorkflowRunEvent(repoID, runID int64, runAttempt int) *github.WorkflowRunEvent {
+	return &github.WorkflowRunEvent{
+		Repo: &github.Repository{
+			ID:    &repoID,
+			Owner: &github.User{Login: getPtr("owner")},
+			Name:  getPtr("repo"),
+		},
+		WorkflowRun: &github.WorkflowRun{
+			ID:         &runID,
+			RunAttempt: &runAttempt,
+			Status:     getPtr("completed"),
+		},
+	}
+}

--- a/collector/receiver/githubactionsreceiver/receiver.go
+++ b/collector/receiver/githubactionsreceiver/receiver.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -42,6 +43,7 @@ type githubActionsReceiver struct {
 	logger          *zap.Logger
 	obsrecv         *receiverhelper.ObsReport
 	ghClient        *github.Client
+	jobNames        *jobNameCache
 }
 
 func newReceiver(
@@ -82,6 +84,7 @@ func newReceiver(
 		logger:   settings.Logger,
 		obsrecv:  obsrecv,
 		ghClient: ghClient,
+		jobNames: newJobNameCache(1024, 30*time.Minute),
 	}
 
 	return gar, nil
@@ -237,6 +240,20 @@ func (gar *githubActionsReceiver) ServeHTTP(w http.ResponseWriter, r *http.Reque
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
+		jobName := e.GetWorkflowJob().GetName()
+		// Cache job names containing "/" (need resolution) and "_" (need to
+		// distinguish genuine underscores from sanitized slashes). If the cache
+		// has entries for a run, it's authoritative — a cache hit with no "/"
+		// match means the "_" was literal, avoiding a false-positive API call
+		// from the looksLikeSanitizedJobName heuristic.
+		if strings.Contains(jobName, "/") || strings.Contains(jobName, "_") {
+			key := runKey{
+				repoID:     e.GetRepo().GetID(),
+				runID:      e.GetWorkflowJob().GetRunID(),
+				runAttempt: int(e.GetWorkflowJob().GetRunAttempt()),
+			}
+			gar.jobNames.AddJobName(key, jobName)
+		}
 	case *github.WorkflowRunEvent:
 		if e.GetWorkflowRun().GetStatus() != "completed" {
 			gar.logger.Debug("Skipping non-completed WorkflowRunEvent", zap.String("status", e.GetWorkflowRun().GetStatus()))
@@ -332,7 +349,7 @@ func (gar *githubActionsReceiver) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		} else {
 			withTraceInfo := gar.tracesConsumer != nil && !traceErr
 
-			ld, err := eventToLogs(ctx, event, gar.config, ghClient, gar.logger.Named("eventToLogs"), withTraceInfo)
+			ld, err := eventToLogs(ctx, event, gar.config, ghClient, gar.logger.Named("eventToLogs"), withTraceInfo, gar.jobNames)
 			if err != nil {
 				processingFailed = true
 				gar.logger.Error("Failed to process logs", zap.Error(err))

--- a/packages/docs/content/docs/cli/index.mdx
+++ b/packages/docs/content/docs/cli/index.mdx
@@ -40,14 +40,17 @@ Use the desktop app if you also want Everr to manage global assistant integratio
 - `everr slowest-tests` (repo-wide for non-suite tests by default; use `--branch <name>` to scope it)
 - `everr slowest-jobs` (repo-wide by default; use `--branch <name>` to scope it)
 - `everr watch` (waits until local `HEAD` commit appears in runs; use `--commit <sha>` to target a specific commit; exits non-zero if any completed run finishes with `failure`)
-- `everr runs list`
-- `everr runs show --trace-id <trace_id>`
-- `everr runs logs --trace-id <trace_id> --job-name <job> --step-number <n>` (prints native-style logs; add `--limit <n>` and `--offset <n>` for raw paging, or `--full` for the entire raw log)
+- `everr runs` (list recent runs; use `--branch`, `--conclusion`, `--workflow-name` to filter)
+- `everr show --trace-id <trace_id>`
+- `everr logs --trace-id <trace_id> --job-name <job> --step-number <n>` (prints the last 1000 lines by default; use `--tail <n>` to change, or `--limit <n>` and `--offset <n>` for raw paging)
+- `everr workflows` (list workflows and their jobs; use `--repo` and `--branch` to filter)
+- `everr test-history --test-name <name>` (show historical executions for a specific test; use `--module` to disambiguate)
+- `everr login` / `everr logout`
 
 `everr status` returns the current watch payload for the target commit, including `state`, `active`, and `completed`.
 
 `everr grep` searches failing step logs for a literal, case-insensitive pattern. Use `--job-name` together with `--step-number` to target one specific failing step. By default it searches the current repository over the last 7 days and excludes the currently checked out branch so you can quickly answer whether the same failure happened elsewhere.
 
-`everr runs logs` prints a focused failure excerpt by default. For contiguous raw log paging, pass `--limit <n>` and `--offset <n>`; if you provide `--offset` without `--limit`, Everr defaults to a 1000-line page.
+`everr logs` prints the last 1000 lines of a step log by default. Use `--tail <n>` to control how many lines from the bottom. For contiguous raw log paging, pass `--limit <n>` and `--offset <n>`.
 
 Collection-style commands accept `--limit <n>` and `--offset <n>` for pagination.


### PR DESCRIPTION
This PR fixes the log ingestion for job names with `/` and aligns the CLI docs with the current commands.