### PR TITLE
feat(notifications): host notification window in a native NSPanel on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,6 +992,7 @@ dependencies = [
  "dirs 6.0.0",
  "everr-core",
  "futures-util",
+ "objc2",
  "objc2-app-kit",
  "serde",
  "serde_json",

--- a/crates/everr-core/src/api.rs
+++ b/crates/everr-core/src/api.rs
@@ -3,8 +3,8 @@ use std::fmt;
 use anyhow::{Context, Result};
 use eventsource_stream::Eventsource;
 use futures_util::StreamExt;
-use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
 use reqwest::StatusCode;
+use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -406,7 +406,6 @@ pub struct RepoEntry {
     pub id: i64,
     pub full_name: String,
 }
-
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]

--- a/crates/everr-core/src/state.rs
+++ b/crates/everr-core/src/state.rs
@@ -575,8 +575,14 @@ mod tests {
 
             store.save_state(&state).expect("save state");
 
-            let tmp_path = store.session_file_path().expect("path").with_extension("tmp");
-            assert!(!tmp_path.exists(), "tmp file should be cleaned up after atomic rename");
+            let tmp_path = store
+                .session_file_path()
+                .expect("path")
+                .with_extension("tmp");
+            assert!(
+                !tmp_path.exists(),
+                "tmp file should be cleaned up after atomic rename"
+            );
             assert_eq!(store.load_state().expect("load state"), state);
         });
     }
@@ -597,8 +603,14 @@ mod tests {
                 })
                 .expect("update state");
 
-            let lock_path = store.session_file_path().expect("path").with_extension("lock");
-            assert!(lock_path.exists(), "lock file should exist after update_state");
+            let lock_path = store
+                .session_file_path()
+                .expect("path")
+                .with_extension("lock");
+            assert!(
+                lock_path.exists(),
+                "lock file should exist after update_state"
+            );
 
             let state = store.load_state().expect("load state");
             assert_eq!(

--- a/crates/everr-core/src/state_watcher.rs
+++ b/crates/everr-core/src/state_watcher.rs
@@ -78,26 +78,27 @@ impl StateWatcher {
             }
         });
 
-        let mut watcher = notify::recommended_watcher(move |event: notify::Result<notify::Event>| {
-            let Ok(event) = event else {
-                return;
-            };
+        let mut watcher =
+            notify::recommended_watcher(move |event: notify::Result<notify::Event>| {
+                let Ok(event) = event else {
+                    return;
+                };
 
-            match event.kind {
-                EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_) => {
-                    let matches_state_file = event.paths.iter().any(|p| {
-                        p.file_name()
-                            .map(|name| name == state_file_name)
-                            .unwrap_or(false)
-                    });
-                    if matches_state_file {
-                        let _ = notify_tx.send(());
+                match event.kind {
+                    EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_) => {
+                        let matches_state_file = event.paths.iter().any(|p| {
+                            p.file_name()
+                                .map(|name| name == state_file_name)
+                                .unwrap_or(false)
+                        });
+                        if matches_state_file {
+                            let _ = notify_tx.send(());
+                        }
                     }
+                    _ => {}
                 }
-                _ => {}
-            }
-        })
-        .context("failed to create filesystem watcher")?;
+            })
+            .context("failed to create filesystem watcher")?;
 
         watcher
             .watch(&watch_dir, RecursiveMode::NonRecursive)
