### PR TITLE
feat: better notifications ux

### DIFF
--- a/packages/desktop-app/src-tauri/src/notifications.rs
+++ b/packages/desktop-app/src-tauri/src/notifications.rs
@@ -348,23 +348,34 @@ pub(crate) fn sync_notification_window(app: &AppHandle, state: &RuntimeState) ->
 
     if has_active_notification {
         show_notification_window(app)?;
+        app.emit(NOTIFICATION_CHANGED_EVENT, ())
+            .context("failed to emit notification update")
     } else {
-        hide_notification_window(app)?;
+        // Slide-out first, then emit the changed event + hide once animation completes.
+        // This keeps the card content visible during the exit animation.
+        hide_notification_window(app)
     }
-
-    app.emit(NOTIFICATION_CHANGED_EVENT, ())
-        .context("failed to emit notification update")
 }
 
 fn show_notification_window(app: &AppHandle) -> Result<()> {
     let window = ensure_notification_window(app)?;
     let was_visible = window.is_visible().unwrap_or(false);
     configure_notification_window_for_fullscreen(&window)?;
-    position_notification_window(app, &window)?;
-    show_without_focus(&window)?;
+
     if !was_visible {
+        // Start off-screen to the right, then animate to final position
+        let (final_x, final_y) = notification_window_position(app)?;
+        let off_screen_x = final_x + NOTIFICATION_WINDOW_WIDTH + NOTIFICATION_WINDOW_INSET + 24.0;
+        window
+            .set_position(LogicalPosition::new(off_screen_x, final_y))
+            .context("failed to set initial off-screen position")?;
+        show_without_focus(&window)?;
+        animate_window_slide(app, final_x, final_y, false);
         start_notification_hover_polling(app);
+    } else {
+        position_notification_window(app, &window)?;
     }
+
     Ok(())
 }
 
