### PR TITLE
Support Linux CLI builds

### DIFF
--- a/.github/workflows/build-everr-cli.yml
+++ b/.github/workflows/build-everr-cli.yml
@@ -12,22 +12,26 @@ on:
     paths:
       - .github/workflows/build-everr-cli.yml
       - packages/desktop-app/src-cli/**
-      - packages/desktop-app/scripts/build-cli.sh
+      - packages/desktop-app/scripts/build-cli.ts
+      - packages/desktop-app/scripts/build-support.ts
       - crates/everr-core/**
       - Makefile
       - packages/docs/Dockerfile
       - packages/docs/public/install.sh
+      - packages/docs/public/install-dev.sh
       - packages/docs/content/docs/cli/**
   push:
     branches: [main]
     paths:
       - .github/workflows/build-everr-cli.yml
       - packages/desktop-app/src-cli/**
-      - packages/desktop-app/scripts/build-cli.sh
+      - packages/desktop-app/scripts/build-cli.ts
+      - packages/desktop-app/scripts/build-support.ts
       - crates/everr-core/**
       - Makefile
       - packages/docs/Dockerfile
       - packages/docs/public/install.sh
+      - packages/docs/public/install-dev.sh
       - packages/docs/content/docs/cli/**
 
 jobs:

--- a/.github/workflows/deploy-desktop-app.yml
+++ b/.github/workflows/deploy-desktop-app.yml
@@ -165,7 +165,7 @@ jobs:
 
           app_path="$(find target/release/bundle/macos packages/desktop-app/src-tauri/target/release/bundle/macos -maxdepth 1 -name 'Everr.app' -print -quit 2>/dev/null || true)"
           dmg_path="target/desktop-release/everr-app/everr-macos-arm64.dmg"
-          cli_path="target/desktop-release/everr"
+          cli_path="target/desktop-release/everr-macos-arm64"
 
           if [[ -z "$app_path" ]]; then
             echo "Could not find the built Everr.app bundle."
@@ -178,6 +178,128 @@ jobs:
           spctl --assess --type open --context context:primary-signature --verbose "$dmg_path"
           xcrun stapler validate "$app_path"
           xcrun stapler validate "$dmg_path"
+
+      - name: Upload macOS release artifact
+        id: upload-macos-release
+        uses: actions/upload-artifact@v4
+        with:
+          name: everr-desktop-release-macos-${{ github.sha }}
+          path: target/desktop-release
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Delete temporary keychain
+        if: always()
+        run: |
+          set -euo pipefail
+          if [[ -n "${APPLE_KEYCHAIN_PATH:-}" && -f "$APPLE_KEYCHAIN_PATH" ]]; then
+            security delete-keychain "$APPLE_KEYCHAIN_PATH"
+          fi
+
+  build-linux-cli:
+    name: Build Linux CLI (${{ matrix.asset }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - asset: everr-linux-x64
+            runner: blacksmith-2vcpu-ubuntu-2404
+          - asset: everr-linux-arm64
+            runner: blacksmith-2vcpu-ubuntu-2404-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Collect resource usage
+        uses: ./.github/actions/everr-resource-usage
+        with:
+          check-run-id: ${{ job.check_run_id }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: . -> target
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: collector/go.mod
+          cache-dependency-path: |
+            collector/**/go.sum
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build release CLI
+        run: pnpm --dir packages/desktop-app build:cli:release
+
+      - name: Verify staged CLI artifact
+        run: |
+          set -euo pipefail
+          test -x "packages/docs/public/${{ matrix.asset }}"
+          test -f "packages/docs/public/${{ matrix.asset }}.sha256"
+
+      - name: Upload Linux CLI artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: everr-cli-${{ matrix.asset }}
+          path: |
+            packages/docs/public/${{ matrix.asset }}
+            packages/docs/public/${{ matrix.asset }}.sha256
+          if-no-files-found: error
+          retention-days: 14
+
+  assemble-release:
+    name: Assemble Release Artifact
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    needs:
+      - build
+      - build-linux-cli
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download macOS release artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: everr-desktop-release-macos-${{ github.sha }}
+          path: target/desktop-release
+
+      - name: Download Linux CLI artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: everr-cli-everr-linux-*
+          path: target/desktop-release
+          merge-multiple: true
+
+      - name: Finalize release metadata
+        run: node packages/desktop-app/scripts/finalize-desktop-release-artifacts.ts
 
       - name: Attest release artifact checksums
         uses: actions/attest@v4
@@ -207,18 +329,10 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Delete temporary keychain
-        if: always()
-        run: |
-          set -euo pipefail
-          if [[ -n "${APPLE_KEYCHAIN_PATH:-}" && -f "$APPLE_KEYCHAIN_PATH" ]]; then
-            security delete-keychain "$APPLE_KEYCHAIN_PATH"
-          fi
-
   notify-deploy:
     name: Notify Deploy Repo
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    needs: build
+    needs: assemble-release
     steps:
       - name: Generate GitHub App token
         id: app-token

--- a/crates/everr-core/src/build.rs
+++ b/crates/everr-core/src/build.rs
@@ -133,7 +133,7 @@ pub fn telemetry_dir() -> anyhow::Result<PathBuf> {
     }
 
     let base = dirs::data_local_dir().context("failed to resolve user local data dir")?;
-    Ok(base.join(SESSION_NAMESPACE).join(TELEMETRY_SUBDIR))
+    Ok(telemetry_dir_from_data_local_dir(&base))
 }
 
 /// Resolve the sibling telemetry directory — used by the CLI for the
