### PR TITLE
docs: devlog #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="packages/app/public/everr.svg" height="60" alt="Everr" />
 </p>
 
-<h3 align="center">Software delivery intelligence for developers and AI agents &mdash; local, CI, and production.</h3>
+<h3 align="center">Software delivery intelligence for developers and AI agents, local, CI, and production.</h3>
 
 <p align="center">
   <a href="https://everr.dev">Website</a> &middot; <a href="https://everr.dev/docs">Docs</a> &middot; <a href="https://everr.dev/devlog">Devlog</a> &middot; <a href="CONTRIBUTING.md">Contributing</a>
@@ -16,36 +16,34 @@
 
 Observability today is trapped behind dashboards, and most "AI integrations" are just legacy tooling with a ChatGPT wrapper slapped on top.
 
-Everr gives you &mdash; and your AI agents &mdash; direct access to the signals that matter, wherever your code runs: on your laptop, in CI, and in production.
+Everr gives you, and your AI agents, direct access to the signals that matter, wherever your code runs: on your laptop, in CI, and in production.
 
 ## The problem
 
-AI coding agents are making development faster than ever. Reading the codebase tells half the story; the other half is what the code actually *does* the moment it runs &mdash; and that half is usually trapped behind a dashboard the agent can't see.
+AI coding agents are making development faster than ever. Reading the codebase tells half the story; the other half is what the code actually *does* the moment it runs, and that half is usually trapped behind a dashboard the agent can't see.
 
 By the time a regression shows up in a production graph, it's already too late. The bottleneck has moved from writing code to validating it.
 
 ## How Everr helps
 
-**Think in Code.** Everr exposes the same OpenTelemetry data &mdash; local, CI, and cloud &mdash; behind a read-only SQL surface. Agents already know how to write SQL, so they can answer "show me flaky failures on `main` last week" without us shipping a new endpoint for every shape of question. No screen-scraping, no log parsing, no custom RPC per workflow.
+**Think in Code.** Everr exposes the same OpenTelemetry data, local, CI, and cloud, behind a read-only SQL surface. Agents already know how to write SQL, so they can answer "show me flaky failures on `main` last week" without us shipping a new endpoint for every shape of question. No screen-scraping, no log parsing, no custom RPC per workflow.
 
-**Built where the work actually happens.** A local collector with an in-process ClickHouse, a CI integration that captures every workflow run, and a hosted backend that ties them together. Same primitives, same data, same answers &mdash; whether the agent is on your laptop, a sandbox in the cloud, or a teammate's machine three time zones away.
+**Built where the work actually happens.** A local collector with an in-process ClickHouse, a CI integration that captures every workflow run, and a hosted backend that ties them together. Same primitives, same data, same answers, whether the agent is on your laptop, a sandbox in the cloud, or a teammate's machine three time zones away.
 
-**Editor- and agent-agnostic.** VS Code, Cursor, Zed, JetBrains, Claude Code, Codex, Copilot &mdash; Everr doesn't replace your stack, it improves it. Bundled skills slot directly into the assistants you already use, so they reach for runtime data the moment a test fails or a span goes missing.
+**Editor- and agent-agnostic.** VS Code, Cursor, Zed, JetBrains, Claude Code, Codex, Copilot, Everr doesn't replace your stack, it improves it. Bundled skills slot directly into the assistants you already use, so they reach for runtime data the moment a test fails or a span goes missing.
 
 ### Key capabilities
 
