### PR TITLE
Add everr wrap command

### DIFF
--- a/crates/everr-core/assets/telemetry-instructions.md
+++ b/crates/everr-core/assets/telemetry-instructions.md
@@ -15,6 +15,8 @@ Commands:
   Always include a time window and a `LIMIT`; responses are capped at 16 MiB.
 - `everr telemetry endpoint`: print the current collector URL if you need to
   confirm the build-specific value.
+- `everr wrap -- <command>`: run a plain command normally while mirroring each
+  stdout/stderr line into `otel_logs` with `service.name = 'everr-wrap-<cmd>'`.
 - `everr telemetry ai-instructions`: print this compact guide.
 
 Schema:
@@ -38,6 +40,8 @@ Investigation playbook:
   `SpanName`, `SeverityNumber`, or attributes.
 - Use traces for flow and latency; use logs for discrete facts and errors.
 - Pivot logs to traces with `TraceId`.
+- For commands that do not emit OTLP themselves, wrap them with
+  `everr wrap -- <command>` and query `ServiceName = 'everr-wrap-<cmd>'`.
 - Empty or stale results usually mean the app is not running, not configured to
   export OTLP to `http://127.0.0.1:54418`, or the collector is not up.
 

--- a/crates/everr-core/assets/telemetry-instructions.md
+++ b/crates/everr-core/assets/telemetry-instructions.md
@@ -1,22 +1,19 @@
-Use Everr telemetry to debug a locally running OpenTelemetry-instrumented app:
-runtime errors, slow requests, regressions, and whether new instrumentation is
-emitting data. Data lives in the local collector sidecar and only exists while
-`everr telemetry start` or Everr Desktop is running.
+Use Everr telemetry to debug local OpenTelemetry apps: runtime errors, slow
+requests, regressions, and whether instrumentation emits data. Data only exists
+while `everr telemetry start` or Everr Desktop is running.
 
 Setup:
-- Standalone CLI: run `everr telemetry start` in one terminal, then run query
-  commands from another terminal.
-- For the normal Everr Desktop app, point OTLP/HTTP exporters at
-  `http://127.0.0.1:54418`.
+- Standalone CLI: run `everr telemetry start`, then query from another terminal.
+- Everr Desktop: point OTLP/HTTP exporters at `http://127.0.0.1:54418`.
 
 Commands:
 - `everr telemetry query "<SQL>"`: run read-only SQL against local telemetry.
   Allowed statements: `SELECT`, `WITH`, `EXPLAIN`, `DESCRIBE`, `DESC`, `SHOW`.
   Always include a time window and a `LIMIT`; responses are capped at 16 MiB.
-- `everr telemetry endpoint`: print the current collector URL if you need to
-  confirm the build-specific value.
-- `everr wrap -- <command>`: run a plain command normally while mirroring each
-  stdout/stderr line into `otel_logs` with `service.name = 'everr-wrap-<cmd>'`.
+- `everr telemetry endpoint`: print the current collector URL.
+- `everr wrap -- <command>`: mirror stdout/stderr into `otel_logs` with
+  `service.name = 'everr-wrap-<cmd>'`. Requires a running collector; without
+  one, the command is not run. Non-zero wrapped exits pass through.
 - `everr telemetry ai-instructions`: print this compact guide.
 
 Schema:

--- a/crates/everr-core/src/assistant.rs
+++ b/crates/everr-core/src/assistant.rs
@@ -739,6 +739,7 @@ mod tests {
         );
         assert!(rendered.contains("http://127.0.0.1:54418"));
         assert!(rendered.contains("everr telemetry query"));
+        assert!(rendered.contains("everr wrap -- <command>"));
         assert!(rendered.contains("everr telemetry ai-instructions"));
         assert!(rendered.contains("DESCRIBE TABLE otel_traces"));
         assert!(rendered.contains("otel_logs"));

