### PR TITLE
Fix health test shutdown cleanup context

### DIFF
--- a/collector/internal/localgateway/health/server_test.go
+++ b/collector/internal/localgateway/health/server_test.go
@@ -1,9 +1,11 @@
 package health
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -11,7 +13,11 @@ import (
 func TestHealthServerReportsReadiness(t *testing.T) {
 	server := NewServer("127.0.0.1:0")
 	require.NoError(t, server.Start())
-	t.Cleanup(func() { require.NoError(t, server.Shutdown(t.Context())) })
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.NoError(t, server.Shutdown(ctx))
+	})
 
 	resp, err := http.Get(server.URL() + "/")
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- Update the local gateway health test cleanup to use a fresh shutdown context.
- Avoid passing `t.Context()` into cleanup, because Go cancels that context before cleanup callbacks run.

## Root cause

`TestHealthServerReportsReadiness` called `server.Shutdown(t.Context())` inside `t.Cleanup`. In Go, the test context is canceled just before cleanup functions run, so `http.Server.Shutdown` could receive an already-canceled context and return `context canceled`.

## Validation

- `go test -v ./... -coverprofile=coverage.out -covermode=atomic` in `collector/internal/localgateway/health`
- `go test -v -run '^TestHealthServerReportsReadiness$' -count=50 ./...` in `collector/internal/localgateway/health`
- `make test-all` in `collector`
- pre-commit hook: collector fmt, tidy, and lint