@@ -151,8 +152,8 @@ fn diff_changes(old: &AppState, new: &AppState) -> Vec<StateChange> {
 
 #[cfg(test)]
 mod tests {
-    use crate::state::{AppSettings, AppState, Session, WizardState};
     use super::*;
+    use crate::state::{AppSettings, AppState, Session, WizardState};
 
     #[test]
     fn diff_detects_session_change() {

--- a/packages/desktop-app/src-cli/src/api.rs
+++ b/packages/desktop-app/src-cli/src/api.rs
@@ -1,1 +1,3 @@
-pub use everr_core::api::{ApiClient, NotifyPayload, ShowJob, ShowRunDetails, StepLogEntry, WatchRun, WatchState};
+pub use everr_core::api::{
+    ApiClient, NotifyPayload, ShowJob, ShowRunDetails, StepLogEntry, WatchRun, WatchState,
+};

--- a/packages/desktop-app/src-cli/src/auth.rs
+++ b/packages/desktop-app/src-cli/src/auth.rs
@@ -37,7 +37,9 @@ pub fn show_device_sign_in_prompt(verification_url: String, user_code: &str) {
 
 pub fn open_browser_immediately(verification_url: String, user_code: &str) {
     if let Err(error) = webbrowser::open(&verification_url) {
-        eprintln!("Could not open browser automatically.\nOpen this URL manually: {verification_url} ({error})");
+        eprintln!(
+            "Could not open browser automatically.\nOpen this URL manually: {verification_url} ({error})"
+        );
     }
 
     let code_line = format!("  Code: {user_code}");

--- a/packages/desktop-app/src-cli/src/cli.rs
+++ b/packages/desktop-app/src-cli/src/cli.rs
@@ -202,9 +202,17 @@ pub struct GetLogsArgs {
     pub trace_id: String,
     #[arg(long, required_unless_present = "job_id", conflicts_with = "job_id")]
     pub job_name: Option<String>,
-    #[arg(long, required_unless_present = "job_name", conflicts_with = "job_name")]
+    #[arg(
+        long,
+        required_unless_present = "job_name",
+        conflicts_with = "job_name"
+    )]
     pub job_id: Option<String>,
-    #[arg(long, required_unless_present = "log_failed", conflicts_with = "log_failed")]
+    #[arg(
+        long,
+        required_unless_present = "log_failed",
+        conflicts_with = "log_failed"
+    )]
     pub step_number: Option<String>,
     /// Automatically resolve and show the first failing step for the given job
     #[arg(long, conflicts_with = "step_number")]
@@ -290,10 +298,13 @@ mod tests {
 
     #[test]
     fn validates_required_trace_id_for_runs_show() {
-        let err =
-            Cli::try_parse_from(["everr", "show"]).expect_err("show should require trace_id");
+        let err = Cli::try_parse_from(["everr", "show"]).expect_err("show should require trace_id");
         let err_string = err.to_string();
-        assert!(err_string.contains("TRACE_ID") || err_string.contains("trace_id") || err_string.contains("required"));
+        assert!(
+            err_string.contains("TRACE_ID")
+                || err_string.contains("trace_id")
+                || err_string.contains("required")
+        );
     }
 
     #[test]
@@ -321,14 +332,8 @@ mod tests {
 
     #[test]
     fn validates_required_arguments_for_runs_logs() {
-        let err = Cli::try_parse_from([
-            "everr",
-            "logs",
-            "trace-1",
-            "--job-name",
-            "build",
-        ])
-        .expect_err("logs should require --step-number or --log-failed");
+        let err = Cli::try_parse_from(["everr", "logs", "trace-1", "--job-name", "build"])
+            .expect_err("logs should require --step-number or --log-failed");
         let err_string = err.to_string();
         assert!(
             err_string.contains("step-number") || err_string.contains("log-failed"),
@@ -339,9 +344,11 @@ mod tests {
     #[test]
     fn logs_accepts_log_failed_without_step_number() {
         let cli = Cli::try_parse_from([
-            "everr", "logs",
+            "everr",
+            "logs",
             "trace-1",
-            "--job-name", "build",
+            "--job-name",
+            "build",
             "--log-failed",
         ])
         .expect("valid logs command with --log-failed");
@@ -357,13 +364,9 @@ mod tests {
 
     #[test]
     fn logs_accepts_job_id_with_log_failed() {
-        let cli = Cli::try_parse_from([
-            "everr", "logs",
-            "trace-1",
-            "--job-id", "42",
-            "--log-failed",
-        ])
-        .expect("valid logs command with --job-id and --log-failed");
+        let cli =
+            Cli::try_parse_from(["everr", "logs", "trace-1", "--job-id", "42", "--log-failed"])
+                .expect("valid logs command with --job-id and --log-failed");
 
         let Commands::RunsLogs(args) = cli.command else {
             panic!("expected logs command");
@@ -377,10 +380,13 @@ mod tests {
     #[test]
     fn logs_accepts_job_id_with_step_number() {
         let cli = Cli::try_parse_from([
-            "everr", "logs",
+            "everr",
+            "logs",
             "trace-1",
-            "--job-id", "42",
-            "--step-number", "3",
+            "--job-id",
+            "42",
+            "--step-number",
+            "3",
         ])
         .expect("valid logs command with --job-id and --step-number");
 
@@ -396,11 +402,15 @@ mod tests {
     #[test]
     fn logs_rejects_both_job_name_and_job_id() {
         let err = Cli::try_parse_from([
-            "everr", "logs",
+            "everr",
+            "logs",
             "trace-1",
-            "--job-name", "build",
-            "--job-id", "42",
-            "--step-number", "1",
+            "--job-name",
+            "build",
+            "--job-id",
+            "42",
+            "--step-number",
+            "1",
         ])
         .expect_err("logs should reject both --job-name and --job-id");
         assert!(err.to_string().contains("job"));
@@ -409,10 +419,13 @@ mod tests {
     #[test]
     fn logs_rejects_both_step_number_and_log_failed() {
         let err = Cli::try_parse_from([
-            "everr", "logs",
+            "everr",
+            "logs",
             "trace-1",
-            "--job-name", "build",
-            "--step-number", "1",
+            "--job-name",
+            "build",
+            "--step-number",
+            "1",
             "--log-failed",
         ])
         .expect_err("logs should reject both --step-number and --log-failed");
@@ -425,12 +438,8 @@ mod tests {
 
     #[test]
     fn logs_requires_job_identifier() {
-        let err = Cli::try_parse_from([
-            "everr", "logs",
-            "trace-1",
-            "--step-number", "1",
-        ])
-        .expect_err("logs should require --job-name or --job-id");
+        let err = Cli::try_parse_from(["everr", "logs", "trace-1", "--step-number", "1"])
+            .expect_err("logs should require --job-name or --job-id");
         let err_string = err.to_string();
         assert!(
             err_string.contains("job-name") || err_string.contains("job-id"),
@@ -846,11 +855,15 @@ mod tests {
     #[test]
     fn runs_logs_accepts_egrep_pattern() {
         let cli = Cli::try_parse_from([
-            "everr", "logs",
+            "everr",
+            "logs",
             "trace-1",
-            "--job-name", "build",
-            "--step-number", "2",
-            "--egrep", "Error.*timeout",
+            "--job-name",
+            "build",
+            "--step-number",
+            "2",
+            "--egrep",
+            "Error.*timeout",
         ])
         .expect("valid logs command with egrep");
 
@@ -864,10 +877,13 @@ mod tests {
     #[test]
     fn runs_logs_egrep_defaults_to_none() {
         let cli = Cli::try_parse_from([
-            "everr", "logs",
+            "everr",
+            "logs",
             "trace-1",
-            "--job-name", "build",
-            "--step-number", "2",
+            "--job-name",
+            "build",
+            "--step-number",
+            "2",
         ])
         .expect("valid logs command");
 

--- a/packages/desktop-app/src-cli/src/core.rs
+++ b/packages/desktop-app/src-cli/src/core.rs
@@ -7,7 +7,9 @@ use tokio::pin;
 
 use futures_util::StreamExt;
 
-use crate::api::{ApiClient, NotifyPayload, ShowJob, ShowRunDetails, StepLogEntry, WatchRun, WatchState};
+use crate::api::{
+    ApiClient, NotifyPayload, ShowJob, ShowRunDetails, StepLogEntry, WatchRun, WatchState,
+};
 use crate::auth;
 use crate::cli::{
     GetLogsArgs, GrepArgs, ListRunsArgs, LogPagingArgs, ShowRunArgs, SlowestJobsArgs,
@@ -281,7 +283,9 @@ pub async fn watch(args: WatchArgs) -> Result<()> {
             .as_deref()
             .map(|b| format!("  branch: {b}"))
             .unwrap_or_default();
-        println!("no runs found yet, waiting...  [repo: {repo}  commit: {target_commit}{branch_part}]");
+        println!(
+            "no runs found yet, waiting...  [repo: {repo}  commit: {target_commit}{branch_part}]"
+        );
     }
 
     if args.fail_fast {
@@ -352,8 +356,7 @@ pub async fn watch(args: WatchArgs) -> Result<()> {
                     run_names.insert(event.trace_id.clone(), event.workflow_name.clone());
                     if event.status == "completed" {
                         println!("{}", format_watch_event_line(&event));
-                        if args.fail_fast
-                            && is_non_success_conclusion(event.conclusion.as_deref())
+                        if args.fail_fast && is_non_success_conclusion(event.conclusion.as_deref())
                         {
                             bail!("run failed: {}", event.name);
                         }
@@ -443,10 +446,7 @@ fn print_watch_summary(completed: &[WatchRun]) {
                 );
             } else {
                 println!("  {}", job.name);
-                println!(
-                    "  everr logs {} --job-name {:?}",
-                    run.trace_id, job.name
-                );
+                println!("  everr logs {} --job-name {:?}", run.trace_id, job.name);
             }
         }
     }
@@ -468,7 +468,10 @@ enum LogsJobFilter {
     ById(String),
 }
 
-async fn resolve_logs_job(client: &ApiClient, args: &GetLogsArgs) -> Result<(LogsJobFilter, String)> {
+async fn resolve_logs_job(
+    client: &ApiClient,
+    args: &GetLogsArgs,
+) -> Result<(LogsJobFilter, String)> {
     // Fast paths: both identifier and step number are known — no API call needed
     if let (Some(name), Some(step)) = (args.job_name.as_deref(), args.step_number.as_deref()) {
         return Ok((LogsJobFilter::ByName(name.to_string()), step.to_string()));
@@ -484,7 +487,9 @@ async fn resolve_logs_job(client: &ApiClient, args: &GetLogsArgs) -> Result<(Log
     } else {
         vec![]
     };
-    let details = client.get_run_details(&args.trace_id, &details_query).await?;
+    let details = client
+        .get_run_details(&args.trace_id, &details_query)
+        .await?;
     let show: ShowRunDetails =
         serde_json::from_value(details).context("failed to parse run details")?;
 
@@ -638,7 +643,10 @@ mod tests {
             conclusion: None,
             job_id: Some(1),
         };
-        assert_eq!(super::format_watch_event_line(&event), "CI → build  in_progress");
+        assert_eq!(
+            super::format_watch_event_line(&event),
+            "CI → build  in_progress"
+        );
     }
 
     #[test]
@@ -659,7 +667,10 @@ mod tests {
             conclusion: Some("success".to_string()),
             job_id: None,
         };
-        assert_eq!(super::format_watch_event_line(&event), "Run completed: CI  success");
+        assert_eq!(
+            super::format_watch_event_line(&event),
+            "Run completed: CI  success"
+        );
     }
 
     #[test]
@@ -765,5 +776,4 @@ mod tests {
             vec![("limit", "25".to_string()), ("offset", "50".to_string())]
         );
     }
-
 }

--- a/packages/desktop-app/src-cli/src/init.rs
+++ b/packages/desktop-app/src-cli/src/init.rs
@@ -34,11 +34,10 @@ pub async fn run() -> Result<()> {
                 "Runs already imported for {repo_full_name}, skipping."
             ))?;
         } else {
-            let import = cliclack::confirm(format!(
-                "Import workflow history for {repo_full_name}?"
-            ))
-            .initial_value(true)
-            .interact()?;
+            let import =
+                cliclack::confirm(format!("Import workflow history for {repo_full_name}?"))
+                    .initial_value(true)
+                    .interact()?;
 
             if import {
                 match client.start_import_repos(&[repo_full_name.clone()]).await {
@@ -54,16 +53,12 @@ pub async fn run() -> Result<()> {
     }
 
     // Step 4: write assistant instructions
-    let written =
-        core_assistant::init_repo_instructions_auto(&cwd, build::command_name())?;
+    let written = core_assistant::init_repo_instructions_auto(&cwd, build::command_name())?;
     for path in &written {
         cliclack::log::success(format!("Updated {}", path.display()))?;
     }
 
-    cliclack::outro(format!(
-        "{} init complete.",
-        build::command_name()
-    ))?;
+    cliclack::outro(format!("{} init complete.", build::command_name()))?;
 
     Ok(())
 }

--- a/packages/desktop-app/src-cli/tests/api_commands.rs
+++ b/packages/desktop-app/src-cli/tests/api_commands.rs
@@ -355,8 +355,10 @@ fn runs_logs_prints_plain_text() {
         .args([
             "logs",
             "trace-123",
-            "--job-name", "build",
-            "--step-number", "2",
+            "--job-name",
+            "build",
+            "--step-number",
+            "2",
         ])
         .assert()
         .success()
@@ -390,9 +392,12 @@ fn runs_logs_offset_without_limit_uses_tail_mode() {
         .args([
             "logs",
             "trace-123",
-            "--job-name", "build",
-            "--step-number", "2",
-            "--offset", "1000",
+            "--job-name",
+            "build",
+            "--step-number",
+            "2",
+            "--offset",
+            "1000",
         ])
         .assert()
         .success()
@@ -428,9 +433,12 @@ fn runs_logs_prints_more_logs_footer_when_page_is_truncated() {
         .args([
             "logs",
             "trace-123",
-            "--job-name", "build",
-            "--step-number", "2",
-            "--limit", "2",
+            "--job-name",
+            "build",
+            "--step-number",
+            "2",
+            "--limit",
+            "2",
         ])
         .assert()
         .success()
@@ -465,9 +473,12 @@ fn runs_logs_egrep_passes_pattern_as_query_param() {
         .args([
             "logs",
             "trace-123",
-            "--job-name", "build",
-            "--step-number", "2",
-            "--egrep", "Error.*timeout",
+            "--job-name",
+            "build",
+            "--step-number",
+            "2",
+            "--egrep",
+            "Error.*timeout",
         ])
         .assert()
         .success()
@@ -494,9 +505,12 @@ fn runs_logs_egrep_exits_one_when_no_lines_match() {
         .args([
             "logs",
             "trace-123",
-            "--job-name", "build",
-            "--step-number", "2",
-            "--egrep", "nonexistent",
+            "--job-name",
+            "build",
+            "--step-number",
+            "2",
+            "--egrep",
+            "nonexistent",
         ])
         .assert()
         .failure()

--- a/packages/desktop-app/src-tauri/Cargo.toml
+++ b/packages/desktop-app/src-tauri/Cargo.toml
@@ -45,6 +45,7 @@ version = "1.44.2"
 features = [ "time", "sync", "macros" ]
 
 [target."cfg(target_os = \"macos\")".dependencies]
+objc2 = "0.6.4"
 objc2-app-kit = "0.3.2"
 
 [dev-dependencies]

--- a/packages/desktop-app/src-tauri/src/auth.rs
+++ b/packages/desktop-app/src-tauri/src/auth.rs
@@ -211,7 +211,10 @@ mod tests {
                 Some("user@example.com"),
                 Some("git@example.com".to_string())
             ),
-            vec!["user@example.com".to_string(), "git@example.com".to_string()]
+            vec![
+                "user@example.com".to_string(),
+                "git@example.com".to_string()
+            ]
         );
     }
 

--- a/packages/desktop-app/src-tauri/src/auto_fix_prompt.rs
+++ b/packages/desktop-app/src-tauri/src/auto_fix_prompt.rs
@@ -15,7 +15,8 @@ fn build_logs_instructions(failure: &FailureNotification) -> String {
         return "Pull the relevant Everr logs for this failure before guessing.".to_string();
     }
 
-    let commands: Vec<String> = failure.failed_jobs
+    let commands: Vec<String> = failure
+        .failed_jobs
         .iter()
         .filter_map(|job| {
             let escaped = serde_json::to_string(&job.job_name).ok()?;
@@ -33,7 +34,8 @@ fn format_notification_failure(failure: &FailureNotification) -> String {
     let jobs_suffix = if failure.failed_jobs.is_empty() {
         String::new()
     } else {
-        let parts: Vec<String> = failure.failed_jobs
+        let parts: Vec<String> = failure
+            .failed_jobs
             .iter()
             .map(|job| {
                 let step_name_suffix = job

--- a/packages/desktop-app/src-tauri/src/commands.rs
+++ b/packages/desktop-app/src-tauri/src/commands.rs
@@ -12,7 +12,7 @@ use crate::auth::{
 use crate::auto_fix_prompt::build_notification_auto_fix_prompt;
 use crate::notifications::{
     build_test_notification, copy_notification_auto_fix_prompt_inner,
-    dismiss_active_notification_inner, open_notification_target_inner, sync_notification_window,
+    dismiss_active_notification_inner, enqueue_notification, open_notification_target_inner,
     reset_notification_state,
 };
 use crate::seen_runs;
@@ -152,10 +152,7 @@ pub(crate) async fn get_notification_emails(
     state: State<'_, RuntimeState>,
 ) -> CommandResult<Vec<String>> {
     let state = state.inner().clone();
-    run_blocking_command(move || {
-        Ok(current_app_state(&state)?.settings.notification_emails)
-    })
-    .await
+    run_blocking_command(move || Ok(current_app_state(&state)?.settings.notification_emails)).await
 }
 
 #[tauri::command]
@@ -199,7 +196,6 @@ pub(crate) async fn get_user_profile(
     .await
 }
 
-
 #[tauri::command]
 pub(crate) fn dismiss_active_notification(
     app: AppHandle,
@@ -229,25 +225,9 @@ pub(crate) fn trigger_test_notification(
     state: State<'_, RuntimeState>,
 ) -> CommandResult<TestNotificationResponse> {
     let notification = build_test_notification().into_command_result()?;
+    enqueue_notification(&app, state.inner(), notification).into_command_result()?;
 
-    seen_runs::add_seen_run(state.inner(), &notification.trace_id).into_command_result()?;
-    let _ = app.emit(SEEN_RUNS_CHANGED_EVENT, ());
-
-    let shown = {
-        let mut notifier = state
-            .notifier
-            .lock()
-            .map_err(|_| "failed to lock notifier state".to_string())?;
-        notifier.queue.enqueue(notification)
-    };
-
-    if shown {
-        sync_notification_window(&app, state.inner()).into_command_result()?;
-    }
-
-    Ok(TestNotificationResponse {
-        status: if shown { "shown" } else { "queued" },
-    })
+    Ok(TestNotificationResponse { status: "queued" })
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -317,9 +297,7 @@ pub(crate) async fn get_runs_list(
 }
 
 #[tauri::command]
-pub(crate) fn get_unseen_trace_ids(
-    state: State<'_, RuntimeState>,
-) -> CommandResult<Vec<String>> {
+pub(crate) fn get_unseen_trace_ids(state: State<'_, RuntimeState>) -> CommandResult<Vec<String>> {
     seen_runs::unseen_trace_ids(state.inner()).into_command_result()
 }
 

--- a/packages/desktop-app/src-tauri/src/lib.rs
+++ b/packages/desktop-app/src-tauri/src/lib.rs
@@ -53,7 +53,7 @@ const NOTIFICATION_EXIT_EVENT: &str = "everr://notification-exit";
 const NOTIFICATION_WINDOW_LABEL: &str = "notification";
 const NOTIFICATION_WINDOW_WIDTH: f64 = 420.0;
 const NOTIFICATION_WINDOW_HEIGHT: f64 = 124.0;
-const NOTIFICATION_WINDOW_MARGIN: f64 = 16.0;
+const NOTIFICATION_WINDOW_MARGIN: f64 = 38.0;
 const NOTIFICATION_WINDOW_INSET: f64 = 12.0;
 const TRAY_ICON_ID: &str = "everr-app";
 const SETTINGS_MENU_ID: &str = "settings";
@@ -234,11 +234,13 @@ pub fn run() {
             let store = current_state_store();
             let _ = store.clear_mismatched_session(build::default_api_base_url())?;
             store.update_state(|state| {
-                state.settings.apply_runtime_base_url(build::default_api_base_url());
+                state
+                    .settings
+                    .apply_runtime_base_url(build::default_api_base_url());
             })?;
             run_local_startup_maintenance(app.handle());
-            let watcher = StateWatcher::start(store.clone())
-                .expect("failed to start state watcher");
+            let watcher =
+                StateWatcher::start(store.clone()).expect("failed to start state watcher");
             let runtime = RuntimeState {
                 store,
                 watcher: Arc::new(watcher),

--- a/packages/desktop-app/src-tauri/src/notifications.rs
+++ b/packages/desktop-app/src-tauri/src/notifications.rs
@@ -1,23 +1,32 @@
+use std::sync::Mutex;
 use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use arboard::Clipboard;
 use everr_core::api::{
-    ApiClient, FailureNotification, NotifyPayload, is_reauthentication_required,
+    is_reauthentication_required, ApiClient, FailureNotification, NotifyPayload,
 };
 use everr_core::git::resolve_git_context;
 use futures_util::StreamExt;
 #[cfg(target_os = "macos")]
-use objc2_app_kit::{NSWindow, NSWindowCollectionBehavior};
+use objc2::{rc::Retained, MainThreadMarker, MainThreadOnly};
+#[cfg(target_os = "macos")]
+use objc2_app_kit::{
+    NSAutoresizingMaskOptions, NSBackingStoreType, NSColor, NSEvent, NSPanel, NSStatusWindowLevel,
+    NSView, NSWindow, NSWindowAnimationBehavior, NSWindowCollectionBehavior, NSWindowStyleMask,
+};
+
 use tauri::Emitter;
-use tauri::{AppHandle, LogicalPosition, Manager, WebviewUrl, WebviewWindow, WebviewWindowBuilder};
+use tauri::{
+    AppHandle, LogicalPosition, Manager, Position, WebviewUrl, WebviewWindow, WebviewWindowBuilder,
+};
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
 use crate::auto_fix_prompt::build_notification_auto_fix_prompt;
 use crate::settings::{current_app_state, emit_auth_changed, update_persisted_state};
 use crate::{
-    current_base_url, NotifierState, NotificationQueue, RuntimeState, NOTIFICATION_CHANGED_EVENT,
+    current_base_url, NotificationQueue, NotifierState, RuntimeState, NOTIFICATION_CHANGED_EVENT,
     NOTIFICATION_EXIT_EVENT, NOTIFICATION_HOVER_EVENT, NOTIFICATION_WINDOW_HEIGHT,
     NOTIFICATION_WINDOW_INSET, NOTIFICATION_WINDOW_LABEL, NOTIFICATION_WINDOW_MARGIN,
     NOTIFICATION_WINDOW_WIDTH, SEEN_RUNS_CHANGED_EVENT,
@@ -29,6 +38,15 @@ macro_rules! dbg_notifier {
             eprintln!("[notifier] {}", format_args!($($arg)*));
         }
     };
+}
+
+#[cfg(test)]
+pub(crate) fn notification_window_uses_native_panel() -> bool {
+    cfg!(target_os = "macos")
+}
+
+pub(crate) fn notification_hover_uses_native_panel_geometry() -> bool {
+    cfg!(target_os = "macos")
 }
 
 pub(crate) fn start_notifier_loop(app: AppHandle, state: RuntimeState) {
@@ -47,10 +65,7 @@ pub(crate) fn start_notifier_loop(app: AppHandle, state: RuntimeState) {
                     if is_reauthentication_required(&error) {
                         crate::crash_log::log_error("notifier SSE auth", &error);
                         if let Err(reset_error) = handle_notifier_auth_failure(&app, &state) {
-                            crate::crash_log::log_error(
-                                "notifier auth reset",
-                                &reset_error,
-                            );
+                            crate::crash_log::log_error("notifier auth reset", &reset_error);
                         }
                         backoff = Duration::from_secs(1);
                         continue;
@@ -162,12 +177,10 @@ async fn run_sse_notifier(app: &AppHandle, state: &RuntimeState) -> Result<()> {
     let mut rx = state.watcher.subscribe();
 
     let Some(session) = current_app_state(state)?.session else {
-        reset_notification_state(app, state)?;
         wait_for_change(&mut rx, &[StateChange::SessionChanged]).await;
         return Ok(());
     };
     if session.api_base_url.trim_end_matches('/') != current_base_url().trim_end_matches('/') {
-        reset_notification_state(app, state)?;
         wait_for_change(&mut rx, &[StateChange::SessionChanged]).await;
         return Ok(());
     }
@@ -181,8 +194,7 @@ async fn run_sse_notifier(app: &AppHandle, state: &RuntimeState) -> Result<()> {
             std::iter::once(profile.email).collect()
         } else {
             // No emails configured and no profile cached — wait for session or filter changes.
-            reset_notification_state(app, state)?;
-            wait_for_change(&mut rx, &[StateChange::SessionChanged, StateChange::EmailsChanged]).await;
+            wait_for_change(&mut rx, &[StateChange::EmailsChanged]).await;
             return Ok(());
         }
     };
@@ -256,7 +268,6 @@ fn handle_notifier_auth_failure(app: &AppHandle, state: &RuntimeState) -> Result
     update_persisted_state(state, |persisted| {
         persisted.session = None;
     })?;
-    reset_notification_state(app, state)?;
     emit_auth_changed(app);
     Ok(())
 }
@@ -308,7 +319,7 @@ async fn handle_notify_event(
     Ok(())
 }
 
-fn enqueue_notification(
+pub(crate) fn enqueue_notification(
     app: &AppHandle,
     state: &RuntimeState,
     notification: FailureNotification,
@@ -412,24 +423,15 @@ pub(crate) fn sync_notification_window(app: &AppHandle, state: &RuntimeState) ->
 
 fn show_notification_window(app: &AppHandle) -> Result<()> {
     let window = ensure_notification_window(app)?;
-    let was_visible = window.is_visible().unwrap_or(false);
-    configure_notification_window_for_fullscreen(&window)?;
+    position_notification_window(app, &window)?;
+    let was_visible = notification_window_is_visible(&window)?;
 
     if !was_visible {
-        position_notification_window(app, &window)?;
-        show_without_focus(&window)?;
+        show_notification_window_host(&window)?;
         start_notification_hover_polling(app);
-    } else {
-        position_notification_window(app, &window)?;
     }
 
     Ok(())
-}
-
-fn show_without_focus(window: &WebviewWindow) -> Result<()> {
-    window
-        .show()
-        .context("failed to show notification window without focus")
 }
 
 fn start_notification_hover_polling(app: &AppHandle) {
@@ -443,7 +445,7 @@ fn start_notification_hover_polling(app: &AppHandle) {
                 break;
             };
 
-            if !window.is_visible().unwrap_or(false) {
+            if !notification_window_is_visible(&window).unwrap_or(false) {
                 break;
             }
 
@@ -457,6 +459,25 @@ fn start_notification_hover_polling(app: &AppHandle) {
 }
 
 fn cursor_is_over_notification_window(app: &AppHandle, window: &WebviewWindow) -> bool {
+    #[cfg(target_os = "macos")]
+    if notification_hover_uses_native_panel_geometry() {
+        return with_notification_native_objects(window, |ns_window, _| {
+            let frame = notification_panel()
+                .map(|panel| panel.frame())
+                .unwrap_or_else(|| ns_window.frame());
+            let cursor = NSEvent::mouseLocation();
+            Ok(point_is_inside_notification_frame(
+                cursor.x,
+                cursor.y,
+                frame.origin.x,
+                frame.origin.y,
+                frame.size.width,
+                frame.size.height,
+            ))
+        })
+        .unwrap_or(false);
+    }
+
     let Ok(cursor) = app.cursor_position() else {
         return false;
     };
@@ -466,27 +487,53 @@ fn cursor_is_over_notification_window(app: &AppHandle, window: &WebviewWindow) -
     let Ok(size) = window.outer_size() else {
         return false;
     };
-    cursor.x >= pos.x as f64
-        && cursor.x < pos.x as f64 + size.width as f64
-        && cursor.y >= pos.y as f64
-        && cursor.y < pos.y as f64 + size.height as f64
+    point_is_inside_notification_frame(
+        cursor.x,
+        cursor.y,
+        pos.x as f64,
+        pos.y as f64,
+        size.width as f64,
+        size.height as f64,
+    )
+}
+
+fn point_is_inside_notification_frame(
+    cursor_x: f64,
+    cursor_y: f64,
+    frame_x: f64,
+    frame_y: f64,
+    frame_width: f64,
+    frame_height: f64,
+) -> bool {
+    cursor_x >= frame_x
+        && cursor_x < frame_x + frame_width
+        && cursor_y >= frame_y
+        && cursor_y < frame_y + frame_height
 }
 
 fn hide_notification_window(app: &AppHandle) -> Result<()> {
     if let Some(window) = app.get_webview_window(NOTIFICATION_WINDOW_LABEL) {
-        if window.is_visible().unwrap_or(false) {
+        if notification_window_is_visible(&window).unwrap_or(false) {
             // Tell the frontend to play the CSS exit animation, then hide after it completes.
             let _ = window.emit(NOTIFICATION_EXIT_EVENT, ());
             let app = app.clone();
             tauri::async_runtime::spawn(async move {
                 tokio::time::sleep(Duration::from_millis(200)).await;
                 if let Some(w) = app.get_webview_window(NOTIFICATION_WINDOW_LABEL) {
+                    let _ = hide_notification_window_host(&w);
+                    // Once the panel releases the webview back to the backing Tauri window,
+                    // keep that owner hidden between notifications.
+                    #[cfg(target_os = "macos")]
                     let _ = w.hide();
                 }
                 let _ = app.emit(NOTIFICATION_CHANGED_EVENT, ());
             });
             return Ok(());
         }
+        hide_notification_window_host(&window)?;
+        // The native panel is only the temporary presenter. After hide, the webview
+        // is reattached to the hidden Tauri window, so hide that owner as well.
+        #[cfg(target_os = "macos")]
         window
             .hide()
             .context("failed to hide notification window")?;
@@ -547,35 +594,63 @@ fn ensure_notification_window(app: &AppHandle) -> Result<WebviewWindow> {
         .context("failed to build notification window")
 }
 
-#[cfg(target_os = "macos")]
-fn configure_notification_window_for_fullscreen(window: &WebviewWindow) -> Result<()> {
-    let window_for_closure = window.clone();
-    window
-        .run_on_main_thread(move || {
-            let Ok(ns_window) = window_for_closure.ns_window() else {
-                return;
-            };
+fn notification_window_is_visible(window: &WebviewWindow) -> Result<bool> {
+    #[cfg(target_os = "macos")]
+    {
+        return with_notification_native_objects(window, |_, _| {
+            Ok(notification_panel()
+                .map(|p| p.isVisible())
+                .unwrap_or(false))
+        });
+    }
 
-            let ns_window: &NSWindow = unsafe { &*ns_window.cast() };
-            let behavior = ns_window.collectionBehavior()
-                | NSWindowCollectionBehavior::CanJoinAllSpaces
-                | NSWindowCollectionBehavior::FullScreenAuxiliary;
-            ns_window.setCollectionBehavior(behavior);
-            ns_window.setAcceptsMouseMovedEvents(true);
-        })
-        .context("failed to configure notification window")
+    #[cfg(not(target_os = "macos"))]
+    Ok(window.is_visible().unwrap_or(false))
 }
 
-#[cfg(not(target_os = "macos"))]
-fn configure_notification_window_for_fullscreen(_window: &WebviewWindow) -> Result<()> {
-    Ok(())
+fn show_notification_window_host(window: &WebviewWindow) -> Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        return show_notification_panel(window);
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        window.show().context("failed to show notification window")
+    }
+}
+
+fn hide_notification_window_host(window: &WebviewWindow) -> Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        return hide_notification_panel(window);
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    window.hide().context("failed to hide notification window")
 }
 
 fn position_notification_window(app: &AppHandle, window: &WebviewWindow) -> Result<()> {
-    let (x, y) = notification_window_position(app)?;
+    let Ok((x, y)) = notification_window_position(app) else {
+        return Ok(());
+    };
+
     window
-        .set_position(LogicalPosition::new(x, y))
-        .context("failed to position notification window")
+        .set_position(Position::Logical(LogicalPosition::new(x, y)))
+        .context("failed to position notification window")?;
+
+    #[cfg(target_os = "macos")]
+    {
+        return with_notification_native_objects(window, |ns_window, _| {
+            if let Some(panel) = notification_panel() {
+                panel.setFrame_display(ns_window.frame(), false);
+            }
+            Ok(())
+        });
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    Ok(())
 }
 
 fn notification_window_position(app: &AppHandle) -> Result<(f64, f64)> {
@@ -587,11 +662,10 @@ fn notification_window_position(app: &AppHandle) -> Result<(f64, f64)> {
         .ok_or_else(|| anyhow!("failed to resolve notification monitor"))?;
     let work_area = monitor.work_area();
     let scale_factor = monitor.scale_factor();
-    let full_width = ((NOTIFICATION_WINDOW_WIDTH
-        + NOTIFICATION_WINDOW_INSET
-        + NOTIFICATION_WINDOW_MARGIN)
-        * scale_factor)
-        .round() as i32;
+    let full_width =
+        ((NOTIFICATION_WINDOW_WIDTH + NOTIFICATION_WINDOW_INSET + NOTIFICATION_WINDOW_MARGIN)
+            * scale_factor)
+            .round() as i32;
     let inset = (NOTIFICATION_WINDOW_INSET * scale_factor).round() as i32;
     let margin = (NOTIFICATION_WINDOW_MARGIN * scale_factor).round() as i32;
     // Window right edge is flush with the work-area edge.
@@ -600,4 +674,150 @@ fn notification_window_position(app: &AppHandle) -> Result<(f64, f64)> {
     let y = work_area.position.y + margin - inset;
 
     Ok((x as f64 / scale_factor, y as f64 / scale_factor))
+}
+
+/// Raw pointer to the singleton NSPanel used for notifications.
+/// Only accessed on the main thread (inside `with_notification_native_objects`).
+#[cfg(target_os = "macos")]
+struct SendPtr(*mut objc2::runtime::AnyObject);
+#[cfg(target_os = "macos")]
+// SAFETY: the pointer is only dereferenced on the main thread.
+unsafe impl Send for SendPtr {}
+#[cfg(target_os = "macos")]
+// SAFETY: access is synchronized by the Mutex.
+unsafe impl Sync for SendPtr {}
+#[cfg(target_os = "macos")]
+static NOTIFICATION_PANEL_PTR: Mutex<Option<SendPtr>> = Mutex::new(None);
+
+#[cfg(target_os = "macos")]
+fn show_notification_panel(window: &WebviewWindow) -> Result<()> {
+    with_notification_native_objects(window, |ns_window, webview_view| {
+        let panel = ensure_notification_panel(ns_window, webview_view)?;
+        panel.setFrame_display(ns_window.frame(), false);
+        panel.orderFrontRegardless();
+        Ok(())
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn hide_notification_panel(window: &WebviewWindow) -> Result<()> {
+    with_notification_native_objects(window, |ns_window, webview_view| {
+        attach_notification_webview_to_backing_window(ns_window, webview_view)?;
+        if let Some(panel) = notification_panel() {
+            panel.orderOut(None);
+        }
+        Ok(())
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn with_notification_native_objects<T, F>(window: &WebviewWindow, f: F) -> Result<T>
+where
+    T: Send + 'static,
+    F: FnOnce(&NSWindow, &NSView) -> Result<T> + Send + 'static,
+{
+    let (tx, rx) = std::sync::mpsc::sync_channel(1);
+    window
+        .with_webview(move |webview| {
+            let result = (|| {
+                let ns_window: &NSWindow = unsafe { &*webview.ns_window().cast() };
+                let webview_view: &NSView = unsafe { &*webview.inner().cast() };
+                f(ns_window, webview_view)
+            })();
+            let _ = tx.send(result);
+        })
+        .context("failed to access native notification webview")?;
+
+    rx.recv()
+        .map_err(|_| anyhow!("failed to receive native notification result"))?
+}
+
+#[cfg(target_os = "macos")]
+fn ensure_notification_panel(
+    ns_window: &NSWindow,
+    webview_view: &NSView,
+) -> Result<Retained<NSPanel>> {
+    if let Some(panel) = notification_panel() {
+        attach_notification_webview_to_panel(&panel, webview_view)?;
+        return Ok(panel);
+    }
+
+    let mtm =
+        MainThreadMarker::new().expect("notification panel must be created on the main thread");
+    let panel = NSPanel::initWithContentRect_styleMask_backing_defer(
+        NSPanel::alloc(mtm),
+        ns_window.frame(),
+        NSWindowStyleMask::Borderless | NSWindowStyleMask::NonactivatingPanel,
+        NSBackingStoreType::Buffered,
+        false,
+    );
+
+    panel.setFloatingPanel(true);
+    panel.setBecomesKeyOnlyIfNeeded(true);
+    panel.setWorksWhenModal(true);
+    panel.setCollectionBehavior(
+        NSWindowCollectionBehavior::Stationary
+            | NSWindowCollectionBehavior::FullScreenAuxiliary
+            | NSWindowCollectionBehavior::CanJoinAllSpaces,
+    );
+    panel.setAnimationBehavior(NSWindowAnimationBehavior::None);
+    panel.setLevel(NSStatusWindowLevel);
+    panel.setOpaque(false);
+    panel.setBackgroundColor(Some(&NSColor::clearColor()));
+    panel.setHasShadow(true);
+    panel.setHidesOnDeactivate(false);
+    panel.setExcludedFromWindowsMenu(true);
+    panel.setAcceptsMouseMovedEvents(true);
+    panel.setIgnoresMouseEvents(false);
+
+    // Transfer one retain count into the static so the panel stays alive.
+    *NOTIFICATION_PANEL_PTR
+        .lock()
+        .map_err(|_| anyhow!("failed to lock notification panel"))? =
+        Some(SendPtr(Retained::into_raw(panel.clone()).cast()));
+
+    attach_notification_webview_to_panel(&panel, webview_view)?;
+
+    Ok(panel)
+}
+
+#[cfg(target_os = "macos")]
+fn notification_panel() -> Option<Retained<NSPanel>> {
+    let guard = NOTIFICATION_PANEL_PTR.lock().ok()?;
+    let ptr = guard.as_ref()?.0;
+    // SAFETY: the pointer was stored by `ensure_notification_panel` on the main thread
+    // and we only call this from `with_notification_native_objects` which also runs on
+    // the main thread. The panel is retained by the Retained we create here.
+    unsafe { Retained::retain(ptr.cast()) }
+}
+
+#[cfg(target_os = "macos")]
+fn attach_notification_webview_to_panel(panel: &NSPanel, webview_view: &NSView) -> Result<()> {
+    let content_view = panel
+        .contentView()
+        .ok_or_else(|| anyhow!("notification panel is missing a content view"))?;
+    attach_notification_webview(content_view.as_ref(), webview_view);
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn attach_notification_webview_to_backing_window(
+    ns_window: &NSWindow,
+    webview_view: &NSView,
+) -> Result<()> {
+    let content_view = ns_window
+        .contentView()
+        .ok_or_else(|| anyhow!("notification window is missing a content view"))?;
+    attach_notification_webview(content_view.as_ref(), webview_view);
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn attach_notification_webview(content_view: &NSView, webview_view: &NSView) {
+    webview_view.removeFromSuperview();
+    webview_view.setFrame(content_view.bounds());
+    webview_view.setAutoresizingMask(
+        NSAutoresizingMaskOptions::ViewWidthSizable | NSAutoresizingMaskOptions::ViewHeightSizable,
+    );
+    content_view.addSubview(webview_view);
 }

--- a/packages/desktop-app/src-tauri/src/startup.rs
+++ b/packages/desktop-app/src-tauri/src/startup.rs
@@ -10,7 +10,9 @@ use tokio::sync::broadcast;
 
 use crate::cli::sync_installed_cli;
 use crate::notifications::reset_notification_state;
-use crate::settings::{current_app_state, emit_auth_changed, emit_settings_changed, update_settings};
+use crate::settings::{
+    current_app_state, emit_auth_changed, emit_settings_changed, update_settings,
+};
 use crate::{should_check_for_updates, RuntimeState, UPDATE_CHECK_INTERVAL_SECONDS};
 
 pub(crate) fn run_local_startup_maintenance(app: &AppHandle) {

--- a/packages/desktop-app/src-tauri/src/tests.rs
+++ b/packages/desktop-app/src-tauri/src/tests.rs
@@ -9,6 +9,10 @@ use tempfile::tempdir;
 use crate::auto_fix_prompt::build_notification_auto_fix_prompt;
 use crate::cli::sync_installed_cli_from_paths;
 use crate::notifications::{active_notification_auto_fix_prompt, reset_notifier_runtime_state};
+#[cfg(target_os = "macos")]
+use crate::notifications::{
+    notification_hover_uses_native_panel_geometry, notification_window_uses_native_panel,
+};
 use crate::settings::{build_assistant_setup_response, build_wizard_status_response};
 use crate::{
     current_app_name, current_base_url, current_state_store, should_check_for_updates,
@@ -194,6 +198,18 @@ fn startup_update_checks_are_disabled_in_dev_only() {
     assert_eq!(should_check_for_updates(), !tauri::is_dev());
 }
 
+#[cfg(target_os = "macos")]
+#[test]
+fn notification_window_uses_native_panel_on_macos() {
+    assert!(notification_window_uses_native_panel());
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn notification_hover_uses_native_panel_geometry_on_macos() {
+    assert!(notification_hover_uses_native_panel_geometry());
+}
+
 #[test]
 fn assistant_setup_response_returns_detected_and_configured_statuses() {
     let response = build_assistant_setup_response(vec![
@@ -289,7 +305,6 @@ fn mismatched_completed_base_url_reopens_the_wizard() {
     settings.apply_runtime_base_url(current_base_url());
     assert!(!settings.wizard_state.wizard_completed);
 }
-
 
 #[test]
 fn sync_installed_cli_installs_missing_binary() {


### PR DESCRIPTION
## Summary

- Reparent the notification webview into an `NSPanel` on macOS so the card floats above fullscreen apps and across all spaces, instead of relying on `NSFloatingWindowLevel` alone.
- Track the singleton panel in a process-wide static (`NOTIFICATION_PANEL_PTR`). Earlier attempts used an ObjC associated object keyed on the NSWindow pointer, but after reparenting `webview.ns_window()` returns the panel itself — a different pointer than the original Tauri `NSWindow` used as the association key — so subsequent lookups missed and the hover-polling loop exited immediately.
- Collapse runtime `cfg!(target_os = "macos")` checks inside `#[cfg(target_os = "macos")]` blocks (they were always-true on macOS and produced unreachable non-macOS fallback code).
- Rest of the diff is rustfmt churn.

## Test plan

- [ ] macOS: trigger a failure notification, confirm the card appears at the top-right of the screen, floats above fullscreen apps, and persists across spaces.
- [ ] macOS: hover the card — auto-dismiss pauses while hovering.
- [ ] macOS: dismiss the card (auto-timeout + manual) and fire another notification — panel reopens correctly.
- [ ] Linux/Windows: confirm the non-macOS code path still builds and the notification still shows/hides through the standard Tauri window.