--- a/crates/everr-core/src/assistant.rs
+++ b/crates/everr-core/src/assistant.rs
@@ -740,6 +740,7 @@ mod tests {
         assert!(rendered.contains("http://127.0.0.1:54418"));
         assert!(rendered.contains("everr telemetry query"));
         assert!(rendered.contains("everr wrap -- <command>"));
+        assert!(rendered.contains("Requires a running collector"));
         assert!(rendered.contains("everr telemetry ai-instructions"));
         assert!(rendered.contains("DESCRIBE TABLE otel_traces"));
         assert!(rendered.contains("otel_logs"));

--- a/crates/everr-core/src/build.rs
+++ b/crates/everr-core/src/build.rs
@@ -90,6 +90,10 @@ pub const SQL_HTTP_PORT: u16 = 54420;
 /// Origin (scheme + host + port) for the local OTLP HTTP collector.
 /// Instrumented code points its OTLP HTTP exporter at this.
 pub fn otlp_http_origin() -> String {
+    #[cfg(debug_assertions)]
+    if let Ok(origin) = std::env::var("EVERR_OTLP_HTTP_ORIGIN") {
+        return origin;
+    }
     format!("http://127.0.0.1:{OTLP_HTTP_PORT}")
 }
 
@@ -178,6 +182,29 @@ mod tests {
         assert!(origin.starts_with("http://127.0.0.1:"));
         let port: u16 = origin.rsplit(':').next().unwrap().parse().unwrap();
         assert_eq!(port, super::SQL_HTTP_PORT);
+    }
+
+    #[test]
+    fn otlp_http_origin_honors_debug_override() {
+        const KEY: &str = "EVERR_OTLP_HTTP_ORIGIN";
+        let previous = std::env::var_os(KEY);
+
+        unsafe {
+            std::env::set_var(KEY, "http://127.0.0.1:65529");
+        }
+
+        let origin = super::otlp_http_origin();
+
+        match previous {
+            Some(value) => unsafe {
+                std::env::set_var(KEY, value);
+            },
+            None => unsafe {
+                std::env::remove_var(KEY);
+            },
+        }
+
+        assert_eq!(origin, "http://127.0.0.1:65529");
     }
 
     #[test]

--- a/packages/desktop-app/src-cli/Cargo.toml
+++ b/packages/desktop-app/src-cli/Cargo.toml
@@ -24,7 +24,7 @@ regex = "1"
 sha2 = "0.10.9"
 strip-ansi-escapes = "0.2"
 tempfile = "3.18.0"
-tokio = { version = "1.44.2", features = ["io-util", "macros", "process", "rt-multi-thread", "signal", "time"] }
+tokio = { version = "1.44.2", features = ["io-std", "io-util", "macros", "process", "rt-multi-thread", "signal", "sync", "time"] }
 webbrowser = "1.0.6"
 
 [dependencies.nix]

--- a/packages/desktop-app/src-cli/src/cli.rs
+++ b/packages/desktop-app/src-cli/src/cli.rs
@@ -57,6 +57,8 @@ pub enum Commands {
     /// List workflows and their jobs for a repository
     #[command(name = "workflows")]
     WorkflowsList(WorkflowsListArgs),
+    /// Run a command and send its stdout/stderr logs to the local collector
+    Wrap(WrapArgs),
     /// Run the full setup wizard (login + org + import + assistant configuration)
     #[command(name = "setup")]
     Setup,
@@ -294,6 +296,18 @@ pub struct WorkflowsListArgs {
     pub branch: Option<String>,
 }
 
+#[derive(Args, Debug, Default)]
+pub struct WrapArgs {
+    /// Command and arguments to run
+    #[arg(
+        required = true,
+        trailing_var_arg = true,
+        allow_hyphen_values = true,
+        value_name = "COMMAND"
+    )]
+    pub command: Vec<String>,
+}
+
 impl GetLogsArgs {
     pub fn paging(&self) -> Option<LogPagingArgs> {
         if self.limit.is_none() {
@@ -339,6 +353,10 @@ mod tests {
         let ai_instructions =
             Cli::try_parse_from(["everr", "ai-instructions"]).expect("ai-instructions command");
         assert!(matches!(ai_instructions.command, Commands::AiInstructions));
+
+        let wrap =
+            Cli::try_parse_from(["everr", "wrap", "--", "cargo", "test"]).expect("wrap command");
+        assert!(matches!(wrap.command, Commands::Wrap(_)));
     }
 
     #[test]
@@ -373,6 +391,36 @@ mod tests {
         assert_eq!(args.repo.as_deref(), Some("everr-labs/everr"));
         assert_eq!(args.branch.as_deref(), Some("feature/tests"));
         assert_eq!(args.commit.as_deref(), Some("abc123def456"));
+    }
+
+    #[test]
+    fn wrap_accepts_command_after_separator() {
+        let cli = Cli::try_parse_from([
+            "everr",
+            "wrap",
+            "--",
+            "cargo",
+            "test",
+            "--package",
+            "everr-cli",
+        ])
+        .expect("valid wrap command");
+
+        let Commands::Wrap(args) = cli.command else {
+            panic!("expected wrap command");
+        };
+
+        assert_eq!(
+            args.command,
+            vec!["cargo", "test", "--package", "everr-cli"]
+        );
+    }
+
+    #[test]
+    fn wrap_requires_command() {
+        let err = Cli::try_parse_from(["everr", "wrap"]).expect_err("wrap should require command");
+
+        assert!(err.to_string().contains("<COMMAND>"));
     }
 
     #[test]

--- a/packages/desktop-app/src-cli/src/main.rs
+++ b/packages/desktop-app/src-cli/src/main.rs
@@ -7,6 +7,7 @@ mod init;
 mod onboarding;
 mod telemetry;
 mod uninstall;
+mod wrap;
 
 use anyhow::Result;
 use clap::Parser;
@@ -32,6 +33,7 @@ async fn main() -> Result<()> {
         Commands::RunsShow(args) => core::runs_show(args).await?,
         Commands::RunsLogs(args) => core::runs_logs(args).await?,
         Commands::WorkflowsList(args) => core::workflows_list(args).await?,
+        Commands::Wrap(args) => wrap::run(args).await?,
         Commands::Setup => onboarding::run().await?,
         Commands::Init => init::run().await?,
         Commands::Telemetry(args) => telemetry::commands::run(args).await?,

--- a/packages/desktop-app/src-cli/src/wrap.rs
+++ b/packages/desktop-app/src-cli/src/wrap.rs
@@ -305,8 +305,6 @@ impl OtlpLogExporter {
                 "resource": {
                     "attributes": [
                         attr("service.name", &self.command.service_name()),
-                        attr("service.version", env!("EVERR_VERSION")),
-                        attr("deployment.environment", everr_core::build::build_type_label()),
                     ],
                 },
                 "scopeLogs": [{

--- a/packages/desktop-app/src-cli/src/wrap.rs
+++ b/packages/desktop-app/src-cli/src/wrap.rs
@@ -4,13 +4,15 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use anyhow::{Context, Result, bail};
 use reqwest::Client;
 use serde_json::{Value, json};
-use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::process::Command;
 use tokio::sync::mpsc;
 
 use crate::cli::WrapArgs;
 
 const BATCH_SIZE: usize = 64;
+const READ_BUFFER_SIZE: usize = 8 * 1024;
+const MAX_LOG_BODY_BYTES: usize = 16 * 1024;
 const FLUSH_INTERVAL: Duration = Duration::from_millis(200);
 const EXPORT_TIMEOUT: Duration = Duration::from_secs(5);
 const EXPORT_DRAIN_TIMEOUT: Duration = Duration::from_secs(1);
@@ -92,20 +94,22 @@ where
     R: AsyncRead + Unpin,
     W: AsyncWrite + Unpin,
 {
-    let mut reader = BufReader::new(reader);
-    let mut buf = Vec::new();
+    let mut reader = reader;
+    let mut buf = [0_u8; READ_BUFFER_SIZE];
+    let mut recorder = StreamLogRecorder::new(stream, records_tx);
 
     loop {
-        buf.clear();
         let read = reader
-            .read_until(b'\n', &mut buf)
+            .read(&mut buf)
             .await
             .with_context(|| format!("read wrapped {stream}"))?;
         if read == 0 {
+            recorder.finish();
             return Ok(());
         }
 
-        if let Err(err) = writer.write_all(&buf).await {
+        let chunk = &buf[..read];
+        if let Err(err) = writer.write_all(chunk).await {
             if err.kind() == std::io::ErrorKind::BrokenPipe {
                 return Ok(());
             }
@@ -118,7 +122,48 @@ where
             return Err(err).with_context(|| format!("flush wrapped {stream}"));
         }
 
-        try_queue_record(&records_tx, LogRecord::line(stream, &buf));
+        recorder.record(chunk);
+    }
+}
+
+struct StreamLogRecorder {
+    stream: &'static str,
+    records_tx: mpsc::Sender<LogRecord>,
+    pending: Vec<u8>,
+}
+
+impl StreamLogRecorder {
+    fn new(stream: &'static str, records_tx: mpsc::Sender<LogRecord>) -> Self {
+        Self {
+            stream,
+            records_tx,
+            pending: Vec::new(),
+        }
+    }
+
+    fn record(&mut self, bytes: &[u8]) {
+        for part in bytes.split_inclusive(|byte| *byte == b'\n') {
+            self.pending.extend_from_slice(part);
+            if part.ends_with(b"\n") || self.pending.len() >= MAX_LOG_BODY_BYTES {
+                self.flush();
+            }
+        }
+    }
+
+    fn finish(&mut self) {
+        self.flush();
+    }
+
+    fn flush(&mut self) {
+        if self.pending.is_empty() {
+            return;
+        }
+
+        try_queue_record(
+            &self.records_tx,
+            LogRecord::line(self.stream, &self.pending),
+        );
+        self.pending.clear();
     }
 }
 

--- a/packages/desktop-app/src-cli/src/wrap.rs
+++ b/packages/desktop-app/src-cli/src/wrap.rs
@@ -1,0 +1,367 @@
+use std::process::Stdio;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result, bail};
+use reqwest::Client;
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
+use tokio::process::Command;
+use tokio::sync::mpsc;
+
+use crate::cli::WrapArgs;
+
+const BATCH_SIZE: usize = 64;
+const FLUSH_INTERVAL: Duration = Duration::from_millis(200);
+const EXPORT_TIMEOUT: Duration = Duration::from_secs(5);
+const COLLECTOR_UNAVAILABLE: &str =
+    "telemetry collector isn't running — run `everr telemetry start` or open Everr Desktop";
+
+pub async fn run(args: WrapArgs) -> Result<()> {
+    let command = WrappedCommand::new(args.command)?;
+    let exporter = OtlpLogExporter::new(command.clone());
+    if exporter.probe().await.is_err() {
+        eprintln!("{COLLECTOR_UNAVAILABLE}");
+        std::process::exit(2);
+    }
+
+    let mut child = Command::new(&command.program)
+        .args(&command.args)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .with_context(|| format!("run wrapped command `{}`", command.display))?;
+
+    let stdout = child.stdout.take().context("capture wrapped stdout")?;
+    let stderr = child.stderr.take().context("capture wrapped stderr")?;
+    let (records_tx, records_rx) = mpsc::channel(BATCH_SIZE * 4);
+    let export_task = tokio::spawn(export_records(exporter, records_rx));
+
+    let stdout_task = tokio::spawn(forward_stream(
+        stdout,
+        tokio::io::stdout(),
+        "stdout",
+        records_tx.clone(),
+    ));
+    let stderr_task = tokio::spawn(forward_stream(
+        stderr,
+        tokio::io::stderr(),
+        "stderr",
+        records_tx.clone(),
+    ));
+
+    let status = child.wait().await.context("wait for wrapped command")?;
+    stdout_task
+        .await
+        .context("stdout forwarding task failed")??;
+    stderr_task
+        .await
+        .context("stderr forwarding task failed")??;
+
+    let exit_code = exit_code_for_status(&status);
+    let _ = records_tx.send(LogRecord::exit(exit_code)).await;
+    drop(records_tx);
+
+    if let Err(err) = export_task.await.context("log export task failed")? {
+        eprintln!("everr wrap: failed to send some logs to the local collector: {err}");
+    }
+
+    if status.success() {
+        return Ok(());
+    }
+
+    std::process::exit(exit_code);
+}
+
+async fn forward_stream<R, W>(
+    reader: R,
+    mut writer: W,
+    stream: &'static str,
+    records_tx: mpsc::Sender<LogRecord>,
+) -> Result<()>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut reader = BufReader::new(reader);
+    let mut buf = Vec::new();
+
+    loop {
+        buf.clear();
+        let read = reader
+            .read_until(b'\n', &mut buf)
+            .await
+            .with_context(|| format!("read wrapped {stream}"))?;
+        if read == 0 {
+            return Ok(());
+        }
+
+        writer
+            .write_all(&buf)
+            .await
+            .with_context(|| format!("write wrapped {stream}"))?;
+        writer
+            .flush()
+            .await
+            .with_context(|| format!("flush wrapped {stream}"))?;
+
+        let _ = records_tx.send(LogRecord::line(stream, &buf)).await;
+    }
+}
+
+async fn export_records(
+    exporter: OtlpLogExporter,
+    mut records_rx: mpsc::Receiver<LogRecord>,
+) -> Result<()> {
+    let mut batch = Vec::with_capacity(BATCH_SIZE);
+    let mut ticker = tokio::time::interval(FLUSH_INTERVAL);
+    let mut first_error = None;
+
+    loop {
+        tokio::select! {
+            maybe_record = records_rx.recv() => {
+                match maybe_record {
+                    Some(record) => {
+                        batch.push(record);
+                        if batch.len() >= BATCH_SIZE {
+                            flush_batch(&exporter, &mut batch, &mut first_error).await;
+                        }
+                    }
+                    None => {
+                        flush_batch(&exporter, &mut batch, &mut first_error).await;
+                        return match first_error {
+                            Some(err) => Err(err),
+                            None => Ok(()),
+                        };
+                    }
+                }
+            }
+            _ = ticker.tick() => {
+                flush_batch(&exporter, &mut batch, &mut first_error).await;
+            }
+        }
+    }
+}
+
+async fn flush_batch(
+    exporter: &OtlpLogExporter,
+    batch: &mut Vec<LogRecord>,
+    first_error: &mut Option<anyhow::Error>,
+) {
+    if batch.is_empty() {
+        return;
+    }
+
+    let records = std::mem::take(batch);
+    if let Err(err) = exporter.send(&records).await {
+        if first_error.is_none() {
+            *first_error = Some(err);
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct WrappedCommand {
+    program: String,
+    args: Vec<String>,
+    display: String,
+}
+
+impl WrappedCommand {
+    fn new(command: Vec<String>) -> Result<Self> {
+        let mut parts = command.into_iter();
+        let program = parts.next().context("provide a command to wrap")?;
+        let args: Vec<String> = parts.collect();
+        let display = std::iter::once(program.as_str())
+            .chain(args.iter().map(String::as_str))
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        Ok(Self {
+            program,
+            args,
+            display,
+        })
+    }
+
+    fn service_name(&self) -> String {
+        format!("everr-wrap-{}", self.program)
+    }
+}
+
+#[derive(Clone)]
+struct OtlpLogExporter {
+    http: Client,
+    endpoint: String,
+    command: WrappedCommand,
+}
+
+impl OtlpLogExporter {
+    fn new(command: WrappedCommand) -> Self {
+        Self {
+            http: Client::builder()
+                .timeout(EXPORT_TIMEOUT)
+                .build()
+                .expect("reqwest client"),
+            endpoint: format!("{}/v1/logs", everr_core::build::otlp_http_origin()),
+            command,
+        }
+    }
+
+    async fn probe(&self) -> Result<()> {
+        self.post(json!({ "resourceLogs": [] })).await
+    }
+
+    async fn send(&self, records: &[LogRecord]) -> Result<()> {
+        if records.is_empty() {
+            return Ok(());
+        }
+
+        self.post(self.payload(records)).await
+    }
+
+    async fn post(&self, payload: Value) -> Result<()> {
+        let response = self
+            .http
+            .post(&self.endpoint)
+            .json(&payload)
+            .send()
+            .await
+            .with_context(|| format!("POST {}", self.endpoint))?;
+        let status = response.status();
+        if status.is_success() {
+            return Ok(());
+        }
+
+        let body = response.text().await.unwrap_or_default();
+        bail!("collector returned {status}: {body}");
+    }
+
+    fn payload(&self, records: &[LogRecord]) -> Value {
+        json!({
+            "resourceLogs": [{
+                "resource": {
+                    "attributes": [
+                        attr("service.name", &self.command.service_name()),
+                        attr("service.version", env!("EVERR_VERSION")),
+                        attr("deployment.environment", everr_core::build::build_type_label()),
+                    ],
+                },
+                "scopeLogs": [{
+                    "scope": {
+                        "name": "everr-cli.wrap",
+                    },
+                    "logRecords": records.iter().map(|record| self.log_record(record)).collect::<Vec<_>>(),
+                }],
+            }],
+        })
+    }
+
+    fn log_record(&self, record: &LogRecord) -> Value {
+        let mut attrs = vec![
+            attr("everr.wrap.stream", record.stream),
+            attr("everr.wrap.command", &self.command.display),
+            attr("everr.wrap.executable", &self.command.program),
+        ];
+        if let Some(exit_code) = record.exit_code {
+            attrs.push(attr("everr.wrap.exit_code", &exit_code.to_string()));
+        }
+
+        json!({
+            "timeUnixNano": record.time_unix_nano,
+            "observedTimeUnixNano": record.time_unix_nano,
+            "severityText": record.severity_text,
+            "severityNumber": record.severity_number,
+            "body": {
+                "stringValue": record.body,
+            },
+            "attributes": attrs,
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+struct LogRecord {
+    time_unix_nano: String,
+    stream: &'static str,
+    severity_text: &'static str,
+    severity_number: u8,
+    body: String,
+    exit_code: Option<i32>,
+}
+
+impl LogRecord {
+    fn line(stream: &'static str, bytes: &[u8]) -> Self {
+        let body = line_body(bytes);
+        let (severity_text, severity_number) = match stream {
+            "stderr" => ("ERROR", 17),
+            _ => ("INFO", 9),
+        };
+
+        Self {
+            time_unix_nano: time_unix_nano(),
+            stream,
+            severity_text,
+            severity_number,
+            body,
+            exit_code: None,
+        }
+    }
+
+    fn exit(exit_code: i32) -> Self {
+        let (severity_text, severity_number) = if exit_code == 0 {
+            ("INFO", 9)
+        } else {
+            ("ERROR", 17)
+        };
+
+        Self {
+            time_unix_nano: time_unix_nano(),
+            stream: "exit",
+            severity_text,
+            severity_number,
+            body: format!("wrapped command exited with code {exit_code}"),
+            exit_code: Some(exit_code),
+        }
+    }
+}
+
+fn attr(key: &str, value: &str) -> Value {
+    json!({
+        "key": key,
+        "value": {
+            "stringValue": value,
+        },
+    })
+}
+
+fn line_body(bytes: &[u8]) -> String {
+    let bytes = bytes.strip_suffix(b"\n").unwrap_or(bytes);
+    let bytes = bytes.strip_suffix(b"\r").unwrap_or(bytes);
+    String::from_utf8_lossy(bytes).to_string()
+}
+
+fn time_unix_nano() -> String {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos().to_string())
+        .unwrap_or_else(|_| "0".to_string())
+}
+
+fn exit_code_for_status(status: &std::process::ExitStatus) -> i32 {
+    if let Some(code) = status.code() {
+        return code;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+
+        if let Some(signal) = status.signal() {
+            return 128 + signal;
+        }
+    }
+
+    1
+}

--- a/packages/desktop-app/src-cli/src/wrap.rs
+++ b/packages/desktop-app/src-cli/src/wrap.rs
@@ -13,6 +13,7 @@ use crate::cli::WrapArgs;
 const BATCH_SIZE: usize = 64;
 const FLUSH_INTERVAL: Duration = Duration::from_millis(200);
 const EXPORT_TIMEOUT: Duration = Duration::from_secs(5);
+const EXPORT_DRAIN_TIMEOUT: Duration = Duration::from_secs(1);
 const COLLECTOR_UNAVAILABLE: &str =
     "telemetry collector isn't running — run `everr telemetry start` or open Everr Desktop";
 
@@ -60,11 +61,18 @@ pub async fn run(args: WrapArgs) -> Result<()> {
         .context("stderr forwarding task failed")??;
 
     let exit_code = exit_code_for_status(&status);
-    let _ = records_tx.send(LogRecord::exit(exit_code)).await;
+    try_queue_record(&records_tx, LogRecord::exit(exit_code));
     drop(records_tx);
 
-    if let Err(err) = export_task.await.context("log export task failed")? {
-        eprintln!("everr wrap: failed to send some logs to the local collector: {err}");
+    match tokio::time::timeout(EXPORT_DRAIN_TIMEOUT, export_task).await {
+        Ok(join_result) => {
+            if let Err(err) = join_result.context("log export task failed")? {
+                eprintln!("everr wrap: failed to send some logs to the local collector: {err}");
+            }
+        }
+        Err(_) => {
+            eprintln!("everr wrap: timed out sending some logs to the local collector");
+        }
     }
 
     if status.success() {
@@ -97,17 +105,25 @@ where
             return Ok(());
         }
 
-        writer
-            .write_all(&buf)
-            .await
-            .with_context(|| format!("write wrapped {stream}"))?;
-        writer
-            .flush()
-            .await
-            .with_context(|| format!("flush wrapped {stream}"))?;
+        if let Err(err) = writer.write_all(&buf).await {
+            if err.kind() == std::io::ErrorKind::BrokenPipe {
+                return Ok(());
+            }
+            return Err(err).with_context(|| format!("write wrapped {stream}"));
+        }
+        if let Err(err) = writer.flush().await {
+            if err.kind() == std::io::ErrorKind::BrokenPipe {
+                return Ok(());
+            }
+            return Err(err).with_context(|| format!("flush wrapped {stream}"));
+        }
 
-        let _ = records_tx.send(LogRecord::line(stream, &buf)).await;
+        try_queue_record(&records_tx, LogRecord::line(stream, &buf));
     }
+}
+
+fn try_queue_record(records_tx: &mpsc::Sender<LogRecord>, record: LogRecord) {
+    let _ = records_tx.try_send(record);
 }
 
 async fn export_records(

--- a/packages/desktop-app/src-cli/tests/help_output.rs
+++ b/packages/desktop-app/src-cli/tests/help_output.rs
@@ -27,6 +27,7 @@ fn root_help_lists_main_commands() {
         .stdout(contains("runs"))
         .stdout(contains("show"))
         .stdout(contains("logs"))
+        .stdout(contains("wrap"))
         .stdout(contains("telemetry"));
 }
 
@@ -102,6 +103,20 @@ fn telemetry_help_lists_start_command() {
         .assert()
         .success()
         .stdout(contains("--quiet"));
+}
+
+#[test]
+fn wrap_help_describes_command_capture() {
+    let env = CliTestEnv::new();
+
+    env.command()
+        .args(["wrap", "--help"])
+        .assert()
+        .success()
+        .stdout(contains("<COMMAND>"))
+        .stdout(contains(
+            "send its stdout/stderr logs to the local collector",
+        ));
 }
 
 #[test]

--- a/packages/desktop-app/src-cli/tests/wrap_command.rs
+++ b/packages/desktop-app/src-cli/tests/wrap_command.rs
@@ -2,9 +2,10 @@ mod support;
 
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
+use std::process::{Command as ProcessCommand, Stdio};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use predicates::str::{contains, diff};
 use support::CliTestEnv;
@@ -83,6 +84,80 @@ fn wrap_refuses_to_run_when_collector_is_unavailable() {
         .stderr(contains("telemetry collector isn't running"));
 }
 
+#[test]
+fn wrap_exits_when_stdout_consumer_closes_pipe() {
+    let collector = OtlpLogServer::start();
+    let env = CliTestEnv::new();
+    let mut wrapped = everr_process(&env, collector.origin())
+        .args([
+            "wrap",
+            "--",
+            "sh",
+            "-c",
+            "i=0; while [ $i -lt 200000 ]; do echo y; i=$((i + 1)); done",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn wrapped command");
+    let wrapped_stdout = wrapped.stdout.take().expect("wrapped stdout");
+    let mut wrapped_stderr = wrapped.stderr.take().expect("wrapped stderr");
+
+    let mut head = ProcessCommand::new("head")
+        .args(["-n", "1"])
+        .stdin(Stdio::from(wrapped_stdout))
+        .stdout(Stdio::null())
+        .spawn()
+        .expect("spawn head");
+
+    let head_status = head.wait().expect("wait for head");
+    assert!(head_status.success(), "head failed: {head_status}");
+
+    let status = wait_for_child(&mut wrapped, Duration::from_secs(3))
+        .expect("wrap should exit after stdout pipe closes");
+    assert!(
+        !status.success(),
+        "wrap should report the closed output pipe"
+    );
+
+    let mut stderr = String::new();
+    wrapped_stderr
+        .read_to_string(&mut stderr)
+        .expect("read wrapped stderr");
+    assert!(
+        !stderr.contains("stdout forwarding task failed") && !stderr.contains("Broken pipe"),
+        "wrap should not print an internal pipe error, got: {stderr}"
+    );
+}
+
+#[test]
+fn slow_collector_does_not_throttle_wrapped_output() {
+    let collector = OtlpLogServer::start_with_non_probe_delay(Duration::from_millis(300));
+    let env = CliTestEnv::new();
+    let started = Instant::now();
+    let mut wrapped = everr_process(&env, collector.origin())
+        .args([
+            "wrap",
+            "--",
+            "sh",
+            "-c",
+            "i=0; while [ $i -lt 2000 ]; do echo line-$i; i=$((i + 1)); done",
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn wrapped command");
+
+    let status = wait_for_child(&mut wrapped, Duration::from_secs(3))
+        .expect("wrap should not wait for collector queue space while reading output");
+    assert!(status.success(), "wrapped command failed: {status}");
+    assert!(
+        started.elapsed() < Duration::from_secs(3),
+        "wrap took too long: {:?}",
+        started.elapsed()
+    );
+}
+
 struct OtlpLogServer {
     origin: String,
     bodies: Arc<Mutex<Vec<String>>>,
@@ -90,6 +165,14 @@ struct OtlpLogServer {
 
 impl OtlpLogServer {
     fn start() -> Self {
+        Self::start_with_delay(None)
+    }
+
+    fn start_with_non_probe_delay(delay: Duration) -> Self {
+        Self::start_with_delay(Some(delay))
+    }
+
+    fn start_with_delay(response_delay_non_probe: Option<Duration>) -> Self {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind OTLP test server");
         let origin = format!("http://{}", listener.local_addr().expect("server addr"));
         let bodies = Arc::new(Mutex::new(Vec::new()));
@@ -105,6 +188,11 @@ impl OtlpLogServer {
                 match listener.accept() {
                     Ok((mut stream, _)) => {
                         if let Some(body) = read_request_body(&mut stream) {
+                            if !is_probe_body(&body) {
+                                if let Some(delay) = response_delay_non_probe {
+                                    thread::sleep(delay);
+                                }
+                            }
                             thread_bodies.lock().expect("lock bodies").push(body);
                         }
                         write_ok(&mut stream);
@@ -134,6 +222,32 @@ impl OtlpLogServer {
             thread::sleep(Duration::from_millis(10));
         }
     }
+}
+
+fn everr_process(env: &CliTestEnv, collector_origin: &str) -> ProcessCommand {
+    let mut command = ProcessCommand::new(assert_cmd::cargo::cargo_bin!("everr"));
+    command.env("HOME", &env.home_dir);
+    command.env("XDG_CONFIG_HOME", &env.config_dir);
+    command.env("XDG_DATA_HOME", env.home_dir.join(".local").join("share"));
+    command.env("EVERR_OTLP_HTTP_ORIGIN", collector_origin);
+    command
+}
+
+fn wait_for_child(
+    child: &mut std::process::Child,
+    timeout: Duration,
+) -> Option<std::process::ExitStatus> {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if let Some(status) = child.try_wait().expect("poll child") {
+            return Some(status);
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+    None
 }
 
 fn read_request_body(stream: &mut TcpStream) -> Option<String> {
@@ -191,4 +305,8 @@ fn write_ok(stream: &mut TcpStream) {
     stream
         .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}")
         .expect("write response");
+}
+
+fn is_probe_body(body: &str) -> bool {
+    body.trim() == r#"{"resourceLogs":[]}"#
 }

--- a/packages/desktop-app/src-cli/tests/wrap_command.rs
+++ b/packages/desktop-app/src-cli/tests/wrap_command.rs
@@ -3,7 +3,7 @@ mod support;
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::process::{Command as ProcessCommand, Stdio};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -56,6 +56,52 @@ fn wrap_preserves_output_and_sends_logs_to_collector() {
             .any(|body| body.contains(r#""service.name""#) && body.contains("everr-wrap-sh")),
         "expected command-specific service name, got: {bodies:#?}"
     );
+}
+
+#[test]
+fn wrap_forwards_partial_output_before_newline() {
+    let collector = OtlpLogServer::start();
+    let env = CliTestEnv::new();
+    let mut wrapped = everr_process(&env, collector.origin())
+        .args([
+            "wrap",
+            "--",
+            "sh",
+            "-c",
+            "printf partial; sleep 3; printf ' done\\n'",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn wrapped command");
+    let mut wrapped_stdout = wrapped.stdout.take().expect("wrapped stdout");
+
+    let (first_tx, first_rx) = mpsc::channel();
+    let reader = thread::spawn(move || {
+        let mut first = [0_u8; 7];
+        let result = wrapped_stdout
+            .read_exact(&mut first)
+            .map(|_| String::from_utf8_lossy(&first).to_string());
+        let _ = first_tx.send(result);
+
+        let mut rest = String::new();
+        let _ = wrapped_stdout.read_to_string(&mut rest);
+        rest
+    });
+
+    match first_rx.recv_timeout(Duration::from_millis(1500)) {
+        Ok(Ok(output)) => assert_eq!(output, "partial"),
+        Ok(Err(err)) => panic!("read partial output: {err}"),
+        Err(err) => {
+            let _ = wrapped.kill();
+            let _ = wrapped.wait();
+            panic!("partial output was not forwarded before newline: {err}");
+        }
+    }
+
+    let status = wrapped.wait().expect("wait for wrapped command");
+    assert!(status.success(), "wrapped command failed: {status}");
+    assert_eq!(reader.join().expect("join stdout reader"), " done\n");
 }
 
 #[test]

--- a/packages/desktop-app/src-cli/tests/wrap_command.rs
+++ b/packages/desktop-app/src-cli/tests/wrap_command.rs
@@ -56,6 +56,18 @@ fn wrap_preserves_output_and_sends_logs_to_collector() {
             .any(|body| body.contains(r#""service.name""#) && body.contains("everr-wrap-sh")),
         "expected command-specific service name, got: {bodies:#?}"
     );
+    assert!(
+        bodies
+            .iter()
+            .all(|body| !body.contains(r#""service.version""#)),
+        "wrap payload should not include service.version, got: {bodies:#?}"
+    );
+    assert!(
+        bodies
+            .iter()
+            .all(|body| !body.contains(r#""deployment.environment""#)),
+        "wrap payload should not include deployment.environment, got: {bodies:#?}"
+    );
 }
 
 #[test]

--- a/packages/desktop-app/src-cli/tests/wrap_command.rs
+++ b/packages/desktop-app/src-cli/tests/wrap_command.rs
@@ -1,0 +1,194 @@
+mod support;
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use predicates::str::{contains, diff};
+use support::CliTestEnv;
+
+#[test]
+fn wrap_preserves_output_and_sends_logs_to_collector() {
+    let collector = OtlpLogServer::start();
+    let env = CliTestEnv::new();
+
+    env.command()
+        .env("EVERR_OTLP_HTTP_ORIGIN", collector.origin())
+        .args([
+            "wrap",
+            "--",
+            "sh",
+            "-c",
+            "printf 'hello stdout\\n'; printf 'hello stderr\\n' >&2",
+        ])
+        .assert()
+        .success()
+        .stdout(diff("hello stdout\n"))
+        .stderr(diff("hello stderr\n"));
+
+    let bodies = collector.bodies();
+    assert!(
+        bodies.iter().any(|body| body.contains("hello stdout")),
+        "expected stdout log in OTLP payloads, got: {bodies:#?}"
+    );
+    assert!(
+        bodies.iter().any(|body| body.contains("hello stderr")),
+        "expected stderr log in OTLP payloads, got: {bodies:#?}"
+    );
+    assert!(
+        bodies
+            .iter()
+            .any(|body| body.contains(r#""everr.wrap.stream""#) && body.contains("stdout")),
+        "expected stdout stream attribute, got: {bodies:#?}"
+    );
+    assert!(
+        bodies
+            .iter()
+            .any(|body| body.contains(r#""everr.wrap.stream""#) && body.contains("stderr")),
+        "expected stderr stream attribute, got: {bodies:#?}"
+    );
+    assert!(
+        bodies
+            .iter()
+            .any(|body| body.contains(r#""service.name""#) && body.contains("everr-wrap-sh")),
+        "expected command-specific service name, got: {bodies:#?}"
+    );
+}
+
+#[test]
+fn wrap_preserves_wrapped_command_exit_code() {
+    let collector = OtlpLogServer::start();
+    let env = CliTestEnv::new();
+
+    env.command()
+        .env("EVERR_OTLP_HTTP_ORIGIN", collector.origin())
+        .args(["wrap", "--", "sh", "-c", "printf 'before fail\\n'; exit 7"])
+        .assert()
+        .code(7)
+        .stdout(diff("before fail\n"));
+}
+
+#[test]
+fn wrap_refuses_to_run_when_collector_is_unavailable() {
+    let env = CliTestEnv::new();
+
+    env.command()
+        .env("EVERR_OTLP_HTTP_ORIGIN", "http://127.0.0.1:9")
+        .args(["wrap", "--", "sh", "-c", "printf 'should not run\\n'"])
+        .assert()
+        .code(2)
+        .stdout(diff(""))
+        .stderr(contains("telemetry collector isn't running"));
+}
+
+struct OtlpLogServer {
+    origin: String,
+    bodies: Arc<Mutex<Vec<String>>>,
+}
+
+impl OtlpLogServer {
+    fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind OTLP test server");
+        let origin = format!("http://{}", listener.local_addr().expect("server addr"));
+        let bodies = Arc::new(Mutex::new(Vec::new()));
+        let thread_bodies = Arc::clone(&bodies);
+
+        thread::spawn(move || {
+            listener
+                .set_nonblocking(true)
+                .expect("set listener nonblocking");
+            let deadline = std::time::Instant::now() + Duration::from_secs(10);
+
+            while std::time::Instant::now() < deadline {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        if let Some(body) = read_request_body(&mut stream) {
+                            thread_bodies.lock().expect("lock bodies").push(body);
+                        }
+                        write_ok(&mut stream);
+                    }
+                    Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        Self { origin, bodies }
+    }
+
+    fn origin(&self) -> &str {
+        &self.origin
+    }
+
+    fn bodies(&self) -> Vec<String> {
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            let current = self.bodies.lock().expect("lock bodies").clone();
+            if current.len() >= 2 || std::time::Instant::now() >= deadline {
+                return current;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+}
+
+fn read_request_body(stream: &mut TcpStream) -> Option<String> {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(1)))
+        .expect("set read timeout");
+
+    let mut buf = Vec::new();
+    let mut chunk = [0_u8; 1024];
+    let mut header_len = None;
+
+    while header_len.is_none() {
+        let read = stream.read(&mut chunk).expect("read request");
+        if read == 0 {
+            return None;
+        }
+        buf.extend_from_slice(&chunk[..read]);
+        header_len = find_header_end(&buf);
+    }
+
+    let header_len = header_len.expect("header end");
+    let header_text = String::from_utf8_lossy(&buf[..header_len]);
+    let content_length = header_text
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            if name.eq_ignore_ascii_case("content-length") {
+                value.trim().parse::<usize>().ok()
+            } else {
+                None
+            }
+        })
+        .unwrap_or(0);
+
+    let body_start = header_len + 4;
+    let body_read = buf.len().saturating_sub(body_start);
+    let mut remaining = content_length.saturating_sub(body_read);
+    while remaining > 0 {
+        let read = stream.read(&mut chunk).expect("read request body");
+        if read == 0 {
+            break;
+        }
+        buf.extend_from_slice(&chunk[..read]);
+        remaining = remaining.saturating_sub(read);
+    }
+
+    Some(String::from_utf8_lossy(&buf[body_start..]).to_string())
+}
+
+fn find_header_end(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|w| w == b"\r\n\r\n")
+}
+
+fn write_ok(stream: &mut TcpStream) {
+    stream
+        .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}")
+        .expect("write response");
+}

--- a/packages/docs/content/docs/cli/commands.mdx
+++ b/packages/docs/content/docs/cli/commands.mdx
@@ -52,6 +52,8 @@ Collection-style commands accept `--limit <n>` and `--offset <n>` for pagination
 - `everr telemetry query "<SQL>"` — query local telemetry with read-only SQL
 - `everr telemetry endpoint` — print the current local collector URL
 - `everr wrap -- <command>` — run a command normally and mirror stdout/stderr into local telemetry
+  - Requires a running collector; if unavailable, the command is not run
+  - Preserves the wrapped command's non-zero exit code
 
 ## Test Analytics
 

--- a/packages/docs/content/docs/cli/commands.mdx
+++ b/packages/docs/content/docs/cli/commands.mdx
@@ -46,6 +46,13 @@ description: Reference for all Everr CLI commands.
 
 Collection-style commands accept `--limit <n>` and `--offset <n>` for pagination.
 
+## Local Telemetry
+
+- `everr telemetry start` — start the local OpenTelemetry collector
+- `everr telemetry query "<SQL>"` — query local telemetry with read-only SQL
+- `everr telemetry endpoint` — print the current local collector URL
+- `everr wrap -- <command>` — run a command normally and mirror stdout/stderr into local telemetry
+
 ## Test Analytics
 
 - `everr test-history --test-name <name>` — show historical executions for a specific test

--- a/packages/docs/content/docs/cli/telemetry.mdx
+++ b/packages/docs/content/docs/cli/telemetry.mdx
@@ -45,6 +45,16 @@ Prints the collector URL for the current build.
 everr telemetry endpoint
 ```
 
+### `everr wrap`
+
+Runs a plain command normally and mirrors each stdout/stderr line into the local collector.
+
+```shell
+everr wrap -- npm test
+```
+
+Use this when a tool is not OpenTelemetry-instrumented yet but you still want its logs in `otel_logs`. The wrapped command keeps its normal terminal output and exit code, and its logs use `service.name = everr-wrap-<cmd>`.
+
 ### Pivoting between logs and traces
 
 Find a log of interest, grab its `TraceId`, and query the matching trace:
@@ -70,8 +80,12 @@ This writes a managed block to your project's `AGENTS.md` or `CLAUDE.md` contain
 
 If you manage your `AGENTS.md` / `CLAUDE.md` by hand, add this block:
 
+<!-- AI_INTEGRATION_SNIPPET_START -->
+
 ```markdown
 For debugging locally running OpenTelemetry-instrumented services — runtime errors, slow requests, or verifying instrumentation changes — or for adding new instrumentation to diagnose slowness, errors, or regressions: call `everr telemetry ai-instructions` for full usage.
 ```
+
+<!-- AI_INTEGRATION_SNIPPET_END -->
 
 The full body is intentionally not duplicated here — run `everr telemetry ai-instructions` to see what your assistant will read.

--- a/packages/docs/content/docs/cli/telemetry.mdx
+++ b/packages/docs/content/docs/cli/telemetry.mdx
@@ -55,6 +55,8 @@ everr wrap -- npm test
 
 Use this when a tool is not OpenTelemetry-instrumented yet but you still want its logs in `otel_logs`. The wrapped command keeps its normal terminal output and exit code, and its logs use `service.name = everr-wrap-<cmd>`.
 
+The local collector must already be running. If the collector is unavailable, `everr wrap` exits without running the command. If the wrapped command exits with a non-zero code, `everr wrap` exits with the same code after forwarding its output and attempting to send its logs.
+
 ### Pivoting between logs and traces
 
 Find a log of interest, grab its `TraceId`, and query the matching trace:


### PR DESCRIPTION
## Summary

- Add `everr wrap -- <command>` to run a local command while mirroring stdout and stderr into the local OTLP collector.
- Preserve the wrapped command's normal terminal output and process exit code.
- Generate command-specific service names like `everr-wrap-cargo` from the wrapped executable so logs can be queried by `ServiceName`.
- Mark wrapped stderr lines as error log records while stdout lines remain info records.
- Emit a final exit log record with `everr.wrap.stream = exit`, `everr.wrap.exit_code = <code>`, and a body like `wrapped command exited with code <code>`.
- Update CLI help, telemetry AI instructions, and docs for the new command.

## Validation

- `cargo test -p everr-cli`
- `cargo test -p everr-core`