-- **Local telemetry, queryable on the spot** &mdash; A sidecar collector embeds [chDB](https://clickhouse.com/docs/chdb) and exposes OpenTelemetry data from your dev server, tests, or any wrapped command over SQL. `everr local query "<SQL>"` from the terminal; the same data drives charts and a logs explorer in the desktop app.
-- **CI observability** &mdash; Every GitHub Actions workflow run becomes a structured trace with flakiness scores, performance trends, failure patterns, and cost breakdowns. No YAML changes, no config files.
-- **Cloud SQL** &mdash; `everr cloud query "<SQL>"` runs read-only ClickHouse against your org's data with per-tenant isolation, quotas, and timeouts.
-- **Shared logs explorer** &mdash; Draggable histogram, level filters, fast text search. Same UI in the web app (cloud data) and the desktop app (local chDB), backed by a shared workspace package.
-- **`everr wrap`** &mdash; `everr wrap -- <command>` mirrors any command's stdout/stderr into local telemetry while preserving exit codes, so test runs and dev servers become queryable instead of scrolling away.
-- **Bundled agent skills** &mdash; `everr skills install` drops CI debugging, local telemetry setup, and local debugging skills into Claude Code, Codex, or Cursor &mdash; globally or per project, kept in sync via `everr skills update`.
+- **Local telemetry, queryable on the spot**, A sidecar collector embeds [chDB](https://clickhouse.com/docs/chdb) and exposes OpenTelemetry data from your dev server, tests, or any wrapped command over SQL. `everr local query "<SQL>"` from the terminal; the same data drives charts and a logs explorer in the desktop app.
+- **CI observability**, Every GitHub Actions workflow run becomes a structured trace with flakiness scores, performance trends, failure patterns, and cost breakdowns. No YAML changes, no config files.
+- **Production observability**, send the same OpenTelemetry data to any standard OTLP collector so it's available in your existing dashboards, or to local agents alongside everything else they already see.
+- **Bundled agent skills**, `everr skills install` drops CI debugging, local telemetry setup, and local debugging skills into Claude Code, Codex, or Cursor, globally or per project, kept in sync via `everr skills update`.
 
 ## Get early access
 
 Everr is currently in closed beta. [Join the waitlist](https://everr.dev/waitlist) to get access.
 
-- **For CI**: install the GitHub App on your repositories &mdash; no YAML changes, no config files, no modifications to your workflows.
+- **For CI**: install the GitHub App on your repositories, no YAML changes, no config files, no modifications to your workflows.
 - **For local**: install the CLI and run `everr local start` to bring up the collector alongside your dev server, tests, or agent terminal.
 
 ## Contributing
@@ -54,4 +52,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup instructions.
 
 ## License
 
-This project is licensed under the [Functional Source License, Version 1.1, ALv2 Future License](LICENSE). Some components are subject to different license terms &mdash; see [NOTICE](NOTICE) for details.
+This project is licensed under the [Functional Source License, Version 1.1, ALv2 Future License](LICENSE). Some components are subject to different license terms, see [NOTICE](NOTICE) for details.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
   <img src="packages/app/public/everr.svg" height="60" alt="Everr" />
 </p>
 
-<h3 align="center">Software delivery intelligence for developers and AI agents.</h3>
+<h3 align="center">Software delivery intelligence for developers and AI agents &mdash; local, CI, and production.</h3>
 
 <p align="center">
-  <a href="https://everr.dev">Website</a> &middot; <a href="https://everr.dev/docs">Docs</a> &middot; <a href="CONTRIBUTING.md">Contributing</a>
+  <a href="https://everr.dev">Website</a> &middot; <a href="https://everr.dev/docs">Docs</a> &middot; <a href="https://everr.dev/devlog">Devlog</a> &middot; <a href="CONTRIBUTING.md">Contributing</a>
 </p>
 
 <p align="center">
@@ -14,39 +14,39 @@
 
 ---
 
-Everr transforms your CI/CD pipelines into fully observable systems. It collects structured telemetry from GitHub Actions and turns it into actionable signals - so both developers and AI coding agents can detect failures, understand root causes, and resolve issues fast.
+Observability today is trapped behind dashboards, and most "AI integrations" are just legacy tooling with a ChatGPT wrapper slapped on top.
 
-<!-- TODO: Add a product screenshot here
-<p align="center">
-  <img src="assets/screenshot.png" alt="Everr dashboard" width="800" />
-</p>
--->
+Everr gives you &mdash; and your AI agents &mdash; direct access to the signals that matter, wherever your code runs: on your laptop, in CI, and in production.
 
 ## The problem
 
-AI coding agents are making development faster than ever. But every change still has to pass through CI - and when pipelines break, everything stops.
+AI coding agents are making development faster than ever. Reading the codebase tells half the story; the other half is what the code actually *does* the moment it runs &mdash; and that half is usually trapped behind a dashboard the agent can't see.
 
-Developers context-switch between dashboards and raw logs. AI agents hit a wall because pipeline data is fragmented and unstructured. **The bottleneck has moved from writing code to validating it.**
+By the time a regression shows up in a production graph, it's already too late. The bottleneck has moved from writing code to validating it.
 
 ## How Everr helps
 
-**Structured telemetry, not raw logs.** Every workflow run is converted into OpenTelemetry traces. Everr automatically surfaces flakiness scores, performance trends, failure patterns, and cost anomalies.
+**Think in Code.** Everr exposes the same OpenTelemetry data &mdash; local, CI, and cloud &mdash; behind a read-only SQL surface. Agents already know how to write SQL, so they can answer "show me flaky failures on `main` last week" without us shipping a new endpoint for every shape of question. No screen-scraping, no log parsing, no custom RPC per workflow.
 
-**Built for humans and agents.** The same structured data is accessible through the web dashboard, a native desktop app, and a CLI designed for AI-native workflows. Agents can query pipeline status, search logs, and act on failures autonomously - no screen-scraping, no log parsing.
+**Built where the work actually happens.** A local collector with an in-process ClickHouse, a CI integration that captures every workflow run, and a hosted backend that ties them together. Same primitives, same data, same answers &mdash; whether the agent is on your laptop, a sandbox in the cloud, or a teammate's machine three time zones away.
+
+**Editor- and agent-agnostic.** VS Code, Cursor, Zed, JetBrains, Claude Code, Codex, Copilot &mdash; Everr doesn't replace your stack, it improves it. Bundled skills slot directly into the assistants you already use, so they reach for runtime data the moment a test fails or a span goes missing.
 
 ### Key capabilities
 
-- **Full run tracing** - Trace waterfall, structured logs, and resource usage for every workflow run. Debug failures in seconds.
-- **Flaky test detection** - Heatmaps and timelines that track flakiness over time. Stop re-running and start fixing.
-- **Cost visibility** - Runner spend broken down by repo, workflow, and runner type. Find what's burning your budget.
-- **Performance trends** - Spot slowdowns across repos, branches, and jobs before your team feels them.
-- **AI-native CLI** - Query status, search logs, and surface slow tests from your terminal - or let your agent do it.
+- **Local telemetry, queryable on the spot** &mdash; A sidecar collector embeds [chDB](https://clickhouse.com/docs/chdb) and exposes OpenTelemetry data from your dev server, tests, or any wrapped command over SQL. `everr local query "<SQL>"` from the terminal; the same data drives charts and a logs explorer in the desktop app.
+- **CI observability** &mdash; Every GitHub Actions workflow run becomes a structured trace with flakiness scores, performance trends, failure patterns, and cost breakdowns. No YAML changes, no config files.
+- **Cloud SQL** &mdash; `everr cloud query "<SQL>"` runs read-only ClickHouse against your org's data with per-tenant isolation, quotas, and timeouts.
+- **Shared logs explorer** &mdash; Draggable histogram, level filters, fast text search. Same UI in the web app (cloud data) and the desktop app (local chDB), backed by a shared workspace package.
+- **`everr wrap`** &mdash; `everr wrap -- <command>` mirrors any command's stdout/stderr into local telemetry while preserving exit codes, so test runs and dev servers become queryable instead of scrolling away.
+- **Bundled agent skills** &mdash; `everr skills install` drops CI debugging, local telemetry setup, and local debugging skills into Claude Code, Codex, or Cursor &mdash; globally or per project, kept in sync via `everr skills update`.
 
 ## Get early access
 
 Everr is currently in closed beta. [Join the waitlist](https://everr.dev/waitlist) to get access.
 
-Once you're in, just install the GitHub App on your repositories - no YAML changes, no config files, no modifications to your workflows.
+- **For CI**: install the GitHub App on your repositories &mdash; no YAML changes, no config files, no modifications to your workflows.
+- **For local**: install the CLI and run `everr local start` to bring up the collector alongside your dev server, tests, or agent terminal.
 
 ## Contributing
 
@@ -54,4 +54,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup instructions.
 
 ## License
 
-This project is licensed under the [Functional Source License, Version 1.1, ALv2 Future License](LICENSE). Some components are subject to different license terms - see [NOTICE](NOTICE) for details.
+This project is licensed under the [Functional Source License, Version 1.1, ALv2 Future License](LICENSE). Some components are subject to different license terms &mdash; see [NOTICE](NOTICE) for details.

--- a/packages/docs/content/devlog/local-sql-logs-explorer-cloud-query.mdx
+++ b/packages/docs/content/devlog/local-sql-logs-explorer-cloud-query.mdx
@@ -82,16 +82,6 @@ This isn't visible to users beyond "downloads work and updates are signed," but 
 
 **Billing with Polar.** We integrated [Polar](https://polar.sh/) for subscriptions. Pricing isn't on the landing page right now, we pulled it for a narrative refresh, but the plumbing is in place behind the scenes.
 
-## Under the hood
-
-**Per-tenant retention.** Both the cloud and local stacks now apply retention policies per tenant, with cloud free tiers reduced and local defaults capped at 2GB and 14 days.
-
-**Dev-time telemetry.** Direct `vite` runs now emit OpenTelemetry by default, and we added TypeScript-side error tracking with the same wiring. We also added a TypeScript instrumentation preload so dev servers come up already instrumented, instead of relying on each entry point to remember.
-
-**SQL fixes that matter.** The logs explorer uses `lower()` instead of `lowerUTF8` (chDB doesn't support the latter), the logs table name is configurable so the same builder works against the cloud and local schemas, and we fixed an SSE leak on the watch endpoint that was leaving server state behind after disconnects.
-
-**Collector hardening.** The wrap path got partial-output forwarding and backpressure fixes, the collector handles healthcheck overrides correctly during startup, and JSON event payloads are normalized before insertion to avoid placeholder mismatches.
-
 ## What's next
 
 We've now got production OTel ingest, the same SQL surface on the local collector and the cloud, a shared logs explorer that consumes both, a way to feed arbitrary commands into the local stack, and skills that tell assistants how to use it all.

--- a/packages/docs/content/devlog/local-sql-logs-explorer-cloud-query.mdx
+++ b/packages/docs/content/devlog/local-sql-logs-explorer-cloud-query.mdx
@@ -92,5 +92,6 @@ The next batch is shaped around four threads:
 - **A simpler OTel setup.** Picking up OpenTelemetry for the first time can be overwhelming. We want the on-ramp to be short and obvious, both for spinning up the local collector and for pointing existing services at the cloud ingest endpoint.
 - **Pushing local telemetry to the cloud.** A way to forward a slice of local telemetry to the cloud, so a teammate can see what your local stack was actually doing, or a cloud agent can pick up the runtime context it needs to keep going.
 - **A collector inside the Everr GitHub Action.** Today, getting CI-time telemetry into Everr means standing up your own OTel collector inside the workflow. Bundling one into the Everr action would make that a one-liner. We also want to find out whether the same channel can push run updates to us faster than the GitHub webhook path we currently rely on.
+- **CD tracking.** With production telemetry landing this cycle, the missing piece is the deploys themselves: knowing when a version went out, where it ran, and being able to trace a production regression back through CI to the commit that caused it.
 
 Same pattern as before: the things we hit in daily use keep turning into PRs the same week.

--- a/packages/docs/content/devlog/local-sql-logs-explorer-cloud-query.mdx
+++ b/packages/docs/content/devlog/local-sql-logs-explorer-cloud-query.mdx
@@ -3,10 +3,10 @@ title: "Devlog #3: Production telemetry, cloud SQL, and a shared logs explorer"
 description: "We started accepting production OpenTelemetry data, opened up read-only SQL against both the cloud and local stacks, built a shared logs explorer on top of them, added `everr wrap`, and replaced AGENTS.md injection with bundled skills."
 date: "2026-05-16"
 author: Everr Team
-commits: 278
+commits: 280
 prs: 37
-additions: 82132
-deletions: 38804
+additions: 82030
+deletions: 38783
 ---
 
 Four weeks since the last devlog. This batch expands Everr in two directions: it now accepts production OpenTelemetry alongside CI data, and the data (cloud and local) is queryable through read-only SQL surfaces. A shared logs explorer sits on top of both, and bundled skills let coding assistants reach for the new surfaces on their own.

--- a/packages/docs/content/devlog/local-sql-logs-explorer-cloud-query.mdx
+++ b/packages/docs/content/devlog/local-sql-logs-explorer-cloud-query.mdx
@@ -86,12 +86,8 @@ This isn't visible to users beyond "downloads work and updates are signed," but 
 
 We've now got production OTel ingest, the same SQL surface on the local collector and the cloud, a shared logs explorer that consumes both, a way to feed arbitrary commands into the local stack, and skills that tell assistants how to use it all.
 
-The next batch is shaped around four threads:
+The next batch is about turning that shared telemetry layer into a fuller working loop. Logs got the explorer this cycle; traces and metrics need the same treatment, and the OpenTelemetry setup needs a shorter on-ramp for both the local collector and cloud ingest. The goal is for a developer, or an assistant, to get from "something is running" to useful runtime context without first becoming an observability expert.
 
-- **Traces and metrics views.** Logs got the explorer this cycle. Traces and metrics need the same treatment so the desktop and web apps cover the full OTel triad, not just one third of it.
-- **A simpler OTel setup.** Picking up OpenTelemetry for the first time can be overwhelming. We want the on-ramp to be short and obvious, both for spinning up the local collector and for pointing existing services at the cloud ingest endpoint.
-- **Pushing local telemetry to the cloud.** A way to forward a slice of local telemetry to the cloud, so a teammate can see what your local stack was actually doing, or a cloud agent can pick up the runtime context it needs to keep going.
-- **A collector inside the Everr GitHub Action.** Today, getting CI-time telemetry into Everr means standing up your own OTel collector inside the workflow. Bundling one into the Everr action would make that a one-liner. We also want to find out whether the same channel can push run updates to us faster than the GitHub webhook path we currently rely on.
-- **CD tracking.** With production telemetry landing this cycle, the missing piece is the deploys themselves: knowing when a version went out, where it ran, and being able to trace a production regression back through CI to the commit that caused it.
+We also want the local and cloud sides to start helping each other. That means forwarding slices of local telemetry when a teammate or cloud agent needs to see what happened on your machine, bundling a collector into the Everr GitHub Action so CI-time telemetry becomes a one-liner, and tracking deploys as first-class events. With production telemetry now landing, the missing piece is the deploy itself: when a version went out, where it ran, and how a production regression connects back through CI to the commit that caused it.
 
 Same pattern as before: the things we hit in daily use keep turning into PRs the same week.

--- a/packages/docs/content/devlog/local-sql-logs-explorer-cloud-query.mdx
+++ b/packages/docs/content/devlog/local-sql-logs-explorer-cloud-query.mdx
@@ -9,9 +9,9 @@ additions: 80752
 deletions: 38219
 ---
 
-Four weeks since the last devlog. The work in this batch all points in one direction: turning local and cloud telemetry into a real, queryable surface — for humans through a logs explorer, and for coding assistants through SQL and bundled skills.
+Four weeks since the last devlog. The work in this batch all points in one direction: turning local and cloud telemetry into a real, queryable surface, for humans through a logs explorer, and for coding assistants through SQL and bundled skills.
 
-Devlog #2 introduced the local observability stack as a v1 with a small set of canned queries. In daily use we kept wanting to ask both that and the cloud data more interesting questions — from scripts, from the CLI, and from inside the desktop app — and the bigger goal of letting an assistant debug on its own was bottlenecked on the same thing. So most of this cycle went into fixing that.
+Devlog #2 introduced the local observability stack as a v1 with a small set of canned queries. In daily use we kept wanting to ask both that and the cloud data more interesting questions, from scripts, from the CLI, and from inside the desktop app, and the bigger goal of letting an assistant debug on its own was bottlenecked on the same thing. So most of this cycle went into fixing that.
 
 Here's what shipped.
 
@@ -21,16 +21,16 @@ Here's what shipped.
 
 Making this safe took most of the work. Each org now gets its own ClickHouse role with hashed name, the `/sql` route enforces read-only mode, execution timeouts, query quotas, and per-tenant isolation through the existing row-level policy. We also backfilled access for existing tenants and dropped the dedicated SQL user in favor of role-based auth.
 
-It's a deliberately small surface — read-only, quota'd, no DDL — but it's enough for an assistant or a power user to answer questions like "show me flaky failures on `main` last week" without us having to ship a new endpoint for every shape of question.
+It's a deliberately small surface, read-only, quota'd, no DDL, but it's enough for an assistant or a power user to answer questions like "show me flaky failures on `main` last week" without us having to ship a new endpoint for every shape of question.
 
 ## A logs explorer in both the web app and the desktop app
 
-On top of that storage layer we built a logs explorer. It has a draggable histogram, level filters, fast text search, a detail panel, and the usual time-range and refresh controls. The point isn't the UI — there are plenty of log viewers in the world — it's that it works against both surfaces:
+On top of that storage layer we built a logs explorer. It has a draggable histogram, level filters, fast text search, a detail panel, and the usual time-range and refresh controls. The point isn't the UI, there are plenty of log viewers in the world, it's that it works against both surfaces:
 
 - In the web app, against our cloud ClickHouse, for CI and ingested workflow logs.
 - In the desktop app, against the local chDB instance, for whatever you've sent into your local collector.
 
-To make that possible without two implementations, the explorer lives in a shared `@everr/logs-explorer` workspace package, with a `SqlClient` interface and a `LogsRepository` that both surfaces wire up to their own backend. The web app talks to it through server functions; the desktop app talks to it through a Tauri command that calls the local SQL endpoint. Same UI, same query builders, same schemas — different transport.
+To make that possible without two implementations, the explorer lives in a shared `@everr/logs-explorer` workspace package, with a `SqlClient` interface and a `LogsRepository` that both surfaces wire up to their own backend. The web app talks to it through server functions; the desktop app talks to it through a Tauri command that calls the local SQL endpoint. Same UI, same query builders, same schemas, different transport.
 
 Day to day it means the logs view is no longer a CI-only feature. If you've pointed any local service at the collector, you can open the desktop app and watch its logs there.
 
@@ -38,7 +38,7 @@ Day to day it means the logs view is no longer a CI-only feature. If you've poin
 
 `everr wrap -- <command>` runs any command and mirrors its stdout/stderr into local telemetry while still printing it to your terminal. The command's exit code is preserved, so it slots into scripts and `Makefile`s without changing behavior, and it refuses to run if the local collector isn't up so you don't silently lose data.
 
-The motivating use case is the same as the rest of this work: getting more runtime context in front of agents. A test run, a dev server, a one-off script — wrap it and the output is queryable from the same place as your OpenTelemetry data, instead of being lost the moment the terminal scrolls.
+The motivating use case is the same as the rest of this work: getting more runtime context in front of agents. A test run, a dev server, a one-off script, wrap it and the output is queryable from the same place as your OpenTelemetry data, instead of being lost the moment the terminal scrolls.
 
 ## A consolidated local telemetry stack
 
@@ -50,9 +50,9 @@ The collector itself got a redesign to support this. We rebuilt the chDB exporte
 
 ## Bundled skills and an installer
 
-We moved away from injecting Everr's instructions into the project's `AGENTS.md` and shipped `everr skills` instead. It installs a small set of bundled skills (CI debugging, local telemetry setup, local debugging) into Claude Code, Codex, or Cursor — globally by default, or per project. `everr skills update` keeps them in sync as we improve them.
+We moved away from injecting Everr's instructions into the project's `AGENTS.md` and shipped `everr skills` instead. It installs a small set of bundled skills (CI debugging, local telemetry setup, local debugging) into Claude Code, Codex, or Cursor, globally by default, or per project. `everr skills update` keeps them in sync as we improve them.
 
-The change is deliberate. `AGENTS.md` content is always loaded into the assistant's context; skills activate only when their description matches what the assistant is actually doing, or when you invoke them explicitly. The result: skills fire less often overall, but they're available the moment you (or the assistant) hit a CI failure or a missing-trace situation — and the rest of the time, they're not eating into the context budget. We think that's a better DX in both directions: lighter by default, explicit when you need it.
+The change is deliberate. `AGENTS.md` content is always loaded into the assistant's context; skills activate only when their description matches what the assistant is actually doing, or when you invoke them explicitly. The result: skills fire less often overall, but they're available the moment you (or the assistant) hit a CI failure or a missing-trace situation, and the rest of the time, they're not eating into the context budget. We think that's a better DX in both directions: lighter by default, explicit when you need it.
 
 The skills themselves describe how to set up local telemetry when it's missing, how to read it once it's there, and how to drive `everr ci` from inside a debugging session. When an assistant hits a failing test in a repo with Everr installed, it has a path to runtime context that doesn't depend on a human pasting things into the prompt.
 
@@ -68,13 +68,13 @@ This isn't visible to users beyond "downloads work and updates are signed," but 
 
 **`everr ci watch --run-id` and `everr ci status --run-id`.** Both commands now accept a specific run id, not just the current HEAD commit. Useful when you're scripting against a known run or following up on a specific failure.
 
-**CLI reorganization.** We grouped commands under their domains — `everr ci status`, `everr ci watch`, `everr ci logs`, `everr cloud login`, `everr local query`, and so on — and removed the standalone `everr ci grep` command in favor of the more general `everr ci logs --egrep`. The CLI guidelines doc we wrote last cycle is now driving these calls.
+**CLI reorganization.** We grouped commands under their domains, `everr ci status`, `everr ci watch`, `everr ci logs`, `everr cloud login`, `everr local query`, and so on, and removed the standalone `everr ci grep` command in favor of the more general `everr ci logs --egrep`. The CLI guidelines doc we wrote last cycle is now driving these calls.
 
 **Removed unread tracking from the desktop app.** The unread badge and seen-runs tracking were more friction than signal in daily use, so we removed them. Notifications themselves stayed; the bookkeeping around "have you looked at this yet" went away.
 
 **Live "When" column.** The runs list now ticks its relative timestamps in real time and refetches in the background, so a tab that's been open for a while stays accurate instead of drifting until you click around.
 
-**Billing with Polar.** We integrated [Polar](https://polar.sh/) for subscriptions. Pricing isn't on the landing page right now — we pulled it for a narrative refresh — but the plumbing is in place behind the scenes.
+**Billing with Polar.** We integrated [Polar](https://polar.sh/) for subscriptions. Pricing isn't on the landing page right now, we pulled it for a narrative refresh, but the plumbing is in place behind the scenes.
 
 ## Under the hood
 

--- a/packages/docs/content/devlog/local-sql-logs-explorer-cloud-query.mdx
+++ b/packages/docs/content/devlog/local-sql-logs-explorer-cloud-query.mdx
@@ -88,9 +88,9 @@ We've now got production OTel ingest, the same SQL surface on the local collecto
 
 The next batch is shaped around four threads:
 
-- **A collector inside the Everr GitHub Action.** Today, getting CI-time telemetry into Everr means standing up your own OTel collector inside the workflow. Bundling one into the Everr action would make that a one-liner. We also want to find out whether the same channel can push run updates to us faster than the GitHub webhook path we currently rely on.
 - **Traces and metrics views.** Logs got the explorer this cycle. Traces and metrics need the same treatment so the desktop and web apps cover the full OTel triad, not just one third of it.
 - **A simpler OTel setup.** Picking up OpenTelemetry for the first time can be overwhelming. We want the on-ramp to be short and obvious, both for spinning up the local collector and for pointing existing services at the cloud ingest endpoint.
 - **Pushing local telemetry to the cloud.** A way to forward a slice of local telemetry to the cloud, so a teammate can see what your local stack was actually doing, or a cloud agent can pick up the runtime context it needs to keep going.
+- **A collector inside the Everr GitHub Action.** Today, getting CI-time telemetry into Everr means standing up your own OTel collector inside the workflow. Bundling one into the Everr action would make that a one-liner. We also want to find out whether the same channel can push run updates to us faster than the GitHub webhook path we currently rely on.
 
 Same pattern as before: the things we hit in daily use keep turning into PRs the same week.

--- a/packages/docs/content/devlog/local-sql-logs-explorer-cloud-query.mdx
+++ b/packages/docs/content/devlog/local-sql-logs-explorer-cloud-query.mdx
@@ -17,7 +17,7 @@ Here's what shipped.
 
 ## Production telemetry
 
-Everr's cloud side now accepts OpenTelemetry data from any service that speaks OTLP, not just CI. Mint an ingest key in the dashboard and point your SDK or collector at `https://ingest.everr.dev`.
+Everr's cloud side now accepts OpenTelemetry data from any service that speaks OTLP, not just CI. Mint an ingest key in the dashboard and point your SDK or collector at `https://ingest.everr.dev`. See the [Sending Telemetry](/docs/sending-telemetry) docs for the full setup.
 
 ## `everr cloud query` for SQL access to your runs
 

--- a/packages/docs/content/devlog/local-sql-logs-explorer-cloud-query.mdx
+++ b/packages/docs/content/devlog/local-sql-logs-explorer-cloud-query.mdx
@@ -104,7 +104,7 @@ We've now got production OTel ingest, the same SQL surface on the local collecto
 
 The next batch is shaped around four threads:
 
-- **The collector inside CI.** The local collector is currently a developer-machine thing. We want it usable from inside CI runs too, so the wrap and SQL surfaces apply to whatever a job is actually executing.
+- **A collector inside the Everr GitHub Action.** Today, getting CI-time telemetry into Everr means standing up your own OTel collector inside the workflow. Bundling one into the Everr action would make that a one-liner. We also want to find out whether the same channel can push run updates to us faster than the GitHub webhook path we currently rely on.
 - **Traces and metrics views.** Logs got the explorer this cycle. Traces and metrics need the same treatment so the desktop and web apps cover the full OTel triad, not just one third of it.
 - **A simpler OTel setup.** Picking up OpenTelemetry for the first time can be overwhelming. We want the on-ramp to be short and obvious, both for spinning up the local collector and for pointing existing services at the cloud ingest endpoint.
 - **Pushing local telemetry to the cloud.** A way to forward a slice of local telemetry to the cloud, so a teammate can see what your local stack was actually doing, or a cloud agent can pick up the runtime context it needs to keep going.

--- a/packages/docs/content/devlog/local-sql-logs-explorer-cloud-query.mdx
+++ b/packages/docs/content/devlog/local-sql-logs-explorer-cloud-query.mdx
@@ -100,6 +100,13 @@ This isn't visible to users beyond "downloads work and updates are signed," but 
 
 ## What's next
 
-We've now got production OTel ingest, the same SQL surface on the local collector and the cloud, a shared logs explorer that consumes both, a way to feed arbitrary commands into the local stack, and skills that tell assistants how to use it all. The shape of the next batch is mostly about pushing on that loop: better skills, more queries surfaced as first-class CLI commands, more of the desktop app rebuilt on top of the shared explorer so that local debugging stops feeling like a separate product from CI debugging, and more of the cloud app reshaped around the idea that not everything it shows comes from CI.
+We've now got production OTel ingest, the same SQL surface on the local collector and the cloud, a shared logs explorer that consumes both, a way to feed arbitrary commands into the local stack, and skills that tell assistants how to use it all.
+
+The next batch is shaped around four threads:
+
+- **The collector inside CI.** The local collector is currently a developer-machine thing. We want it usable from inside CI runs too, so the wrap and SQL surfaces apply to whatever a job is actually executing.
+- **Traces and metrics views.** Logs got the explorer this cycle. Traces and metrics need the same treatment so the desktop and web apps cover the full OTel triad, not just one third of it.
+- **A simpler OTel setup.** Picking up OpenTelemetry for the first time can be overwhelming. We want the on-ramp to be short and obvious, both for spinning up the local collector and for pointing existing services at the cloud ingest endpoint.
+- **Pushing local telemetry to the cloud.** A way to forward a slice of local telemetry to the cloud, so a teammate can see what your local stack was actually doing, or a cloud agent can pick up the runtime context it needs to keep going.
 
 Same pattern as before: the things we hit in daily use keep turning into PRs the same week.

--- a/packages/docs/content/devlog/local-sql-logs-explorer-cloud-query.mdx
+++ b/packages/docs/content/devlog/local-sql-logs-explorer-cloud-query.mdx
@@ -1,0 +1,93 @@
+---
+title: "Devlog #3: A local SQL telemetry stack, a logs explorer, and cloud queries"
+description: "We embedded an in-process ClickHouse in the local collector, built a shared logs explorer on top of it, added `everr wrap` and `everr cloud query`, and shipped bundled skills so coding assistants can use the new surfaces."
+date: "2026-05-15"
+author: Everr Team
+commits: 265
+prs: 35
+additions: 80752
+deletions: 38219
+---
+
+Four weeks since the last devlog. The work in this batch all points in one direction: turning local and cloud telemetry into a real, queryable surface — for humans through a logs explorer, and for coding assistants through SQL and bundled skills.
+
+Devlog #2 introduced the local observability stack as a v1 with a small set of canned queries. In daily use we kept wanting to ask both that and the cloud data more interesting questions — from scripts, from the CLI, and from inside the desktop app — and the bigger goal of letting an assistant debug on its own was bottlenecked on the same thing. So most of this cycle went into fixing that.
+
+Here's what shipped.
+
+## `everr cloud query` for SQL access to your runs
+
+`everr cloud query "<SQL>"` lets you run read-only ClickHouse queries against your own org's data from the CLI. Same shape and dialect as the local SQL surface below, just pointed at cloud data instead of local.
+
+Making this safe took most of the work. Each org now gets its own ClickHouse role with hashed name, the `/sql` route enforces read-only mode, execution timeouts, query quotas, and per-tenant isolation through the existing row-level policy. We also backfilled access for existing tenants and dropped the dedicated SQL user in favor of role-based auth.
+
+It's a deliberately small surface — read-only, quota'd, no DDL — but it's enough for an assistant or a power user to answer questions like "show me flaky failures on `main` last week" without us having to ship a new endpoint for every shape of question.
+
+## A logs explorer in both the web app and the desktop app
+
+On top of that storage layer we built a logs explorer. It has a draggable histogram, level filters, fast text search, a detail panel, and the usual time-range and refresh controls. The point isn't the UI — there are plenty of log viewers in the world — it's that it works against both surfaces:
+
+- In the web app, against our cloud ClickHouse, for CI and ingested workflow logs.
+- In the desktop app, against the local chDB instance, for whatever you've sent into your local collector.
+
+To make that possible without two implementations, the explorer lives in a shared `@everr/logs-explorer` workspace package, with a `SqlClient` interface and a `LogsRepository` that both surfaces wire up to their own backend. The web app talks to it through server functions; the desktop app talks to it through a Tauri command that calls the local SQL endpoint. Same UI, same query builders, same schemas — different transport.
+
+Day to day it means the logs view is no longer a CI-only feature. If you've pointed any local service at the collector, you can open the desktop app and watch its logs there.
+
+## `everr wrap` for arbitrary commands
+
+`everr wrap -- <command>` runs any command and mirrors its stdout/stderr into local telemetry while still printing it to your terminal. The command's exit code is preserved, so it slots into scripts and `Makefile`s without changing behavior, and it refuses to run if the local collector isn't up so you don't silently lose data.
+
+The motivating use case is the same as the rest of this work: getting more runtime context in front of agents. A test run, a dev server, a one-off script — wrap it and the output is queryable from the same place as your OpenTelemetry data, instead of being lost the moment the terminal scrolls.
+
+## A consolidated local telemetry stack
+
+We also rebuilt the local telemetry storage so the logs explorer, `everr wrap`, and `everr local query` can all sit on top of the same SQL surface. The local collector now embeds [chDB](https://clickhouse.com/docs/chdb), an in-process build of ClickHouse, as its storage backend, and exposes an HTTP SQL endpoint that the CLI and desktop app can hit directly.
+
+In practice that means local OTLP data lands in something that looks and queries like our cloud ClickHouse, with no separate process to run. You can throw arbitrary read-only SQL at it from `everr local query`, and the desktop app can render charts and tables against the same data without going through a custom RPC. Retention is configurable per tenant and capped to keep the on-disk footprint small.
+
+The collector itself got a redesign to support this. We rebuilt the chDB exporter, moved the SQL endpoint behind a new local gateway, and reworked startup so the collector can be embedded in the CLI binary without bringing along a separate sidecar. None of this is visible from the outside, but it makes the next round of features cheaper to build.
+
+## Bundled skills and an installer
+
+We moved away from injecting Everr's instructions into the project's `AGENTS.md` and shipped `everr skills` instead. It installs a small set of bundled skills (CI debugging, local telemetry setup, local debugging) into Claude Code, Codex, or Cursor — globally by default, or per project. `everr skills update` keeps them in sync as we improve them.
+
+The change is deliberate. `AGENTS.md` content is always loaded into the assistant's context; skills activate only when their description matches what the assistant is actually doing, or when you invoke them explicitly. The result: skills fire less often overall, but they're available the moment you (or the assistant) hit a CI failure or a missing-trace situation — and the rest of the time, they're not eating into the context budget. We think that's a better DX in both directions: lighter by default, explicit when you need it.
+
+The skills themselves describe how to set up local telemetry when it's missing, how to read it once it's there, and how to drive `everr ci` from inside a debugging session. When an assistant hits a failing test in a repo with Everr installed, it has a path to runtime context that doesn't depend on a human pasting things into the prompt.
+
+## Desktop releases through GitHub and a SHA-based identity
+
+The desktop app now releases through GitHub Releases, with a build-and-sign workflow that signs and notarizes the DMG before staging artifacts. Release identity is keyed off the commit SHA rather than a hand-bumped version, which means we can ship pre-release builds without inventing version numbers, and the docs site serves redirects to the right artifact instead of hardcoding URLs.
+
+This isn't visible to users beyond "downloads work and updates are signed," but it's what makes the desktop app actually shippable on a regular cadence.
+
+## Other improvements in the same direction
+
+**Onboarding-focused home.** The web app's home is now built around getting started: a prominent "Install Everr" card, the rest stripped down. The dashboard overview that used to live there has been replaced by surfaces that better fit how people actually use the app once they're past day one.
+
+**`everr ci watch --run-id` and `everr ci status --run-id`.** Both commands now accept a specific run id, not just the current HEAD commit. Useful when you're scripting against a known run or following up on a specific failure.
+
+**CLI reorganization.** We grouped commands under their domains — `everr ci status`, `everr ci watch`, `everr ci logs`, `everr cloud login`, `everr local query`, and so on — and removed the standalone `everr ci grep` command in favor of the more general `everr ci logs --egrep`. The CLI guidelines doc we wrote last cycle is now driving these calls.
+
+**Removed unread tracking from the desktop app.** The unread badge and seen-runs tracking were more friction than signal in daily use, so we removed them. Notifications themselves stayed; the bookkeeping around "have you looked at this yet" went away.
+
+**Live "When" column.** The runs list now ticks its relative timestamps in real time and refetches in the background, so a tab that's been open for a while stays accurate instead of drifting until you click around.
+
+**Billing with Polar.** We integrated [Polar](https://polar.sh/) for subscriptions. Pricing isn't on the landing page right now — we pulled it for a narrative refresh — but the plumbing is in place behind the scenes.
+
+## Under the hood
+
+**Per-tenant retention.** Both the cloud and local stacks now apply retention policies per tenant, with cloud free tiers reduced and local defaults capped at 2GB and 14 days.
+
+**Dev-time telemetry.** Direct `vite` runs now emit OpenTelemetry by default, and we added TypeScript-side error tracking with the same wiring. We also added a TypeScript instrumentation preload so dev servers come up already instrumented, instead of relying on each entry point to remember.
+
+**SQL fixes that matter.** The logs explorer uses `lower()` instead of `lowerUTF8` (chDB doesn't support the latter), the logs table name is configurable so the same builder works against the cloud and local schemas, and we fixed an SSE leak on the watch endpoint that was leaving server state behind after disconnects.
+
+**Collector hardening.** The wrap path got partial-output forwarding and backpressure fixes, the collector handles healthcheck overrides correctly during startup, and JSON event payloads are normalized before insertion to avoid placeholder mismatches.
+
+## What's next
+
+We've now got the same SQL surface on the local collector and the cloud, a shared logs explorer that consumes both, a way to feed arbitrary commands into the local one, and skills that tell assistants how to use it all. The shape of the next batch is mostly about pushing on that loop: better skills, more queries surfaced as first-class CLI commands, and more of the desktop app rebuilt on top of the shared explorer so that local debugging stops feeling like a separate product from CI debugging.
+
+Same pattern as before: the things we hit in daily use keep turning into PRs the same week.

--- a/packages/docs/content/devlog/local-sql-logs-explorer-cloud-query.mdx
+++ b/packages/docs/content/devlog/local-sql-logs-explorer-cloud-query.mdx
@@ -1,19 +1,31 @@
 ---
-title: "Devlog #3: A local SQL telemetry stack, a logs explorer, and cloud queries"
-description: "We embedded an in-process ClickHouse in the local collector, built a shared logs explorer on top of it, added `everr wrap` and `everr cloud query`, and shipped bundled skills so coding assistants can use the new surfaces."
-date: "2026-05-15"
+title: "Devlog #3: Production telemetry, cloud SQL, and a shared logs explorer"
+description: "We started accepting production OpenTelemetry data, opened up read-only SQL against both the cloud and local stacks, built a shared logs explorer on top of them, added `everr wrap`, and replaced AGENTS.md injection with bundled skills."
+date: "2026-05-16"
 author: Everr Team
-commits: 265
-prs: 35
-additions: 80752
-deletions: 38219
+commits: 278
+prs: 37
+additions: 82132
+deletions: 38804
 ---
 
-Four weeks since the last devlog. The work in this batch all points in one direction: turning local and cloud telemetry into a real, queryable surface, for humans through a logs explorer, and for coding assistants through SQL and bundled skills.
+Four weeks since the last devlog. This batch expands Everr in two directions: it now accepts production OpenTelemetry alongside CI data, and the data (cloud and local) is queryable through read-only SQL surfaces. A shared logs explorer sits on top of both, and bundled skills let coding assistants reach for the new surfaces on their own.
 
-Devlog #2 introduced the local observability stack as a v1 with a small set of canned queries. In daily use we kept wanting to ask both that and the cloud data more interesting questions, from scripts, from the CLI, and from inside the desktop app, and the bigger goal of letting an assistant debug on its own was bottlenecked on the same thing. So most of this cycle went into fixing that.
+Devlog #2 introduced the local observability stack as a v1 with a small set of canned queries. In daily use we kept wanting to ask both that and the cloud data more interesting questions, from scripts, from the CLI, and from inside the desktop app, and the bigger goal of letting an assistant debug on its own was bottlenecked on the same thing. So most of this cycle went into fixing that, plus opening up the cloud side to data that doesn't come from CI.
 
 Here's what shipped.
+
+## Production telemetry with ingest keys
+
+Until this cycle, Everr's cloud side was CI-only. The new ingest path opens it to production OpenTelemetry from any service that speaks OTLP. You mint an org-scoped ingest key from the dashboard (under **Ingest Keys** in the user menu), point your SDK or collector at `https://ingest.everr.dev`, and the data lands in the same ClickHouse tables you can already query with `everr cloud query` and the logs explorer.
+
+A few things worth calling out:
+
+- **Tenant identity comes from the key, not the client.** The `everr.tenant.id` resource attribute on incoming spans is stripped and overwritten with the value derived from your ingest key, so a misconfigured SDK can't accidentally write into the wrong org.
+- **Authentication is hot-path-aware.** Verification runs through a new `everrapikeyauth` collector extension that singleflights concurrent verifies, keeps an LRU positive cache, and uses a separate negative cache. Revocation propagates within about 30 seconds, which is the positive cache TTL.
+- **Standard OTLP, no client SDK required.** Any OpenTelemetry SDK or existing collector works. The common shape is forwarding from a collector you already run, as a second exporter alongside whatever's already feeding your existing observability tooling.
+
+Production data, CI data, and local data now all sit behind the same query surfaces, which is what makes the rest of this devlog work the way it does.
 
 ## `everr cloud query` for SQL access to your runs
 
@@ -88,6 +100,6 @@ This isn't visible to users beyond "downloads work and updates are signed," but 
 
 ## What's next
 
-We've now got the same SQL surface on the local collector and the cloud, a shared logs explorer that consumes both, a way to feed arbitrary commands into the local one, and skills that tell assistants how to use it all. The shape of the next batch is mostly about pushing on that loop: better skills, more queries surfaced as first-class CLI commands, and more of the desktop app rebuilt on top of the shared explorer so that local debugging stops feeling like a separate product from CI debugging.
+We've now got production OTel ingest, the same SQL surface on the local collector and the cloud, a shared logs explorer that consumes both, a way to feed arbitrary commands into the local stack, and skills that tell assistants how to use it all. The shape of the next batch is mostly about pushing on that loop: better skills, more queries surfaced as first-class CLI commands, more of the desktop app rebuilt on top of the shared explorer so that local debugging stops feeling like a separate product from CI debugging, and more of the cloud app reshaped around the idea that not everything it shows comes from CI.
 
 Same pattern as before: the things we hit in daily use keep turning into PRs the same week.

--- a/packages/docs/content/devlog/local-sql-logs-explorer-cloud-query.mdx
+++ b/packages/docs/content/devlog/local-sql-logs-explorer-cloud-query.mdx
@@ -17,7 +17,9 @@ Here's what shipped.
 
 ## Production telemetry
 
-Everr's cloud side now accepts OpenTelemetry data from any service that speaks OTLP, not just CI. Mint an ingest key in the dashboard and point your SDK or collector at `https://ingest.everr.dev`. See the [Sending Telemetry](/docs/sending-telemetry) docs for the full setup.
+Everr's cloud side now accepts OpenTelemetry data from any service that speaks OTLP, not just CI.
+
+See the [Sending Telemetry](/docs/sending-telemetry) docs for the full setup.
 
 ## `everr cloud query` for SQL access to your runs
 

--- a/packages/docs/content/devlog/local-sql-logs-explorer-cloud-query.mdx
+++ b/packages/docs/content/devlog/local-sql-logs-explorer-cloud-query.mdx
@@ -15,17 +15,9 @@ Devlog #2 introduced the local observability stack as a v1 with a small set of c
 
 Here's what shipped.
 
-## Production telemetry with ingest keys
+## Production telemetry
 
-Until this cycle, Everr's cloud side was CI-only. The new ingest path opens it to production OpenTelemetry from any service that speaks OTLP. You mint an org-scoped ingest key from the dashboard (under **Ingest Keys** in the user menu), point your SDK or collector at `https://ingest.everr.dev`, and the data lands in the same ClickHouse tables you can already query with `everr cloud query` and the logs explorer.
-
-A few things worth calling out:
-
-- **Tenant identity comes from the key, not the client.** The `everr.tenant.id` resource attribute on incoming spans is stripped and overwritten with the value derived from your ingest key, so a misconfigured SDK can't accidentally write into the wrong org.
-- **Authentication is hot-path-aware.** Verification runs through a new `everrapikeyauth` collector extension that singleflights concurrent verifies, keeps an LRU positive cache, and uses a separate negative cache. Revocation propagates within about 30 seconds, which is the positive cache TTL.
-- **Standard OTLP, no client SDK required.** Any OpenTelemetry SDK or existing collector works. The common shape is forwarding from a collector you already run, as a second exporter alongside whatever's already feeding your existing observability tooling.
-
-Production data, CI data, and local data now all sit behind the same query surfaces, which is what makes the rest of this devlog work the way it does.
+Everr's cloud side now accepts OpenTelemetry data from any service that speaks OTLP, not just CI. Mint an ingest key in the dashboard and point your SDK or collector at `https://ingest.everr.dev`.
 
 ## `everr cloud query` for SQL access to your runs
 

--- a/packages/docs/src/routes/devlog/index.tsx
+++ b/packages/docs/src/routes/devlog/index.tsx
@@ -42,7 +42,8 @@ const loadDevlogPosts = createServerFn({ method: "GET" }).handler(async () => {
       description: post.data.description,
       date: post.data.date,
       author: post.data.author,
-    }));
+    }))
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 });
 
 function DevlogIndex() {


### PR DESCRIPTION
## Summary

- Adds Devlog #3 covering the 28 days since Devlog #2 (cloud SQL query, logs explorer, `everr wrap`, consolidated local telemetry stack, bundled skills, desktop releases, plus the smaller stuff).
- Sorts `/devlog` index by date descending so the newest post is always first (otherwise it'd render in filename order).

## Test plan

- [ ] `/devlog` lists Devlog #3 at the top, #2 second, #1 third
- [ ] Devlog #3 page renders, stats in the header look right (265 / 35 / +80,752 / −38,219)
- [ ] Skim copy once more for anything that should be tightened before publish