### PR TITLE
feat(login): open browser immediately and show user/org on device page

### DIFF
--- a/packages/app/src/routes/cli/device.tsx
+++ b/packages/app/src/routes/cli/device.tsx
@@ -7,6 +7,7 @@ import { z } from "zod";
 import { GithubInstallStep } from "@/components/github-install-step";
 import { OnboardingLayout } from "@/components/onboarding-layout";
 import { ensureOrganizationForDevice } from "@/data/onboarding";
+import { workOS } from "@/lib/workos";
 
 export const Route = createFileRoute("/cli/device")({
   validateSearch: z.object({
@@ -23,9 +24,24 @@ export const Route = createFileRoute("/cli/device")({
       throw redirect({ href: signInUrl });
     }
 
+    const hasOrg = !!auth.organizationId;
+
+    const [orgName] = await Promise.all([
+      hasOrg
+        ? workOS.organizations
+            .getOrganization(auth.organizationId!)
+            .then((org) => org.name)
+            .catch(() => null)
+        : Promise.resolve(null),
+    ]);
+
+    const firstName = auth.user.firstName ?? auth.user.email.split("@")[0];
+
     return {
       deviceCode: deps.code?.toUpperCase() ?? "",
-      hasOrg: !!auth.user && !!auth.organizationId,
+      hasOrg,
+      userName: firstName,
+      orgName,
     };
   },
   component: CliDeviceApprovalPage,
@@ -36,13 +52,19 @@ function formatCodeForDisplay(code: string): string {
 }
 
 function CliDeviceApprovalPage() {
-  const { deviceCode, hasOrg } = Route.useLoaderData();
+  const { deviceCode, hasOrg, userName, orgName } = Route.useLoaderData();
 
   if (!hasOrg) {
     return <NewUserDeviceFlow deviceCode={deviceCode} />;
   }
 
-  return <ExistingUserDeviceFlow deviceCode={deviceCode} />;
+  return (
+    <ExistingUserDeviceFlow
+      deviceCode={deviceCode}
+      userName={userName}
+      orgName={orgName}
+    />
+  );
 }
 
 type NewUserStep = "setup" | "github" | "approving" | "done" | "error";
@@ -125,7 +147,15 @@ function NewUserDeviceFlow({ deviceCode }: { deviceCode: string }) {
   );
 }
 
-function ExistingUserDeviceFlow({ deviceCode }: { deviceCode: string }) {
+function ExistingUserDeviceFlow({
+  deviceCode,
+  userName,
+  orgName,
+}: {
+  deviceCode: string;
+  userName: string;
+  orgName: string | null;
+}) {
   const [status, setStatus] = useState<
     "idle" | "approved" | "denied" | "error"
   >("idle");
@@ -159,6 +189,9 @@ function ExistingUserDeviceFlow({ deviceCode }: { deviceCode: string }) {
         <h1 className="text-center text-4xl font-semibold tracking-tight">
           Device activation
         </h1>
+        <p className="text-muted-foreground mt-3 text-center text-base">
+          {orgName ? `${userName} · ${orgName}` : userName}
+        </p>
 
         <section className="bg-background mt-10 rounded-2xl border px-6 py-10 sm:px-12">
           {status === "idle" || status === "error" ? (

--- a/packages/app/src/routes/cli/device.tsx
+++ b/packages/app/src/routes/cli/device.tsx
@@ -6,8 +6,8 @@ import { useEffect, useState } from "react";
 import { z } from "zod";
 import { GithubInstallStep } from "@/components/github-install-step";
 import { OnboardingLayout } from "@/components/onboarding-layout";
+import { getActiveOrganization } from "@/data/auth";
 import { ensureOrganizationForDevice } from "@/data/onboarding";
-import { workOS } from "@/lib/workos";
 
 export const Route = createFileRoute("/cli/device")({
   validateSearch: z.object({
@@ -26,10 +26,9 @@ export const Route = createFileRoute("/cli/device")({
 
     const hasOrg = !!auth.organizationId;
 
-    const orgName = auth.organizationId
-      ? await workOS.organizations
-          .getOrganization(auth.organizationId)
-          .then((org) => org.name)
+    const orgName = hasOrg
+      ? await getActiveOrganization()
+          .then((org) => org?.name ?? null)
           .catch(() => null)
       : null;
 

--- a/packages/app/src/routes/cli/device.tsx
+++ b/packages/app/src/routes/cli/device.tsx
@@ -26,14 +26,12 @@ export const Route = createFileRoute("/cli/device")({
 
     const hasOrg = !!auth.organizationId;
 
-    const [orgName] = await Promise.all([
-      hasOrg
-        ? workOS.organizations
-            .getOrganization(auth.organizationId!)
-            .then((org) => org.name)
-            .catch(() => null)
-        : Promise.resolve(null),
-    ]);
+    const orgName = auth.organizationId
+      ? await workOS.organizations
+          .getOrganization(auth.organizationId)
+          .then((org) => org.name)
+          .catch(() => null)
+      : null;
 
     const firstName = auth.user.firstName ?? auth.user.email.split("@")[0];
 

--- a/packages/app/src/routes/cli/device.tsx
+++ b/packages/app/src/routes/cli/device.tsx
@@ -184,7 +184,7 @@ function ExistingUserDeviceFlow({
     <main className="bg-muted/20 flex min-h-screen items-center justify-center px-4 py-10">
       <div className="w-full max-w-2xl">
         <h1 className="text-center text-4xl font-semibold tracking-tight">
-          Device activation
+          Authenticate Device
         </h1>
         <p className="text-muted-foreground mt-3 text-center text-base">
           {orgName ? `${userName} · ${orgName}` : userName}

--- a/packages/desktop-app/src-cli/src/auth.rs
+++ b/packages/desktop-app/src-cli/src/auth.rs
@@ -37,15 +37,19 @@ pub fn show_device_sign_in_prompt(verification_url: String, user_code: &str) {
 
 pub fn open_browser_immediately(verification_url: String, user_code: &str) {
     if let Err(error) = webbrowser::open(&verification_url) {
-        let _ = cliclack::log::warning(format!(
-            "Could not open browser automatically.\nOpen this URL manually: {verification_url} ({error})"
-        ));
+        eprintln!("Could not open browser automatically.\nOpen this URL manually: {verification_url} ({error})");
     }
 
-    let _ = cliclack::note(
-        "Authenticate",
-        format!("Code: {user_code}\nURL:  {verification_url}"),
-    );
+    let code_line = format!("  Code: {user_code}");
+    let url_line = format!("  URL:  {verification_url}");
+    let width = code_line.len().max(url_line.len()) + 2;
+    let bar = "─".repeat(width);
+    println!("┌{bar}┐");
+    println!("│{:width$}│", "  Authenticate", width = width);
+    println!("│{:width$}│", "", width = width);
+    println!("│{code_line:<width$}│", width = width);
+    println!("│{url_line:<width$}│", width = width);
+    println!("└{bar}┘");
 }
 
 fn trimmed_non_empty(value: &str) -> Option<&str> {

--- a/packages/desktop-app/src-cli/src/auth.rs
+++ b/packages/desktop-app/src-cli/src/auth.rs
@@ -10,7 +10,7 @@ const API_BASE_URL_OVERRIDE_ENV: &str = "EVERR_API_BASE_URL_FOR_TESTS";
 pub async fn login(_args: LoginArgs) -> Result<()> {
     let config = resolve_auth_config()?;
     let store = state_store();
-    login_with_prompt(&config, &store, show_device_sign_in_prompt).await?;
+    login_with_prompt(&config, &store, open_browser_immediately).await?;
     println!(
         "Logged in. Session saved at {}",
         store.session_file_path()?.display()
@@ -33,6 +33,19 @@ pub fn show_device_sign_in_prompt(verification_url: String, user_code: &str) {
             "Could not open browser automatically.\nOpen this URL manually: {verification_url} ({error})"
         ));
     }
+}
+
+pub fn open_browser_immediately(verification_url: String, user_code: &str) {
+    if let Err(error) = webbrowser::open(&verification_url) {
+        let _ = cliclack::log::warning(format!(
+            "Could not open browser automatically.\nOpen this URL manually: {verification_url} ({error})"
+        ));
+    }
+
+    let _ = cliclack::note(
+        "Authenticate",
+        format!("Code: {user_code}\nURL:  {verification_url}"),
+    );
 }
 
 fn trimmed_non_empty(value: &str) -> Option<&str> {


### PR DESCRIPTION
## Summary

- `everr login` now opens the browser immediately instead of waiting for Enter (Enter prompt is kept in `everr setup` where it fits the guided flow)
- Device activation page (`/cli/device`) now shows the logged-in user name and org name below the title, and is renamed to "Authenticate Device"

## CLI output

```
┌────────────────────────────────────────────────────┐
│  Authenticate                                      │
│                                                    │
│  Code: ABCD-EFGH                                   │
│  URL:  https://auth.everr.dev/activate             │
└────────────────────────────────────────────────────┘
Logged in. Session saved at ~/.config/everr/session.json
```

<img width="2560" height="1355" alt="image" src="https://github.com/user-attachments/assets/e8ecb0fb-f7a4-4d70-b28c-202c00fe7175" />


## Test plan

- [ ] `everr login` opens browser without prompting for Enter
- [ ] `everr setup` still prompts "Press Enter to open in your browser"
- [ ] `/cli/device?code=...` shows user name and org name when logged in
- [ ] `/cli/device` title reads "Authenticate Device"