### PR TITLE
Self-discover check_run_id; drop check-run-id input from everr-action

### DIFF
--- a/.changeset/self-discover-check-run-id.md
+++ b/.changeset/self-discover-check-run-id.md
@@ -1,0 +1,10 @@
+---
+"@everr/action": minor
+---
+
+Drop the `check-run-id` input. The action now self-discovers its own
+check_run_id via the GitHub Jobs API using the workflow's GITHUB_TOKEN
+(default `${{ github.token }}`), so external consumers no longer have
+to plumb `${{ job.check_run_id }}` at every call site. Calling
+workflows must grant `actions: read` permission. To override the
+discovered token, pass `github-token` explicitly.

--- a/.github/actions/everr-action/action.yml
+++ b/.github/actions/everr-action/action.yml
@@ -6,10 +6,13 @@ inputs:
     description: Collect per-job machine resource usage and upload a best-effort artifact
     required: false
     default: "false"
-  check-run-id:
-    description: Check run id for the current workflow job. Required when resource-usage is true.
+  github-token:
+    description: |
+      Token used to look up the current job's check_run_id via the GitHub API
+      when resource-usage is enabled. The default uses the workflow-provided
+      GITHUB_TOKEN; the calling workflow must grant `actions: read`.
     required: false
-    default: ""
+    default: ${{ github.token }}
 
 runs:
   using: node24

--- a/.github/actions/everr-action/src/index.test.ts
+++ b/.github/actions/everr-action/src/index.test.ts
@@ -8,17 +8,60 @@ import { fileURLToPath } from "node:url";
 import {
   artifactNameForCheckRun,
   buildRuntimePaths,
+  checkRunIdFromUrl,
+  discoverCurrentCheckRunId,
   finalizeAndUploadResourceUsage,
   isResourceUsageEnabled,
   normalizeCheckRunId,
   resolveActionRoot,
-  resolveCheckRunIdInput,
   startResourceUsage,
 } from "./index.ts";
 
 function inputResolver(values: Record<string, string>): (name: string) => string {
   return (name: string) => values[name] ?? "";
 }