@@ -416,11 +427,66 @@ fn cursor_is_over_notification_window(app: &AppHandle, window: &WebviewWindow) -
 
 fn hide_notification_window(app: &AppHandle) -> Result<()> {
     if let Some(window) = app.get_webview_window(NOTIFICATION_WINDOW_LABEL) {
+        if window.is_visible().unwrap_or(false) {
+            if let Ok((final_x, final_y)) = notification_window_position(app) {
+                let off_screen_x =
+                    final_x + NOTIFICATION_WINDOW_WIDTH + NOTIFICATION_WINDOW_INSET + 24.0;
+                animate_window_slide(app, off_screen_x, final_y, true);
+                return Ok(());
+            }
+        }
         window
             .hide()
             .context("failed to hide notification window")?;
     }
-    Ok(())
+    app.emit(NOTIFICATION_CHANGED_EVENT, ())
+        .context("failed to emit notification update")
+}
+
+/// Smoothly slides the notification window to `(target_x, target_y)`.
+/// When `hide_after` is true the window is hidden once the animation completes.
+fn animate_window_slide(app: &AppHandle, target_x: f64, target_y: f64, hide_after: bool) {
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        const DURATION_MS: u64 = 200;
+        const FRAME_MS: u64 = 6;
+        let steps = DURATION_MS / FRAME_MS;
+
+        let Some(window) = app.get_webview_window(NOTIFICATION_WINDOW_LABEL) else {
+            return;
+        };
+        let Ok(start_pos) = window.outer_position() else {
+            return;
+        };
+        let scale = app
+            .cursor_position()
+            .ok()
+            .and_then(|c| app.monitor_from_point(c.x, c.y).ok().flatten())
+            .or_else(|| app.primary_monitor().ok().flatten())
+            .map(|m| m.scale_factor())
+            .unwrap_or(1.0);
+        let start_x = start_pos.x as f64 / scale;
+        let start_y = start_pos.y as f64 / scale;
+
+        for i in 1..=steps {
+            let t = i as f64 / steps as f64;
+            // ease-out cubic for slide-in, ease-in cubic for slide-out
+            let eased = if hide_after {
+                t * t * t
+            } else {
+                1.0 - (1.0 - t).powi(3)
+            };
+            let x = start_x + (target_x - start_x) * eased;
+            let y = start_y + (target_y - start_y) * eased;
+            let _ = window.set_position(LogicalPosition::new(x, y));
+            tokio::time::sleep(Duration::from_millis(FRAME_MS)).await;
+        }
+
+        if hide_after {
+            let _ = app.emit(NOTIFICATION_CHANGED_EVENT, ());
+            let _ = window.hide();
+        }
+    });
 }
 
 fn ensure_notification_window(app: &AppHandle) -> Result<WebviewWindow> {

--- a/packages/desktop-app/src/App.test.tsx
+++ b/packages/desktop-app/src/App.test.tsx
@@ -709,6 +709,13 @@ describe("notification window", () => {
     await waitFor(() => {
       expect(dismissSpy).toHaveBeenCalledTimes(1);
     });
+
+    // Backend emits the changed event after the slide-out animation completes
+    await act(async () => {
+      await emit(NOTIFICATION_CHANGED_EVENT);
+      await Promise.resolve();
+    });
+
     await waitFor(() => {
       expect(screen.queryByText("CI")).not.toBeInTheDocument();
     });
@@ -723,6 +730,13 @@ describe("notification window", () => {
     await waitFor(() => {
       expect(openSpy).toHaveBeenCalledTimes(1);
     });
+
+    // Backend emits the changed event after the slide-out animation completes
+    await act(async () => {
+      await emit(NOTIFICATION_CHANGED_EVENT);
+      await Promise.resolve();
+    });
+
     await waitFor(() => {
       expect(screen.queryByText("CI")).not.toBeInTheDocument();
     });

--- a/packages/desktop-app/src/App.test.tsx
+++ b/packages/desktop-app/src/App.test.tsx
@@ -784,13 +784,13 @@ describe("notification window", () => {
     vi.useFakeTimers();
 
     const { dismissSpy } = await renderNotificationCard();
-    const card = screen.getByText("CI");
+    const section = screen.getByText("CI").closest("section");
 
-    fireEvent.mouseEnter(card.closest(".notificationCard") as HTMLElement);
+    fireEvent.mouseEnter(section as HTMLElement);
     await vi.advanceTimersByTimeAsync(NOTIFICATION_AUTO_DISMISS_MS);
     expect(dismissSpy).not.toHaveBeenCalled();
 
-    fireEvent.mouseLeave(card.closest(".notificationCard") as HTMLElement);
+    fireEvent.mouseLeave(section as HTMLElement);
     await vi.advanceTimersByTimeAsync(NOTIFICATION_AUTO_DISMISS_MS);
     await flushNotificationRender();
 

--- a/packages/desktop-app/src/features/notifications/notification-window.tsx
+++ b/packages/desktop-app/src/features/notifications/notification-window.tsx
@@ -91,28 +91,14 @@ function useActiveNotificationQuery() {
 }
 
 function useDismissActiveNotificationMutation() {
-  const queryClient = useQueryClient();
-
   return useMutation({
     mutationFn: dismissActiveNotification,
-    onSuccess() {
-      void queryClient.invalidateQueries({
-        queryKey: activeNotificationQueryKey,
-      });
-    },
   });
 }
 
 function useOpenNotificationTargetMutation() {
-  const queryClient = useQueryClient();
-
   return useMutation({
     mutationFn: openNotificationTarget,
-    onSuccess() {
-      void queryClient.invalidateQueries({
-        queryKey: activeNotificationQueryKey,
-      });
-    },
   });
 }
 
@@ -228,7 +214,6 @@ export function NotificationCard({
     copyMutation.isPending;
 
   useEffect(() => {
-    setHovered(false);
     setCopiedAutoFixPrompt(false);
     setRemainingMs(AUTO_DISMISS_MS);
     setDeadlineAt(Date.now() + AUTO_DISMISS_MS);
@@ -285,12 +270,7 @@ export function NotificationCard({
 
   return (
     <main className="h-screen pt-3 pl-3">
-      {/** biome-ignore lint/a11y/noStaticElementInteractions: we need to track mouse enter and leave events */}
-      <section
-        className="notificationCard group relative flex h-full flex-col bg-card"
-        onMouseEnter={pauseAutoDismiss}
-        onMouseLeave={resumeAutoDismiss}
-      >
+      <div className="relative h-full">
         <button
           type="button"
           className={`cursor-pointer absolute -left-[11px] -top-[11px] z-10 flex size-[22px] items-center justify-center rounded-full transition-opacity duration-150 bg-accent text-accent-foreground disabled:pointer-events-none ${hovered ? "opacity-100" : "opacity-0"}`}
@@ -311,78 +291,84 @@ export function NotificationCard({
             <path d="M10 2 2 10" />
           </svg>
         </button>
-
-        <div className="flex flex-1 items-center gap-3 px-[18px] py-3">
-          <div className="grid min-w-0 flex-1 gap-[3px]">
-            <p className="m-0 text-[0.58rem] font-medium uppercase tracking-[0.06em] text-muted-foreground">
-              Everr - Failed run
-            </p>
-            <h1 className="m-0 text-[0.8rem] font-semibold leading-[1.15] text-card-foreground">
-              {notification.workflowName}
-            </h1>
-            <p className="m-0 flex min-w-0 items-center gap-1 text-[0.66rem] leading-[1.3] text-muted-foreground">
-              <span className="truncate">{notification.repo}</span>
-              <span className="text-border">•</span>
-              <span>{notification.branch}</span>
-            </p>
-            {failureScope ? (
-              <p className="m-0 text-[0.66rem] leading-[1.35] text-muted-foreground">
-                {failureScope}
+        {/** biome-ignore lint/a11y/noStaticElementInteractions: we need to track mouse enter and leave events */}
+        <section
+          className="notificationCard group flex h-full flex-col overflow-hidden bg-card"
+          onMouseEnter={pauseAutoDismiss}
+          onMouseLeave={resumeAutoDismiss}
+        >
+          <div className="flex flex-1 items-center gap-3 px-[18px] py-3">
+            <div className="grid min-w-0 flex-1 gap-[3px]">
+              <p className="m-0 text-[0.58rem] font-medium uppercase tracking-[0.06em] text-muted-foreground">
+                Everr - Failed run
               </p>
-            ) : null}
-            <p className="m-0 flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5 text-[0.64rem] font-medium tracking-[0.01em] text-muted-foreground/70">
-              <span>{absoluteTime}</span>
-              <span className="text-border">·</span>
-              <span>{relativeTime}</span>
-            </p>
+              <h1 className="m-0 text-[0.8rem] font-semibold leading-[1.15] text-card-foreground">
+                {notification.workflowName}
+              </h1>
+              <p className="m-0 flex min-w-0 items-center gap-1 text-[0.66rem] leading-[1.3] text-muted-foreground">
+                <span className="truncate">{notification.repo}</span>
+                <span className="text-border">•</span>
+                <span>{notification.branch}</span>
+              </p>
+              {failureScope ? (
+                <p className="m-0 text-[0.66rem] leading-[1.35] text-muted-foreground">
+                  {failureScope}
+                </p>
+              ) : null}
+              <p className="m-0 flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5 text-[0.64rem] font-medium tracking-[0.01em] text-muted-foreground/70">
+                <span>{absoluteTime}</span>
+                <span className="text-border">·</span>
+                <span>{relativeTime}</span>
+              </p>
+            </div>
+
+            <div className="flex min-w-0 shrink-0 flex-col items-stretch gap-2">
+              <Button
+                size="lg"
+                className="min-w-0 px-3.5 text-[0.72rem] cursor-pointer"
+                disabled={busy}
+                onClick={() =>
+                  void copyMutation.mutateAsync(undefined, {
+                    onSuccess() {
+                      setCopiedAutoFixPrompt(true);
+                    },
+                  })
+                }
+              >
+                <span className="grid">
+                  <span
+                    aria-hidden="true"
+                    className="invisible col-start-1 row-start-1"
+                  >
+                    Auto-fix prompt
+                  </span>
+                  <span className="col-start-1 row-start-1">
+                    {copyAutoFixPromptLabel}
+                  </span>
+                </span>
+              </Button>
+              <Button
+                size="lg"
+                variant="outline"
+                className="min-w-0 px-3.5 text-[0.72rem] cursor-pointer"
+                disabled={busy}
+                onClick={() => void openMutation.mutateAsync()}
+              >
+                {openMutation.isPending ? "Opening..." : "Open"}
+              </Button>
+            </div>
           </div>
 
-          <div className="flex min-w-0 shrink-0 flex-col items-stretch gap-2">
-            <Button
-              size="lg"
-              className="min-w-0 px-3.5 text-[0.72rem] cursor-pointer"
-              disabled={busy}
-              onClick={() =>
-                void copyMutation.mutateAsync(undefined, {
-                  onSuccess() {
-                    setCopiedAutoFixPrompt(true);
-                  },
-                })
-              }
-            >
-              <span className="grid">
-                <span
-                  aria-hidden="true"
-                  className="invisible col-start-1 row-start-1"
-                >
-                  Auto-fix prompt
-                </span>
-                <span className="col-start-1 row-start-1">
-                  {copyAutoFixPromptLabel}
-                </span>
-              </span>
-            </Button>
-            <Button
-              size="lg"
-              variant="outline"
-              className="min-w-0 px-3.5 text-[0.72rem] cursor-pointer"
-              disabled={busy}
-              onClick={() => void openMutation.mutateAsync()}
-            >
-              {openMutation.isPending ? "Opening..." : "Open"}
-            </Button>
+          <div className="h-[3px] w-full shrink-0 bg-muted">
+            <div
+              key={notification.dedupeKey}
+              className="notification-progress h-full bg-primary origin-left"
+              style={{ animationDuration: `${AUTO_DISMISS_MS}ms` }}
+              data-paused={hovered || undefined}
+            />
           </div>
-        </div>
-
-        <div className="h-[3px] w-full shrink-0 bg-muted">
-          <div
-            key={notification.dedupeKey}
-            className="notification-progress h-full bg-primary origin-left"
-            style={{ animationDuration: `${AUTO_DISMISS_MS}ms` }}
-            data-paused={hovered || undefined}
-          />
-        </div>
-      </section>
+        </section>
+      </div>
     </main>
   );
 }

--- a/packages/desktop-app/src/features/notifications/notification-window.tsx
+++ b/packages/desktop-app/src/features/notifications/notification-window.tsx
@@ -293,7 +293,7 @@ export function NotificationCard({
         </button>
         {/** biome-ignore lint/a11y/noStaticElementInteractions: we need to track mouse enter and leave events */}
         <section
-          className="notificationCard group flex h-full flex-col overflow-hidden bg-card"
+          className="group flex h-full flex-col overflow-hidden bg-card rounded-xl"
           onMouseEnter={pauseAutoDismiss}
           onMouseLeave={resumeAutoDismiss}
         >
@@ -380,7 +380,7 @@ function NotificationLoadingState() {
 function NotificationErrorState({ onRetry }: { onRetry: () => void }) {
   return (
     <main className="h-screen bg-card">
-      <section className="notificationCard grid h-full items-center bg-card px-[18px] py-4">
+      <section className="grid h-full items-center bg-card px-[18px] py-4 rounded-xl">
         <div className="grid min-w-0 gap-3">
           <div className="grid min-w-0 gap-1">
             <p className="m-0 text-[0.58rem] font-medium uppercase tracking-[0.06em] text-muted-foreground">

--- a/packages/desktop-app/src/styles/desktop-app.css
+++ b/packages/desktop-app/src/styles/desktop-app.css
@@ -36,3 +36,7 @@
 .notification-progress[data-paused] {
   animation-play-state: paused;
 }
+
+.notificationCard {
+  border-radius: 14px;
+}

--- a/packages/desktop-app/src/styles/desktop-app.css
+++ b/packages/desktop-app/src/styles/desktop-app.css
@@ -36,7 +36,3 @@
 .notification-progress[data-paused] {
   animation-play-state: paused;
 }
-
-.notificationCard {
-  border-radius: 14px;
-}


### PR DESCRIPTION
## Better desktop notifications

  ### Rounded corners
  - Notification card uses `rounded-xl` with `overflow-hidden` to clip content (including the progress bar) to the rounded shape
  - Close button moved outside the card into a wrapper `div` so it isn't clipped by `overflow-hidden`
  - Error state card also uses `rounded-xl` for consistency

  ### Slide-in / slide-out window animation
  - Notification window now slides in from the right when appearing and slides out to the right when dismissing
  - Animation runs at the Tauri window level (`set_position` in an async loop with cubic easing, 200ms duration) rather than CSS transforms, so the entire window moves
  - `NOTIFICATION_CHANGED_EVENT` is deferred until after the slide-out animation completes, keeping the card content visible during the exit
  - Removed eager `onSuccess` query invalidation from dismiss/open mutations — the backend event now drives the UI update

  ### Hover state across queued notifications
  - Hover state is no longer reset when a new notification replaces the current one, so the close button stays visible and auto-dismiss stays paused while the mouse is over the card
