### PR TITLE
Report all failed jobs in failure notifications

### DIFF
--- a/crates/everr-core/src/api.rs
+++ b/crates/everr-core/src/api.rs
@@ -380,8 +380,20 @@ pub struct FailureNotification {
     pub workflow_name: String,
     pub failed_at: String,
     pub details_url: String,
+    /// All failed jobs in the run with their first failing step.
+    #[serde(default)]
+    pub failed_jobs: Vec<FailedJobInfo>,
+    // Legacy single-job fields kept for backward compatibility with older servers.
     pub job_name: Option<String>,
     pub step_number: Option<String>,
+    pub step_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct FailedJobInfo {
+    pub job_name: String,
+    pub step_number: String,
     pub step_name: Option<String>,
 }
 

--- a/crates/everr-core/src/api.rs
+++ b/crates/everr-core/src/api.rs
@@ -383,10 +383,6 @@ pub struct FailureNotification {
     /// All failed jobs in the run with their first failing step.
     #[serde(default)]
     pub failed_jobs: Vec<FailedJobInfo>,
-    // Legacy single-job fields kept for backward compatibility with older servers.
-    pub job_name: Option<String>,
-    pub step_number: Option<String>,
-    pub step_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]

--- a/crates/everr-core/src/notifier.rs
+++ b/crates/everr-core/src/notifier.rs
@@ -37,9 +37,6 @@ mod tests {
             failed_at: "2026-03-07T10:00:00Z".to_string(),
             details_url: "https://example.com".to_string(),
             failed_jobs: vec![],
-            job_name: Some("build".to_string()),
-            step_number: Some("3".to_string()),
-            step_name: Some("Install dependencies".to_string()),
         };
 
         assert_eq!(tracker.retain_new(vec![failure.clone()]).len(), 1);

--- a/crates/everr-core/src/notifier.rs
+++ b/crates/everr-core/src/notifier.rs
@@ -36,6 +36,7 @@ mod tests {
             workflow_name: "build".to_string(),
             failed_at: "2026-03-07T10:00:00Z".to_string(),
             details_url: "https://example.com".to_string(),
+            failed_jobs: vec![],
             job_name: Some("build".to_string()),
             step_number: Some("3".to_string()),
             step_name: Some("Install dependencies".to_string()),

--- a/packages/app/src/data/notifications.ts
+++ b/packages/app/src/data/notifications.ts
@@ -2,26 +2,21 @@ import { pool } from "@/db/client";
 import type { WorkflowJobStep } from "@/db/schema";
 import type { AuthContext } from "@/lib/auth-context";
 
-type FirstFailingStep = {
-  jobId: string;
-  jobName: string;
-  stepName: string;
-  stepNumber: string;
-};
-
-type FailureRunRow = {
+type FailureRow = {
   traceId: string;
   repo: string;
   branch: string;
   workflowName: string;
   failureTime: Date;
+  jobId: string | null;
+  jobName: string | null;
+  steps: WorkflowJobStep[] | null;
 };
 
-type FailedJobRow = {
-  traceId: string;
-  jobId: string;
+export type FailedJobInfo = {
   jobName: string;
-  steps: WorkflowJobStep[] | null;
+  stepNumber: string;
+  stepName?: string;
 };
 
 export type FailureNotification = {
@@ -32,8 +27,12 @@ export type FailureNotification = {
   workflowName: string;
   failedAt: string;
   detailsUrl: string;
+  failedJobs: FailedJobInfo[];
+  /** @deprecated Legacy single-job field kept for backward compatibility. */
   jobName?: string;
+  /** @deprecated Legacy single-job field kept for backward compatibility. */
   stepNumber?: string;
+  /** @deprecated Legacy single-job field kept for backward compatibility. */
   stepName?: string;
 };
 
@@ -49,147 +48,134 @@ export async function getFailureNotifications({
   traceId,
 }: FailureNotificationsOptions): Promise<FailureNotification[]> {
   const tenantId = context.session.tenantId;
-  const failures = await loadFailureRunByTraceId(tenantId, traceId);
-  if (failures.length === 0) {
+  const rows = await loadFailureWithJobs(tenantId, traceId);
+  if (rows.length === 0) {
     return [];
   }
 
-  const firstFailingStepByTraceId = await loadFirstFailingSteps(
-    tenantId,
-    failures.map((row) => row.traceId),
+  // All rows share the same run-level fields; group the job rows.
+  const run = rows[0];
+  const failedAt =
+    run.failureTime instanceof Date
+      ? run.failureTime.toISOString()
+      : String(run.failureTime);
+
+  const jobRows = rows.filter(
+    (r): r is FailureRow & { jobId: string; jobName: string } =>
+      r.jobId != null && r.jobName != null,
   );
 
-  return failures.map((row) => {
-    const failingStep = firstFailingStepByTraceId.get(row.traceId);
-    const detailsUrl = buildFailureDetailsUrl(origin, row.traceId, failingStep);
-    const failedAt =
-      row.failureTime instanceof Date
-        ? row.failureTime.toISOString()
-        : String(row.failureTime);
+  const failedJobs = buildFailedJobInfos(jobRows);
+  const firstFailingStep = findFirstFailingStep(jobRows);
+  const detailsUrl = buildFailureDetailsUrl(
+    origin,
+    run.traceId,
+    firstFailingStep,
+  );
 
-    return {
-      dedupeKey: `${row.traceId}:${failedAt}`,
-      traceId: row.traceId,
-      repo: row.repo,
-      branch: row.branch,
-      workflowName: row.workflowName || "Workflow",
+  return [
+    {
+      dedupeKey: `${run.traceId}:${failedAt}`,
+      traceId: run.traceId,
+      repo: run.repo,
+      branch: run.branch,
+      workflowName: run.workflowName || "Workflow",
       failedAt,
       detailsUrl,
-      jobName: failingStep?.jobName,
-      stepNumber: failingStep?.stepNumber,
-      stepName: failingStep?.stepName,
-    };
-  });
+      failedJobs,
+      jobName: firstFailingStep?.jobName,
+      stepNumber: firstFailingStep?.stepNumber,
+      stepName: firstFailingStep?.stepName,
+    },
+  ];
 }
 
-async function loadFailureRunByTraceId(
+async function loadFailureWithJobs(
   tenantId: number,
   traceId: string,
-): Promise<FailureRunRow[]> {
-  const result = await pool.query<FailureRunRow>(
+): Promise<FailureRow[]> {
+  const result = await pool.query<FailureRow>(
     `
       SELECT
-        trace_id      AS "traceId",
-        repository    AS "repo",
-        ref           AS "branch",
-        workflow_name AS "workflowName",
-        last_event_at AS "failureTime"
-      FROM workflow_runs
-      WHERE tenant_id = $1
-        AND trace_id = $2
-        AND conclusion = 'failure'
-      LIMIT 1
+        r.trace_id      AS "traceId",
+        r.repository    AS "repo",
+        r.ref           AS "branch",
+        r.workflow_name AS "workflowName",
+        r.last_event_at AS "failureTime",
+        j.job_id::text  AS "jobId",
+        j.job_name      AS "jobName",
+        j.metadata->'steps' AS "steps"
+      FROM workflow_runs r
+      LEFT JOIN workflow_jobs j
+        ON  j.tenant_id = r.tenant_id
+        AND j.trace_id  = r.trace_id
+        AND j.conclusion = 'failure'
+      WHERE r.tenant_id = $1
+        AND r.trace_id  = $2
+        AND r.conclusion = 'failure'
+      ORDER BY j.started_at ASC NULLS LAST
     `,
     [tenantId, traceId],
   );
   return result.rows;
 }
 
-async function loadFirstFailingSteps(
-  tenantId: number,
-  traceIds: string[],
-): Promise<Map<string, FirstFailingStep>> {
-  if (traceIds.length === 0) {
-    return new Map();
+type FirstFailingStep = {
+  jobId: string;
+  jobName: string;
+  stepName: string;
+  stepNumber: string;
+};
+
+type JobRow = {
+  jobId: string;
+  jobName: string;
+  steps: WorkflowJobStep[] | null;
+};
+
+function buildFailedJobInfos(jobs: JobRow[]): FailedJobInfo[] {
+  const infos: FailedJobInfo[] = [];
+  for (const job of jobs) {
+    const step = findFirstFailingStepForJob(job);
+    if (step) {
+      infos.push({
+        jobName: job.jobName,
+        stepNumber: String(step.number),
+        stepName: step.name || undefined,
+      });
+    }
   }
-
-  const result = await pool.query<FailedJobRow>(
-    `
-      SELECT
-        trace_id          AS "traceId",
-        job_id::text      AS "jobId",
-        job_name          AS "jobName",
-        metadata->'steps' AS "steps"
-      FROM workflow_jobs
-      WHERE tenant_id = $1
-        AND trace_id = ANY($2::text[])
-        AND conclusion = 'failure'
-      ORDER BY trace_id ASC, started_at ASC NULLS LAST
-    `,
-    [tenantId, traceIds],
-  );
-
-  return buildFirstFailingStepByTraceId(result.rows);
+  return infos;
 }
 
-function buildFirstFailingStepByTraceId(
-  rows: FailedJobRow[],
-): Map<string, FirstFailingStep> {
-  const jobsByTrace = new Map<string, FailedJobRow[]>();
-  for (const row of rows) {
-    const jobs = jobsByTrace.get(row.traceId) ?? [];
-    jobs.push(row);
-    jobsByTrace.set(row.traceId, jobs);
-  }
-
-  const result = new Map<string, FirstFailingStep>();
-  for (const [traceId, jobs] of jobsByTrace) {
-    const step = findFirstFailingStep(jobs);
-    if (step) {
-      result.set(traceId, step);
-    }
-  }
-  return result;
-}
-
-function findFirstFailingStep(
-  jobs: FailedJobRow[],
-): FirstFailingStep | undefined {
-  // Tier 1: first step with a failure or cancelled conclusion
+function findFirstFailingStep(jobs: JobRow[]): FirstFailingStep | undefined {
   for (const job of jobs) {
-    const step = (job.steps ?? [])
-      // Treat cancelled steps as failures — consistent with branch-status.ts
-      .filter((s) => s.conclusion === "failure" || s.conclusion === "cancelled")
-      .sort((a, b) => a.number - b.number)[0];
+    const step = findFirstFailingStepForJob(job);
     if (step) {
       return toFirstFailingStep(job, step);
     }
   }
-
-  // Tier 2: last non-skipped step of the first failed job
-  for (const job of jobs) {
-    const step = (job.steps ?? [])
-      // GitHub webhook steps use "skipped" (not "skip" which was a ClickHouse span artifact)
-      .filter((s) => s.conclusion !== "skipped")
-      .sort((a, b) => b.number - a.number)[0];
-    if (step) {
-      return toFirstFailingStep(job, step);
-    }
-  }
-
-  // Tier 3: last step of the first failed job
-  for (const job of jobs) {
-    const step = (job.steps ?? []).sort((a, b) => b.number - a.number)[0];
-    if (step) {
-      return toFirstFailingStep(job, step);
-    }
-  }
-
   return undefined;
 }
 
+function findFirstFailingStepForJob(job: JobRow): WorkflowJobStep | undefined {
+  const steps = job.steps ?? [];
+
+  const failed = steps
+    .filter((s) => s.conclusion === "failure" || s.conclusion === "cancelled")
+    .sort((a, b) => a.number - b.number)[0];
+  if (failed) return failed;
+
+  const nonSkipped = steps
+    .filter((s) => s.conclusion !== "skipped")
+    .sort((a, b) => b.number - a.number)[0];
+  if (nonSkipped) return nonSkipped;
+
+  return [...steps].sort((a, b) => b.number - a.number)[0];
+}
+
 function toFirstFailingStep(
-  job: FailedJobRow,
+  job: JobRow,
   step: WorkflowJobStep,
 ): FirstFailingStep {
   return {

--- a/packages/app/src/data/notifications.ts
+++ b/packages/app/src/data/notifications.ts
@@ -28,12 +28,6 @@ export type FailureNotification = {
   failedAt: string;
   detailsUrl: string;
   failedJobs: FailedJobInfo[];
-  /** @deprecated Legacy single-job field kept for backward compatibility. */
-  jobName?: string;
-  /** @deprecated Legacy single-job field kept for backward compatibility. */
-  stepNumber?: string;
-  /** @deprecated Legacy single-job field kept for backward compatibility. */
-  stepName?: string;
 };
 
 type FailureNotificationsOptions = {
@@ -83,9 +77,6 @@ export async function getFailureNotifications({
       failedAt,
       detailsUrl,
       failedJobs,
-      jobName: firstFailingStep?.jobName,
-      stepNumber: firstFailingStep?.stepNumber,
-      stepName: firstFailingStep?.stepName,
     },
   ];
 }

--- a/packages/desktop-app/src-tauri/src/auto_fix_prompt.md
+++ b/packages/desktop-app/src-tauri/src/auto_fix_prompt.md
@@ -13,7 +13,7 @@ Step 2:
 
 Step 3:
 - if it looks flaky and doesn't come from this branch, explain the issue and ask me if we should proceed with a more in-depth analysis
-- if it looks like it will cost many tokens to fix it,  explain the issue and ask me if we should proceed with the dix
+- if it looks like it will cost many tokens to fix it,  explain the issue and ask me if we should proceed with the fix
 - otherwise, fix the problem and run the narrowest relevant test or check before finishing.
 
 Return a concise summary: root cause, whether it's a flaky test or a real regression, code changes (if any), verification, and any follow-up risk.

--- a/packages/desktop-app/src-tauri/src/auto_fix_prompt.rs
+++ b/packages/desktop-app/src-tauri/src/auto_fix_prompt.rs
@@ -1,23 +1,21 @@
-use everr_core::api::{FailedJobInfo, FailureNotification};
+use everr_core::api::FailureNotification;
 
 const TEMPLATE: &str = include_str!("auto_fix_prompt.md");
 
 pub(crate) fn build_notification_auto_fix_prompt(failure: &FailureNotification) -> String {
-    let jobs = effective_jobs(failure);
-
     TEMPLATE
-        .replace("{{failure_details}}", &format_notification_failure(failure, &jobs))
-        .replace("{{logs_instruction}}", &build_logs_instructions(failure, &jobs))
+        .replace("{{failure_details}}", &format_notification_failure(failure))
+        .replace("{{logs_instruction}}", &build_logs_instructions(failure))
         .trim_end()
         .to_string()
 }
 
-fn build_logs_instructions(failure: &FailureNotification, jobs: &[FailedJobInfo]) -> String {
-    if jobs.is_empty() {
+fn build_logs_instructions(failure: &FailureNotification) -> String {
+    if failure.failed_jobs.is_empty() {
         return "Pull the relevant Everr logs for this failure before guessing.".to_string();
     }
 
-    let commands: Vec<String> = jobs
+    let commands: Vec<String> = failure.failed_jobs
         .iter()
         .filter_map(|job| {
             let escaped = serde_json::to_string(&job.job_name).ok()?;
@@ -31,27 +29,11 @@ fn build_logs_instructions(failure: &FailureNotification, jobs: &[FailedJobInfo]
     commands.join("\n  ")
 }
 
-/// Return all failed jobs. Falls back to the legacy single-job fields when `failed_jobs` is empty.
-fn effective_jobs(failure: &FailureNotification) -> Vec<FailedJobInfo> {
-    if !failure.failed_jobs.is_empty() {
-        return failure.failed_jobs.clone();
-    }
-    // Legacy fallback
-    match (failure.job_name.as_deref(), failure.step_number.as_deref()) {
-        (Some(job), Some(step)) => vec![FailedJobInfo {
-            job_name: job.to_string(),
-            step_number: step.to_string(),
-            step_name: failure.step_name.clone(),
-        }],
-        _ => vec![],
-    }
-}
-
-fn format_notification_failure(failure: &FailureNotification, jobs: &[FailedJobInfo]) -> String {
-    let jobs_suffix = if jobs.is_empty() {
+fn format_notification_failure(failure: &FailureNotification) -> String {
+    let jobs_suffix = if failure.failed_jobs.is_empty() {
         String::new()
     } else {
-        let parts: Vec<String> = jobs
+        let parts: Vec<String> = failure.failed_jobs
             .iter()
             .map(|job| {
                 let step_name_suffix = job

--- a/packages/desktop-app/src-tauri/src/auto_fix_prompt.rs
+++ b/packages/desktop-app/src-tauri/src/auto_fix_prompt.rs
@@ -1,51 +1,72 @@
-use everr_core::api::FailureNotification;
+use everr_core::api::{FailedJobInfo, FailureNotification};
 
 const TEMPLATE: &str = include_str!("auto_fix_prompt.md");
 
 pub(crate) fn build_notification_auto_fix_prompt(failure: &FailureNotification) -> String {
-    let logs_instruction = match build_runs_logs_command(failure) {
-        Some(cmd) => format!("`{cmd}`"),
-        None => "Pull the relevant Everr logs for this failure before guessing.".to_string(),
-    };
+    let jobs = effective_jobs(failure);
 
     TEMPLATE
-        .replace("{{failure_details}}", &format_notification_failure(failure))
-        .replace("{{logs_instruction}}", &logs_instruction)
+        .replace("{{failure_details}}", &format_notification_failure(failure, &jobs))
+        .replace("{{logs_instruction}}", &build_logs_instructions(failure, &jobs))
         .trim_end()
         .to_string()
 }
 
-pub(crate) fn build_runs_logs_command(failure: &FailureNotification) -> Option<String> {
-    let job_name = failure.job_name.as_deref()?;
-    let step_number = failure.step_number.as_deref()?;
-    let escaped_job_name = serde_json::to_string(job_name).ok()?;
+fn build_logs_instructions(failure: &FailureNotification, jobs: &[FailedJobInfo]) -> String {
+    if jobs.is_empty() {
+        return "Pull the relevant Everr logs for this failure before guessing.".to_string();
+    }
 
-    Some(format!(
-        "everr logs {} --job-name {} --step-number {}",
-        failure.trace_id, escaped_job_name, step_number
-    ))
+    let commands: Vec<String> = jobs
+        .iter()
+        .filter_map(|job| {
+            let escaped = serde_json::to_string(&job.job_name).ok()?;
+            Some(format!(
+                "`everr logs {} --job-name {} --step-number {}`",
+                failure.trace_id, escaped, job.step_number
+            ))
+        })
+        .collect();
+
+    commands.join("\n  ")
 }
 
-fn format_notification_failure(failure: &FailureNotification) -> String {
+/// Return all failed jobs. Falls back to the legacy single-job fields when `failed_jobs` is empty.
+fn effective_jobs(failure: &FailureNotification) -> Vec<FailedJobInfo> {
+    if !failure.failed_jobs.is_empty() {
+        return failure.failed_jobs.clone();
+    }
+    // Legacy fallback
+    match (failure.job_name.as_deref(), failure.step_number.as_deref()) {
+        (Some(job), Some(step)) => vec![FailedJobInfo {
+            job_name: job.to_string(),
+            step_number: step.to_string(),
+            step_name: failure.step_name.clone(),
+        }],
+        _ => vec![],
+    }
+}
+
+fn format_notification_failure(failure: &FailureNotification, jobs: &[FailedJobInfo]) -> String {
+    let jobs_suffix = if jobs.is_empty() {
+        String::new()
+    } else {
+        let parts: Vec<String> = jobs
+            .iter()
+            .map(|job| {
+                let step_name_suffix = job
+                    .step_name
+                    .as_deref()
+                    .map(|name| format!(" ({name})"))
+                    .unwrap_or_default();
+                format!("{} #{}{}", job.job_name, job.step_number, step_name_suffix)
+            })
+            .collect();
+        format!(" | failing steps: {}", parts.join(", "))
+    };
+
     format!(
         "branch {} | workflow {} | trace {}{}",
-        failure.branch,
-        failure.workflow_name,
-        failure.trace_id,
-        format_failing_step_suffix(failure)
+        failure.branch, failure.workflow_name, failure.trace_id, jobs_suffix
     )
-}
-
-fn format_failing_step_suffix(failure: &FailureNotification) -> String {
-    match (failure.job_name.as_deref(), failure.step_number.as_deref()) {
-        (Some(job_name), Some(step_number)) => {
-            let step_suffix = failure
-                .step_name
-                .as_deref()
-                .map(|step_name| format!(" ({step_name})"))
-                .unwrap_or_default();
-            format!(" | step {job_name} #{step_number}{step_suffix}")
-        }
-        _ => String::new(),
-    }
 }

--- a/packages/desktop-app/src-tauri/src/notifications.rs
+++ b/packages/desktop-app/src-tauri/src/notifications.rs
@@ -125,9 +125,6 @@ pub(crate) fn build_test_notification() -> Result<FailureNotification> {
             step_number: "1".to_string(),
             step_name: Some("Preview desktop notification".to_string()),
         }],
-        job_name: Some("Developer settings".to_string()),
-        step_number: Some("1".to_string()),
-        step_name: Some("Preview desktop notification".to_string()),
     })
 }
 

--- a/packages/desktop-app/src-tauri/src/notifications.rs
+++ b/packages/desktop-app/src-tauri/src/notifications.rs
@@ -120,6 +120,11 @@ pub(crate) fn build_test_notification() -> Result<FailureNotification> {
         workflow_name: "Test notification".to_string(),
         failed_at: timestamp,
         details_url,
+        failed_jobs: vec![everr_core::api::FailedJobInfo {
+            job_name: "Developer settings".to_string(),
+            step_number: "1".to_string(),
+            step_name: Some("Preview desktop notification".to_string()),
+        }],
         job_name: Some("Developer settings".to_string()),
         step_number: Some("1".to_string()),
         step_name: Some("Preview desktop notification".to_string()),

--- a/packages/desktop-app/src-tauri/src/tests.rs
+++ b/packages/desktop-app/src-tauri/src/tests.rs
@@ -46,9 +46,6 @@ fn failure(dedupe_key: &str) -> FailureNotification {
             step_number: "2".to_string(),
             step_name: Some("Run suite".to_string()),
         }],
-        job_name: Some("test".to_string()),
-        step_number: Some("2".to_string()),
-        step_name: Some("Run suite".to_string()),
     }
 }
 
@@ -151,9 +148,6 @@ fn notification_prompt_lists_all_failed_jobs() {
                 step_name: Some("Biome check".to_string()),
             },
         ],
-        job_name: Some("test".to_string()),
-        step_number: Some("3".to_string()),
-        step_name: Some("Run suite".to_string()),
     };
 
     let prompt = build_notification_auto_fix_prompt(&notification);

--- a/packages/desktop-app/src-tauri/src/tests.rs
+++ b/packages/desktop-app/src-tauri/src/tests.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex};
 
-use everr_core::api::FailureNotification;
+use everr_core::api::{FailedJobInfo, FailureNotification};
 use everr_core::assistant::{AssistantKind, AssistantStatus};
 use everr_core::state::{AppSettings, AppStateStore, WizardState};
 use everr_core::state_watcher::StateWatcher;
@@ -41,6 +41,11 @@ fn failure(dedupe_key: &str) -> FailureNotification {
         workflow_name: "CI".to_string(),
         failed_at: "2026-03-07T10:00:00Z".to_string(),
         details_url: format!("https://example.com/{dedupe_key}"),
+        failed_jobs: vec![FailedJobInfo {
+            job_name: "test".to_string(),
+            step_number: "2".to_string(),
+            step_name: Some("Run suite".to_string()),
+        }],
         job_name: Some("test".to_string()),
         step_number: Some("2".to_string()),
         step_name: Some("Run suite".to_string()),
@@ -118,10 +123,53 @@ fn notification_prompt_builder_formats_single_failure_with_exact_logs_command() 
 
     assert!(prompt.contains("Investigate and fix this CI pipeline failure."));
     assert!(prompt.contains("Failure details:"));
-    assert!(prompt.contains("workflow CI | trace trace-one | step test #2 (Run suite)"));
+    assert!(prompt.contains("workflow CI | trace trace-one | failing steps: test #2 (Run suite)"));
     assert!(prompt.contains("everr logs trace-one --job-name \"test\" --step-number 2"));
     assert!(prompt.contains("Step 2"));
     assert!(prompt.contains("Step 3"));
+}
+
+#[test]
+fn notification_prompt_lists_all_failed_jobs() {
+    let notification = FailureNotification {
+        dedupe_key: "multi".to_string(),
+        trace_id: "trace-multi".to_string(),
+        repo: "everr-labs/everr".to_string(),
+        branch: "main".to_string(),
+        workflow_name: "CI".to_string(),
+        failed_at: "2026-03-07T10:00:00Z".to_string(),
+        details_url: "https://example.com/multi".to_string(),
+        failed_jobs: vec![
+            FailedJobInfo {
+                job_name: "test".to_string(),
+                step_number: "3".to_string(),
+                step_name: Some("Run suite".to_string()),
+            },
+            FailedJobInfo {
+                job_name: "lint".to_string(),
+                step_number: "2".to_string(),
+                step_name: Some("Biome check".to_string()),
+            },
+        ],
+        job_name: Some("test".to_string()),
+        step_number: Some("3".to_string()),
+        step_name: Some("Run suite".to_string()),
+    };
+
+    let prompt = build_notification_auto_fix_prompt(&notification);
+
+    assert!(
+        prompt.contains("failing steps: test #3 (Run suite), lint #2 (Biome check)"),
+        "prompt should list all failed jobs, got: {prompt}"
+    );
+    assert!(
+        prompt.contains("everr logs trace-multi --job-name \"test\" --step-number 3"),
+        "prompt should include logs command for first job"
+    );
+    assert!(
+        prompt.contains("everr logs trace-multi --job-name \"lint\" --step-number 2"),
+        "prompt should include logs command for second job"
+    );
 }
 
 #[test]

--- a/packages/desktop-app/src/App.test.tsx
+++ b/packages/desktop-app/src/App.test.tsx
@@ -68,10 +68,7 @@ type FailureNotification = {
   workflowName: string;
   failedAt: string;
   detailsUrl: string;
-  failedJobs?: FailedJobInfo[];
-  jobName?: string;
-  stepNumber?: string;
-  stepName?: string;
+  failedJobs: FailedJobInfo[];
 };
 
 type TestNotificationResponse = {
@@ -159,9 +156,7 @@ function createNotification(
     workflowName: "CI",
     failedAt: "2026-03-07T13:32:00Z",
     detailsUrl: "https://example.com/runs/trace-one/jobs/job-one/steps/3",
-    jobName: "test",
-    stepNumber: "3",
-    stepName: "Run suite",
+    failedJobs: [{ jobName: "test", stepNumber: "3", stepName: "Run suite" }],
     ...overrides,
   };
 }

--- a/packages/desktop-app/src/App.test.tsx
+++ b/packages/desktop-app/src/App.test.tsx
@@ -54,6 +54,12 @@ type AssistantSetup = {
   assistant_statuses: AssistantStatus[];
 };
 
+type FailedJobInfo = {
+  jobName: string;
+  stepNumber: string;
+  stepName?: string;
+};
+
 type FailureNotification = {
   dedupeKey: string;
   traceId: string;
@@ -62,6 +68,7 @@ type FailureNotification = {
   workflowName: string;
   failedAt: string;
   detailsUrl: string;
+  failedJobs?: FailedJobInfo[];
   jobName?: string;
   stepNumber?: string;
   stepName?: string;

--- a/packages/desktop-app/src/features/notifications/notification-window.tsx
+++ b/packages/desktop-app/src/features/notifications/notification-window.tsx
@@ -22,6 +22,12 @@ import { SettingsSection } from "../desktop-shell/ui";
 
 const AUTO_DISMISS_MS = 40_000;
 
+type FailedJobInfo = {
+  jobName: string;
+  stepNumber: string;
+  stepName?: string;
+};
+
 export type FailureNotification = {
   dedupeKey: string;
   traceId: string;
@@ -30,9 +36,7 @@ export type FailureNotification = {
   workflowName: string;
   failedAt: string;
   detailsUrl: string;
-  jobName?: string;
-  stepNumber?: string;
-  stepName?: string;
+  failedJobs: FailedJobInfo[];
 };
 
 type TestNotificationResponse = {
@@ -419,25 +423,16 @@ function NotificationErrorState({ onRetry }: { onRetry: () => void }) {
 }
 
 function formatFailureScope(notification: FailureNotification): string | null {
-  if (
-    notification.jobName &&
-    notification.stepNumber &&
-    notification.stepName
-  ) {
-    return `${notification.jobName} • Step ${notification.stepNumber}: ${notification.stepName}`;
+  if (notification.failedJobs.length === 0) {
+    return null;
   }
 
-  if (notification.jobName && notification.stepName) {
-    return `${notification.jobName} • ${notification.stepName}`;
-  }
-
-  if (notification.jobName && notification.stepNumber) {
-    return `${notification.jobName} • Step ${notification.stepNumber}`;
-  }
-
-  if (notification.jobName) {
-    return `Job: ${notification.jobName}`;
-  }
-
-  return null;
+  return notification.failedJobs
+    .map((job) => {
+      if (job.stepName) {
+        return `${job.jobName} • Step ${job.stepNumber}: ${job.stepName}`;
+      }
+      return `${job.jobName} • Step ${job.stepNumber}`;
+    })
+    .join(", ");
 }


### PR DESCRIPTION
Noticed that when two jobs were failing we reported only the first one.

Fixing by listing all the failed jobs for the run.