### PR TITLE
Hardcode desktop app download URL

### DIFF
--- a/packages/app/src/components/nav-user.tsx
+++ b/packages/app/src/components/nav-user.tsx
@@ -27,7 +27,7 @@ import {
   LogOut,
   Users,
 } from "lucide-react";
-import { PLATFORMS, useDownloadUrl } from "@/lib/app-download";
+import { PLATFORMS } from "@/lib/app-download";
 import { authClient } from "@/lib/auth-client";
 
 export function NavUser() {
@@ -36,7 +36,7 @@ export function NavUser() {
   const { data: session } = authClient.useSession();
   const { data: activeOrg } = authClient.useActiveOrganization();
   const { data: orgs } = authClient.useListOrganizations();
-  const downloadUrl = useDownloadUrl(PLATFORMS[0].updaterTarget);
+  const downloadUrl = PLATFORMS[0].downloadUrl;
   const userRole = activeOrg?.members?.find(
     (m) => m.userId === session?.user?.id,
   )?.role;
@@ -160,20 +160,18 @@ export function NavUser() {
                   </DropdownMenuItem>
                 </>
               )}
-              {downloadUrl ? (
-                <DropdownMenuItem
-                  nativeButton={false}
-                  render={
-                    <a href={downloadUrl} download>
-                      <Download />
-                      Download App
-                    </a>
-                  }
-                >
-                  <Download />
-                  Download App
-                </DropdownMenuItem>
-              ) : null}
+              <DropdownMenuItem
+                nativeButton={false}
+                render={
+                  <a href={downloadUrl} download>
+                    <Download />
+                    Download App
+                  </a>
+                }
+              >
+                <Download />
+                Download App
+              </DropdownMenuItem>
             </DropdownMenuGroup>
             <DropdownMenuSeparator />
             <DropdownMenuItem

--- a/packages/app/src/lib/app-download.ts
+++ b/packages/app/src/lib/app-download.ts
@@ -1,55 +1,8 @@
-import { useEffect, useState } from "react";
-
-const DOCS_ORIGIN = import.meta.env.DEV
-  ? "http://localhost:3000"
-  : "https://everr.dev";
-const LATEST_MANIFEST_URL = `${DOCS_ORIGIN}/everr-app/latest.json`;
-
 export const PLATFORMS = [
   {
     label: "macOS (Apple Silicon)",
     os: "macos",
     arch: "arm64",
-    updaterTarget: "darwin-aarch64",
+    downloadUrl: "https://everr.dev/everr-app/everr-macos-arm64.dmg",
   },
 ] as const;
-
-type LatestManifest = {
-  platforms: Record<string, { url: string }>;
-};
-
-async function fetchLatestManifest(): Promise<LatestManifest> {
-  const response = await fetch(LATEST_MANIFEST_URL, { cache: "no-cache" });
-  if (!response.ok) {
-    throw new Error(
-      `Failed to fetch ${LATEST_MANIFEST_URL}: ${response.status}`,
-    );
-  }
-  return (await response.json()) as LatestManifest;
-}
-
-export function useDownloadUrl(updaterTarget: string) {
-  const [url, setUrl] = useState<string | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    fetchLatestManifest()
-      .then((manifest) => {
-        if (cancelled) return;
-        const platformUrl = manifest.platforms[updaterTarget]?.url;
-        if (platformUrl) {
-          // latest.json archive URL points at the updater .app.tar.gz — swap
-          // for the matching .dmg which sits alongside in the same release.
-          setUrl(platformUrl.replace(/\.app\.tar\.gz$/, ".dmg"));
-        }
-      })
-      .catch(() => {
-        if (!cancelled) setUrl(null);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [updaterTarget]);
-
-  return url;
-}


### PR DESCRIPTION
## Summary
- Removed the `latest.json` fetch in `packages/app` and point the sidebar Download App link straight at `https://everr.dev/everr-app/everr-macos-arm64.dmg`.
- Replaced the async `useDownloadUrl` hook with a static URL on `PLATFORMS` and dropped the now-dead `downloadUrl ?` fallback in `nav-user.tsx`.

## Test plan
- [ ] `pnpm --filter @everr/app tsc --noEmit`
- [ ] Open the app sidebar locally, confirm Download App opens the `.dmg` URL directly with no network call to `latest.json`.