@@ -141,11 +141,19 @@ pub fn telemetry_dir() -> anyhow::Result<PathBuf> {
 /// build is debug, and vice versa.
 pub fn telemetry_dir_sibling() -> anyhow::Result<PathBuf> {
     let base = dirs::data_local_dir().context("failed to resolve user local data dir")?;
+    Ok(telemetry_dir_sibling_from_data_local_dir(&base))
+}
+
+pub fn telemetry_dir_from_data_local_dir(base: &std::path::Path) -> PathBuf {
+    base.join(SESSION_NAMESPACE).join(TELEMETRY_SUBDIR)
+}
+
+pub fn telemetry_dir_sibling_from_data_local_dir(base: &std::path::Path) -> PathBuf {
     #[cfg(debug_assertions)]
     let sibling = "telemetry";
     #[cfg(not(debug_assertions))]
     let sibling = "telemetry-dev";
-    Ok(base.join(SESSION_NAMESPACE).join(sibling))
+    base.join(SESSION_NAMESPACE).join(sibling)
 }
 
 #[cfg(test)]
@@ -175,6 +183,18 @@ mod tests {
         // On debug builds the last two components are `everr` then `telemetry-dev`.
         assert_eq!(components[0], "telemetry-dev");
         assert_eq!(components[1], "everr");
+    }
+
+    #[test]
+    fn telemetry_dir_uses_linux_data_home_layout() {
+        let dir = super::telemetry_dir_from_data_local_dir(std::path::Path::new(
+            "/home/alice/.local/share",
+        ));
+
+        assert_eq!(
+            dir,
+            std::path::Path::new("/home/alice/.local/share/everr/telemetry-dev")
+        );
     }
 
     #[test]

--- a/crates/everr-core/src/state.rs
+++ b/crates/everr-core/src/state.rs
@@ -114,7 +114,11 @@ impl AppStateStore {
 
     pub fn session_file_path(&self) -> Result<PathBuf> {
         let config_dir = dirs::config_dir().context("failed to resolve user config dir")?;
-        Ok(config_dir.join(&self.namespace).join(&self.state_file_name))
+        Ok(self.session_file_path_from_config_dir(&config_dir))
+    }
+
+    pub fn session_file_path_from_config_dir(&self, config_dir: &std::path::Path) -> PathBuf {
+        config_dir.join(&self.namespace).join(&self.state_file_name)
     }
 
     pub fn load_state(&self) -> Result<AppState> {
@@ -300,6 +304,18 @@ mod tests {
 
         assert_eq!(store.namespace(), "everr");
         assert_eq!(store.session_file_name(), "session-dev.json");
+    }
+
+    #[test]
+    fn session_file_path_uses_linux_config_home_layout() {
+        let store = AppStateStore::for_namespace("everr");
+        let path =
+            store.session_file_path_from_config_dir(std::path::Path::new("/home/alice/.config"));
+
+        assert_eq!(
+            path,
+            std::path::Path::new("/home/alice/.config/everr/session-dev.json")
+        );
     }
 
     #[test]

--- a/docs/desktop-release-secrets.md
+++ b/docs/desktop-release-secrets.md
@@ -120,6 +120,12 @@ It contains:
 ```text
 everr
 everr.sha256
+everr-macos-arm64
+everr-macos-arm64.sha256
+everr-linux-x64
+everr-linux-x64.sha256
+everr-linux-arm64
+everr-linux-arm64.sha256
 SHA256SUMS
 release-metadata.json
 everr-app/latest.json
@@ -128,8 +134,8 @@ everr-app/everr-macos-arm64.app.tar.gz
 everr-app/everr-macos-arm64.app.tar.gz.sig
 ```
 
-During deploy, the CLI files are published under `everr-app/everr` and `everr-app/everr.sha256`.
-The public installer still stays at `https://everr.dev/install.sh`, but it downloads those release-managed CLI files through the docs redirect route.
+During deploy, the CLI files are published under `everr-app/`.
+The public installer still stays at `https://everr.dev/install.sh`, but it chooses the matching release-managed CLI file for the current OS and CPU architecture through the docs redirect route.
 
 ## Pull From The Deploy Repo
 

--- a/packages/desktop-app/README.md
+++ b/packages/desktop-app/README.md
@@ -18,7 +18,8 @@ pnpm build:desktop
 
 That release command always builds both the macOS `app` and `dmg` bundle targets so Tauri can emit the signed updater archive alongside the DMG.
 It also runs the Tauri bundle step with `CI=true` so DMG generation skips Finder AppleScript setup and works reliably from the terminal.
-It stages the release DMG, updater archive, updater signature, `latest.json`, release metadata, checksums, and signed CLI files into `target/desktop-release/`.
+It stages the release DMG, updater archive, updater signature, `latest.json`, release metadata, checksums, and signed macOS CLI files into `target/desktop-release/`.
+The release workflow then adds Linux x64 and Linux arm64 CLI files before publishing the final artifact.
 
 CI uses the same release path through:
 

--- a/packages/desktop-app/scripts/build-support.test.ts
+++ b/packages/desktop-app/scripts/build-support.test.ts
@@ -7,9 +7,11 @@ import {
   CHDB_LIB_ASSET_NAME,
   CHDB_RELEASE_VERSION,
   chdbReleaseAssetUrl,
+  getCliReleaseTarget,
   defaultDesktopVersionPaths,
   publishCliArtifact,
   readDesktopTauriConfigVersion,
+  resolveChdbLibAsset,
   resolveDesktopReleaseIdentity,
   sha256File,
   type DesktopVersionPaths,
@@ -172,6 +174,20 @@ describe("build-support chDB helpers", () => {
     );
   });
 
+  it("uses the official Linux x64 chDB release asset", () => {
+    expect(resolveChdbLibAsset("linux", "x64")).toEqual({
+      assetName: "linux-x86_64-libchdb.tar.gz",
+      archiveSha256: "fb722f81c61c1fb2eb3511f17a5adc85b231f6bbc2415de6aea3ad9b73bb272e",
+    });
+  });
+
+  it("uses the official Linux arm64 chDB release asset", () => {
+    expect(resolveChdbLibAsset("linux", "arm64")).toEqual({
+      assetName: "linux-aarch64-libchdb.tar.gz",
+      archiveSha256: "ed43e29314f8337f858420354d88d5db4cce9c38155aff43f7816d1112cd7465",
+    });
+  });
+
   it("calculates sha256 for downloaded archives", async () => {
     const rootDir = await makeTempDir();
     const archivePath = path.join(rootDir, "archive.tar.gz");
@@ -184,16 +200,68 @@ describe("build-support chDB helpers", () => {
 });
 
 describe("build-support CLI artifact helpers", () => {
-  it("publishes one CLI binary and its checksum", async () => {
+  it("resolves supported CLI release artifact names", () => {
+    expect(getCliReleaseTarget("darwin", "arm64")).toEqual({
+      platform: "macos",
+      arch: "arm64",
+      binaryName: "everr-macos-arm64",
+      checksumName: "everr-macos-arm64.sha256",
+    });
+    expect(getCliReleaseTarget("linux", "x64")).toEqual({
+      platform: "linux",
+      arch: "x64",
+      binaryName: "everr-linux-x64",
+      checksumName: "everr-linux-x64.sha256",
+    });
+    expect(getCliReleaseTarget("linux", "arm64")).toEqual({
+      platform: "linux",
+      arch: "arm64",
+      binaryName: "everr-linux-arm64",
+      checksumName: "everr-linux-arm64.sha256",
+    });
+  });
+
+  it("rejects unsupported CLI release targets", () => {
+    expect(() => getCliReleaseTarget("darwin", "x64")).toThrow(/Unsupported CLI release target/);
+    expect(() => getCliReleaseTarget("linux", "arm")).toThrow(/Unsupported CLI release target/);
+  });
+
+  it("publishes a target-named CLI binary and its checksum", async () => {
     const rootDir = await makeTempDir();
     const sourceBin = path.join(rootDir, "built-everr");
     const outputDir = path.join(rootDir, "release");
 
     await writeFile(sourceBin, "cli bytes");
 
-    await expect(publishCliArtifact(sourceBin, { outputDir })).resolves.toEqual({
-      outputBin: path.join(outputDir, "everr"),
-      outputSha: path.join(outputDir, "everr.sha256"),
+    await expect(
+      publishCliArtifact(sourceBin, {
+        outputDir,
+        target: getCliReleaseTarget("linux", "x64"),
+      }),
+    ).resolves.toEqual({
+      outputBin: path.join(outputDir, "everr-linux-x64"),
+      outputSha: path.join(outputDir, "everr-linux-x64.sha256"),
+    });
+
+    await expect(readFile(path.join(outputDir, "everr-linux-x64"), "utf8")).resolves.toBe(
+      "cli bytes",
+    );
+    await expect(readFile(path.join(outputDir, "everr-linux-x64.sha256"), "utf8")).resolves.toBe(
+      "178893fed67c46f50c58cd77b698bb27649bee32019baa1e72b5142f9676e7a2  everr-linux-x64\n",
+    );
+  });
+
+  it("can publish legacy macOS CLI aliases for the existing install URL", async () => {
+    const rootDir = await makeTempDir();
+    const sourceBin = path.join(rootDir, "built-everr");
+    const outputDir = path.join(rootDir, "release");
+
+    await writeFile(sourceBin, "cli bytes");
+
+    await publishCliArtifact(sourceBin, {
+      outputDir,
+      target: getCliReleaseTarget("darwin", "arm64"),
+      writeLegacyAlias: true,
     });
 
     await expect(readFile(path.join(outputDir, "everr"), "utf8")).resolves.toBe("cli bytes");

--- a/packages/desktop-app/scripts/build-support.ts
+++ b/packages/desktop-app/scripts/build-support.ts
@@ -37,6 +37,55 @@ export const CHDB_LIB_ARCHIVE_SHA256 =
   "54b4da9c4d71f09b8a37e823a7addba392c4789a7034192a4863a1edd452f9e8";
 export const LOCAL_COLLECTOR_BIN_NAME = "everr-local-collector";
 export const CHDB_LIB_FILE_NAME = "libchdb.so";
+export const LEGACY_CLI_RELEASE_BINARY_NAME = "everr";
+
+export type ChdbLibAsset = {
+  assetName: string;
+  archiveSha256: string;
+};
+
+export type CliReleaseTarget = {
+  platform: "macos" | "linux";
+  arch: "arm64" | "x64";
+  binaryName: string;
+  checksumName: string;
+};
+
+export const CLI_RELEASE_TARGETS: CliReleaseTarget[] = [
+  {
+    platform: "macos",
+    arch: "arm64",
+    binaryName: "everr-macos-arm64",
+    checksumName: "everr-macos-arm64.sha256",
+  },
+  {
+    platform: "linux",
+    arch: "x64",
+    binaryName: "everr-linux-x64",
+    checksumName: "everr-linux-x64.sha256",
+  },
+  {
+    platform: "linux",
+    arch: "arm64",
+    binaryName: "everr-linux-arm64",
+    checksumName: "everr-linux-arm64.sha256",
+  },
+];
+
+const CHDB_LIB_ASSETS_BY_TARGET: Record<string, ChdbLibAsset> = {
+  "darwin:arm64": {
+    assetName: CHDB_LIB_ASSET_NAME,
+    archiveSha256: CHDB_LIB_ARCHIVE_SHA256,
+  },
+  "linux:x64": {
+    assetName: "linux-x86_64-libchdb.tar.gz",
+    archiveSha256: "fb722f81c61c1fb2eb3511f17a5adc85b231f6bbc2415de6aea3ad9b73bb272e",
+  },
+  "linux:arm64": {
+    assetName: "linux-aarch64-libchdb.tar.gz",
+    archiveSha256: "ed43e29314f8337f858420354d88d5db4cce9c38155aff43f7816d1112cd7465",
+  },
+};
 
 let didLoadEnvFile = false;
 
@@ -65,6 +114,56 @@ export function chdbReleaseAssetUrl(
   assetName = CHDB_LIB_ASSET_NAME,
 ) {
   return `https://github.com/chdb-io/chdb/releases/download/${version}/${assetName}`;
+}
+
+export function resolveChdbLibAsset(
+  platform = process.platform,
+  arch = process.arch,
+): ChdbLibAsset {
+  const asset = CHDB_LIB_ASSETS_BY_TARGET[`${platform}:${arch}`];
+  if (!asset) {
+    throw new Error(
+      `Bundled chDB resources are not supported on ${platform}/${arch}. Supported targets are macOS arm64, Linux x64, and Linux arm64.`,
+    );
+  }
+
+  return asset;
+}
+
+function normalizeCliReleasePlatform(platform: string) {
+  return platform === "darwin" ? "macos" : platform;
+}
+
+function normalizeCliReleaseArch(arch: string) {
+  switch (arch) {
+    case "amd64":
+    case "x86_64":
+      return "x64";
+    case "aarch64":
+      return "arm64";
+    default:
+      return arch;
+  }
+}
+
+export function getCliReleaseTarget(
+  platform = process.platform,
+  arch = process.arch,
+): CliReleaseTarget {
+  const normalizedPlatform = normalizeCliReleasePlatform(platform);
+  const normalizedArch = normalizeCliReleaseArch(arch);
+  const target = CLI_RELEASE_TARGETS.find(
+    (candidate) =>
+      candidate.platform === normalizedPlatform && candidate.arch === normalizedArch,
+  );
+
+  if (!target) {
+    throw new Error(
+      `Unsupported CLI release target: ${platform}/${arch}. Supported targets are macOS arm64, Linux x64, and Linux arm64.`,
+    );
+  }
+
+  return target;
 }
 
 export async function sha256File(filePath: string) {
@@ -98,16 +197,19 @@ async function findFileByName(rootDir: string, fileName: string): Promise<string
   return undefined;
 }
 
-async function downloadChdbArchive(archivePath: string) {
+async function downloadChdbArchive(archivePath: string, asset: ChdbLibAsset) {
   await mkdir(path.dirname(archivePath), { recursive: true });
   const tmpPath = `${archivePath}.tmp`;
   await rm(tmpPath, { force: true });
-  await $`curl --fail --location --silent --show-error --output ${tmpPath} ${chdbReleaseAssetUrl()}`;
+  await $`curl --fail --location --silent --show-error --output ${tmpPath} ${chdbReleaseAssetUrl(
+    CHDB_RELEASE_VERSION,
+    asset.assetName,
+  )}`;
   const digest = await sha256File(tmpPath);
-  if (digest !== CHDB_LIB_ARCHIVE_SHA256) {
+  if (digest !== asset.archiveSha256) {
     await rm(tmpPath, { force: true });
     throw new Error(
-      `Downloaded ${CHDB_LIB_ASSET_NAME} has sha256 ${digest}; expected ${CHDB_LIB_ARCHIVE_SHA256}.`,
+      `Downloaded ${asset.assetName} has sha256 ${digest}; expected ${asset.archiveSha256}.`,
     );
   }
   await rm(archivePath, { force: true });
@@ -115,18 +217,18 @@ async function downloadChdbArchive(archivePath: string) {
   await rm(tmpPath, { force: true });
 }
 
-async function ensureChdbArchive(archivePath: string) {
+async function ensureChdbArchive(archivePath: string, asset: ChdbLibAsset) {
   if (await pathExists(archivePath)) {
     const digest = await sha256File(archivePath);
-    if (digest === CHDB_LIB_ARCHIVE_SHA256) {
+    if (digest === asset.archiveSha256) {
       return;
     }
     console.error(
-      `Ignoring cached ${archivePath} because sha256 is ${digest}; expected ${CHDB_LIB_ARCHIVE_SHA256}.`,
+      `Ignoring cached ${archivePath} because sha256 is ${digest}; expected ${asset.archiveSha256}.`,
     );
   }
 
-  await downloadChdbArchive(archivePath);
+  await downloadChdbArchive(archivePath, asset);
 }
 
 export async function prepareChdbLibResource(mode: string) {
@@ -138,25 +240,20 @@ async function prepareChdbLibAt(mode: string, destLib: string) {
     throw new Error(`Unsupported mode: ${mode}`);
   }
 
-  if (process.platform !== "darwin") {
-    throw new Error("Bundled chDB resources are currently only supported on macOS.");
-  }
-  if (process.arch !== "arm64") {
-    throw new Error("Bundled chDB resources are currently only supported on macOS arm64.");
-  }
+  const chdbAsset = resolveChdbLibAsset();
 
   const chdbCacheDir = path.join(repoDir, "target", "chdb");
-  const archivePath = path.join(chdbCacheDir, `${CHDB_RELEASE_VERSION}-${CHDB_LIB_ASSET_NAME}`);
+  const archivePath = path.join(chdbCacheDir, `${CHDB_RELEASE_VERSION}-${chdbAsset.assetName}`);
   const extractDir = path.join(chdbCacheDir, `${CHDB_RELEASE_VERSION}-extract`);
 
-  await ensureChdbArchive(archivePath);
+  await ensureChdbArchive(archivePath, chdbAsset);
   await rm(extractDir, { recursive: true, force: true });
   await mkdir(extractDir, { recursive: true });
   await $`tar -xzf ${archivePath} -C ${extractDir}`;
 
   const extractedLib = await findFileByName(extractDir, "libchdb.so");
   if (!extractedLib) {
-    throw new Error(`${CHDB_LIB_ASSET_NAME} did not contain libchdb.so.`);
+    throw new Error(`${chdbAsset.assetName} did not contain libchdb.so.`);
   }
 
   const extractedStat = await stat(extractedLib);
@@ -294,6 +391,8 @@ export async function signBinaryIfNeeded(binaryPath: string) {
 
 export type PublishCliArtifactOptions = {
   outputDir?: string;
+  target?: CliReleaseTarget;
+  writeLegacyAlias?: boolean;
 };
 
 export async function publishCliArtifact(
@@ -303,20 +402,34 @@ export async function publishCliArtifact(
   loadBuildEnvFile();
 
   const outputDir = options.outputDir ?? docsPublicDir;
-  const outputBin = path.join(outputDir, "everr");
-  const outputSha = path.join(outputDir, "everr.sha256");
+  const target = options.target ?? getCliReleaseTarget();
+  const outputBin = path.join(outputDir, target.binaryName);
+  const outputSha = path.join(outputDir, target.checksumName);
 
   await mkdir(outputDir, { recursive: true });
   await copyFile(sourceBin, outputBin);
   await chmod(outputBin, 0o755);
 
-  await signBinaryIfNeeded(outputBin);
+  if (target.platform === "macos") {
+    await signBinaryIfNeeded(outputBin);
+  }
 
   const digest = createHash("sha256")
     .update(await readFile(outputBin))
     .digest("hex");
 
-  await writeFile(outputSha, `${digest}  everr\n`);
+  await writeFile(outputSha, `${digest}  ${target.binaryName}\n`);
+
+  if (options.writeLegacyAlias) {
+    const legacyBin = path.join(outputDir, LEGACY_CLI_RELEASE_BINARY_NAME);
+    const legacySha = path.join(outputDir, `${LEGACY_CLI_RELEASE_BINARY_NAME}.sha256`);
+
+    await copyFile(outputBin, legacyBin);
+    await chmod(legacyBin, 0o755);
+    await writeFile(legacySha, `${digest}  ${LEGACY_CLI_RELEASE_BINARY_NAME}\n`);
+    console.log(`Wrote ${legacyBin}`);
+    console.log(`Wrote ${legacySha}`);
+  }
 
   console.log(`Wrote ${outputBin}`);
   console.log(`Wrote ${outputSha}`);

--- a/packages/desktop-app/scripts/copy-release-artifact.test.ts
+++ b/packages/desktop-app/scripts/copy-release-artifact.test.ts
@@ -3,11 +3,13 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  assertCliReleaseArtifactsPresent,
   buildPublicArtifactUrl,
   buildReleaseMetadata,
   buildUpdaterManifest,
   findReleaseArtifacts,
   getDesktopReleaseTarget,
+  refreshReleaseFilesIndex,
   resolveDmgNotarizationRequest,
   writeReleaseChecksums,
 } from "./copy-release-artifact";
@@ -202,6 +204,63 @@ describe("copy-release-artifact helpers", () => {
         "a7937b64b8caa58f03721bb6bacf5c78cb235febe0e70b1b84cd99541461a08e  nested/a.txt",
         "",
       ].join("\n"),
+    );
+  });
+
+  it("requires every platform CLI artifact before publishing the assembled release", async () => {
+    const releaseDir = await makeTempDir();
+    for (const name of [
+      "everr",
+      "everr.sha256",
+      "everr-macos-arm64",
+      "everr-macos-arm64.sha256",
+      "everr-linux-x64",
+      "everr-linux-x64.sha256",
+      "everr-linux-arm64",
+    ]) {
+      await writeFile(path.join(releaseDir, name), name);
+    }
+
+    await expect(assertCliReleaseArtifactsPresent(releaseDir)).rejects.toThrow(
+      /everr-linux-arm64\.sha256/,
+    );
+
+    await writeFile(path.join(releaseDir, "everr-linux-arm64.sha256"), "checksum");
+
+    await expect(assertCliReleaseArtifactsPresent(releaseDir)).resolves.toBeUndefined();
+  });
+
+  it("refreshes release metadata and checksums after adding Linux CLI files", async () => {
+    const releaseDir = await makeTempDir();
+    await writeFile(path.join(releaseDir, "everr-macos-arm64"), "mac cli");
+    await writeFile(path.join(releaseDir, "everr-macos-arm64.sha256"), "mac checksum");
+    await writeFile(path.join(releaseDir, "everr-linux-x64"), "linux cli");
+    await writeFile(path.join(releaseDir, "everr-linux-x64.sha256"), "linux checksum");
+    await mkdir(path.join(releaseDir, "everr-app"), { recursive: true });
+    await writeFile(path.join(releaseDir, "everr-app", "latest.json"), "{}");
+    await writeFile(
+      path.join(releaseDir, "release-metadata.json"),
+      buildReleaseMetadata({
+        platformVersion: "0.1.1264",
+        releaseSha: "82efe1cf1358e8395b2862c4ee9f93567f10c16e",
+        releaseShortSha: "82efe1c",
+        publicBaseUrl: "https://everr.dev/everr-app",
+        target: getDesktopReleaseTarget("macos", "arm64"),
+        createdAt: "2026-03-14T17:00:00.000Z",
+        files: [],
+      }),
+    );
+
+    await refreshReleaseFilesIndex(releaseDir);
+
+    const metadata = JSON.parse(
+      await readFile(path.join(releaseDir, "release-metadata.json"), "utf8"),
+    );
+    expect(metadata.files.map((file: { path: string }) => file.path)).toContain(
+      "everr-linux-x64",
+    );
+    await expect(readFile(path.join(releaseDir, "SHA256SUMS"), "utf8")).resolves.toContain(
+      "everr-linux-x64",
     );
   });
 });

--- a/packages/desktop-app/scripts/copy-release-artifact.ts
+++ b/packages/desktop-app/scripts/copy-release-artifact.ts
@@ -14,7 +14,9 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { $ } from "zx";
 import {
+  CLI_RELEASE_TARGETS,
   desktopReleaseDir,
+  LEGACY_CLI_RELEASE_BINARY_NAME,
   loadBuildEnvFile,
   resolveDesktopReleaseIdentity,
 } from "./build-support.ts";
@@ -56,6 +58,17 @@ type ReleaseFileEntry = {
   path: string;
   sha256: string;
   size: number;
+};
+
+type ReleaseMetadata = {
+  platform_version?: string;
+  release_sha?: string;
+  release_short_sha?: string;
+  public_base_url?: string;
+  target?: DesktopReleaseTarget;
+  build?: {
+    created_at?: string;
+  };
 };
 
 export function normalizePlatform(value: NodeJS.Platform) {
@@ -372,7 +385,20 @@ async function collectReleaseFiles(rootDir: string) {
 
 async function assertCliArtifactsPresent(rootDir: string) {
   const missing: string[] = [];
-  for (const name of ["everr", "everr.sha256"]) {
+  const macosCliTarget = CLI_RELEASE_TARGETS.find(
+    (target) => target.platform === "macos" && target.arch === "arm64",
+  );
+
+  if (!macosCliTarget) {
+    throw new Error("Could not resolve the macOS arm64 CLI release target.");
+  }
+
+  for (const name of [
+    LEGACY_CLI_RELEASE_BINARY_NAME,
+    `${LEGACY_CLI_RELEASE_BINARY_NAME}.sha256`,
+    macosCliTarget.binaryName,
+    macosCliTarget.checksumName,
+  ]) {
     if (!(await pathExists(path.join(rootDir, name)))) {
       missing.push(name);
     }
@@ -383,6 +409,57 @@ async function assertCliArtifactsPresent(rootDir: string) {
       `Missing staged CLI artifact(s): ${missing.join(", ")}. The desktop release build must run the release CLI sidecar preparation before staging artifacts.`,
     );
   }
+}
+
+export async function assertCliReleaseArtifactsPresent(rootDir = desktopReleaseDir) {
+  const missing: string[] = [];
+  const requiredNames = [
+    LEGACY_CLI_RELEASE_BINARY_NAME,
+    `${LEGACY_CLI_RELEASE_BINARY_NAME}.sha256`,
+    ...CLI_RELEASE_TARGETS.flatMap((target) => [target.binaryName, target.checksumName]),
+  ];
+
+  for (const name of requiredNames) {
+    if (!(await pathExists(path.join(rootDir, name)))) {
+      missing.push(name);
+    }
+  }
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing release CLI artifact(s): ${missing.join(", ")}. Build every supported CLI target before publishing the desktop release artifact.`,
+    );
+  }
+}
+
+export async function refreshReleaseFilesIndex(rootDir = desktopReleaseDir) {
+  const metadataPath = path.join(rootDir, RELEASE_METADATA_NAME);
+  const metadata = JSON.parse(await readFile(metadataPath, "utf8")) as ReleaseMetadata;
+
+  if (
+    !metadata.platform_version ||
+    !metadata.release_sha ||
+    !metadata.release_short_sha ||
+    !metadata.public_base_url ||
+    !metadata.target
+  ) {
+    throw new Error(`Could not refresh release metadata from ${metadataPath}.`);
+  }
+
+  const files = await collectReleaseFiles(rootDir);
+  await writeFile(
+    metadataPath,
+    buildReleaseMetadata({
+      platformVersion: metadata.platform_version,
+      releaseSha: metadata.release_sha,
+      releaseShortSha: metadata.release_short_sha,
+      publicBaseUrl: metadata.public_base_url,
+      target: metadata.target,
+      createdAt: metadata.build?.created_at ?? new Date().toISOString(),
+      files,
+    }),
+  );
+  await writeReleaseChecksums(rootDir);
 }
 
 export async function writeReleaseChecksums(rootDir: string) {

--- a/packages/desktop-app/scripts/desktop-release-workflow.test.ts
+++ b/packages/desktop-app/scripts/desktop-release-workflow.test.ts
@@ -22,4 +22,16 @@ describe("desktop release workflow", () => {
       'spctl --assess --type open --context context:primary-signature --verbose "$dmg_path"',
     );
   });
+
+  it("builds Linux CLI artifacts before assembling the final release artifact", async () => {
+    const workflow = await readFile(workflowPath, "utf8");
+
+    expect(workflow).toContain("build-linux-cli:");
+    expect(workflow).toContain("blacksmith-2vcpu-ubuntu-2404");
+    expect(workflow).toContain("blacksmith-2vcpu-ubuntu-2404-arm");
+    expect(workflow).toContain("everr-linux-x64");
+    expect(workflow).toContain("everr-linux-arm64");
+    expect(workflow).toContain("finalize-desktop-release-artifacts.ts");
+    expect(workflow).toContain("name: everr-desktop-release-${{ github.sha }}");
+  });
 });

--- a/packages/desktop-app/scripts/finalize-desktop-release-artifacts.ts
+++ b/packages/desktop-app/scripts/finalize-desktop-release-artifacts.ts
@@ -1,0 +1,10 @@
+import { desktopReleaseDir } from "./build-support.ts";
+import {
+  assertCliReleaseArtifactsPresent,
+  refreshReleaseFilesIndex,
+} from "./copy-release-artifact.ts";
+
+await assertCliReleaseArtifactsPresent(desktopReleaseDir);
+await refreshReleaseFilesIndex(desktopReleaseDir);
+
+console.log(`Finalized desktop release artifacts in ${desktopReleaseDir}`);

--- a/packages/desktop-app/scripts/install-script.test.ts
+++ b/packages/desktop-app/scripts/install-script.test.ts
@@ -1,0 +1,135 @@
+// @vitest-environment node
+
+import { execFile as execFileWithCallback } from "node:child_process";
+import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const repoDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const installScript = path.join(repoDir, "packages", "docs", "public", "install.sh");
+const tempDirs: string[] = [];
+const execFile = promisify(execFileWithCallback);
+
+async function makeTempDir() {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "everr-install-script-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function writeExecutable(filePath: string, contents: string) {
+  await writeFile(filePath, contents);
+  await chmod(filePath, 0o755);
+}
+
+async function runInstallerFor(target: { os: string; arch: string }) {
+  const rootDir = await makeTempDir();
+  const binDir = path.join(rootDir, "bin");
+  const homeDir = path.join(rootDir, "home");
+  const curlLog = path.join(rootDir, "curl.log");
+
+  await mkdir(binDir, { recursive: true });
+  await mkdir(homeDir, { recursive: true });
+  await writeExecutable(
+    path.join(binDir, "uname"),
+    `#!/usr/bin/env bash
+case "$1" in
+  -s) printf '%s\\n' "$FAKE_UNAME_OS" ;;
+  -m) printf '%s\\n' "$FAKE_UNAME_ARCH" ;;
+  *) exit 1 ;;
+esac
+`,
+  );
+  await writeExecutable(
+    path.join(binDir, "curl"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+output=""
+url=""
+while (($#)); do
+  case "$1" in
+    -o)
+      output="$2"
+      shift 2
+      ;;
+    -*)
+      shift
+      ;;
+    *)
+      url="$1"
+      shift
+      ;;
+  esac
+done
+printf '%s\\n' "$url" >> "$FAKE_CURL_LOG"
+asset="\${url##*/}"
+if [[ "$asset" == *.sha256 ]]; then
+  binary="\${asset%.sha256}"
+  printf '178893fed67c46f50c58cd77b698bb27649bee32019baa1e72b5142f9676e7a2  %s\\n' "$binary" > "$output"
+else
+  printf 'cli bytes' > "$output"
+fi
+`,
+  );
+
+  await execFile("bash", [installScript], {
+    env: {
+      ...process.env,
+      FAKE_CURL_LOG: curlLog,
+      FAKE_UNAME_ARCH: target.arch,
+      FAKE_UNAME_OS: target.os,
+      HOME: homeDir,
+      PATH: `${binDir}:${process.env.PATH}`,
+    },
+  });
+
+  return {
+    curlLog,
+    installPath: path.join(homeDir, ".local", "bin", "everr"),
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("install.sh", () => {
+  it("downloads the Linux x64 CLI artifact on x86_64 Linux", async () => {
+    const result = await runInstallerFor({ os: "Linux", arch: "x86_64" });
+
+    await expect(readFile(result.curlLog, "utf8")).resolves.toBe(
+      [
+        "https://everr.dev/everr-app/everr-linux-x64",
+        "https://everr.dev/everr-app/everr-linux-x64.sha256",
+        "",
+      ].join("\n"),
+    );
+    await expect(readFile(result.installPath, "utf8")).resolves.toBe("cli bytes");
+  });
+
+  it("downloads the Linux arm64 CLI artifact on aarch64 Linux", async () => {
+    const result = await runInstallerFor({ os: "Linux", arch: "aarch64" });
+
+    await expect(readFile(result.curlLog, "utf8")).resolves.toContain(
+      "https://everr.dev/everr-app/everr-linux-arm64\n",
+    );
+  });
+
+  it("downloads the macOS arm64 CLI artifact on Apple Silicon", async () => {
+    const result = await runInstallerFor({ os: "Darwin", arch: "arm64" });
+
+    await expect(readFile(result.curlLog, "utf8")).resolves.toContain(
+      "https://everr.dev/everr-app/everr-macos-arm64\n",
+    );
+  });
+
+  it("prints a clear error for unsupported architectures", async () => {
+    await expect(
+      runInstallerFor({ os: "Linux", arch: "armv7l" }),
+    ).rejects.toMatchObject({
+      stderr: expect.stringContaining("unsupported architecture"),
+    });
+  });
+});

--- a/packages/desktop-app/scripts/prepare-tauri-cli-sidecar.ts
+++ b/packages/desktop-app/scripts/prepare-tauri-cli-sidecar.ts
@@ -41,7 +41,10 @@ await chmod(destBin, 0o755);
 
 if (mode === "release") {
   await signBinaryIfNeeded(destBin);
-  await publishCliArtifact(sourceBin, { outputDir: desktopReleaseDir });
+  await publishCliArtifact(sourceBin, {
+    outputDir: desktopReleaseDir,
+    writeLegacyAlias: true,
+  });
 }
 
 console.log(`Prepared bundled CLI resource at ${destBin}`);

--- a/packages/desktop-app/src-cli/src/onboarding.rs
+++ b/packages/desktop-app/src-cli/src/onboarding.rs
@@ -348,6 +348,13 @@ fn outro_message(skills_installed: bool, desktop_installed: bool) -> &'static st
 }
 
 async fn step_install_desktop_app() -> Result<bool> {
+    if !is_desktop_app_install_supported(std::env::consts::OS) {
+        cliclack::log::remark(
+            "Everr desktop app install is currently available on macOS. On Linux, use `everr local start` to run the local collector.",
+        )?;
+        return Ok(false);
+    }
+
     let interactive = std::io::stdin().is_terminal();
     let app_path = Path::new("/Applications/Everr.app");
     let already_installed = app_path.exists();
@@ -453,6 +460,10 @@ async fn step_install_desktop_app() -> Result<bool> {
     Ok(true)
 }
 
+fn is_desktop_app_install_supported(os: &str) -> bool {
+    os == "macos"
+}
+
 fn print_banner() {
     let banner = render_banner();
     if should_use_color() {
@@ -520,6 +531,11 @@ mod tests {
     #[test]
     fn outro_message_without_skills_installed() {
         assert!(super::outro_message(false, false).contains("everr skills install --all"));
+    }
+
+    #[test]
+    fn desktop_app_install_is_skipped_on_linux() {
+        assert!(!super::is_desktop_app_install_supported("linux"));
     }
 
     #[test]

--- a/packages/desktop-app/src-cli/src/telemetry/collector.rs
+++ b/packages/desktop-app/src-cli/src/telemetry/collector.rs
@@ -113,11 +113,20 @@ async fn wait_for_shutdown_signal() -> Result<()> {
 }
 
 fn ensure_supported_platform() -> Result<()> {
-    if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+    if is_supported_embedded_collector_target(std::env::consts::OS, std::env::consts::ARCH) {
         return Ok(());
     }
 
-    bail!("embedded local collector is currently supported only on macOS arm64");
+    bail!(
+        "embedded local collector is currently supported only on macOS arm64 and Linux x64/arm64"
+    );
+}
+
+fn is_supported_embedded_collector_target(os: &str, arch: &str) -> bool {
+    matches!(
+        (os, arch),
+        ("macos", "aarch64") | ("linux", "x86_64") | ("linux", "aarch64")
+    )
 }
 
 async fn spawn_collector(assets: &ExtractedAssets, config_path: &Path) -> Result<Child> {
@@ -190,10 +199,9 @@ fn kill_orphaned_collector() {
 }
 
 fn extract_embedded_assets() -> Result<ExtractedAssets> {
-    let cache_root = dirs::cache_dir()
-        .context("failed to resolve user cache directory")?
-        .join(everr_core::build::session_namespace())
-        .join("collector-assets");
+    let cache_root = asset_cache_root_from_cache_dir(
+        &dirs::cache_dir().context("failed to resolve user cache directory")?,
+    );
     extract_assets_to_cache(
         &cache_root,
         COLLECTOR_GZ,
@@ -201,6 +209,12 @@ fn extract_embedded_assets() -> Result<ExtractedAssets> {
         COLLECTOR_GZ_SHA256,
         CHDB_GZ_SHA256,
     )
+}
+
+fn asset_cache_root_from_cache_dir(cache_dir: &Path) -> PathBuf {
+    cache_dir
+        .join(everr_core::build::session_namespace())
+        .join("collector-assets")
 }
 
 fn extract_assets_to_cache(
@@ -331,6 +345,19 @@ mod tests {
     use flate2::write::GzEncoder;
 
     use super::*;
+
+    #[test]
+    fn embedded_collector_supports_linux_targets() {
+        assert!(is_supported_embedded_collector_target("linux", "x86_64"));
+        assert!(is_supported_embedded_collector_target("linux", "aarch64"));
+    }
+
+    #[test]
+    fn asset_cache_root_uses_linux_cache_home_layout() {
+        let dir = asset_cache_root_from_cache_dir(Path::new("/home/alice/.cache"));
+
+        assert_eq!(dir, Path::new("/home/alice/.cache/everr/collector-assets"));
+    }
 
     #[test]
     fn extraction_requires_embedded_assets() {

--- a/packages/desktop-app/src-cli/tests/support/mod.rs
+++ b/packages/desktop-app/src-cli/tests/support/mod.rs
@@ -54,10 +54,8 @@ impl CliTestEnv {
     }
 
     pub fn telemetry_dir(&self) -> PathBuf {
-        self.home_dir
-            .join("Library")
-            .join("Application Support")
-            .join("everr")
+        platform_data_dir(&self.home_dir)
+            .join(build::session_namespace())
             .join("telemetry-dev")
     }
 
@@ -115,6 +113,18 @@ fn platform_config_dir(home_dir: &Path) -> PathBuf {
     #[cfg(not(target_os = "macos"))]
     {
         home_dir.join(".config")
+    }
+}
+
+fn platform_data_dir(home_dir: &Path) -> PathBuf {
+    #[cfg(target_os = "macos")]
+    {
+        home_dir.join("Library").join("Application Support")
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        home_dir.join(".local").join("share")
     }
 }
 

--- a/packages/desktop-app/src/test-setup.ts
+++ b/packages/desktop-app/src/test-setup.ts
@@ -3,22 +3,28 @@ import { clearMocks } from "@tauri-apps/api/mocks";
 import { cleanup } from "@testing-library/react";
 import { afterEach, vi } from "vitest";
 
-Object.defineProperty(window, "matchMedia", {
-  writable: true,
-  value: vi.fn().mockImplementation((query: string) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: vi.fn(),
-    removeListener: vi.fn(),
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    dispatchEvent: vi.fn(),
-  })),
-});
+if (typeof window !== "undefined") {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
 
 afterEach(() => {
-  cleanup();
-  clearMocks();
+  if (typeof document !== "undefined") {
+    cleanup();
+  }
+  if (typeof window !== "undefined") {
+    clearMocks();
+  }
   vi.useRealTimers();
 });

--- a/packages/docs/public/install-dev.sh
+++ b/packages/docs/public/install-dev.sh
@@ -2,22 +2,59 @@
 set -euo pipefail
 
 DOWNLOAD_BASE_URL="http://localhost:3000/everr-app"
-BINARY_NAME="everr"
 INSTALL_DIR="${HOME}/.local/bin"
 INSTALL_PATH="${INSTALL_DIR}/everr"
 
-os="$(uname -s)"
-arch="$(uname -m)"
+detect_target() {
+  local os="$1"
+  local arch="$2"
 
-if [ "${os}" != "Darwin" ]; then
-  echo "everr install script currently supports macOS only (detected: ${os})." >&2
-  exit 1
-fi
+  case "${os}" in
+    Darwin)
+      case "${arch}" in
+        arm64|aarch64) printf '%s\n' "macos-arm64" ;;
+        *)
+          echo "everr install script unsupported architecture for macOS: ${arch}." >&2
+          return 1
+          ;;
+      esac
+      ;;
+    Linux)
+      case "${arch}" in
+        x86_64|amd64) printf '%s\n' "linux-x64" ;;
+        aarch64|arm64) printf '%s\n' "linux-arm64" ;;
+        *)
+          echo "everr install script unsupported architecture for Linux: ${arch}." >&2
+          return 1
+          ;;
+      esac
+      ;;
+    *)
+      echo "everr install script unsupported operating system: ${os}." >&2
+      return 1
+      ;;
+  esac
+}
 
-if [ "${arch}" != "arm64" ]; then
-  echo "everr install script currently supports macOS arm64 only (detected: ${arch})." >&2
-  exit 1
-fi
+verify_checksum() {
+  local checksum_file="$1"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c "${checksum_file}" > /dev/null
+    return
+  fi
+
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -c "${checksum_file}" > /dev/null
+    return
+  fi
+
+  echo "everr install script needs sha256sum or shasum to verify the download." >&2
+  return 1
+}
+
+target="$(detect_target "$(uname -s)" "$(uname -m)")"
+binary_name="everr-${target}"
 
 tmp_dir="$(mktemp -d)"
 cleanup() {
@@ -25,20 +62,20 @@ cleanup() {
 }
 trap cleanup EXIT
 
-binary_url="${DOWNLOAD_BASE_URL%/}/${BINARY_NAME}"
-checksum_url="${DOWNLOAD_BASE_URL%/}/${BINARY_NAME}.sha256"
+binary_url="${DOWNLOAD_BASE_URL%/}/${binary_name}"
+checksum_url="${DOWNLOAD_BASE_URL%/}/${binary_name}.sha256"
 
 echo "Downloading Everr CLI..."
-curl -fsSL "${binary_url}" -o "${tmp_dir}/${BINARY_NAME}"
-curl -fsSL "${checksum_url}" -o "${tmp_dir}/${BINARY_NAME}.sha256"
+curl -fsSL "${binary_url}" -o "${tmp_dir}/${binary_name}"
+curl -fsSL "${checksum_url}" -o "${tmp_dir}/${binary_name}.sha256"
 
 (
   cd "${tmp_dir}"
-  shasum -a 256 -c "${BINARY_NAME}.sha256" > /dev/null
+  verify_checksum "${binary_name}.sha256"
 )
 
 mkdir -p "${INSTALL_DIR}"
-mv "${tmp_dir}/${BINARY_NAME}" "${INSTALL_PATH}"
+mv "${tmp_dir}/${binary_name}" "${INSTALL_PATH}"
 chmod +x "${INSTALL_PATH}"
 
 echo "  Installed to ${INSTALL_PATH}"

--- a/packages/docs/public/install.sh
+++ b/packages/docs/public/install.sh
@@ -2,22 +2,59 @@
 set -euo pipefail
 
 DOWNLOAD_BASE_URL="https://everr.dev/everr-app"
-BINARY_NAME="everr"
 INSTALL_DIR="${HOME}/.local/bin"
 INSTALL_PATH="${INSTALL_DIR}/everr"
 
-os="$(uname -s)"
-arch="$(uname -m)"
+detect_target() {
+  local os="$1"
+  local arch="$2"
 
-if [ "${os}" != "Darwin" ]; then
-  echo "everr install script currently supports macOS only (detected: ${os})." >&2
-  exit 1
-fi
+  case "${os}" in
+    Darwin)
+      case "${arch}" in
+        arm64|aarch64) printf '%s\n' "macos-arm64" ;;
+        *)
+          echo "everr install script unsupported architecture for macOS: ${arch}." >&2
+          return 1
+          ;;
+      esac
+      ;;
+    Linux)
+      case "${arch}" in
+        x86_64|amd64) printf '%s\n' "linux-x64" ;;
+        aarch64|arm64) printf '%s\n' "linux-arm64" ;;
+        *)
+          echo "everr install script unsupported architecture for Linux: ${arch}." >&2
+          return 1
+          ;;
+      esac
+      ;;
+    *)
+      echo "everr install script unsupported operating system: ${os}." >&2
+      return 1
+      ;;
+  esac
+}
 
-if [ "${arch}" != "arm64" ]; then
-  echo "everr install script currently supports macOS arm64 only (detected: ${arch})." >&2
-  exit 1
-fi
+verify_checksum() {
+  local checksum_file="$1"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c "${checksum_file}" > /dev/null
+    return
+  fi
+
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -c "${checksum_file}" > /dev/null
+    return
+  fi
+
+  echo "everr install script needs sha256sum or shasum to verify the download." >&2
+  return 1
+}
+
+target="$(detect_target "$(uname -s)" "$(uname -m)")"
+binary_name="everr-${target}"
 
 tmp_dir="$(mktemp -d)"
 cleanup() {
@@ -25,20 +62,20 @@ cleanup() {
 }
 trap cleanup EXIT
 
-binary_url="${DOWNLOAD_BASE_URL%/}/${BINARY_NAME}"
-checksum_url="${DOWNLOAD_BASE_URL%/}/${BINARY_NAME}.sha256"
+binary_url="${DOWNLOAD_BASE_URL%/}/${binary_name}"
+checksum_url="${DOWNLOAD_BASE_URL%/}/${binary_name}.sha256"
 
 echo "Downloading Everr CLI..."
-curl -fsSL "${binary_url}" -o "${tmp_dir}/${BINARY_NAME}"
-curl -fsSL "${checksum_url}" -o "${tmp_dir}/${BINARY_NAME}.sha256"
+curl -fsSL "${binary_url}" -o "${tmp_dir}/${binary_name}"
+curl -fsSL "${checksum_url}" -o "${tmp_dir}/${binary_name}.sha256"
 
 (
   cd "${tmp_dir}"
-  shasum -a 256 -c "${BINARY_NAME}.sha256" > /dev/null
+  verify_checksum "${binary_name}.sha256"
 )
 
 mkdir -p "${INSTALL_DIR}"
-mv "${tmp_dir}/${BINARY_NAME}" "${INSTALL_PATH}"
+mv "${tmp_dir}/${binary_name}" "${INSTALL_PATH}"
 chmod +x "${INSTALL_PATH}"
 
 echo "  Installed to ${INSTALL_PATH}"

--- a/packages/docs/src/lib/desktop-release-redirect.test.ts
+++ b/packages/docs/src/lib/desktop-release-redirect.test.ts
@@ -18,18 +18,20 @@ describe("resolveDesktopReleaseRedirectUrl", () => {
   it("redirects CLI release files to the public artifact base URL", () => {
     expect(
       resolveDesktopReleaseRedirectUrl({
-        pathname: "/everr-app/everr",
-        publicBaseUrl,
-      }),
-    ).toBe("https://desktop-release.example.com/releases/everr-app/everr");
-
-    expect(
-      resolveDesktopReleaseRedirectUrl({
-        pathname: "/everr-app/everr.sha256",
+        pathname: "/everr-app/everr-linux-x64",
         publicBaseUrl,
       }),
     ).toBe(
-      "https://desktop-release.example.com/releases/everr-app/everr.sha256",
+      "https://desktop-release.example.com/releases/everr-app/everr-linux-x64",
+    );
+
+    expect(
+      resolveDesktopReleaseRedirectUrl({
+        pathname: "/everr-app/everr-linux-x64.sha256",
+        publicBaseUrl,
+      }),
+    ).toBe(
+      "https://desktop-release.example.com/releases/everr-app/everr-linux-x64.sha256",
     );
   });
 

--- a/packages/docs/src/lib/desktop-release-redirect.ts
+++ b/packages/docs/src/lib/desktop-release-redirect.ts
@@ -4,6 +4,12 @@ const DEFAULT_DESKTOP_RELEASE_PUBLIC_BASE_URL =
 export const allowedDesktopReleasePaths = new Set([
   "everr",
   "everr.sha256",
+  "everr-macos-arm64",
+  "everr-macos-arm64.sha256",
+  "everr-linux-x64",
+  "everr-linux-x64.sha256",
+  "everr-linux-arm64",
+  "everr-linux-arm64.sha256",
   "latest.json",
   "everr-macos-arm64.dmg",
   "everr-macos-arm64.app.tar.gz",

--- a/packages/docs/src/lib/desktop-release-route.test.ts
+++ b/packages/docs/src/lib/desktop-release-route.test.ts
@@ -30,12 +30,14 @@ describe("/everr-app/$", () => {
 
   it("redirects known CLI release files", async () => {
     const response = await getHandler()({
-      request: new Request("https://everr.dev/everr-app/everr.sha256"),
+      request: new Request(
+        "https://everr.dev/everr-app/everr-linux-arm64.sha256",
+      ),
     });
 
     expect(response.status).toBe(307);
     expect(response.headers.get("location")).toContain(
-      "/everr-app/everr.sha256",
+      "/everr-app/everr-linux-arm64.sha256",
     );
   });
 


### PR DESCRIPTION
## Summary

- Select the correct pinned chDB library archive for macOS arm64, Linux x64, and Linux arm64 when preparing embedded CLI assets.
- Allow the embedded local collector runtime on Linux x64 and Linux arm64.
- Let `everr setup` run on Linux without trying the macOS desktop app installer; it now skips that step with Linux guidance.
- Pin the expected Linux storage layouts for config, telemetry data, and embedded collector assets.
- Publish target-named CLI release binaries for macOS arm64, Linux x64, and Linux arm64, then assemble them into the desktop release artifact with refreshed metadata/checksums.
- Update `install.sh` and `install-dev.sh` to detect OS/CPU architecture and download the matching CLI binary.

## Root Cause

The CLI build path always downloaded the macOS arm64 chDB archive and the runtime guard rejected every non-macOS target, so Linux builds could not produce a usable embedded collector CLI. The setup flow also assumed the macOS desktop app path, app launcher, and DMG installer, which is not valid on Linux.

The release installer also downloaded a single `everr` file, so it had no way to choose the correct binary once Linux release artifacts existed.

## Linux Storage Paths Checked

- Config/session state: `~/.config/everr/session-dev.json`
- Local telemetry data: `~/.local/share/everr/telemetry-dev`
- Embedded collector assets: `~/.cache/everr/collector-assets`

## Validation

- `cargo fmt --check --all`
- `cargo test --package everr-core`
- `cargo test --manifest-path packages/desktop-app/src-cli/Cargo.toml`
- `pnpm --filter @everr/desktop-app test -- scripts/build-support.test.ts`
- `pnpm --dir packages/desktop-app exec vitest run scripts/build-support.test.ts scripts/copy-release-artifact.test.ts scripts/install-script.test.ts scripts/desktop-release-workflow.test.ts`
- `pnpm exec vitest run packages/docs/src/lib/desktop-release-redirect.test.ts packages/docs/src/lib/desktop-release-route.test.ts`
- `bash -n packages/docs/public/install.sh && bash -n packages/docs/public/install-dev.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-desktop-app.yml"); YAML.load_file(".github/workflows/build-everr-cli.yml")'`
- `git diff --check`
- Linux arm64 container: built `build:cli:debug`, ran `everr setup` with a saved session and confirmed it skipped macOS desktop install, started `everr local start`, sent one OTLP log, and queried it back with `everr local query`.

Note: Linux amd64 runtime validation on Apple Silicon was blocked by Docker/QEMU crashing `rustc` before project code ran. `pnpm check` currently fails on existing unrelated Biome diagnostics in `packages/app` plus the repo schema-version notice; the changed files pass the pre-commit Biome check.
