### PR TITLE
Fix local collector browser telemetry

### DIFF
--- a/packages/desktop-app/src-tauri/src/telemetry/collector.yaml.tmpl
+++ b/packages/desktop-app/src-tauri/src/telemetry/collector.yaml.tmpl
@@ -3,6 +3,8 @@ receivers:
     protocols:
       http:
         endpoint: 127.0.0.1:{OTLP_PORT}
+        cors:
+          allowed_origins: ["*"]
 
 processors:
   batch:

--- a/packages/desktop-app/src-tauri/src/telemetry/sidecar.rs
+++ b/packages/desktop-app/src-tauri/src/telemetry/sidecar.rs
@@ -66,6 +66,7 @@ impl Sidecar {
             match app.shell().sidecar("everr-local-collector").and_then(|s| {
                 s.args(["--config", &config_path.display().to_string()])
                     .env(chdb_env_name, chdb_env_value)
+                    .env("TZ", "UTC")
                     .spawn()
             }) {
                 Ok(pair) => pair,
@@ -345,6 +346,7 @@ pub async fn spawn_collector_detached(
         .arg("--config")
         .arg(&config_path)
         .env(chdb_env_name, chdb_env_value)
+        .env("TZ", "UTC")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true)


### PR DESCRIPTION
## Summary

- Allow CORS requests to the local OTLP HTTP receiver so browser-based telemetry can post logs and traces.
- Start the Tauri-managed local collector with `TZ=UTC` so chdb parses OTLP timestamps and evaluates `now()` windows consistently.

## Impact

Browser telemetry sent from localhost dev servers can reach the local collector, and time-window queries such as `Timestamp > now() - INTERVAL 10 MINUTE` work for newly ingested rows after the desktop sidecar restarts.

## Validation

- `cargo check -p everr-app`
- `git diff --check`