+
+function jsonResponse(status: number, body: unknown) {
+  return {
+    json: async () => body,
+    ok: status >= 200 && status < 300,
+    status,
+  };
+}
+
+function mockFetch(
+  responses: Array<{ body: unknown; status: number }>,
+): {
+  calls: Array<{ headers: Record<string, string>; url: string }>;
+  fetch: (
+    input: string,
+    init: { headers: Record<string, string> },
+  ) => Promise<ReturnType<typeof jsonResponse>>;
+} {
+  const calls: Array<{ headers: Record<string, string>; url: string }> = [];
+  let i = 0;
+  return {
+    calls,
+    fetch: async (
+      input: string,
+      init: { headers: Record<string, string> },
+    ) => {
+      calls.push({ headers: init.headers, url: input });
+      const next = responses[i++];
+      if (!next) {
+        throw new Error("no more mocked responses");
+      }
+      return jsonResponse(next.status, next.body);
+    },
+  };
+}
+
+const defaultEnvForDiscovery = {
+  GITHUB_REPOSITORY: "everr-labs/everr",
+  GITHUB_RUN_ATTEMPT: "1",
+  GITHUB_RUN_ID: "12",
+  RUNNER_NAME: "runner-7",
+};
 
 test("artifactNameForCheckRun uses the direct per-job naming contract", () => {
   assert.equal(artifactNameForCheckRun("123"), "everr-resource-usage-v2-123");
@@ -54,16 +97,114 @@ test("normalizeCheckRunId trims valid ids and rejects malformed values", () => {
   assert.equal(normalizeCheckRunId("abc"), null);
 });
 
-test("resolveCheckRunIdInput warns when the workflow does not provide a valid id", () => {
-  const warnings: string[] = [];
+test("checkRunIdFromUrl extracts the trailing id and rejects malformed values", () => {
+  assert.equal(
+    checkRunIdFromUrl("https://api.github.com/repos/o/r/check-runs/12345"),
+    "12345",
+  );
+  assert.equal(checkRunIdFromUrl("https://api.github.com/repos/o/r/check-runs/"), null);
+  assert.equal(checkRunIdFromUrl(""), null);
+});
 
-  const checkRunId = resolveCheckRunIdInput({
-    getInput: () => "not-a-number",
+test("discoverCurrentCheckRunId returns the in_progress job on this runner", async () => {
+  const { calls, fetch } = mockFetch([
+    {
+      status: 200,
+      body: {
+        total_count: 2,
+        jobs: [
+          {
+            name: "Build",
+            runner_name: "runner-9",
+            status: "in_progress",
+            check_run_url: "https://api.github.com/repos/everr-labs/everr/check-runs/9999",
+          },
+          {
+            name: "Lint",
+            runner_name: "runner-7",
+            status: "in_progress",
+            check_run_url: "https://api.github.com/repos/everr-labs/everr/check-runs/4242",
+          },
+        ],
+      },
+    },
+  ]);
+
+  const result = await discoverCurrentCheckRunId({
+    env: defaultEnvForDiscovery,
+    fetchImpl: fetch,
+    token: "ghs_xyz",
+    warning: () => {},
+  });
+
+  assert.equal(result, "4242");
+  assert.equal(calls.length, 1);
+  assert.match(
+    calls[0].url,
+    /\/repos\/everr-labs\/everr\/actions\/runs\/12\/attempts\/1\/jobs/,
+  );
+  assert.equal(calls[0].headers.Authorization, "Bearer ghs_xyz");
+});
+
+test("discoverCurrentCheckRunId warns and returns null when the API rejects the request", async () => {
+  const warnings: string[] = [];
+  const { fetch } = mockFetch([{ status: 403, body: { message: "no" } }]);
+
+  const result = await discoverCurrentCheckRunId({
+    env: defaultEnvForDiscovery,
+    fetchImpl: fetch,
+    token: "ghs_xyz",
     warning: (message: string) => warnings.push(message),
   });
 
-  assert.equal(checkRunId, null);
-  assert.match(warnings[0], /missing or invalid check-run-id input/);
+  assert.equal(result, null);
+  assert.match(warnings[0], /jobs API returned 403/);
+});
+
+test("discoverCurrentCheckRunId warns when no in_progress job matches the runner", async () => {
+  const warnings: string[] = [];
+  const { fetch } = mockFetch([
+    {
+      status: 200,
+      body: {
+        total_count: 1,
+        jobs: [
+          {
+            name: "Build",
+            runner_name: "runner-9",
+            status: "in_progress",
+            check_run_url: "https://api.github.com/repos/o/r/check-runs/9999",
+          },
+        ],
+      },
+    },
+  ]);
+
+  const result = await discoverCurrentCheckRunId({
+    env: defaultEnvForDiscovery,
+    fetchImpl: fetch,
+    token: "ghs_xyz",
+    warning: (message: string) => warnings.push(message),
+  });
+
+  assert.equal(result, null);
+  assert.match(warnings[0], /no in_progress job on runner 'runner-7'/);
+});
+
+test("discoverCurrentCheckRunId warns when required env vars are missing", async () => {
+  const warnings: string[] = [];
+  const { fetch, calls } = mockFetch([]);
+
+  const result = await discoverCurrentCheckRunId({
+    env: { GITHUB_RUN_ID: "12" },
+    fetchImpl: fetch,
+    token: "ghs_xyz",
+    warning: (message: string) => warnings.push(message),
+  });
+
+  assert.equal(result, null);
+  assert.equal(calls.length, 0);
+  assert.match(warnings[0], /GITHUB_REPOSITORY, GITHUB_RUN_ID, or RUNNER_NAME is missing/);
 });
 
 test("isResourceUsageEnabled accepts only the literal string 'true'", () => {
@@ -83,7 +224,7 @@ test("startResourceUsage no-ops when resource-usage input is not enabled", async
     env: {
       RUNNER_OS: "Linux",
     },
-    getInput: inputResolver({ "resource-usage": "false", "check-run-id": "123" }),
+    getInput: inputResolver({ "resource-usage": "false", "github-token": "ghs_xyz" }),
     saveState: (key: string, value: string) => savedState.set(key, value),
     info: (message: string) => infoMessages.push(message),
     warning: () => {},
@@ -102,7 +243,7 @@ test("startResourceUsage no-ops on non-linux runners", async () => {
     env: {
       RUNNER_OS: "Windows",
     },
-    getInput: inputResolver({ "resource-usage": "true", "check-run-id": "123" }),
+    getInput: inputResolver({ "resource-usage": "true", "github-token": "ghs_xyz" }),
     saveState: (key: string, value: string) => savedState.set(key, value),
     info: (message: string) => infoMessages.push(message),
     warning: () => {},
@@ -113,7 +254,7 @@ test("startResourceUsage no-ops on non-linux runners", async () => {
   assert.match(infoMessages[0], /supported only on Linux runners/);
 });
 
-test("startResourceUsage skips sampling when check-run-id is missing", async () => {
+test("startResourceUsage skips sampling when github-token is missing", async () => {
   const savedState = new Map<string, string>();
   const warnings: string[] = [];
 
@@ -121,7 +262,7 @@ test("startResourceUsage skips sampling when check-run-id is missing", async () 
     env: {
       RUNNER_OS: "Linux",
     },
-    getInput: inputResolver({ "resource-usage": "true", "check-run-id": "" }),
+    getInput: inputResolver({ "resource-usage": "true", "github-token": "" }),
     saveState: (key: string, value: string) => savedState.set(key, value),
     info: () => {},
     warning: (message: string) => warnings.push(message),
@@ -129,26 +270,46 @@ test("startResourceUsage skips sampling when check-run-id is missing", async () 
 
   assert.equal(result.enabled, false);
   assert.equal(savedState.get("enabled"), "0");
-  assert.match(warnings[0], /missing or invalid check-run-id input/);
+  assert.match(warnings[0], /no github-token/);
 });
+
+function jobsApiResponseFor(checkRunId: string, runnerName: string) {
+  return {
+    status: 200,
+    body: {
+      total_count: 1,
+      jobs: [
+        {
+          name: "lint",
+          runner_name: runnerName,
+          status: "in_progress",
+          check_run_url: `https://api.github.com/repos/everr-labs/everr/check-runs/${checkRunId}`,
+        },
+      ],
+    },
+  };
+}
 
 test("startResourceUsage downgrades sampler startup failures to warnings", async () => {
   const savedState = new Map<string, string>();
   const warnings: string[] = [];
   const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "everr-ru-start-"));
+  const { fetch } = mockFetch([jobsApiResponseFor("111", "runner-7")]);
 
   try {
     const result = await startResourceUsage({
       env: {
         RUNNER_OS: "Linux",
         RUNNER_TEMP: tempDir,
+        RUNNER_NAME: "runner-7",
         GITHUB_RUN_ID: "12",
         GITHUB_RUN_ATTEMPT: "1",
         GITHUB_JOB: "lint",
         GITHUB_REPOSITORY: "everr-labs/everr",
         GITHUB_WORKSPACE: tempDir,
       },
-      getInput: inputResolver({ "resource-usage": "true", "check-run-id": "111" }),
+      getInput: inputResolver({ "resource-usage": "true", "github-token": "ghs_xyz" }),
+      fetchImpl: fetch,
       saveState: (key: string, value: string) => savedState.set(key, value),
       warning: (message: string) => warnings.push(message),
       spawnImpl: () => {
@@ -168,6 +329,7 @@ test("startResourceUsage downgrades sampler startup failures to warnings", async
 test("startResourceUsage resolves sampler path without GITHUB_ACTION_PATH", async () => {
   const savedState = new Map<string, string>();
   const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "everr-ru-spawn-"));
+  const { fetch } = mockFetch([jobsApiResponseFor("222", "runner-7")]);
   let spawnInvocation:
     | {
         args: readonly string[];
@@ -180,13 +342,15 @@ test("startResourceUsage resolves sampler path without GITHUB_ACTION_PATH", asyn
       env: {
         RUNNER_OS: "Linux",
         RUNNER_TEMP: tempDir,
+        RUNNER_NAME: "runner-7",
         GITHUB_RUN_ID: "12",
         GITHUB_RUN_ATTEMPT: "1",
         GITHUB_JOB: "lint",
         GITHUB_REPOSITORY: "everr-labs/everr",
         GITHUB_WORKSPACE: tempDir,
       },
-      getInput: inputResolver({ "resource-usage": "true", "check-run-id": "222" }),
+      getInput: inputResolver({ "resource-usage": "true", "github-token": "ghs_xyz" }),
+      fetchImpl: fetch,
       saveState: (key: string, value: string) => savedState.set(key, value),
       info: () => {},
       warning: () => {},

--- a/.github/actions/everr-action/src/index.ts
+++ b/.github/actions/everr-action/src/index.ts
@@ -41,10 +41,32 @@ type UploadArtifactImpl = (
   options: { retentionDays: number },
 ) => Promise<unknown>;
 
+interface JobsApiResponse {
+  jobs: Array<{
+    check_run_url: string;
+    name: string;
+    runner_name: string | null;
+    status: string;
+  }>;
+  total_count: number;
+}
+
+interface FetchResponseLike {
+  json: () => Promise<unknown>;
+  ok: boolean;
+  status: number;
+}
+
+type FetchImpl = (
+  input: string,
+  init: { headers: Record<string, string> },
+) => Promise<FetchResponseLike>;
+
 const defaultSampleIntervalSeconds = "5";
 
 interface StartResourceUsageOptions {
   env?: Env;
+  fetchImpl?: FetchImpl;
   fsModule?: typeof fs;
   fspModule?: typeof fsp;
   getInput?: GetInput;
@@ -101,16 +123,83 @@ function normalizeCheckRunId(rawCheckRunId: string): string | null {
   return checkRunId;
 }
 
-function resolveCheckRunIdInput({
-  getInput = core.getInput,
+function checkRunIdFromUrl(checkRunUrl: string): string | null {
+  const tail = checkRunUrl.split("/").pop() || "";
+  return normalizeCheckRunId(tail);
+}
+
+async function discoverCurrentCheckRunId({
+  env,
+  fetchImpl = globalThis.fetch as unknown as FetchImpl,
+  token,
   warning = core.warning,
 }: {
-  getInput?: GetInput;
+  env: Env;
+  fetchImpl?: FetchImpl;
+  token: string;
   warning?: Log;
-} = {}): string | null {
-  const checkRunId = normalizeCheckRunId(getInput("check-run-id"));
+}): Promise<string | null> {
+  const repo = env.GITHUB_REPOSITORY;
+  const runId = env.GITHUB_RUN_ID;
+  const attempt = env.GITHUB_RUN_ATTEMPT || "1";
+  const runnerName = env.RUNNER_NAME;
+  const apiUrl = env.GITHUB_API_URL || "https://api.github.com";
+
+  if (!repo || !runId || !runnerName) {
+    warning(
+      "resource-usage skipped: GITHUB_REPOSITORY, GITHUB_RUN_ID, or RUNNER_NAME is missing",
+    );
+    return null;
+  }
+
+  const url = `${apiUrl}/repos/${repo}/actions/runs/${runId}/attempts/${attempt}/jobs?per_page=100`;
+
+  let response: FetchResponseLike;
+  try {
+    response = await fetchImpl(url, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "User-Agent": "everr-action",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+  } catch (error) {
+    warning(
+      `resource-usage skipped: GitHub jobs API request failed: ${formatError(error)}`,
+    );
+    return null;
+  }
+
+  if (!response.ok) {
+    warning(
+      `resource-usage skipped: GitHub jobs API returned ${response.status}`,
+    );
+    return null;
+  }
+
+  const body = (await response.json()) as JobsApiResponse;
+  if (body.total_count > body.jobs.length) {
+    warning(
+      `resource-usage: only fetched ${body.jobs.length} of ${body.total_count} jobs; matching may be incomplete`,
+    );
+  }
+
+  const match = body.jobs.find(
+    (job) => job.runner_name === runnerName && job.status === "in_progress",
+  );
+  if (!match) {
+    warning(
+      `resource-usage skipped: no in_progress job on runner '${runnerName}'`,
+    );
+    return null;
+  }
+
+  const checkRunId = checkRunIdFromUrl(match.check_run_url);
   if (!checkRunId) {
-    warning("resource-usage skipped: missing or invalid check-run-id input");
+    warning(
+      `resource-usage skipped: could not parse check_run_id from '${match.check_run_url}'`,
+    );
     return null;
   }
 
@@ -123,6 +212,7 @@ function isResourceUsageEnabled(getInput: GetInput): boolean {
 
 async function startResourceUsage({
   env = process.env,
+  fetchImpl,
   fsModule = fs,
   fspModule = fsp,
   saveState = core.saveState,
@@ -149,7 +239,21 @@ async function startResourceUsage({
     return { enabled: false };
   }
 
-  const checkRunId = resolveCheckRunIdInput({ getInput, warning });
+  const token = getInput("github-token");
+  if (!token) {
+    warning(
+      "resource-usage skipped: no github-token; ensure the workflow grants actions: read and exposes GITHUB_TOKEN",
+    );
+    saveState("enabled", "0");
+    return { enabled: false };
+  }
+
+  const checkRunId = await discoverCurrentCheckRunId({
+    env,
+    fetchImpl,
+    token,
+    warning,
+  });
   if (!checkRunId) {
     saveState("enabled", "0");
     return { enabled: false };
@@ -445,13 +549,14 @@ if (entrypointPath === fileURLToPath(import.meta.url)) {
 export {
   artifactNameForCheckRun,
   buildRuntimePaths,
+  checkRunIdFromUrl,
+  discoverCurrentCheckRunId,
   ensureSamplesFile,
   finalizeAndUploadResourceUsage,
   formatError,
   isResourceUsageEnabled,
   normalizeCheckRunId,
   resolveActionRoot,
-  resolveCheckRunIdInput,
   resolveWorkspaceFilesystemInfo,
   startResourceUsage,
   stopSampler,

--- a/.github/workflows/build-and-push-images.yml
+++ b/.github/workflows/build-and-push-images.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: build-and-push-images
@@ -76,7 +77,6 @@ jobs:
         uses: ./.github/actions/everr-action
         with:
           resource-usage: "true"
-          check-run-id: ${{ job.check_run_id }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -112,7 +112,6 @@ jobs:
         uses: ./.github/actions/everr-action
         with:
           resource-usage: "true"
-          check-run-id: ${{ job.check_run_id }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -148,7 +147,6 @@ jobs:
         uses: ./.github/actions/everr-action
         with:
           resource-usage: "true"
-          check-run-id: ${{ job.check_run_id }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/build-and-test-app.yml
+++ b/.github/workflows/build-and-test-app.yml
@@ -2,6 +2,7 @@ name: Build & Test App
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   # For pushes, this lets concurrent runs happen, so each push gets a result.
@@ -49,7 +50,6 @@ jobs:
         uses: ./.github/actions/everr-action
         with:
           resource-usage: "true"
-          check-run-id: ${{ job.check_run_id }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/build-and-test-collector.yml
+++ b/.github/workflows/build-and-test-collector.yml
@@ -11,6 +11,7 @@ concurrency:
 
 permissions:
   contents: read
+  actions: read
 
 on:
   pull_request:
@@ -36,7 +37,6 @@ jobs:
         uses: ./.github/actions/everr-action
         with:
           resource-usage: "true"
-          check-run-id: ${{ job.check_run_id }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -77,7 +77,6 @@ jobs:
         uses: ./.github/actions/everr-action
         with:
           resource-usage: "true"
-          check-run-id: ${{ job.check_run_id }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -137,7 +136,6 @@ jobs:
         uses: ./.github/actions/everr-action
         with:
           resource-usage: "true"
-          check-run-id: ${{ job.check_run_id }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -177,7 +175,6 @@ jobs:
         uses: ./.github/actions/everr-action
         with:
           resource-usage: "true"
-          check-run-id: ${{ job.check_run_id }}
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/build-and-test-desktop-app.yml
+++ b/.github/workflows/build-and-test-desktop-app.yml
@@ -2,6 +2,7 @@ name: Build & Test Desktop App
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   # For pushes, this lets concurrent runs happen, so each push gets a result.
@@ -49,7 +50,6 @@ jobs:
         uses: ./.github/actions/everr-action
         with:
           resource-usage: "true"
-          check-run-id: ${{ job.check_run_id }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/build-everr-cli.yml
+++ b/.github/workflows/build-everr-cli.yml
@@ -2,6 +2,7 @@ name: Everr CLI CI
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -42,7 +43,6 @@ jobs:
         uses: ./.github/actions/everr-action
         with:
           resource-usage: "true"
-          check-run-id: ${{ job.check_run_id }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/deploy-desktop-app.yml
+++ b/.github/workflows/deploy-desktop-app.yml
@@ -2,6 +2,7 @@ name: Deploy Desktop App
 
 permissions:
   contents: read
+  actions: read
   id-token: write
   attestations: write
 
@@ -28,7 +29,6 @@ jobs:
         uses: ./.github/actions/everr-action
         with:
           resource-usage: "true"
-          check-run-id: ${{ job.check_run_id }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary
- Replaces the required `check-run-id` input on `everr-action` with API-based self-discovery: the action calls the GitHub Jobs API and matches its own row by `RUNNER_NAME` + `status=in_progress`, then extracts `check_run_id` from `check_run_url`.
- Drops `with: check-run-id` from all 11 in-repo call sites.
- Adds a `github-token` input defaulting to `\${{ github.token }}`.
- Grants `actions: read` on the six workflows that use the action so the default `GITHUB_TOKEN` can read jobs.

## Why
- The old API was Everr-specific (external consumers had no `\${{ job.check_run_id }}` to pass) and added boilerplate everywhere we called it.
- After this, the published `v0` API has no Everr-specific input; external repos can use `uses: everr-labs/everr-action@v0` with just `resource-usage: \"true\"`.

## Base
- Stacked on top of #121. Merge that first so the action package path and dist verification are in place.

## Test plan
- [ ] `pnpm --filter @everr/action test` (20/20 locally)
- [ ] Verify-action-dist CI runs green
- [ ] After both this and #121 land + the bot App is installed, trigger a release and confirm the action correctly self-discovers check_run_id during one of the workflows