### PR TITLE
Tick the Runs "When" column in real time

### DIFF
--- a/packages/desktop-app/src/features/notifications/notifications-page.tsx
+++ b/packages/desktop-app/src/features/notifications/notifications-page.tsx
@@ -18,7 +18,7 @@ import {
 } from "@everr/ui/components/tooltip";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { Check, Clipboard, Workflow } from "lucide-react";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { invokeCommand, NOTIFIER_CHECKED_EVENT } from "@/lib/tauri";
 import { useInvalidateOnTauriEvent } from "@/lib/tauri-events";
 import { formatNotificationRelativeTime } from "../../notification-time";
@@ -50,6 +50,15 @@ function getRunsList(timeRange: TimeRange) {
   });
 }
 
+function useNow(tickMs: number) {
+  const [now, setNow] = useState(() => new Date());
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(new Date()), tickMs);
+    return () => window.clearInterval(id);
+  }, [tickMs]);
+  return now;
+}
+
 export function NotificationsPage() {
   const [timeRange, setTimeRange] = useState<TimeRange>({
     from: "now-1h",
@@ -66,6 +75,7 @@ export function NotificationsPage() {
   });
 
   const runs = runsQuery.data ?? [];
+  const now = useNow(30_000);
 
   return (
     <div className="pt-8">
@@ -120,7 +130,7 @@ export function NotificationsPage() {
             </thead>
             <tbody>
               {runs.map((run) => (
-                <RunRow key={run.traceId} run={run} />
+                <RunRow key={run.traceId} run={run} now={now} />
               ))}
             </tbody>
           </table>
@@ -143,8 +153,8 @@ function conclusionBadgeClass(conclusion: string): string {
   }
 }
 
-function RunRow({ run }: { run: RunListItem }) {
-  const relativeTime = formatNotificationRelativeTime(run.timestamp);
+function RunRow({ run, now }: { run: RunListItem; now: Date }) {
+  const relativeTime = formatNotificationRelativeTime(run.timestamp, { now });
   const [copied, setCopied] = useState(false);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 

--- a/packages/desktop-app/src/features/notifications/notifications-page.tsx
+++ b/packages/desktop-app/src/features/notifications/notifications-page.tsx
@@ -72,6 +72,8 @@ export function NotificationsPage() {
     queryKey: [...runsListQueryKey, timeRange.from, timeRange.to],
     queryFn: () => getRunsList(timeRange),
     refetchOnWindowFocus: true,
+    staleTime: 0,
+    refetchInterval: 30_000,
   });
 
   const runs = runsQuery.data ?? [];


### PR DESCRIPTION
## Summary
- The Runs page computed each row's relative time once per render, so the "When" column stayed frozen at the value captured on the last API fetch.
- Introduce a local 30s clock (`useNow`) and thread `now` into `formatNotificationRelativeTime`, so all rows tick together between refetches.

## Test plan
- [x] `pnpm test` in `packages/desktop-app` — 58/58 pass
- [x] `biome check` on the touched file
- [ ] Manually verify the "When" column advances (e.g. "just now" → "1m ago") without a window focus or query refetch