### PR TITLE
Design GitHub deploy CDEvents ingest

### DIFF
--- a/collector/receiver/githubactionsreceiver/deploy_attributes.go
+++ b/collector/receiver/githubactionsreceiver/deploy_attributes.go
@@ -1,0 +1,37 @@
+package githubactionsreceiver
+
+import (
+	"strings"
+
+	"github.com/google/go-github/v67/github"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	conventions "go.opentelemetry.io/otel/semconv/v1.38.0"
+
+	"github.com/everr-labs/everr/collector/semconv"
+)
+
+const githubDeploymentsServiceName = "github-deployments"
+
+func setDeploymentResourceAttributes(attrs pcommon.Map, repo *github.Repository, environment string) {
+	attrs.PutStr("service.name", githubDeploymentsServiceName)
+	if environment != "" {
+		attrs.PutStr("deployment.environment.name", environment)
+	}
+	if repo != nil {
+		attrs.PutStr(string(conventions.VCSRepositoryNameKey), repo.GetName())
+		attrs.PutStr("vcs.repository.url.full", repo.GetHTMLURL())
+		attrs.PutStr(semconv.EverrGitHubRepositoryFullName, repo.GetFullName())
+		attrs.PutStr(semconv.EverrGitHubRepositoryOwnerLogin, repo.GetOwner().GetLogin())
+	}
+}
+
+func deploymentServiceName(task string) string {
+	task = strings.TrimSpace(task)
+	if task == "" {
+		return "deploy"
+	}
+	if after, ok := strings.CutPrefix(task, "deploy:"); ok && strings.TrimSpace(after) != "" {
+		return strings.TrimSpace(after)
+	}
+	return task
+}

--- a/collector/receiver/githubactionsreceiver/deploy_event_handling.go
+++ b/collector/receiver/githubactionsreceiver/deploy_event_handling.go
@@ -71,7 +71,7 @@ func deploymentEventToLogs(event interface{}, deliveryID string, logger *zap.Log
 
 	switch e := event.(type) {
 	case *github.DeploymentEvent:
-		return deploymentCreatedToLogs(e, deliveryID, logger)
+		return deploymentCreatedToLogs(e, deliveryID)
 	case *github.DeploymentStatusEvent:
 		return deploymentStatusToLogs(e, deliveryID, logger)
 	default:
@@ -79,8 +79,7 @@ func deploymentEventToLogs(event interface{}, deliveryID string, logger *zap.Log
 	}
 }
 
-func deploymentCreatedToLogs(e *github.DeploymentEvent, deliveryID string, logger *zap.Logger) (*plog.Logs, error) {
-	_ = logger
+func deploymentCreatedToLogs(e *github.DeploymentEvent, deliveryID string) (*plog.Logs, error) {
 	logs, records := newDeploymentLogs(e.GetRepo(), e.GetDeployment().GetEnvironment())
 	record := records.AppendEmpty()
 	fillDeploymentLogRecord(record, deploymentLogInput{
@@ -202,11 +201,17 @@ func firstNonZeroTime(values ...time.Time) time.Time {
 	return time.Now().UTC()
 }
 
+// cdeventsSource returns a CDEvents `context.source` value: an absolute URI
+// per CDEvents v0.5.0 ("An absolute URI is RECOMMENDED"). It mirrors the
+// repository's HTML URL so downstream consumers can join on the same identity
+// they would derive from `vcs.repository.url.full`.
 func cdeventsSource(repo *github.Repository) string {
-	if repo == nil || repo.GetFullName() == "" {
-		return "/github/deployments"
+	if repo != nil {
+		if htmlURL := repo.GetHTMLURL(); htmlURL != "" {
+			return htmlURL
+		}
 	}
-	return fmt.Sprintf("/github/%s/deployments", repo.GetFullName())
+	return "https://github.com"
 }
 
 func cdeventsID(input deploymentLogInput) string {

--- a/collector/receiver/githubactionsreceiver/deploy_event_handling.go
+++ b/collector/receiver/githubactionsreceiver/deploy_event_handling.go
@@ -28,19 +28,27 @@ type cdeventsBody struct {
 	Subject cdeventsSubject `json:"subject"`
 }
 
+// cdeventsContext mirrors the CDEvents v0.5.0 context object. The spec text
+// and conformance examples (cdevents/spec @ v0.5.0/conformance/) name the
+// version field `specversion`; the v0.5.0 JSON schema's `required` array
+// erroneously lists `version`, but its `properties` only define `specversion`,
+// so we follow the spec text and conformance examples here.
 type cdeventsContext struct {
-	Version   string `json:"version"`
-	ID        string `json:"id"`
-	Source    string `json:"source"`
-	Type      string `json:"type"`
-	Timestamp string `json:"timestamp,omitempty"`
+	Specversion string `json:"specversion"`
+	ID          string `json:"id"`
+	Source      string `json:"source"`
+	Type        string `json:"type"`
+	Timestamp   string `json:"timestamp,omitempty"`
 }
 
+// cdeventsSubject mirrors the CDEvents v0.5.0 subject object. The subject
+// has no `type` field (the event type lives in context.type only), and
+// `content` is event-type specific — we use per-event-type content builders
+// below so the body remains schema-valid (`additionalProperties: false`).
 type cdeventsSubject struct {
-	ID      string         `json:"id"`
-	Type    string         `json:"type"`
-	Source  string         `json:"source,omitempty"`
-	Content map[string]any `json:"content,omitempty"`
+	ID      string `json:"id"`
+	Source  string `json:"source,omitempty"`
+	Content any    `json:"content"`
 }
 
 type deploymentLogInput struct {
@@ -250,13 +258,6 @@ func workflowRunLink(deployment *github.Deployment, workflowRun *github.Workflow
 	return payload.WorkflowRunID, payload.WorkflowRunAttempt
 }
 
-func cdeventsSubjectType(eventType string) string {
-	if eventType == cdeventsServiceDeployed {
-		return "service"
-	}
-	return "pipelineRun"
-}
-
 func cdeventsSubjectID(input deploymentLogInput) string {
 	if input.EventType == cdeventsServiceDeployed {
 		return deploymentServiceName(input.Deployment.GetTask())
@@ -267,51 +268,108 @@ func cdeventsSubjectID(input deploymentLogInput) string {
 	return "github-deployment"
 }
 
-func artifactID(repo *github.Repository, sha string) string {
-	if repo == nil || repo.GetFullName() == "" || sha == "" {
-		return ""
-	}
-	return fmt.Sprintf("pkg:github/%s@%s", repo.GetFullName(), sha)
+// pipelineRunContent matches the CDEvents v0.5.0 pipelinerun.* subject content
+// schema (cdevents/spec @ v0.5.0/schemas/pipelinerun{queued,started,finished}.json,
+// additionalProperties: false). Only `pipelineName`, `uri`, `outcome`, and
+// `errors` are permitted across the three pipelinerun event types.
+type pipelineRunContent struct {
+	PipelineName string `json:"pipelineName,omitempty"`
+	URI          string `json:"uri,omitempty"`
+	Outcome      string `json:"outcome,omitempty"`
+	Errors       string `json:"errors,omitempty"`
 }
 
-func deploymentContent(input deploymentLogInput) map[string]any {
-	repoFullName := ""
-	if input.Repo != nil {
-		repoFullName = input.Repo.GetFullName()
-	}
-	content := map[string]any{
-		"environment": map[string]string{
-			"id":   input.Deployment.GetEnvironment(),
-			"name": input.Deployment.GetEnvironment(),
-		},
-		"deploymentId": deploymentIDString(input.Deployment),
-		"repository":   repoFullName,
-		"sha":          input.Deployment.GetSHA(),
-		"ref":          input.Deployment.GetRef(),
-	}
-	if artifact := artifactID(input.Repo, input.Deployment.GetSHA()); artifact != "" {
-		content["artifactId"] = artifact
-	}
+// serviceDeployedContent matches the CDEvents v0.5.0 service.deployed subject
+// content schema. Both `environment` and `artifactId` are required and no
+// additional properties are allowed.
+type serviceDeployedContent struct {
+	Environment serviceEnvironment `json:"environment"`
+	ArtifactID  string             `json:"artifactId"`
+}
+
+type serviceEnvironment struct {
+	ID     string `json:"id"`
+	Source string `json:"source,omitempty"`
+}
+
+// deploymentPipelineURI returns the URI advertised in pipelinerun event bodies.
+// pipelinerun.started requires a non-empty uri per the schema, so fall back to
+// the repository URL when GitHub has not yet attached any status URL.
+func deploymentPipelineURI(input deploymentLogInput) string {
 	if input.URL != "" {
-		content["uri"] = input.URL
+		return input.URL
+	}
+	if input.Repo != nil {
+		if htmlURL := input.Repo.GetHTMLURL(); htmlURL != "" {
+			return htmlURL
+		}
+	}
+	return "https://github.com"
+}
+
+func pipelineRunCDEventsContent(input deploymentLogInput) pipelineRunContent {
+	content := pipelineRunContent{
+		PipelineName: firstString(input.Deployment.GetTask(), "deploy"),
+		URI:          deploymentPipelineURI(input),
+	}
+	if input.EventType == cdeventsPipelineRunDone {
+		content.Outcome = input.Result
+		if input.Status != nil {
+			content.Errors = input.Status.GetDescription()
+		}
 	}
 	return content
 }
 
+// deploymentArtifactID returns a purl-style identifier for the deployed
+// artifact. service.deployed requires a non-empty artifactId per the schema,
+// so always return a stable string even when SHA or repo are missing.
+func deploymentArtifactID(repo *github.Repository, sha string) string {
+	switch {
+	case repo == nil || repo.GetFullName() == "":
+		if sha != "" {
+			return fmt.Sprintf("pkg:github/unknown@%s", sha)
+		}
+		return "pkg:github/unknown"
+	case sha == "":
+		return fmt.Sprintf("pkg:github/%s", repo.GetFullName())
+	default:
+		return fmt.Sprintf("pkg:github/%s@%s", repo.GetFullName(), sha)
+	}
+}
+
+func serviceDeployedCDEventsContent(input deploymentLogInput) serviceDeployedContent {
+	envID := input.Deployment.GetEnvironment()
+	if envID == "" {
+		envID = "unknown"
+	}
+	return serviceDeployedContent{
+		Environment: serviceEnvironment{ID: envID},
+		ArtifactID:  deploymentArtifactID(input.Repo, input.Deployment.GetSHA()),
+	}
+}
+
+func deploymentCDEventsContent(input deploymentLogInput) any {
+	if input.EventType == cdeventsServiceDeployed {
+		return serviceDeployedCDEventsContent(input)
+	}
+	return pipelineRunCDEventsContent(input)
+}
+
 func deploymentCDEventsBody(input deploymentLogInput) cdeventsBody {
+	source := cdeventsSource(input.Repo)
 	return cdeventsBody{
 		Context: cdeventsContext{
-			Version:   cdeventsSpecVersion,
-			ID:        cdeventsID(input),
-			Source:    cdeventsSource(input.Repo),
-			Type:      input.EventType,
-			Timestamp: input.Time.UTC().Format(time.RFC3339Nano),
+			Specversion: cdeventsSpecVersion,
+			ID:          cdeventsID(input),
+			Source:      source,
+			Type:        input.EventType,
+			Timestamp:   input.Time.UTC().Format(time.RFC3339Nano),
 		},
 		Subject: cdeventsSubject{
 			ID:      cdeventsSubjectID(input),
-			Type:    cdeventsSubjectType(input.EventType),
-			Source:  cdeventsSource(input.Repo),
-			Content: deploymentContent(input),
+			Source:  source,
+			Content: deploymentCDEventsContent(input),
 		},
 	}
 }

--- a/collector/receiver/githubactionsreceiver/deploy_event_handling.go
+++ b/collector/receiver/githubactionsreceiver/deploy_event_handling.go
@@ -1,0 +1,382 @@
+package githubactionsreceiver
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/go-github/v67/github"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	conventions "go.opentelemetry.io/otel/semconv/v1.38.0"
+	"go.uber.org/zap"
+
+	"github.com/everr-labs/everr/collector/semconv"
+)
+
+const (
+	cdeventsSpecVersion        = "0.5.0"
+	cdeventsPipelineRunQueued  = "dev.cdevents.pipelinerun.queued.0.3.0"
+	cdeventsPipelineRunStarted = "dev.cdevents.pipelinerun.started.0.3.0"
+	cdeventsPipelineRunDone    = "dev.cdevents.pipelinerun.finished.0.3.0"
+	cdeventsServiceDeployed    = "dev.cdevents.service.deployed.0.3.0"
+	everrDeploySuperseded      = "everr.deploy.superseded"
+)
+
+type cdeventsBody struct {
+	Context cdeventsContext `json:"context"`
+	Subject cdeventsSubject `json:"subject"`
+}
+
+type cdeventsContext struct {
+	Version   string `json:"version"`
+	ID        string `json:"id"`
+	Source    string `json:"source"`
+	Type      string `json:"type"`
+	Timestamp string `json:"timestamp,omitempty"`
+}
+
+type cdeventsSubject struct {
+	ID      string         `json:"id"`
+	Type    string         `json:"type"`
+	Source  string         `json:"source,omitempty"`
+	Content map[string]any `json:"content,omitempty"`
+}
+
+type deploymentLogInput struct {
+	EventType        string
+	DeliveryID       string
+	CDEventsIDSuffix string
+	Repo             *github.Repository
+	Deployment       *github.Deployment
+	Status           *github.DeploymentStatus
+	WorkflowRun      *github.WorkflowRun
+	WorkflowRunID    int64
+	RunAttempt       int
+	State            string
+	Result           string
+	URL              string
+	Time             time.Time
+}
+
+type deploymentPayload struct {
+	WorkflowRunID      int64 `json:"workflow_run_id"`
+	WorkflowRunAttempt int   `json:"workflow_run_attempt"`
+}
+
+func deploymentEventToLogs(event interface{}, deliveryID string, logger *zap.Logger) (*plog.Logs, error) {
+	if deliveryID == "" {
+		return nil, fmt.Errorf("missing x-github-delivery")
+	}
+
+	switch e := event.(type) {
+	case *github.DeploymentEvent:
+		return deploymentCreatedToLogs(e, deliveryID, logger)
+	case *github.DeploymentStatusEvent:
+		return deploymentStatusToLogs(e, deliveryID, logger)
+	default:
+		return nil, nil
+	}
+}
+
+func deploymentCreatedToLogs(e *github.DeploymentEvent, deliveryID string, logger *zap.Logger) (*plog.Logs, error) {
+	_ = logger
+	logs, records := newDeploymentLogs(e.GetRepo(), e.GetDeployment().GetEnvironment())
+	record := records.AppendEmpty()
+	fillDeploymentLogRecord(record, deploymentLogInput{
+		EventType:   cdeventsPipelineRunQueued,
+		DeliveryID:  deliveryID,
+		Repo:        e.GetRepo(),
+		Deployment:  e.GetDeployment(),
+		WorkflowRun: e.GetWorkflowRun(),
+		State:       "pending",
+		Result:      "",
+		URL:         "",
+		Time:        firstNonZeroTime(e.GetDeployment().GetCreatedAt().Time, e.GetDeployment().GetUpdatedAt().Time),
+	})
+	return &logs, nil
+}
+
+func deploymentStatusToLogs(e *github.DeploymentStatusEvent, deliveryID string, logger *zap.Logger) (*plog.Logs, error) {
+	status := e.GetDeploymentStatus()
+	state := status.GetState()
+	logs, records := newDeploymentLogs(e.GetRepo(), e.GetDeployment().GetEnvironment())
+
+	switch state {
+	case "in_progress":
+		record := records.AppendEmpty()
+		fillDeploymentLogRecord(record, deploymentLogInput{
+			EventType:  cdeventsPipelineRunStarted,
+			DeliveryID: deliveryID,
+			Repo:       e.GetRepo(),
+			Deployment: e.GetDeployment(),
+			Status:     status,
+			State:      "executing",
+			URL:        firstString(status.GetEnvironmentURL(), status.GetTargetURL(), status.GetLogURL()),
+			Time:       firstNonZeroTime(status.GetCreatedAt().Time, status.GetUpdatedAt().Time),
+		})
+	case "queued", "pending":
+		logger.Debug("Skipping deployment_status state already represented by deployment event", zap.String("state", state))
+	case "success":
+		finished := records.AppendEmpty()
+		fillDeploymentLogRecord(finished, deploymentLogInput{
+			EventType:  cdeventsPipelineRunDone,
+			DeliveryID: deliveryID,
+			Repo:       e.GetRepo(),
+			Deployment: e.GetDeployment(),
+			Status:     status,
+			Result:     "success",
+			URL:        firstString(status.GetEnvironmentURL(), status.GetTargetURL(), status.GetLogURL()),
+			Time:       firstNonZeroTime(status.GetCreatedAt().Time, status.GetUpdatedAt().Time),
+		})
+		deployed := records.AppendEmpty()
+		fillDeploymentLogRecord(deployed, deploymentLogInput{
+			EventType:        cdeventsServiceDeployed,
+			DeliveryID:       deliveryID,
+			CDEventsIDSuffix: "service-deployed",
+			Repo:             e.GetRepo(),
+			Deployment:       e.GetDeployment(),
+			Status:           status,
+			Result:           "success",
+			URL:              firstString(status.GetEnvironmentURL(), status.GetTargetURL(), status.GetLogURL()),
+			Time:             firstNonZeroTime(status.GetCreatedAt().Time, status.GetUpdatedAt().Time),
+		})
+	case "failure", "error":
+		record := records.AppendEmpty()
+		fillDeploymentLogRecord(record, deploymentLogInput{
+			EventType:  cdeventsPipelineRunDone,
+			DeliveryID: deliveryID,
+			Repo:       e.GetRepo(),
+			Deployment: e.GetDeployment(),
+			Status:     status,
+			Result:     state,
+			URL:        firstString(status.GetEnvironmentURL(), status.GetTargetURL(), status.GetLogURL()),
+			Time:       firstNonZeroTime(status.GetCreatedAt().Time, status.GetUpdatedAt().Time),
+		})
+	case "inactive":
+		record := records.AppendEmpty()
+		fillDeploymentLogRecord(record, deploymentLogInput{
+			EventType:  everrDeploySuperseded,
+			DeliveryID: deliveryID,
+			Repo:       e.GetRepo(),
+			Deployment: e.GetDeployment(),
+			Status:     status,
+			URL:        firstString(status.GetEnvironmentURL(), status.GetTargetURL(), status.GetLogURL()),
+			Time:       firstNonZeroTime(status.GetCreatedAt().Time, status.GetUpdatedAt().Time),
+		})
+	default:
+		logger.Debug("Skipping unsupported deployment_status state", zap.String("state", state))
+	}
+
+	if logs.LogRecordCount() == 0 {
+		return nil, nil
+	}
+	return &logs, nil
+}
+
+func newDeploymentLogs(repo *github.Repository, environment string) (plog.Logs, plog.LogRecordSlice) {
+	logs := plog.NewLogs()
+	resourceLogs := logs.ResourceLogs().AppendEmpty()
+	resourceLogs.SetSchemaUrl(conventions.SchemaURL)
+	setDeploymentResourceAttributes(resourceLogs.Resource().Attributes(), repo, environment)
+	scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
+	scopeLogs.Scope().SetName("github-deployments")
+	return logs, scopeLogs.LogRecords()
+}
+
+func firstString(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func firstNonZeroTime(values ...time.Time) time.Time {
+	for _, value := range values {
+		if !value.IsZero() {
+			return value
+		}
+	}
+	return time.Now().UTC()
+}
+
+func cdeventsSource(repo *github.Repository) string {
+	if repo == nil || repo.GetFullName() == "" {
+		return "/github/deployments"
+	}
+	return fmt.Sprintf("/github/%s/deployments", repo.GetFullName())
+}
+
+func cdeventsID(input deploymentLogInput) string {
+	if input.CDEventsIDSuffix != "" {
+		return fmt.Sprintf("%s-%s", input.DeliveryID, input.CDEventsIDSuffix)
+	}
+	return input.DeliveryID
+}
+
+func githubIDString(id int64) string {
+	if id == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d", id)
+}
+
+func deploymentIDString(deployment *github.Deployment) string {
+	return githubIDString(deployment.GetID())
+}
+
+func deploymentStatusIDString(status *github.DeploymentStatus) string {
+	return githubIDString(status.GetID())
+}
+
+func workflowRunLink(deployment *github.Deployment, workflowRun *github.WorkflowRun) (int64, int) {
+	if workflowRun != nil && workflowRun.GetID() > 0 && workflowRun.GetRunAttempt() > 0 {
+		return workflowRun.GetID(), workflowRun.GetRunAttempt()
+	}
+	if deployment == nil || len(deployment.Payload) == 0 {
+		return 0, 0
+	}
+	var payload deploymentPayload
+	if err := json.Unmarshal(deployment.Payload, &payload); err != nil {
+		return 0, 0
+	}
+	return payload.WorkflowRunID, payload.WorkflowRunAttempt
+}
+
+func cdeventsSubjectType(eventType string) string {
+	if eventType == cdeventsServiceDeployed {
+		return "service"
+	}
+	return "pipelineRun"
+}
+
+func cdeventsSubjectID(input deploymentLogInput) string {
+	if input.EventType == cdeventsServiceDeployed {
+		return deploymentServiceName(input.Deployment.GetTask())
+	}
+	if id := deploymentIDString(input.Deployment); id != "" {
+		return fmt.Sprintf("github-deployment-%s", id)
+	}
+	return "github-deployment"
+}
+
+func artifactID(repo *github.Repository, sha string) string {
+	if repo == nil || repo.GetFullName() == "" || sha == "" {
+		return ""
+	}
+	return fmt.Sprintf("pkg:github/%s@%s", repo.GetFullName(), sha)
+}
+
+func deploymentContent(input deploymentLogInput) map[string]any {
+	repoFullName := ""
+	if input.Repo != nil {
+		repoFullName = input.Repo.GetFullName()
+	}
+	content := map[string]any{
+		"environment": map[string]string{
+			"id":   input.Deployment.GetEnvironment(),
+			"name": input.Deployment.GetEnvironment(),
+		},
+		"deploymentId": deploymentIDString(input.Deployment),
+		"repository":   repoFullName,
+		"sha":          input.Deployment.GetSHA(),
+		"ref":          input.Deployment.GetRef(),
+	}
+	if artifact := artifactID(input.Repo, input.Deployment.GetSHA()); artifact != "" {
+		content["artifactId"] = artifact
+	}
+	if input.URL != "" {
+		content["uri"] = input.URL
+	}
+	return content
+}
+
+func deploymentCDEventsBody(input deploymentLogInput) cdeventsBody {
+	return cdeventsBody{
+		Context: cdeventsContext{
+			Version:   cdeventsSpecVersion,
+			ID:        cdeventsID(input),
+			Source:    cdeventsSource(input.Repo),
+			Type:      input.EventType,
+			Timestamp: input.Time.UTC().Format(time.RFC3339Nano),
+		},
+		Subject: cdeventsSubject{
+			ID:      cdeventsSubjectID(input),
+			Type:    cdeventsSubjectType(input.EventType),
+			Source:  cdeventsSource(input.Repo),
+			Content: deploymentContent(input),
+		},
+	}
+}
+
+func deploymentStatusValue(input deploymentLogInput) string {
+	if input.Status != nil && input.Status.GetState() != "" {
+		return input.Status.GetState()
+	}
+	return input.State
+}
+
+func fillDeploymentLogRecord(record plog.LogRecord, input deploymentLogInput) {
+	record.SetEventName(input.EventType)
+	record.SetTimestamp(pcommon.NewTimestampFromTime(input.Time))
+	workflowRunID := input.WorkflowRunID
+	runAttempt := input.RunAttempt
+	if workflowRunID == 0 || runAttempt == 0 {
+		workflowRunID, runAttempt = workflowRunLink(input.Deployment, input.WorkflowRun)
+	}
+	if input.Repo != nil && input.Repo.GetID() > 0 && workflowRunID > 0 && runAttempt > 0 {
+		traceID, err := generateTraceID(input.Repo.GetID(), workflowRunID, runAttempt)
+		if err == nil {
+			record.SetTraceID(traceID)
+		}
+	}
+	attrs := record.Attributes()
+	attrs.PutStr(semconv.EverrGitHubDeliveryID, input.DeliveryID)
+	if input.EventType != everrDeploySuperseded {
+		attrs.PutStr(semconv.CDEventsType, input.EventType)
+		attrs.PutStr(semconv.CDEventsID, cdeventsID(input))
+		attrs.PutStr(semconv.CDEventsSource, cdeventsSource(input.Repo))
+	}
+	deploymentID := deploymentIDString(input.Deployment)
+	attrs.PutStr(string(conventions.CICDPipelineRunIDKey), deploymentID)
+	attrs.PutStr(string(conventions.CICDPipelineNameKey), firstString(input.Deployment.GetTask(), "deploy"))
+	if input.State != "" {
+		attrs.PutStr(string(conventions.CICDPipelineRunStateKey), input.State)
+	}
+	if input.Result != "" {
+		attrs.PutStr(string(conventions.CICDPipelineResultKey), input.Result)
+	}
+	attrs.PutStr(string(conventions.VCSRefHeadRevisionKey), input.Deployment.GetSHA())
+	attrs.PutStr(string(conventions.VCSRefHeadNameKey), input.Deployment.GetRef())
+	attrs.PutStr(semconv.EverrDeployID, deploymentID)
+	attrs.PutStr(semconv.EverrDeployServiceName, deploymentServiceName(input.Deployment.GetTask()))
+	attrs.PutStr(semconv.EverrDeployStatus, deploymentStatusValue(input))
+	if input.URL != "" {
+		attrs.PutStr(semconv.EverrDeployURL, input.URL)
+	}
+	if input.Deployment.GetID() > 0 {
+		attrs.PutInt(semconv.EverrGitHubDeploymentID, input.Deployment.GetID())
+	}
+	attrs.PutStr(semconv.EverrGitHubDeploymentCreatorLogin, input.Deployment.GetCreator().GetLogin())
+	if input.Status != nil && input.Status.GetID() > 0 {
+		attrs.PutInt(semconv.EverrGitHubDeploymentStatusID, input.Status.GetID())
+	}
+	if workflowRunID > 0 && runAttempt > 0 {
+		attrs.PutInt(semconv.EverrGitHubWorkflowRunID, workflowRunID)
+		attrs.PutInt(semconv.EverrGitHubWorkflowRunRunAttempt, int64(runAttempt))
+	}
+	if input.EventType == everrDeploySuperseded {
+		bodyBytes, _ := json.Marshal(map[string]any{
+			"deploymentId":       deploymentIDString(input.Deployment),
+			"deploymentStatusId": deploymentStatusIDString(input.Status),
+			"environment":        input.Deployment.GetEnvironment(),
+			"githubDeliveryId":   input.DeliveryID,
+		})
+		record.Body().SetStr(string(bodyBytes))
+	} else {
+		bodyBytes, _ := json.Marshal(deploymentCDEventsBody(input))
+		record.Body().SetStr(string(bodyBytes))
+	}
+}

--- a/collector/receiver/githubactionsreceiver/deploy_event_handling_test.go
+++ b/collector/receiver/githubactionsreceiver/deploy_event_handling_test.go
@@ -33,6 +33,35 @@ func deploymentStatusEventWithState(t *testing.T, state string) *github.Deployme
 	return event
 }
 
+func keysOf(m map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func rawSubjectContent(t *testing.T, body string) map[string]json.RawMessage {
+	t.Helper()
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(body), &raw))
+	var subject map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw["subject"], &subject))
+	var content map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(subject["content"], &content))
+	return content
+}
+
+func jsonString(t *testing.T, raw json.RawMessage) string {
+	t.Helper()
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	require.NoError(t, json.Unmarshal(raw, &s))
+	return s
+}
+
 func TestDeploymentEventToLogsMapsDeploymentCreated(t *testing.T) {
 	event := parseGitHubTestEvent[*github.DeploymentEvent](t, "testdata/deployment/deployment_created.json", "deployment")
 
@@ -65,12 +94,28 @@ func TestDeploymentEventToLogsMapsDeploymentCreated(t *testing.T) {
 
 	var body cdeventsBody
 	require.NoError(t, json.Unmarshal([]byte(record.Body().Str()), &body))
-	require.Equal(t, "0.5.0", body.Context.Version)
+	require.Equal(t, "0.5.0", body.Context.Specversion)
 	require.Equal(t, "delivery-deploy-created-1", body.Context.ID)
 	require.Equal(t, "dev.cdevents.pipelinerun.queued.0.3.0", body.Context.Type)
 	require.Equal(t, "https://github.com/everr-labs/everr-deploy", body.Context.Source)
 	require.Equal(t, "https://github.com/everr-labs/everr-deploy", body.Subject.Source)
 	require.Equal(t, "https://github.com/everr-labs/everr-deploy", record.Attributes().AsRaw()[semconv.CDEventsSource])
+
+	// Raw body shape: assert the JSON contains only the CDEvents-allowed keys
+	// (the schema for pipelinerun events sets `additionalProperties: false`).
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(record.Body().Str()), &raw))
+	require.ElementsMatch(t, []string{"context", "subject"}, keysOf(raw))
+	var rawContext, rawSubject map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw["context"], &rawContext))
+	require.NoError(t, json.Unmarshal(raw["subject"], &rawSubject))
+	require.ElementsMatch(t, []string{"specversion", "id", "source", "type", "timestamp"}, keysOf(rawContext))
+	require.ElementsMatch(t, []string{"id", "source", "content"}, keysOf(rawSubject))
+	var rawContent map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rawSubject["content"], &rawContent))
+	for k := range rawContent {
+		require.Contains(t, []string{"pipelineName", "uri", "outcome", "errors"}, k)
+	}
 }
 
 func TestDeploymentStatusSuccessEmitsPipelineFinishedAndServiceDeployed(t *testing.T) {
@@ -92,15 +137,37 @@ func TestDeploymentStatusSuccessEmitsPipelineFinishedAndServiceDeployed(t *testi
 
 	var finishedBody cdeventsBody
 	require.NoError(t, json.Unmarshal([]byte(records.At(0).Body().Str()), &finishedBody))
-	require.Equal(t, "0.5.0", finishedBody.Context.Version)
+	require.Equal(t, "0.5.0", finishedBody.Context.Specversion)
 	require.Equal(t, "delivery-deploy-status-success-1", finishedBody.Context.ID)
 	require.Equal(t, "dev.cdevents.pipelinerun.finished.0.3.0", finishedBody.Context.Type)
 
+	// pipelinerun.finished content: only {pipelineName, uri, outcome, errors} are
+	// allowed per the CDEvents v0.5.0 schema (additionalProperties: false).
+	finishedContent := rawSubjectContent(t, records.At(0).Body().Str())
+	for k := range finishedContent {
+		require.Contains(t, []string{"pipelineName", "uri", "outcome", "errors"}, k)
+	}
+	require.Equal(t, "success", jsonString(t, finishedContent["outcome"]))
+	require.NotEmpty(t, jsonString(t, finishedContent["pipelineName"]))
+	require.NotEmpty(t, jsonString(t, finishedContent["uri"]))
+
 	var deployedBody cdeventsBody
 	require.NoError(t, json.Unmarshal([]byte(records.At(1).Body().Str()), &deployedBody))
-	require.Equal(t, "0.5.0", deployedBody.Context.Version)
+	require.Equal(t, "0.5.0", deployedBody.Context.Specversion)
 	require.Equal(t, "delivery-deploy-status-success-1-service-deployed", deployedBody.Context.ID)
 	require.Equal(t, "dev.cdevents.service.deployed.0.3.0", deployedBody.Context.Type)
+
+	// service.deployed content: only {environment, artifactId} are allowed and
+	// both are required per the CDEvents v0.5.0 schema.
+	deployedContent := rawSubjectContent(t, records.At(1).Body().Str())
+	require.ElementsMatch(t, []string{"environment", "artifactId"}, keysOf(deployedContent))
+	require.Equal(t, "pkg:github/everr-labs/everr-deploy@abc123", jsonString(t, deployedContent["artifactId"]))
+	var env map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(deployedContent["environment"], &env))
+	for k := range env {
+		require.Contains(t, []string{"id", "source"}, k)
+	}
+	require.Equal(t, "production", jsonString(t, env["id"]))
 }
 
 func TestDeploymentStatusInactiveEmitsSuperseded(t *testing.T) {
@@ -204,7 +271,12 @@ func TestDeploymentLogUsesEmptyStringForMissingDeploymentID(t *testing.T) {
 	require.Equal(t, "", attrs[string(conventions.CICDPipelineRunIDKey)])
 	require.Equal(t, "", attrs[semconv.EverrDeployID])
 	require.NotContains(t, attrs, semconv.EverrGitHubDeploymentID)
-	require.Contains(t, record.Body().Str(), `"deploymentId":""`)
+	// CDEvents subject.content for pipelinerun has no deploymentId field —
+	// the deployment id lives in the queryable log attributes above. The
+	// subject.id falls back to "github-deployment" when the id is missing.
+	var body cdeventsBody
+	require.NoError(t, json.Unmarshal([]byte(record.Body().Str()), &body))
+	require.Equal(t, "github-deployment", body.Subject.ID)
 }
 
 func TestDeploymentEventUsesWorkflowTraceIDWhenPresent(t *testing.T) {

--- a/collector/receiver/githubactionsreceiver/deploy_event_handling_test.go
+++ b/collector/receiver/githubactionsreceiver/deploy_event_handling_test.go
@@ -1,0 +1,208 @@
+package githubactionsreceiver
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/google/go-github/v67/github"
+	"github.com/stretchr/testify/require"
+	conventions "go.opentelemetry.io/otel/semconv/v1.38.0"
+	"go.uber.org/zap"
+
+	"github.com/everr-labs/everr/collector/semconv"
+)
+
+func parseGitHubTestEvent[T any](t *testing.T, path string, eventType string) T {
+	t.Helper()
+	payload, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	event, err := github.ParseWebHook(eventType, payload)
+	require.NoError(t, err)
+
+	typed, ok := event.(T)
+	require.True(t, ok)
+	return typed
+}
+
+func deploymentStatusEventWithState(t *testing.T, state string) *github.DeploymentStatusEvent {
+	t.Helper()
+	event := parseGitHubTestEvent[*github.DeploymentStatusEvent](t, "testdata/deployment/deployment_status_success.json", "deployment_status")
+	event.DeploymentStatus.State = github.String(state)
+	return event
+}
+
+func TestDeploymentEventToLogsMapsDeploymentCreated(t *testing.T) {
+	event := parseGitHubTestEvent[*github.DeploymentEvent](t, "testdata/deployment/deployment_created.json", "deployment")
+
+	logs, err := deploymentEventToLogs(event, "delivery-deploy-created-1", zap.NewNop())
+
+	require.NoError(t, err)
+	require.NotNil(t, logs)
+	require.Equal(t, 1, logs.LogRecordCount())
+
+	record := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	require.Equal(t, "dev.cdevents.pipelinerun.queued.0.3.0", record.EventName())
+	require.Equal(t, "dev.cdevents.pipelinerun.queued.0.3.0", record.Attributes().AsRaw()[semconv.CDEventsType])
+	require.Equal(t, "delivery-deploy-created-1", record.Attributes().AsRaw()[semconv.CDEventsID])
+	require.NotContains(t, record.Attributes().AsRaw(), "event.name")
+	require.NotContains(t, record.Attributes().AsRaw(), "deployment.environment.name")
+	require.Equal(t, int64(987), record.Attributes().AsRaw()[semconv.EverrGitHubDeploymentID])
+	require.Equal(t, "987", record.Attributes().AsRaw()[string(conventions.CICDPipelineRunIDKey)])
+	require.Equal(t, "987", record.Attributes().AsRaw()[semconv.EverrDeployID])
+
+	require.Equal(t, conventions.SchemaURL, logs.ResourceLogs().At(0).SchemaUrl())
+	resourceAttrs := logs.ResourceLogs().At(0).Resource().Attributes().AsRaw()
+	require.Equal(t, "github-deployments", resourceAttrs["service.name"])
+	require.Equal(t, "production", resourceAttrs["deployment.environment.name"])
+	require.Equal(t, "everr-deploy", resourceAttrs[string(conventions.VCSRepositoryNameKey)])
+	require.Equal(t, "https://github.com/everr-labs/everr-deploy", resourceAttrs["vcs.repository.url.full"])
+	require.Equal(t, "everr-labs/everr-deploy", resourceAttrs[semconv.EverrGitHubRepositoryFullName])
+	require.Equal(t, "everr-labs", resourceAttrs[semconv.EverrGitHubRepositoryOwnerLogin])
+	require.NotContains(t, resourceAttrs, string(conventions.VCSProviderNameKey))
+	require.NotContains(t, resourceAttrs, string(conventions.VCSOwnerNameKey))
+
+	var body cdeventsBody
+	require.NoError(t, json.Unmarshal([]byte(record.Body().Str()), &body))
+	require.Equal(t, "0.5.0", body.Context.Version)
+	require.Equal(t, "delivery-deploy-created-1", body.Context.ID)
+	require.Equal(t, "dev.cdevents.pipelinerun.queued.0.3.0", body.Context.Type)
+}
+
+func TestDeploymentStatusSuccessEmitsPipelineFinishedAndServiceDeployed(t *testing.T) {
+	event := parseGitHubTestEvent[*github.DeploymentStatusEvent](t, "testdata/deployment/deployment_status_success.json", "deployment_status")
+
+	logs, err := deploymentEventToLogs(event, "delivery-deploy-status-success-1", zap.NewNop())
+
+	require.NoError(t, err)
+	require.NotNil(t, logs)
+	require.Equal(t, 2, logs.LogRecordCount())
+
+	records := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords()
+	require.Equal(t, "dev.cdevents.pipelinerun.finished.0.3.0", records.At(0).EventName())
+	require.Equal(t, "delivery-deploy-status-success-1", records.At(0).Attributes().AsRaw()[semconv.CDEventsID])
+	require.Equal(t, "success", records.At(0).Attributes().AsRaw()[string(conventions.CICDPipelineResultKey)])
+	require.Equal(t, "dev.cdevents.service.deployed.0.3.0", records.At(1).EventName())
+	require.Equal(t, "delivery-deploy-status-success-1-service-deployed", records.At(1).Attributes().AsRaw()[semconv.CDEventsID])
+	require.Equal(t, "https://app.everr.dev", records.At(1).Attributes().AsRaw()[semconv.EverrDeployURL])
+
+	var finishedBody cdeventsBody
+	require.NoError(t, json.Unmarshal([]byte(records.At(0).Body().Str()), &finishedBody))
+	require.Equal(t, "0.5.0", finishedBody.Context.Version)
+	require.Equal(t, "delivery-deploy-status-success-1", finishedBody.Context.ID)
+	require.Equal(t, "dev.cdevents.pipelinerun.finished.0.3.0", finishedBody.Context.Type)
+
+	var deployedBody cdeventsBody
+	require.NoError(t, json.Unmarshal([]byte(records.At(1).Body().Str()), &deployedBody))
+	require.Equal(t, "0.5.0", deployedBody.Context.Version)
+	require.Equal(t, "delivery-deploy-status-success-1-service-deployed", deployedBody.Context.ID)
+	require.Equal(t, "dev.cdevents.service.deployed.0.3.0", deployedBody.Context.Type)
+}
+
+func TestDeploymentStatusInactiveEmitsSuperseded(t *testing.T) {
+	event := parseGitHubTestEvent[*github.DeploymentStatusEvent](t, "testdata/deployment/deployment_status_inactive.json", "deployment_status")
+
+	logs, err := deploymentEventToLogs(event, "delivery-deploy-status-inactive-1", zap.NewNop())
+
+	require.NoError(t, err)
+	require.NotNil(t, logs)
+	require.Equal(t, 1, logs.LogRecordCount())
+	record := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	require.Equal(t, "everr.deploy.superseded", record.EventName())
+	require.Equal(t, "delivery-deploy-status-inactive-1", record.Attributes().AsRaw()[semconv.EverrGitHubDeliveryID])
+	require.NotContains(t, record.Attributes().AsRaw(), semconv.CDEventsType)
+	require.NotContains(t, record.Attributes().AsRaw(), semconv.CDEventsID)
+	require.NotContains(t, record.Attributes().AsRaw(), string(conventions.CICDPipelineResultKey))
+	require.NotContains(t, record.Body().Str(), "service.removed")
+}
+
+func TestDeploymentStatusQueuedAndPendingAreSkipped(t *testing.T) {
+	for _, state := range []string{"queued", "pending"} {
+		event := deploymentStatusEventWithState(t, state)
+
+		logs, err := deploymentEventToLogs(event, "delivery-deploy-status-"+state, zap.NewNop())
+
+		require.NoError(t, err)
+		require.Nil(t, logs)
+	}
+}
+
+func TestDeploymentStatusInProgressEmitsPipelineStarted(t *testing.T) {
+	event := deploymentStatusEventWithState(t, "in_progress")
+
+	logs, err := deploymentEventToLogs(event, "delivery-deploy-status-started-1", zap.NewNop())
+
+	require.NoError(t, err)
+	require.Equal(t, 1, logs.LogRecordCount())
+	record := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	require.Equal(t, "dev.cdevents.pipelinerun.started.0.3.0", record.EventName())
+	require.Equal(t, "executing", record.Attributes().AsRaw()[string(conventions.CICDPipelineRunStateKey)])
+	require.Equal(t, "in_progress", record.Attributes().AsRaw()[semconv.EverrDeployStatus])
+}
+
+func TestDeploymentStatusFailureAndErrorEmitPipelineFinished(t *testing.T) {
+	for _, state := range []string{"failure", "error"} {
+		event := deploymentStatusEventWithState(t, state)
+
+		logs, err := deploymentEventToLogs(event, "delivery-deploy-status-"+state, zap.NewNop())
+
+		require.NoError(t, err)
+		require.Equal(t, 1, logs.LogRecordCount())
+		record := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+		require.Equal(t, "dev.cdevents.pipelinerun.finished.0.3.0", record.EventName())
+		require.Equal(t, state, record.Attributes().AsRaw()[string(conventions.CICDPipelineResultKey)])
+		require.Equal(t, state, record.Attributes().AsRaw()[semconv.EverrDeployStatus])
+	}
+}
+
+func TestDeploymentLogTraceIDEmptyWithoutWorkflowRun(t *testing.T) {
+	event := parseGitHubTestEvent[*github.DeploymentEvent](t, "testdata/deployment/deployment_created.json", "deployment")
+
+	logs, err := deploymentEventToLogs(event, "delivery-deploy-no-workflow-1", zap.NewNop())
+
+	require.NoError(t, err)
+	record := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	require.True(t, record.TraceID().IsEmpty())
+}
+
+func TestDeploymentLogUsesWorkflowTraceIDFromDeploymentPayload(t *testing.T) {
+	event := parseGitHubTestEvent[*github.DeploymentEvent](t, "testdata/deployment/deployment_created.json", "deployment")
+	event.WorkflowRun = nil
+	event.Deployment.Payload = json.RawMessage(`{"workflow_run_id":456,"workflow_run_attempt":2}`)
+
+	logs, err := deploymentEventToLogs(event, "delivery-deploy-payload-trace-1", zap.NewNop())
+
+	require.NoError(t, err)
+	expected, err := generateTraceID(654321, 456, 2)
+	require.NoError(t, err)
+	record := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	require.Equal(t, expected, record.TraceID())
+}
+
+func TestDeploymentLogUsesEmptyStringForMissingDeploymentID(t *testing.T) {
+	event := parseGitHubTestEvent[*github.DeploymentEvent](t, "testdata/deployment/deployment_created.json", "deployment")
+	event.Deployment.ID = nil
+
+	logs, err := deploymentEventToLogs(event, "delivery-deploy-missing-id-1", zap.NewNop())
+
+	require.NoError(t, err)
+	record := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	attrs := record.Attributes().AsRaw()
+	require.Equal(t, "", attrs[string(conventions.CICDPipelineRunIDKey)])
+	require.Equal(t, "", attrs[semconv.EverrDeployID])
+	require.NotContains(t, attrs, semconv.EverrGitHubDeploymentID)
+	require.Contains(t, record.Body().Str(), `"deploymentId":""`)
+}
+
+func TestDeploymentEventUsesWorkflowTraceIDWhenPresent(t *testing.T) {
+	event := parseGitHubTestEvent[*github.DeploymentEvent](t, "testdata/deployment/deployment_created_with_workflow_run.json", "deployment")
+
+	logs, err := deploymentEventToLogs(event, "delivery-deploy-created-trace-1", zap.NewNop())
+
+	require.NoError(t, err)
+	expected, err := generateTraceID(654321, 456, 2)
+	require.NoError(t, err)
+	record := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	require.Equal(t, expected, record.TraceID())
+}

--- a/collector/receiver/githubactionsreceiver/deploy_event_handling_test.go
+++ b/collector/receiver/githubactionsreceiver/deploy_event_handling_test.go
@@ -68,6 +68,9 @@ func TestDeploymentEventToLogsMapsDeploymentCreated(t *testing.T) {
 	require.Equal(t, "0.5.0", body.Context.Version)
 	require.Equal(t, "delivery-deploy-created-1", body.Context.ID)
 	require.Equal(t, "dev.cdevents.pipelinerun.queued.0.3.0", body.Context.Type)
+	require.Equal(t, "https://github.com/everr-labs/everr-deploy", body.Context.Source)
+	require.Equal(t, "https://github.com/everr-labs/everr-deploy", body.Subject.Source)
+	require.Equal(t, "https://github.com/everr-labs/everr-deploy", record.Attributes().AsRaw()[semconv.CDEventsSource])
 }
 
 func TestDeploymentStatusSuccessEmitsPipelineFinishedAndServiceDeployed(t *testing.T) {
@@ -126,6 +129,15 @@ func TestDeploymentStatusQueuedAndPendingAreSkipped(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, logs)
 	}
+}
+
+func TestDeploymentStatusUnknownStateYieldsNoLogs(t *testing.T) {
+	event := deploymentStatusEventWithState(t, "waiting")
+
+	logs, err := deploymentEventToLogs(event, "delivery-deploy-status-waiting-1", zap.NewNop())
+
+	require.NoError(t, err)
+	require.Nil(t, logs)
 }
 
 func TestDeploymentStatusInProgressEmitsPipelineStarted(t *testing.T) {

--- a/collector/receiver/githubactionsreceiver/receiver.go
+++ b/collector/receiver/githubactionsreceiver/receiver.go
@@ -234,10 +234,49 @@ func (gar *githubActionsReceiver) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Handle events based on specific types and completion status
+	gar.logger.Debug("Received valid GitHub event", zap.String("type", eventType))
+
+	// Preserve incoming request headers in client metadata so downstream
+	// processors (and the deploy dispatch below) can enrich telemetry using
+	// from_context metadata access.
+	ci := client.FromContext(ctx)
+	ci.Metadata = client.NewMetadata(r.Header)
+	ctx = client.NewContext(ctx, ci)
+
+	// Handle events based on specific types and completion status.
+	// Deploy events are dispatched inline so the set of deploy webhook types
+	// lives in exactly one place.
 	switch e := event.(type) {
 	case *github.DeploymentEvent, *github.DeploymentStatusEvent:
-		// Deploy events are mapped directly to logs below.
+		_ = e
+		if gar.logsConsumer == nil {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+
+		deliveryID := r.Header.Get("x-github-delivery")
+		if deliveryID == "" {
+			http.Error(w, "Missing x-github-delivery", http.StatusBadRequest)
+			return
+		}
+
+		ld, err := deploymentEventToLogs(event, deliveryID, gar.logger.Named("deploymentEventToLogs"))
+		if err != nil {
+			gar.logger.Error("Failed to process deployment event", zap.Error(err))
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		if ld != nil {
+			if err := gar.logsConsumer.ConsumeLogs(ctx, *ld); err != nil {
+				gar.logger.Error("Failed to consume deployment logs", zap.Error(err))
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+		}
+
+		w.WriteHeader(http.StatusAccepted)
+		return
 	case *github.WorkflowJobEvent:
 		if e.GetWorkflowJob().GetStatus() != "completed" {
 			gar.logger.Debug("Skipping non-completed WorkflowJobEvent", zap.String("status", e.GetWorkflowJob().GetStatus()))
@@ -288,41 +327,8 @@ func (gar *githubActionsReceiver) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	gar.logger.Debug("Received valid GitHub event", zap.String("type", eventType))
 	var processingFailed bool
 	traceErr := false
-
-	// Preserve incoming request headers in client metadata so downstream processors
-	// can enrich telemetry using from_context metadata access.
-	ci := client.FromContext(ctx)
-	ci.Metadata = client.NewMetadata(r.Header)
-	ctx = client.NewContext(ctx, ci)
-
-	if isDeploymentWebhookEvent(event) {
-		if gar.logsConsumer == nil {
-			w.WriteHeader(http.StatusAccepted)
-			return
-		}
-
-		deliveryID := r.Header.Get("x-github-delivery")
-		ld, err := deploymentEventToLogs(event, deliveryID, gar.logger.Named("deploymentEventToLogs"))
-		if err != nil {
-			gar.logger.Error("Failed to process deployment event", zap.Error(err))
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-
-		if ld != nil {
-			if err := gar.logsConsumer.ConsumeLogs(ctx, *ld); err != nil {
-				gar.logger.Error("Failed to consume deployment logs", zap.Error(err))
-				w.WriteHeader(http.StatusInternalServerError)
-				return
-			}
-		}
-
-		w.WriteHeader(http.StatusAccepted)
-		return
-	}
 
 	installationID, err := installationIDFromWebhookEvent(event)
 	if err != nil {
@@ -460,15 +466,6 @@ func (gar *githubActionsReceiver) githubClientForInstallation(installationID int
 	}
 
 	return client, nil
-}
-
-func isDeploymentWebhookEvent(event interface{}) bool {
-	switch event.(type) {
-	case *github.DeploymentEvent, *github.DeploymentStatusEvent:
-		return true
-	default:
-		return false
-	}
 }
 
 func installationIDFromWebhookEvent(event interface{}) (int64, error) {

--- a/collector/receiver/githubactionsreceiver/receiver.go
+++ b/collector/receiver/githubactionsreceiver/receiver.go
@@ -236,6 +236,8 @@ func (gar *githubActionsReceiver) ServeHTTP(w http.ResponseWriter, r *http.Reque
 
 	// Handle events based on specific types and completion status
 	switch e := event.(type) {
+	case *github.DeploymentEvent, *github.DeploymentStatusEvent:
+		// Deploy events are mapped directly to logs below.
 	case *github.WorkflowJobEvent:
 		if e.GetWorkflowJob().GetStatus() != "completed" {
 			gar.logger.Debug("Skipping non-completed WorkflowJobEvent", zap.String("status", e.GetWorkflowJob().GetStatus()))
@@ -295,6 +297,32 @@ func (gar *githubActionsReceiver) ServeHTTP(w http.ResponseWriter, r *http.Reque
 	ci := client.FromContext(ctx)
 	ci.Metadata = client.NewMetadata(r.Header)
 	ctx = client.NewContext(ctx, ci)
+
+	if isDeploymentWebhookEvent(event) {
+		if gar.logsConsumer == nil {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+
+		deliveryID := r.Header.Get("x-github-delivery")
+		ld, err := deploymentEventToLogs(event, deliveryID, gar.logger.Named("deploymentEventToLogs"))
+		if err != nil {
+			gar.logger.Error("Failed to process deployment event", zap.Error(err))
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		if ld != nil {
+			if err := gar.logsConsumer.ConsumeLogs(ctx, *ld); err != nil {
+				gar.logger.Error("Failed to consume deployment logs", zap.Error(err))
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+		}
+
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
 
 	installationID, err := installationIDFromWebhookEvent(event)
 	if err != nil {
@@ -432,6 +460,15 @@ func (gar *githubActionsReceiver) githubClientForInstallation(installationID int
 	}
 
 	return client, nil
+}
+
+func isDeploymentWebhookEvent(event interface{}) bool {
+	switch event.(type) {
+	case *github.DeploymentEvent, *github.DeploymentStatusEvent:
+		return true
+	default:
+		return false
+	}
 }
 
 func installationIDFromWebhookEvent(event interface{}) (int64, error) {

--- a/collector/receiver/githubactionsreceiver/receiver_test.go
+++ b/collector/receiver/githubactionsreceiver/receiver_test.go
@@ -7,10 +7,17 @@
 package githubactionsreceiver
 
 import (
+	"bytes"
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,17 +25,54 @@ import (
 	"github.com/everr-labs/everr/collector/semconv"
 	"github.com/google/go-github/v67/github"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 	conventions "go.opentelemetry.io/otel/semconv/v1.38.0"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 )
+
+// capturingLogsConsumer records consumed logs and the client metadata captured
+// from context, so tests can assert headers propagated by the receiver.
+type capturingLogsConsumer struct {
+	mu       sync.Mutex
+	logs     []plog.Logs
+	metadata client.Metadata
+}
+
+func newCapturingLogsConsumer() *capturingLogsConsumer {
+	return &capturingLogsConsumer{}
+}
+
+func (c *capturingLogsConsumer) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
+}
+
+func (c *capturingLogsConsumer) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.logs) == 0 {
+		c.metadata = client.FromContext(ctx).Metadata
+	}
+	c.logs = append(c.logs, ld)
+	return nil
+}
+
+// signGitHubRequest sets a valid GitHub webhook signature header for the payload.
+func signGitHubRequest(req *http.Request, secret string, payload []byte) {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(payload)
+	sig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+	req.Header.Set("X-Hub-Signature-256", sig)
+	req.Header.Set("Content-Type", "application/json")
+}
 
 func int64Ptr(v int64) *int64 {
 	return &v
@@ -430,4 +474,33 @@ func TestCreateRootSpanZeroTimestamps(t *testing.T) {
 
 func getPtr(str string) *string {
 	return &str
+}
+
+func TestReceiverDeploymentStatusDoesNotRequireGitHubAPIClient(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.Path = "/webhook/github"
+	cfg.Secret = "secret"
+	cfg.GitHubAPIConfig.Auth.AppID = 0
+	cfg.GitHubAPIConfig.Auth.PrivateKey = ""
+
+	consumer := newCapturingLogsConsumer()
+	rcv, err := newReceiver(receivertest.NewNopSettings(metadata.Type), cfg)
+	require.NoError(t, err)
+	rcv.logsConsumer = consumer
+
+	payload, err := os.ReadFile("testdata/deployment/deployment_status_success.json")
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/webhook/github", bytes.NewReader(payload))
+	signGitHubRequest(req, "secret", payload)
+	req.Header.Set("x-github-event", "deployment_status")
+	req.Header.Set("x-github-delivery", "delivery-deploy-status-success-1")
+	req.Header.Set("x-everr-tenant-id", "42")
+	rec := httptest.NewRecorder()
+
+	rcv.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusAccepted, rec.Code)
+	require.Len(t, consumer.logs, 1)
+	require.Equal(t, 2, consumer.logs[0].LogRecordCount())
+	require.Contains(t, consumer.metadata.Get("x-everr-tenant-id"), "42")
 }

--- a/collector/receiver/githubactionsreceiver/receiver_test.go
+++ b/collector/receiver/githubactionsreceiver/receiver_test.go
@@ -504,3 +504,28 @@ func TestReceiverDeploymentStatusDoesNotRequireGitHubAPIClient(t *testing.T) {
 	require.Equal(t, 2, consumer.logs[0].LogRecordCount())
 	require.Contains(t, consumer.metadata.Get("x-everr-tenant-id"), "42")
 }
+
+func TestReceiverDeploymentEventRejectsMissingDeliveryID(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.Path = "/webhook/github"
+	cfg.Secret = "secret"
+	cfg.GitHubAPIConfig.Auth.AppID = 0
+	cfg.GitHubAPIConfig.Auth.PrivateKey = ""
+
+	consumer := newCapturingLogsConsumer()
+	rcv, err := newReceiver(receivertest.NewNopSettings(metadata.Type), cfg)
+	require.NoError(t, err)
+	rcv.logsConsumer = consumer
+
+	payload, err := os.ReadFile("testdata/deployment/deployment_status_success.json")
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/webhook/github", bytes.NewReader(payload))
+	signGitHubRequest(req, "secret", payload)
+	req.Header.Set("x-github-event", "deployment_status")
+	rec := httptest.NewRecorder()
+
+	rcv.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Empty(t, consumer.logs)
+}

--- a/collector/receiver/githubactionsreceiver/testdata/deployment/deployment_created.json
+++ b/collector/receiver/githubactionsreceiver/testdata/deployment/deployment_created.json
@@ -1,0 +1,22 @@
+{
+  "action": "created",
+  "deployment": {
+    "id": 987,
+    "sha": "abc123",
+    "ref": "main",
+    "task": "deploy:app",
+    "environment": "production",
+    "created_at": "2026-05-17T10:00:00Z",
+    "updated_at": "2026-05-17T10:00:00Z",
+    "creator": { "login": "github-actions[bot]" }
+  },
+  "repository": {
+    "id": 654321,
+    "name": "everr-deploy",
+    "full_name": "everr-labs/everr-deploy",
+    "html_url": "https://github.com/everr-labs/everr-deploy",
+    "owner": { "login": "everr-labs" }
+  },
+  "installation": { "id": 123 },
+  "sender": { "login": "github-actions[bot]" }
+}

--- a/collector/receiver/githubactionsreceiver/testdata/deployment/deployment_created_with_workflow_run.json
+++ b/collector/receiver/githubactionsreceiver/testdata/deployment/deployment_created_with_workflow_run.json
@@ -1,0 +1,26 @@
+{
+  "action": "created",
+  "deployment": {
+    "id": 987,
+    "sha": "abc123",
+    "ref": "main",
+    "task": "deploy:app",
+    "environment": "production",
+    "created_at": "2026-05-17T10:00:00Z",
+    "updated_at": "2026-05-17T10:00:00Z",
+    "creator": { "login": "github-actions[bot]" }
+  },
+  "workflow_run": {
+    "id": 456,
+    "run_attempt": 2
+  },
+  "repository": {
+    "id": 654321,
+    "name": "everr-deploy",
+    "full_name": "everr-labs/everr-deploy",
+    "html_url": "https://github.com/everr-labs/everr-deploy",
+    "owner": { "login": "everr-labs" }
+  },
+  "installation": { "id": 123 },
+  "sender": { "login": "github-actions[bot]" }
+}

--- a/collector/receiver/githubactionsreceiver/testdata/deployment/deployment_status_inactive.json
+++ b/collector/receiver/githubactionsreceiver/testdata/deployment/deployment_status_inactive.json
@@ -1,0 +1,31 @@
+{
+  "action": "created",
+  "deployment": {
+    "id": 986,
+    "sha": "def456",
+    "ref": "main",
+    "task": "deploy:app",
+    "environment": "production",
+    "created_at": "2026-05-17T09:00:00Z",
+    "updated_at": "2026-05-17T09:00:00Z",
+    "creator": { "login": "github-actions[bot]" }
+  },
+  "deployment_status": {
+    "id": 989,
+    "state": "inactive",
+    "environment_url": "https://app.everr.dev",
+    "target_url": "https://github.com/everr-labs/everr-deploy/actions/runs/1",
+    "description": "superseded by a newer deployment",
+    "created_at": "2026-05-17T10:05:00Z",
+    "updated_at": "2026-05-17T10:05:00Z"
+  },
+  "repository": {
+    "id": 654321,
+    "name": "everr-deploy",
+    "full_name": "everr-labs/everr-deploy",
+    "html_url": "https://github.com/everr-labs/everr-deploy",
+    "owner": { "login": "everr-labs" }
+  },
+  "installation": { "id": 123 },
+  "sender": { "login": "github-actions[bot]" }
+}

--- a/collector/receiver/githubactionsreceiver/testdata/deployment/deployment_status_success.json
+++ b/collector/receiver/githubactionsreceiver/testdata/deployment/deployment_status_success.json
@@ -1,0 +1,31 @@
+{
+  "action": "created",
+  "deployment": {
+    "id": 987,
+    "sha": "abc123",
+    "ref": "main",
+    "task": "deploy:app",
+    "environment": "production",
+    "created_at": "2026-05-17T10:00:00Z",
+    "updated_at": "2026-05-17T10:00:00Z",
+    "creator": { "login": "github-actions[bot]" }
+  },
+  "deployment_status": {
+    "id": 988,
+    "state": "success",
+    "environment_url": "https://app.everr.dev",
+    "target_url": "https://github.com/everr-labs/everr-deploy/actions/runs/1",
+    "description": "app rollout completed",
+    "created_at": "2026-05-17T10:04:00Z",
+    "updated_at": "2026-05-17T10:04:00Z"
+  },
+  "repository": {
+    "id": 654321,
+    "name": "everr-deploy",
+    "full_name": "everr-labs/everr-deploy",
+    "html_url": "https://github.com/everr-labs/everr-deploy",
+    "owner": { "login": "everr-labs" }
+  },
+  "installation": { "id": 123 },
+  "sender": { "login": "github-actions[bot]" }
+}

--- a/collector/semconv/cicd.go
+++ b/collector/semconv/cicd.go
@@ -50,20 +50,29 @@ const (
 
 // Everr — CDEvents and deployment attributes.
 //
-// OTel does define `deployment.id`, `deployment.name`, and `deployment.status`,
-// and `cloudevents.event_id` / `cloudevents.event_source` / `cloudevents.event_type`
-// (the last three could in principle alias the `cdevents.*` keys since CDEvents
-// builds on CloudEvents). All of these are at Development stability in OTel
-// semconv as of v1.41 / v1.38.0, which means their semantics and value spaces
-// may still change in a non-backward-compatible way.
+// REVIEW NOTE (2026-05-18, deploy-cdevents-ingest): a reviewer suggested
+// replacing these with OTel `deployment.id` / `deployment.name` /
+// `deployment.status` and CloudEvents `cloudevents.event_id` /
+// `cloudevents.event_source` / `cloudevents.event_type`. We deliberately
+// did not swap because, as of OTel semconv v1.41 / v1.38.0:
+//   - https://opentelemetry.io/docs/specs/semconv/registry/attributes/deployment/
+//   - https://opentelemetry.io/docs/specs/semconv/registry/attributes/cloudevents/
+//
+// every one of those attributes is at Development stability — the same
+// stability bucket the deploy-cdevents-ingest design doc flagged as the
+// reason to avoid `deployment.*` in the first place. Switching now would
+// trade churn risk for no real interoperability gain.
 //
 // V1 of the deploy ingest pins the deploy run identifier to the stable
 // `cicd.pipeline.run.id` / `cicd.pipeline.name` / `cicd.pipeline.run.state` /
 // `cicd.pipeline.result` attributes, and uses `everr.deploy.*` / `cdevents.*` /
-// `everr.github.*` for fields with no stable equivalent. When the OTel
-// `deployment.*` and `cloudevents.*` attributes graduate to Stable, emit them
-// as aliases so OTel-native tooling can consume the deploy stream without
-// changing the existing query contract.
+// `everr.github.*` for fields with no stable equivalent.
+//
+// REVISIT when either OTel `deployment.*` or `cloudevents.*` graduate to
+// Stable: emit them as aliases so OTel-native tooling can consume the
+// deploy stream without changing the existing `cicd.*` query contract.
+// Check the URLs above before reopening this — if they still say
+// Development, the answer is still no.
 const (
 	CDEventsType   = "cdevents.type"
 	CDEventsID     = "cdevents.id"

--- a/collector/semconv/cicd.go
+++ b/collector/semconv/cicd.go
@@ -47,3 +47,23 @@ const (
 	EverrGitHubWorkflowJobStepStartedAt   = "everr.github.workflow_job_step.started_at"
 	EverrGitHubWorkflowJobStepCompletedAt = "everr.github.workflow_job_step.completed_at"
 )
+
+// Everr — CDEvents and deployment attributes with no stable OTel equivalent.
+const (
+	CDEventsType   = "cdevents.type"
+	CDEventsID     = "cdevents.id"
+	CDEventsSource = "cdevents.source"
+
+	EverrDeployID          = "everr.deploy.id"
+	EverrDeployServiceName = "everr.deploy.service.name"
+	EverrDeployStatus      = "everr.deploy.status"
+	EverrDeployURL         = "everr.deploy.url"
+
+	EverrGitHubDeliveryID             = "everr.github.delivery.id"
+	EverrGitHubDeploymentID           = "everr.github.deployment.id"
+	EverrGitHubDeploymentStatusID     = "everr.github.deployment_status.id"
+	EverrGitHubDeploymentCreatorLogin = "everr.github.deployment.creator.login"
+	EverrGitHubRepositoryFullName     = "everr.github.repository.full_name"
+	EverrGitHubRepositoryOwnerLogin   = "everr.github.repository.owner.login"
+	EverrGitHubWorkflowRunID          = "everr.github.workflow_run.id"
+)

--- a/collector/semconv/cicd.go
+++ b/collector/semconv/cicd.go
@@ -50,29 +50,26 @@ const (
 
 // Everr — CDEvents and deployment attributes.
 //
-// REVIEW NOTE (2026-05-18, deploy-cdevents-ingest): a reviewer suggested
-// replacing these with OTel `deployment.id` / `deployment.name` /
-// `deployment.status` and CloudEvents `cloudevents.event_id` /
-// `cloudevents.event_source` / `cloudevents.event_type`. We deliberately
-// did not swap because, as of OTel semconv v1.41 / v1.38.0:
+// We intentionally do not use the OTel `deployment.id` / `deployment.name` /
+// `deployment.status` or CloudEvents `cloudevents.event_id` /
+// `cloudevents.event_source` / `cloudevents.event_type` attributes. As of
+// OTel semconv v1.41 / v1.38.0 all of those are at Development stability:
 //   - https://opentelemetry.io/docs/specs/semconv/registry/attributes/deployment/
 //   - https://opentelemetry.io/docs/specs/semconv/registry/attributes/cloudevents/
 //
-// every one of those attributes is at Development stability — the same
-// stability bucket the deploy-cdevents-ingest design doc flagged as the
-// reason to avoid `deployment.*` in the first place. Switching now would
-// trade churn risk for no real interoperability gain.
+// Development-stage attributes can still change semantics or value space in
+// a non-backward-compatible way, which would break the deploy query
+// contract that lands in ClickHouse. V1 instead pins the deploy run
+// identifier to the stable `cicd.pipeline.run.id` / `cicd.pipeline.name` /
+// `cicd.pipeline.run.state` / `cicd.pipeline.result` attributes, and uses
+// the custom `everr.deploy.*` / `cdevents.*` / `everr.github.*` namespaces
+// for fields with no stable equivalent.
 //
-// V1 of the deploy ingest pins the deploy run identifier to the stable
-// `cicd.pipeline.run.id` / `cicd.pipeline.name` / `cicd.pipeline.run.state` /
-// `cicd.pipeline.result` attributes, and uses `everr.deploy.*` / `cdevents.*` /
-// `everr.github.*` for fields with no stable equivalent.
-//
-// REVISIT when either OTel `deployment.*` or `cloudevents.*` graduate to
-// Stable: emit them as aliases so OTel-native tooling can consume the
-// deploy stream without changing the existing `cicd.*` query contract.
-// Check the URLs above before reopening this — if they still say
-// Development, the answer is still no.
+// Revisit when either OTel `deployment.*` or `cloudevents.*` graduate to
+// Stable: at that point emit them as aliases so OTel-native tooling can
+// consume the deploy stream without changing the existing `cicd.*` query
+// contract. Check the URLs above first — if they still say Development,
+// the answer is still no.
 const (
 	CDEventsType   = "cdevents.type"
 	CDEventsID     = "cdevents.id"

--- a/collector/semconv/cicd.go
+++ b/collector/semconv/cicd.go
@@ -48,7 +48,22 @@ const (
 	EverrGitHubWorkflowJobStepCompletedAt = "everr.github.workflow_job_step.completed_at"
 )
 
-// Everr — CDEvents and deployment attributes with no stable OTel equivalent.
+// Everr — CDEvents and deployment attributes.
+//
+// OTel does define `deployment.id`, `deployment.name`, and `deployment.status`,
+// and `cloudevents.event_id` / `cloudevents.event_source` / `cloudevents.event_type`
+// (the last three could in principle alias the `cdevents.*` keys since CDEvents
+// builds on CloudEvents). All of these are at Development stability in OTel
+// semconv as of v1.41 / v1.38.0, which means their semantics and value spaces
+// may still change in a non-backward-compatible way.
+//
+// V1 of the deploy ingest pins the deploy run identifier to the stable
+// `cicd.pipeline.run.id` / `cicd.pipeline.name` / `cicd.pipeline.run.state` /
+// `cicd.pipeline.result` attributes, and uses `everr.deploy.*` / `cdevents.*` /
+// `everr.github.*` for fields with no stable equivalent. When the OTel
+// `deployment.*` and `cloudevents.*` attributes graduate to Stable, emit them
+// as aliases so OTel-native tooling can consume the deploy stream without
+// changing the existing query contract.
 const (
 	CDEventsType   = "cdevents.type"
 	CDEventsID     = "cdevents.id"

--- a/docs/superpowers/plans/2026-05-17-deploy-cdevents-ingest.md
+++ b/docs/superpowers/plans/2026-05-17-deploy-cdevents-ingest.md
@@ -119,8 +119,8 @@ Every deploy OTel log record:
   - `everr.github.delivery.id`
   - `cicd.pipeline.run.id`
   - `cicd.pipeline.name`
-  - `cicd.pipeline.run.state` for queued/started states
-  - `cicd.pipeline.result` for finished states
+  - `cicd.pipeline.run.state` for `pending` and `executing`
+  - `cicd.pipeline.result` for `success`, `failure`, and `error`
   - `vcs.ref.head.revision`
   - `vcs.ref.head.name`
   - `everr.deploy.id`
@@ -158,6 +158,8 @@ Trace linkage:
 - `everr.deploy.superseded`
 
 Do not map `inactive` to `service.removed`; GitHub can mark older deployments inactive when a newer successful deployment supersedes them.
+
+Skip `deployment_status: queued` and `deployment_status: pending` in v1. The `deployment` webhook already emits the queued pipeline record, so mapping those statuses as started would make waiting deploys look like they are already running.
 
 ## Tasks
 
@@ -585,6 +587,7 @@ const (
 	EverrGitHubRepositoryFullName     = "everr.github.repository.full_name"
 	EverrGitHubRepositoryOwnerLogin   = "everr.github.repository.owner.login"
 	EverrGitHubWorkflowRunID          = "everr.github.workflow_run.id"
+	EverrGitHubWorkflowRunRunAttempt  = "everr.github.workflow_run.run_attempt"
 )
 ```
 
@@ -756,7 +759,19 @@ func TestDeploymentStatusInactiveEmitsSuperseded(t *testing.T) {
 	require.Equal(t, "delivery-deploy-status-inactive-1", record.Attributes().AsRaw()[semconv.EverrGitHubDeliveryID])
 	require.NotContains(t, record.Attributes().AsRaw(), semconv.CDEventsType)
 	require.NotContains(t, record.Attributes().AsRaw(), semconv.CDEventsID)
+	require.NotContains(t, record.Attributes().AsRaw(), string(conventions.CICDPipelineResultKey))
 	require.NotContains(t, record.Body().Str(), "service.removed")
+}
+
+func TestDeploymentStatusQueuedAndPendingAreSkipped(t *testing.T) {
+	for _, state := range []string{"queued", "pending"} {
+		event := deploymentStatusEventWithState(t, state)
+
+		logs, err := deploymentEventToLogs(event, "delivery-deploy-status-"+state, zap.NewNop())
+
+		require.NoError(t, err)
+		require.Nil(t, logs)
+	}
 }
 
 func TestDeploymentStatusInProgressEmitsPipelineStarted(t *testing.T) {
@@ -795,6 +810,21 @@ func TestDeploymentLogTraceIDEmptyWithoutWorkflowRun(t *testing.T) {
 	require.NoError(t, err)
 	record := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
 	require.True(t, record.TraceID().IsEmpty())
+}
+
+func TestDeploymentLogUsesEmptyStringForMissingDeploymentID(t *testing.T) {
+	event := parseGitHubTestEvent[*github.DeploymentEvent](t, "testdata/deployment/deployment_created.json", "deployment")
+	event.Deployment.ID = nil
+
+	logs, err := deploymentEventToLogs(event, "delivery-deploy-missing-id-1", zap.NewNop())
+
+	require.NoError(t, err)
+	record := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	attrs := record.Attributes().AsRaw()
+	require.Equal(t, "", attrs[string(conventions.CICDPipelineRunIDKey)])
+	require.Equal(t, "", attrs[semconv.EverrDeployID])
+	require.NotContains(t, attrs, semconv.EverrGitHubDeploymentID)
+	require.Contains(t, record.Body().Str(), `"deploymentId":""`)
 }
 ```
 
@@ -949,7 +979,7 @@ func deploymentStatusToLogs(e *github.DeploymentStatusEvent, deliveryID string, 
 	logs, records := newDeploymentLogs(e.GetRepo(), e.GetDeployment().GetEnvironment())
 
 	switch state {
-	case "in_progress", "queued", "pending":
+	case "in_progress":
 		record := records.AppendEmpty()
 		fillDeploymentLogRecord(record, deploymentLogInput{
 			EventType: cdeventsPipelineRunStarted,
@@ -961,6 +991,8 @@ func deploymentStatusToLogs(e *github.DeploymentStatusEvent, deliveryID string, 
 			URL: firstString(status.GetEnvironmentURL(), status.GetTargetURL(), status.GetLogURL()),
 			Time: firstNonZeroTime(status.GetCreatedAt().Time, status.GetUpdatedAt().Time),
 		})
+	case "queued", "pending":
+		logger.Debug("Skipping deployment_status state already represented by deployment event", zap.String("state", state))
 	case "success":
 		finished := records.AppendEmpty()
 		fillDeploymentLogRecord(finished, deploymentLogInput{
@@ -1005,7 +1037,6 @@ func deploymentStatusToLogs(e *github.DeploymentStatusEvent, deliveryID string, 
 			Repo: e.GetRepo(),
 			Deployment: e.GetDeployment(),
 			Status: status,
-			Result: "inactive",
 			URL: firstString(status.GetEnvironmentURL(), status.GetTargetURL(), status.GetLogURL()),
 			Time: firstNonZeroTime(status.GetCreatedAt().Time, status.GetUpdatedAt().Time),
 		})
@@ -1103,6 +1134,21 @@ func cdeventsID(input deploymentLogInput) string {
 	return input.DeliveryID
 }
 
+func githubIDString(id int64) string {
+	if id == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d", id)
+}
+
+func deploymentIDString(deployment *github.Deployment) string {
+	return githubIDString(deployment.GetID())
+}
+
+func deploymentStatusIDString(status *github.DeploymentStatus) string {
+	return githubIDString(status.GetID())
+}
+
 func cdeventsSubjectType(eventType string) string {
 	if eventType == cdeventsServiceDeployed {
 		return "service"
@@ -1114,7 +1160,10 @@ func cdeventsSubjectID(input deploymentLogInput) string {
 	if input.EventType == cdeventsServiceDeployed {
 		return deploymentServiceName(input.Deployment.GetTask())
 	}
-	return fmt.Sprintf("github-deployment-%d", input.Deployment.GetID())
+	if id := deploymentIDString(input.Deployment); id != "" {
+		return fmt.Sprintf("github-deployment-%s", id)
+	}
+	return "github-deployment"
 }
 
 func artifactID(repo *github.Repository, sha string) string {
@@ -1134,7 +1183,7 @@ func deploymentContent(input deploymentLogInput) map[string]any {
 			"id": input.Deployment.GetEnvironment(),
 			"name": input.Deployment.GetEnvironment(),
 		},
-		"deploymentId": fmt.Sprintf("%d", input.Deployment.GetID()),
+		"deploymentId": deploymentIDString(input.Deployment),
 		"repository": repoFullName,
 		"sha": input.Deployment.GetSHA(),
 		"ref": input.Deployment.GetRef(),
@@ -1192,16 +1241,28 @@ if input.EventType != everrDeploySuperseded {
 	attrs.PutStr(semconv.CDEventsID, cdeventsID(input))
 	attrs.PutStr(semconv.CDEventsSource, cdeventsSource(input.Repo))
 }
-attrs.PutStr(string(conventions.CICDPipelineRunIDKey), fmt.Sprintf("%d", input.Deployment.GetID()))
+deploymentID := deploymentIDString(input.Deployment)
+attrs.PutStr(string(conventions.CICDPipelineRunIDKey), deploymentID)
 attrs.PutStr(string(conventions.CICDPipelineNameKey), firstString(input.Deployment.GetTask(), "deploy"))
+if input.State != "" {
+	attrs.PutStr(string(conventions.CICDPipelineRunStateKey), input.State)
+}
+if input.Result != "" {
+	attrs.PutStr(string(conventions.CICDPipelineResultKey), input.Result)
+}
 attrs.PutStr(string(conventions.VCSRefHeadRevisionKey), input.Deployment.GetSHA())
 attrs.PutStr(string(conventions.VCSRefHeadNameKey), input.Deployment.GetRef())
-attrs.PutStr(semconv.EverrDeployID, fmt.Sprintf("%d", input.Deployment.GetID()))
+attrs.PutStr(semconv.EverrDeployID, deploymentID)
 attrs.PutStr(semconv.EverrDeployServiceName, deploymentServiceName(input.Deployment.GetTask()))
 attrs.PutStr(semconv.EverrDeployStatus, deploymentStatusValue(input))
-attrs.PutInt(semconv.EverrGitHubDeploymentID, input.Deployment.GetID())
+if input.URL != "" {
+	attrs.PutStr(semconv.EverrDeployURL, input.URL)
+}
+if input.Deployment.GetID() > 0 {
+	attrs.PutInt(semconv.EverrGitHubDeploymentID, input.Deployment.GetID())
+}
 attrs.PutStr(semconv.EverrGitHubDeploymentCreatorLogin, input.Deployment.GetCreator().GetLogin())
-if input.Status != nil {
+if input.Status != nil && input.Status.GetID() > 0 {
 	attrs.PutInt(semconv.EverrGitHubDeploymentStatusID, input.Status.GetID())
 }
 if input.WorkflowRun != nil {
@@ -1210,8 +1271,8 @@ if input.WorkflowRun != nil {
 }
 if input.EventType == everrDeploySuperseded {
 	bodyBytes, _ := json.Marshal(map[string]any{
-		"deploymentId": fmt.Sprintf("%d", input.Deployment.GetID()),
-		"deploymentStatusId": fmt.Sprintf("%d", input.Status.GetID()),
+		"deploymentId": deploymentIDString(input.Deployment),
+		"deploymentStatusId": deploymentStatusIDString(input.Status),
 		"environment": input.Deployment.GetEnvironment(),
 		"githubDeliveryId": input.DeliveryID,
 	})
@@ -1222,7 +1283,7 @@ if input.EventType == everrDeploySuperseded {
 }
 ```
 
-Set `cicd.pipeline.run.state` only for `pending` and `executing`. Set `cicd.pipeline.result` only for `success`, `failure`, `error`, and `inactive`.
+Set `cicd.pipeline.run.state` only for `pending` and `executing`. Set `cicd.pipeline.result` only for `success`, `failure`, and `error`. Keep `everr.deploy.status = inactive` on `everr.deploy.superseded`, but do not set `cicd.pipeline.result` for inactive.
 
 When building a CDEvents body, set `body.Context.ID = cdeventsID(input)` and `body.Context.Type = input.EventType`. The log attribute `cdevents.id` must always be copied from the same value used for `body.Context.ID`.
 

--- a/docs/superpowers/plans/2026-05-17-deploy-cdevents-ingest.md
+++ b/docs/superpowers/plans/2026-05-17-deploy-cdevents-ingest.md
@@ -43,6 +43,7 @@ Current `../everr-deploy` flow:
   - `dev.cdevents.pipelinerun.finished.0.3.0`
   - `dev.cdevents.service.deployed.0.3.0`
 - CDEvents versioning guidance says event versions live in event `type`, while spec version lives in `context.version`: https://cdevents.dev/docs/primer/#versioning-of-cdevents
+- CDEvents builds on CloudEvents. CloudEvents says producers must keep `source + id` unique for each distinct event, so two CDEvents records emitted from one webhook need different `context.id` values: https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#id
 - OTel logs are the right signal because OTel treats events as a special type of log: https://opentelemetry.io/docs/concepts/signals/logs/
 - Use the OTel log record event-name field through `LogRecord.SetEventName(...)`; do not duplicate it in `LogAttributes['event.name']`.
 - Use stable OTel attributes where they match:
@@ -113,6 +114,7 @@ Every deploy OTel log record:
   - `cdevents.type`
   - `cdevents.id`
   - `cdevents.source`
+  - `everr.github.delivery.id`
   - `cicd.pipeline.run.id`
   - `cicd.pipeline.name`
   - `cicd.pipeline.run.state` for queued/started states
@@ -127,6 +129,17 @@ Every deploy OTel log record:
   - `everr.github.deployment_status.id` for deployment_status events
   - `everr.github.deployment.creator.login`
   - `everr.github.workflow_run.id` and `everr.github.workflow_run.run_attempt` when present
+
+`cdevents.*` attributes apply only to CDEvents records. Custom records such as `everr.deploy.superseded` leave `cdevents.*` empty and still set `everr.github.delivery.id`.
+
+Identifier rules:
+
+- `cdevents.id` equals the CDEvents body `context.id`.
+- For webhooks that emit one CDEvents record, set `context.id = cdevents.id = <x-github-delivery>`.
+- For `deployment_status: success`, the pipeline-finished record uses `<x-github-delivery>` and the service-deployed record uses `<x-github-delivery>-service-deployed`.
+- `everr.github.delivery.id` always stores the raw GitHub `x-github-delivery` header on every deploy row, including custom rows such as `everr.deploy.superseded`.
+- `cicd.pipeline.run.id` is the GitHub deployment id string.
+- `everr.deploy.id` equals the same GitHub deployment id string. This deliberate duplicate gives future `everr/action` task-run or phase events a stable Everr-owned deploy join key without depending on OTel CI/CD semantic convention evolution.
 
 Trace linkage:
 
@@ -562,6 +575,7 @@ const (
 	EverrDeployServiceName = "everr.deploy.service.name"
 	EverrDeployURL         = "everr.deploy.url"
 
+	EverrGitHubDeliveryID              = "everr.github.delivery.id"
 	EverrGitHubDeploymentID           = "everr.github.deployment.id"
 	EverrGitHubDeploymentStatusID     = "everr.github.deployment_status.id"
 	EverrGitHubDeploymentCreatorLogin = "everr.github.deployment.creator.login"
@@ -677,7 +691,7 @@ In `collector/receiver/githubactionsreceiver/deploy_event_handling_test.go`, add
 func TestDeploymentEventToLogsMapsDeploymentCreated(t *testing.T) {
 	event := parseGitHubTestEvent[*github.DeploymentEvent](t, "testdata/deployment/deployment_created.json", "deployment")
 
-	logs, err := deploymentEventToLogs(event, zap.NewNop())
+	logs, err := deploymentEventToLogs(event, "delivery-deploy-created-1", zap.NewNop())
 
 	require.NoError(t, err)
 	require.NotNil(t, logs)
@@ -686,8 +700,10 @@ func TestDeploymentEventToLogsMapsDeploymentCreated(t *testing.T) {
 	record := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
 	require.Equal(t, "dev.cdevents.pipelinerun.queued.0.3.0", record.EventName())
 	require.Equal(t, "dev.cdevents.pipelinerun.queued.0.3.0", record.Attributes().AsRaw()[semconv.CDEventsType])
+	require.Equal(t, "delivery-deploy-created-1", record.Attributes().AsRaw()[semconv.CDEventsID])
 	require.Equal(t, int64(987), record.Attributes().AsRaw()[semconv.EverrGitHubDeploymentID])
 	require.Equal(t, "987", record.Attributes().AsRaw()[string(conventions.CICDPipelineRunIDKey)])
+	require.Equal(t, "987", record.Attributes().AsRaw()[semconv.EverrDeployID])
 
 	resourceAttrs := logs.ResourceLogs().At(0).Resource().Attributes().AsRaw()
 	require.Equal(t, "github-deployments", resourceAttrs["service.name"])
@@ -698,7 +714,7 @@ func TestDeploymentEventToLogsMapsDeploymentCreated(t *testing.T) {
 func TestDeploymentStatusSuccessEmitsPipelineFinishedAndServiceDeployed(t *testing.T) {
 	event := parseGitHubTestEvent[*github.DeploymentStatusEvent](t, "testdata/deployment/deployment_status_success.json", "deployment_status")
 
-	logs, err := deploymentEventToLogs(event, zap.NewNop())
+	logs, err := deploymentEventToLogs(event, "delivery-deploy-status-success-1", zap.NewNop())
 
 	require.NoError(t, err)
 	require.NotNil(t, logs)
@@ -706,21 +722,24 @@ func TestDeploymentStatusSuccessEmitsPipelineFinishedAndServiceDeployed(t *testi
 
 	records := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords()
 	require.Equal(t, "dev.cdevents.pipelinerun.finished.0.3.0", records.At(0).EventName())
+	require.Equal(t, "delivery-deploy-status-success-1", records.At(0).Attributes().AsRaw()[semconv.CDEventsID])
 	require.Equal(t, "success", records.At(0).Attributes().AsRaw()[string(conventions.CICDPipelineResultKey)])
 	require.Equal(t, "dev.cdevents.service.deployed.0.3.0", records.At(1).EventName())
+	require.Equal(t, "delivery-deploy-status-success-1-service-deployed", records.At(1).Attributes().AsRaw()[semconv.CDEventsID])
 	require.Equal(t, "https://app.everr.dev", records.At(1).Attributes().AsRaw()[semconv.EverrDeployURL])
 }
 
 func TestDeploymentStatusInactiveEmitsSuperseded(t *testing.T) {
 	event := parseGitHubTestEvent[*github.DeploymentStatusEvent](t, "testdata/deployment/deployment_status_inactive.json", "deployment_status")
 
-	logs, err := deploymentEventToLogs(event, zap.NewNop())
+	logs, err := deploymentEventToLogs(event, "delivery-deploy-status-inactive-1", zap.NewNop())
 
 	require.NoError(t, err)
 	require.NotNil(t, logs)
 	require.Equal(t, 1, logs.LogRecordCount())
 	record := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
 	require.Equal(t, "everr.deploy.superseded", record.EventName())
+	require.Equal(t, "delivery-deploy-status-inactive-1", record.Attributes().AsRaw()[semconv.EverrGitHubDeliveryID])
 	require.NotContains(t, record.Body().Str(), "service.removed")
 }
 ```
@@ -825,12 +844,12 @@ const (
 	everrDeploySuperseded      = "everr.deploy.superseded"
 )
 
-func deploymentEventToLogs(event interface{}, logger *zap.Logger) (*plog.Logs, error) {
+func deploymentEventToLogs(event interface{}, deliveryID string, logger *zap.Logger) (*plog.Logs, error) {
 	switch e := event.(type) {
 	case *github.DeploymentEvent:
-		return deploymentCreatedToLogs(e, logger)
+		return deploymentCreatedToLogs(e, deliveryID, logger)
 	case *github.DeploymentStatusEvent:
-		return deploymentStatusToLogs(e, logger)
+		return deploymentStatusToLogs(e, deliveryID, logger)
 	default:
 		return nil, nil
 	}
@@ -840,11 +859,12 @@ func deploymentEventToLogs(event interface{}, logger *zap.Logger) (*plog.Logs, e
 Implement `deploymentCreatedToLogs`, `deploymentStatusToLogs`, and helpers so:
 
 ```go
-func deploymentCreatedToLogs(e *github.DeploymentEvent, logger *zap.Logger) (*plog.Logs, error) {
+func deploymentCreatedToLogs(e *github.DeploymentEvent, deliveryID string, logger *zap.Logger) (*plog.Logs, error) {
 	logs, records := newDeploymentLogs(e.GetRepo(), e.GetDeployment().GetEnvironment())
 	record := records.AppendEmpty()
 	fillDeploymentLogRecord(record, deploymentLogInput{
 		EventType: cdeventsPipelineRunQueued,
+		DeliveryID: deliveryID,
 		Repo: e.GetRepo(),
 		Deployment: e.GetDeployment(),
 		State: "pending",
@@ -857,7 +877,7 @@ func deploymentCreatedToLogs(e *github.DeploymentEvent, logger *zap.Logger) (*pl
 ```
 
 ```go
-func deploymentStatusToLogs(e *github.DeploymentStatusEvent, logger *zap.Logger) (*plog.Logs, error) {
+func deploymentStatusToLogs(e *github.DeploymentStatusEvent, deliveryID string, logger *zap.Logger) (*plog.Logs, error) {
 	status := e.GetDeploymentStatus()
 	state := status.GetState()
 	logs, records := newDeploymentLogs(e.GetRepo(), e.GetDeployment().GetEnvironment())
@@ -867,6 +887,7 @@ func deploymentStatusToLogs(e *github.DeploymentStatusEvent, logger *zap.Logger)
 		record := records.AppendEmpty()
 		fillDeploymentLogRecord(record, deploymentLogInput{
 			EventType: cdeventsPipelineRunStarted,
+			DeliveryID: deliveryID,
 			Repo: e.GetRepo(),
 			Deployment: e.GetDeployment(),
 			Status: status,
@@ -878,6 +899,7 @@ func deploymentStatusToLogs(e *github.DeploymentStatusEvent, logger *zap.Logger)
 		finished := records.AppendEmpty()
 		fillDeploymentLogRecord(finished, deploymentLogInput{
 			EventType: cdeventsPipelineRunDone,
+			DeliveryID: deliveryID,
 			Repo: e.GetRepo(),
 			Deployment: e.GetDeployment(),
 			Status: status,
@@ -888,6 +910,8 @@ func deploymentStatusToLogs(e *github.DeploymentStatusEvent, logger *zap.Logger)
 		deployed := records.AppendEmpty()
 		fillDeploymentLogRecord(deployed, deploymentLogInput{
 			EventType: cdeventsServiceDeployed,
+			DeliveryID: deliveryID,
+			CDEventsIDSuffix: "service-deployed",
 			Repo: e.GetRepo(),
 			Deployment: e.GetDeployment(),
 			Status: status,
@@ -899,6 +923,7 @@ func deploymentStatusToLogs(e *github.DeploymentStatusEvent, logger *zap.Logger)
 		record := records.AppendEmpty()
 		fillDeploymentLogRecord(record, deploymentLogInput{
 			EventType: cdeventsPipelineRunDone,
+			DeliveryID: deliveryID,
 			Repo: e.GetRepo(),
 			Deployment: e.GetDeployment(),
 			Status: status,
@@ -910,6 +935,7 @@ func deploymentStatusToLogs(e *github.DeploymentStatusEvent, logger *zap.Logger)
 		record := records.AppendEmpty()
 		fillDeploymentLogRecord(record, deploymentLogInput{
 			EventType: everrDeploySuperseded,
+			DeliveryID: deliveryID,
 			Repo: e.GetRepo(),
 			Deployment: e.GetDeployment(),
 			Status: status,
@@ -956,14 +982,16 @@ Use this input type and helper set:
 
 ```go
 type deploymentLogInput struct {
-	EventType  string
-	Repo      *github.Repository
-	Deployment *github.Deployment
-	Status    *github.DeploymentStatus
-	State     string
-	Result    string
-	URL       string
-	Time      time.Time
+	EventType        string
+	DeliveryID       string
+	CDEventsIDSuffix string
+	Repo             *github.Repository
+	Deployment      *github.Deployment
+	Status          *github.DeploymentStatus
+	State           string
+	Result          string
+	URL             string
+	Time            time.Time
 }
 
 func newDeploymentLogs(repo *github.Repository, environment string) (plog.Logs, plog.LogRecordSlice) {
@@ -1001,10 +1029,18 @@ func cdeventsSource(repo *github.Repository) string {
 }
 
 func cdeventsID(input deploymentLogInput) string {
+	if input.DeliveryID != "" {
+		if input.CDEventsIDSuffix != "" {
+			return fmt.Sprintf("%s-%s", input.DeliveryID, input.CDEventsIDSuffix)
+		}
+		return input.DeliveryID
+	}
+
 	statusID := int64(0)
 	if input.Status != nil {
 		statusID = input.Status.GetID()
 	}
+
 	hash := sha256.Sum256([]byte(fmt.Sprintf("%s:%d:%d", input.EventType, input.Deployment.GetID(), statusID)))
 	return hex.EncodeToString(hash[:])
 }
@@ -1016,15 +1052,18 @@ Inside `fillDeploymentLogRecord(...)`, set:
 record.SetEventName(input.EventType)
 record.SetTimestamp(pcommon.NewTimestampFromTime(input.Time))
 attrs := record.Attributes()
-attrs.PutStr(semconv.CDEventsType, input.EventType)
-attrs.PutStr(semconv.CDEventsID, cdeventsID(input))
-attrs.PutStr(semconv.CDEventsSource, cdeventsSource(input.Repo))
+attrs.PutStr(semconv.EverrGitHubDeliveryID, input.DeliveryID)
+if input.EventType != everrDeploySuperseded {
+	attrs.PutStr(semconv.CDEventsType, input.EventType)
+	attrs.PutStr(semconv.CDEventsID, cdeventsID(input))
+	attrs.PutStr(semconv.CDEventsSource, cdeventsSource(input.Repo))
+}
 attrs.PutStr(string(conventions.CICDPipelineRunIDKey), fmt.Sprintf("%d", input.Deployment.GetID()))
 attrs.PutStr(string(conventions.CICDPipelineNameKey), firstString(input.Deployment.GetTask(), "deploy"))
 attrs.PutStr("deployment.environment.name", input.Deployment.GetEnvironment())
 attrs.PutStr(string(conventions.VCSRefHeadRevisionKey), input.Deployment.GetSHA())
 attrs.PutStr(string(conventions.VCSRefHeadNameKey), input.Deployment.GetRef())
-attrs.PutStr(semconv.EverrDeployID, fmt.Sprintf("github-deployment-%d", input.Deployment.GetID()))
+attrs.PutStr(semconv.EverrDeployID, fmt.Sprintf("%d", input.Deployment.GetID()))
 attrs.PutStr(semconv.EverrDeployServiceName, deploymentServiceName(input.Deployment.GetTask()))
 attrs.PutInt(semconv.EverrGitHubDeploymentID, input.Deployment.GetID())
 attrs.PutStr(semconv.EverrGitHubDeploymentCreatorLogin, input.Deployment.GetCreator().GetLogin())
@@ -1032,7 +1071,9 @@ attrs.PutStr(semconv.EverrGitHubDeploymentCreatorLogin, input.Deployment.GetCrea
 
 Set `cicd.pipeline.run.state` only for `pending` and `executing`. Set `cicd.pipeline.result` only for `success`, `failure`, `error`, and `inactive`.
 
-Marshal the CDEvents body and store it in `record.Body().SetStr(...)`.
+For CDEvents records, marshal the CDEvents body and store it in `record.Body().SetStr(...)`. For `everr.deploy.superseded`, leave `cdevents.*` attributes empty and set a small JSON body with the deployment id, status id, environment, and raw GitHub delivery id.
+
+When building a CDEvents body, set `body.Context.ID = cdeventsID(input)` and `body.Context.Type = input.EventType`. The log attribute `cdevents.id` must always be copied from the same value used for `body.Context.ID`.
 
 - [ ] **Step 7: Add trace linkage test**
 
@@ -1082,7 +1123,7 @@ Add a test:
 func TestDeploymentStatusUsesWorkflowTraceIDWhenPresent(t *testing.T) {
 	event := parseGitHubTestEvent[*github.DeploymentStatusEvent](t, "testdata/deployment/deployment_status_success_with_workflow_run.json", "deployment_status")
 
-	logs, err := deploymentEventToLogs(event, zap.NewNop())
+	logs, err := deploymentEventToLogs(event, "delivery-deploy-status-success-trace-1", zap.NewNop())
 
 	require.NoError(t, err)
 	expected, err := generateTraceID(654321, 456, 2)
@@ -1134,6 +1175,7 @@ func TestReceiverDeploymentStatusDoesNotRequireGitHubAPIClient(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/webhook/github", bytes.NewReader(payload))
 	signGitHubRequest(req, "secret", payload)
 	req.Header.Set("x-github-event", "deployment_status")
+	req.Header.Set("x-github-delivery", "delivery-deploy-status-success-1")
 	req.Header.Set("x-everr-tenant-id", "42")
 	rec := httptest.NewRecorder()
 
@@ -1191,7 +1233,8 @@ if isDeploymentWebhookEvent(event) {
 		return
 	}
 
-	ld, err := deploymentEventToLogs(event, gar.logger.Named("deploymentEventToLogs"))
+	deliveryID := r.Header.Get("x-github-delivery")
+	ld, err := deploymentEventToLogs(event, deliveryID, gar.logger.Named("deploymentEventToLogs"))
 	if err != nil {
 		gar.logger.Error("Failed to process deployment event", zap.Error(err))
 		w.WriteHeader(http.StatusInternalServerError)

--- a/docs/superpowers/plans/2026-05-17-deploy-cdevents-ingest.md
+++ b/docs/superpowers/plans/2026-05-17-deploy-cdevents-ingest.md
@@ -36,6 +36,7 @@ Current `../everr-deploy` flow:
 ## Standards Locked For V1
 
 - GitHub Deployments are the user-facing source. GitHub says deployments are deploy requests, and statuses can be `error`, `failure`, `pending`, `in_progress`, `queued`, or `success`: https://docs.github.com/en/enterprise-cloud@latest/rest/deployments/deployments
+- `actions/checkout` fetches only the triggering commit by default. Changed-service detection needs the previous push SHA, so set `fetch-depth: 0` in `../everr-deploy` before running `git diff`: https://github.com/actions/checkout/blob/main/README.md
 - CDEvents spec version is pinned to `0.5.0`: https://cdevents.dev/docs/
 - CDEvents event types stay pinned to:
   - `dev.cdevents.pipelinerun.queued.0.3.0`
@@ -1909,7 +1910,20 @@ Add under workflow `env:`:
   DEPLOY_ENVIRONMENT: production
 ```
 
-- [ ] **Step 6: Add deployment creation before apply**
+- [ ] **Step 6: Fetch enough Git history for changed-service detection**
+
+In `../everr-deploy/.github/workflows/deploy.yml`, update the checkout step:
+
+```yaml
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+```
+
+`changed-ecs-services.sh` compares `github.event.before` to `github.sha`. GitHub push workflows can otherwise check out only the triggering commit, which means the base SHA may not exist locally and `git diff "$base" "$head"` can fail before deployments are created.
+
+- [ ] **Step 7: Add deployment creation before apply**
 
 In the `apply-infra` job, after `Init` and before `Apply`, add:
 
@@ -1935,7 +1949,7 @@ In the `apply-infra` job, after `Init` and before `Apply`, add:
           done
 ```
 
-- [ ] **Step 7: Add failure trap around apply and rollout wait**
+- [ ] **Step 8: Add failure trap around apply and rollout wait**
 
 Replace the current `Apply` step with:
 
@@ -2015,7 +2029,7 @@ Because the job default working directory is `./infra`, script paths in this ste
 
 The failure trap skips services already marked successful. If `app` completes and `docs` fails later, the trap must not emit a failure status for `app`.
 
-- [ ] **Step 8: Validate workflow YAML and shell scripts**
+- [ ] **Step 9: Validate workflow YAML and shell scripts**
 
 Run from `../everr-deploy`:
 
@@ -2037,7 +2051,7 @@ PY
 
 Expected: shell syntax passes, shellcheck passes when installed, and workflow YAML parses.
 
-- [ ] **Step 9: Commit everr-deploy workflow changes**
+- [ ] **Step 10: Commit everr-deploy workflow changes**
 
 Run from `../everr-deploy`:
 

--- a/docs/superpowers/plans/2026-05-17-deploy-cdevents-ingest.md
+++ b/docs/superpowers/plans/2026-05-17-deploy-cdevents-ingest.md
@@ -517,6 +517,8 @@ export function parseQueuedCollectorEvent(
 
 Change `installationIdFromQueuedEvent(...)` to accept `ParsedQueuedCollectorEvent` instead of only `ParsedQueuedWorkflowEvent`.
 
+No body change should be needed for `installationIdFromQueuedEvent(...)`: the existing `event.payload.installation?.id` logic works because the deployment schemas keep the same `installation: { id }` shape as workflow events.
+
 - [ ] **Step 5: Use collector parser only in collector worker**
 
 In `packages/app/src/server/github-events/runtime.ts`, import `parseQueuedCollectorEvent` and use it only in `processCollectorJob`.
@@ -532,6 +534,8 @@ The status worker remains:
 ```ts
 const parsed = parseQueuedWorkflowEvent(eventType, body);
 ```
+
+If this step is missed, deploy jobs still call `parseQueuedWorkflowEvent(...)` in `processCollectorJob`, throw `TerminalEventError("unsupported workflow event type \"deployment\"")`, and get dropped as terminal collector errors without reaching the collector.
 
 - [ ] **Step 6: Run app tests**
 
@@ -1356,8 +1360,57 @@ Expected: deploy mapper tests pass.
 
 - Modify: `collector/receiver/githubactionsreceiver/receiver.go`
 - Modify: `collector/receiver/githubactionsreceiver/receiver_test.go`
+- Inspect, and modify only if needed: `collector/config.yml`
+- Inspect, and modify only if needed: `collector/config.example.yml`
 
-- [ ] **Step 1: Add receiver test proving deploy path does not need GitHub API auth**
+- [ ] **Step 1: Verify tenant resource enrichment path**
+
+Before relying on `everr.tenant.id` from the data contract, verify the collector configuration that runs after the receiver:
+
+- `collector/config.yml` and `collector/config.example.yml` must define the internal `resource` processor with `everr.tenant.id` upserted from `metadata.x-everr-tenant-id`.
+- The same processor must convert `everr.tenant.id` to an integer.
+- `service.pipelines.logs.receivers` must include `githubactions`.
+- `service.pipelines.logs.processors` must include `resource` before `batch`.
+- The processor must not be scoped to workflow-only scope names; it must also apply to deploy logs with scope name `github-deployments`.
+
+The current receiver copies request headers into collector client metadata with `client.NewMetadata(r.Header)` before dispatch. The deploy path must stay after that metadata copy. A receiver unit test can assert that metadata propagation, but it cannot assert the final `ResourceAttributes['everr.tenant.id']` because processors run after the receiver.
+
+Add or keep this config validation as part of the collector verification:
+
+```bash
+python3 - <<'PY'
+import pathlib, yaml
+
+for path in [pathlib.Path("collector/config.yml"), pathlib.Path("collector/config.example.yml")]:
+    cfg = yaml.safe_load(path.read_text())
+    attrs = cfg["processors"]["resource"]["attributes"]
+    assert any(
+        item.get("action") == "upsert"
+        and item.get("key") == "everr.tenant.id"
+        and item.get("from_context") == "metadata.x-everr-tenant-id"
+        for item in attrs
+    ), f"{path}: missing everr.tenant.id metadata upsert"
+    assert any(
+        item.get("action") == "convert"
+        and item.get("key") == "everr.tenant.id"
+        and item.get("converted_type") == "int"
+        for item in attrs
+    ), f"{path}: missing everr.tenant.id integer conversion"
+    logs = cfg["service"]["pipelines"]["logs"]
+    assert "githubactions" in logs["receivers"], f"{path}: logs pipeline must receive githubactions"
+    processors = logs["processors"]
+    assert "resource" in processors, f"{path}: logs pipeline must run resource processor"
+    assert "batch" in processors, f"{path}: logs pipeline must run batch processor"
+    assert processors.index("resource") < processors.index("batch"), f"{path}: resource processor must run before batch"
+print("tenant resource processor covers githubactions logs")
+PY
+```
+
+This is the collector-level coverage for `ResourceAttributes['everr.tenant.id']`: the receiver test below proves the header survives as request metadata, and this config validation proves the logs pipeline turns that metadata into the resource attribute before ClickHouse export.
+
+If this validation fails, do not proceed with only mapper changes. Either fix the internal logs pipeline to apply the broad `resource` processor to GitHub receiver logs, or pass the tenant id from request metadata into `newDeploymentLogs(...)` and set `everr.tenant.id` directly on the deploy resource.
+
+- [ ] **Step 2: Add receiver test proving deploy path does not need GitHub API auth**
 
 Add a receiver test using a valid GitHub webhook signature and a `deployment_status` payload, but config with no GitHub API app id/private key. The logs consumer should receive logs and the response should be `202`.
 
@@ -1388,12 +1441,13 @@ func TestReceiverDeploymentStatusDoesNotRequireGitHubAPIClient(t *testing.T) {
 	require.Equal(t, http.StatusAccepted, rec.Code)
 	require.Len(t, consumer.logs, 1)
 	require.Equal(t, 2, consumer.logs[0].LogRecordCount())
+	require.Contains(t, consumer.metadata.Get("x-everr-tenant-id"), "42")
 }
 ```
 
-Use existing receiver test helpers where possible. If helper names differ, keep the same assertions and use the existing test style in `receiver_test.go`.
+Use existing receiver test helpers where possible. If helper names differ, keep the same assertions and use the existing test style in `receiver_test.go`. The capturing logs consumer should record both the consumed logs and `client.FromContext(ctx).Metadata`, so this test proves deploy logs keep the tenant header metadata that the resource processor reads.
 
-- [ ] **Step 2: Run the failing receiver test**
+- [ ] **Step 3: Run the failing receiver test**
 
 Run:
 
@@ -1404,7 +1458,7 @@ go test ./... -run 'TestReceiverDeploymentStatusDoesNotRequireGitHubAPIClient' -
 
 Expected: failure because current receiver rejects unsupported event types or initializes GitHub API auth before logs.
 
-- [ ] **Step 3: Add deploy event detection**
+- [ ] **Step 4: Add deploy event detection**
 
 In `collector/receiver/githubactionsreceiver/receiver.go`, add:
 
@@ -1426,7 +1480,9 @@ case *github.DeploymentEvent, *github.DeploymentStatusEvent:
 	// Deploy events are mapped directly to logs below.
 ```
 
-- [ ] **Step 4: Dispatch deploy logs before installation client setup**
+This case must be added to the existing top-level `ServeHTTP` switch immediately after `github.ParseWebHook(...)`, where unsupported events currently hit the default branch and return `204`. Adding deployment handling anywhere later is not enough, because the current default branch exits before request metadata, deploy mapping, or workflow processing can run.
+
+- [ ] **Step 5: Dispatch deploy logs before installation client setup**
 
 After request metadata is copied into `client.Metadata`, add this block before `installationIDFromWebhookEvent(...)`:
 
@@ -1460,22 +1516,48 @@ if isDeploymentWebhookEvent(event) {
 
 Leave the workflow-run and workflow-job path unchanged.
 
-- [ ] **Step 5: Keep installation helper workflow-only**
+- [ ] **Step 6: Keep installation helper workflow-only**
 
 Do not add deployment cases to `installationIDFromWebhookEvent(...)`. The deploy path returns before that helper and does not need a GitHub API client.
 
-- [ ] **Step 6: Run collector tests**
+- [ ] **Step 7: Run collector tests**
 
 Run:
 
 ```bash
+python3 - <<'PY'
+import pathlib, yaml
+
+for path in [pathlib.Path("collector/config.yml"), pathlib.Path("collector/config.example.yml")]:
+    cfg = yaml.safe_load(path.read_text())
+    attrs = cfg["processors"]["resource"]["attributes"]
+    assert any(
+        item.get("action") == "upsert"
+        and item.get("key") == "everr.tenant.id"
+        and item.get("from_context") == "metadata.x-everr-tenant-id"
+        for item in attrs
+    ), f"{path}: missing everr.tenant.id metadata upsert"
+    assert any(
+        item.get("action") == "convert"
+        and item.get("key") == "everr.tenant.id"
+        and item.get("converted_type") == "int"
+        for item in attrs
+    ), f"{path}: missing everr.tenant.id integer conversion"
+    logs = cfg["service"]["pipelines"]["logs"]
+    processors = logs["processors"]
+    assert "githubactions" in logs["receivers"], f"{path}: logs pipeline must receive githubactions"
+    assert "resource" in processors, f"{path}: logs pipeline must run resource processor"
+    assert "batch" in processors, f"{path}: logs pipeline must run batch processor"
+    assert processors.index("resource") < processors.index("batch"), f"{path}: resource processor must run before batch"
+print("tenant resource processor covers githubactions logs")
+PY
 cd collector/receiver/githubactionsreceiver
 go test ./... -count=1
 ```
 
-Expected: all receiver tests pass.
+Expected: tenant resource config validation passes and all receiver tests pass.
 
-- [ ] **Step 7: Commit collector changes**
+- [ ] **Step 8: Commit collector changes**
 
 Run:
 
@@ -2041,7 +2123,7 @@ if command -v shellcheck >/dev/null; then
 else
   echo "shellcheck not installed; skipped"
 fi
-python - <<'PY'
+python3 - <<'PY'
 import pathlib, yaml
 for path in pathlib.Path(".github/workflows").glob("*.yml"):
     yaml.safe_load(path.read_text())

--- a/docs/superpowers/plans/2026-05-17-deploy-cdevents-ingest.md
+++ b/docs/superpowers/plans/2026-05-17-deploy-cdevents-ingest.md
@@ -102,14 +102,16 @@ ClickHouse/docs changes:
 Every deploy OTel log record:
 
 - `EventName`: one of the CDEvents event types or `everr.deploy.superseded`.
-- `Body`: JSON CDEvents-shaped object.
+- `Body`: JSON CDEvents-shaped object for CDEvents records, and a small Everr JSON object for `everr.deploy.superseded`.
 - `ResourceAttributes`:
   - `everr.tenant.id`: set by the collector resource processor from `x-everr-tenant-id`.
   - `service.name`: `github-deployments`.
   - `deployment.environment.name`: GitHub deployment environment.
-  - `vcs.provider.name`: `github`.
-  - `vcs.repository.name`: GitHub repository full name.
-  - `vcs.owner.name`: GitHub repository owner login when available.
+  - `vcs.repository.name`: GitHub repository name only, such as `everr-deploy`.
+  - `vcs.repository.url.full`: GitHub repository HTML URL.
+  - `everr.github.repository.full_name`: GitHub `owner/repo` value.
+  - `everr.github.repository.owner.login`: GitHub owner or organization login.
+  - `ResourceLogs.SchemaUrl`: `conventions.SchemaURL`.
 - `LogAttributes`:
   - `cdevents.type`
   - `cdevents.id`
@@ -119,11 +121,11 @@ Every deploy OTel log record:
   - `cicd.pipeline.name`
   - `cicd.pipeline.run.state` for queued/started states
   - `cicd.pipeline.result` for finished states
-  - `deployment.environment.name`
   - `vcs.ref.head.revision`
   - `vcs.ref.head.name`
   - `everr.deploy.id`
   - `everr.deploy.service.name`
+  - `everr.deploy.status`
   - `everr.deploy.url` when GitHub status provides `environment_url` or `target_url`
   - `everr.github.deployment.id`
   - `everr.github.deployment_status.id` for deployment_status events
@@ -573,12 +575,16 @@ const (
 
 	EverrDeployID          = "everr.deploy.id"
 	EverrDeployServiceName = "everr.deploy.service.name"
+	EverrDeployStatus      = "everr.deploy.status"
 	EverrDeployURL         = "everr.deploy.url"
 
 	EverrGitHubDeliveryID              = "everr.github.delivery.id"
 	EverrGitHubDeploymentID           = "everr.github.deployment.id"
 	EverrGitHubDeploymentStatusID     = "everr.github.deployment_status.id"
 	EverrGitHubDeploymentCreatorLogin = "everr.github.deployment.creator.login"
+	EverrGitHubRepositoryFullName     = "everr.github.repository.full_name"
+	EverrGitHubRepositoryOwnerLogin   = "everr.github.repository.owner.login"
+	EverrGitHubWorkflowRunID          = "everr.github.workflow_run.id"
 )
 ```
 
@@ -701,14 +707,22 @@ func TestDeploymentEventToLogsMapsDeploymentCreated(t *testing.T) {
 	require.Equal(t, "dev.cdevents.pipelinerun.queued.0.3.0", record.EventName())
 	require.Equal(t, "dev.cdevents.pipelinerun.queued.0.3.0", record.Attributes().AsRaw()[semconv.CDEventsType])
 	require.Equal(t, "delivery-deploy-created-1", record.Attributes().AsRaw()[semconv.CDEventsID])
+	require.NotContains(t, record.Attributes().AsRaw(), "event.name")
+	require.NotContains(t, record.Attributes().AsRaw(), "deployment.environment.name")
 	require.Equal(t, int64(987), record.Attributes().AsRaw()[semconv.EverrGitHubDeploymentID])
 	require.Equal(t, "987", record.Attributes().AsRaw()[string(conventions.CICDPipelineRunIDKey)])
 	require.Equal(t, "987", record.Attributes().AsRaw()[semconv.EverrDeployID])
 
+	require.Equal(t, conventions.SchemaURL, logs.ResourceLogs().At(0).SchemaUrl())
 	resourceAttrs := logs.ResourceLogs().At(0).Resource().Attributes().AsRaw()
 	require.Equal(t, "github-deployments", resourceAttrs["service.name"])
 	require.Equal(t, "production", resourceAttrs["deployment.environment.name"])
-	require.Equal(t, "everr-labs/everr-deploy", resourceAttrs[string(conventions.VCSRepositoryNameKey)])
+	require.Equal(t, "everr-deploy", resourceAttrs[string(conventions.VCSRepositoryNameKey)])
+	require.Equal(t, "https://github.com/everr-labs/everr-deploy", resourceAttrs["vcs.repository.url.full"])
+	require.Equal(t, "everr-labs/everr-deploy", resourceAttrs[semconv.EverrGitHubRepositoryFullName])
+	require.Equal(t, "everr-labs", resourceAttrs[semconv.EverrGitHubRepositoryOwnerLogin])
+	require.NotContains(t, resourceAttrs, string(conventions.VCSProviderNameKey))
+	require.NotContains(t, resourceAttrs, string(conventions.VCSOwnerNameKey))
 }
 
 func TestDeploymentStatusSuccessEmitsPipelineFinishedAndServiceDeployed(t *testing.T) {
@@ -740,7 +754,47 @@ func TestDeploymentStatusInactiveEmitsSuperseded(t *testing.T) {
 	record := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
 	require.Equal(t, "everr.deploy.superseded", record.EventName())
 	require.Equal(t, "delivery-deploy-status-inactive-1", record.Attributes().AsRaw()[semconv.EverrGitHubDeliveryID])
+	require.NotContains(t, record.Attributes().AsRaw(), semconv.CDEventsType)
+	require.NotContains(t, record.Attributes().AsRaw(), semconv.CDEventsID)
 	require.NotContains(t, record.Body().Str(), "service.removed")
+}
+
+func TestDeploymentStatusInProgressEmitsPipelineStarted(t *testing.T) {
+	event := deploymentStatusEventWithState(t, "in_progress")
+
+	logs, err := deploymentEventToLogs(event, "delivery-deploy-status-started-1", zap.NewNop())
+
+	require.NoError(t, err)
+	require.Equal(t, 1, logs.LogRecordCount())
+	record := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	require.Equal(t, "dev.cdevents.pipelinerun.started.0.3.0", record.EventName())
+	require.Equal(t, "executing", record.Attributes().AsRaw()[string(conventions.CICDPipelineRunStateKey)])
+	require.Equal(t, "in_progress", record.Attributes().AsRaw()[semconv.EverrDeployStatus])
+}
+
+func TestDeploymentStatusFailureAndErrorEmitPipelineFinished(t *testing.T) {
+	for _, state := range []string{"failure", "error"} {
+		event := deploymentStatusEventWithState(t, state)
+
+		logs, err := deploymentEventToLogs(event, "delivery-deploy-status-"+state, zap.NewNop())
+
+		require.NoError(t, err)
+		require.Equal(t, 1, logs.LogRecordCount())
+		record := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+		require.Equal(t, "dev.cdevents.pipelinerun.finished.0.3.0", record.EventName())
+		require.Equal(t, state, record.Attributes().AsRaw()[string(conventions.CICDPipelineResultKey)])
+		require.Equal(t, state, record.Attributes().AsRaw()[semconv.EverrDeployStatus])
+	}
+}
+
+func TestDeploymentLogTraceIDEmptyWithoutWorkflowRun(t *testing.T) {
+	event := parseGitHubTestEvent[*github.DeploymentEvent](t, "testdata/deployment/deployment_created.json", "deployment")
+
+	logs, err := deploymentEventToLogs(event, "delivery-deploy-no-workflow-1", zap.NewNop())
+
+	require.NoError(t, err)
+	record := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	require.True(t, record.TraceID().IsEmpty())
 }
 ```
 
@@ -758,6 +812,13 @@ func parseGitHubTestEvent[T any](t *testing.T, path string, eventType string) T 
 	typed, ok := event.(T)
 	require.True(t, ok)
 	return typed
+}
+
+func deploymentStatusEventWithState(t *testing.T, state string) *github.DeploymentStatusEvent {
+	t.Helper()
+	event := parseGitHubTestEvent[*github.DeploymentStatusEvent](t, "testdata/deployment/deployment_status_success.json", "deployment_status")
+	event.DeploymentStatus.State = github.String(state)
+	return event
 }
 ```
 
@@ -782,6 +843,7 @@ package githubactionsreceiver
 import (
 	"strings"
 
+	"github.com/everr-labs/everr/collector/semconv"
 	"github.com/google/go-github/v67/github"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	conventions "go.opentelemetry.io/otel/semconv/v1.38.0"
@@ -794,10 +856,11 @@ func setDeploymentResourceAttributes(attrs pcommon.Map, repo *github.Repository,
 	if environment != "" {
 		attrs.PutStr("deployment.environment.name", environment)
 	}
-	attrs.PutStr(string(conventions.VCSProviderNameKey), "github")
 	if repo != nil {
-		attrs.PutStr(string(conventions.VCSRepositoryNameKey), repo.GetFullName())
-		attrs.PutStr(string(conventions.VCSOwnerNameKey), repo.GetOwner().GetLogin())
+		attrs.PutStr(string(conventions.VCSRepositoryNameKey), repo.GetName())
+		attrs.PutStr("vcs.repository.url.full", repo.GetHTMLURL())
+		attrs.PutStr(semconv.EverrGitHubRepositoryFullName, repo.GetFullName())
+		attrs.PutStr(semconv.EverrGitHubRepositoryOwnerLogin, repo.GetOwner().GetLogin())
 	}
 }
 
@@ -821,14 +884,12 @@ Create `collector/receiver/githubactionsreceiver/deploy_event_handling.go` with 
 package githubactionsreceiver
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"time"
 
-	"github.com/google/go-github/v67/github"
 	"github.com/everr-labs/everr/collector/semconv"
+	"github.com/google/go-github/v67/github"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	conventions "go.opentelemetry.io/otel/semconv/v1.38.0"
@@ -845,6 +906,10 @@ const (
 )
 
 func deploymentEventToLogs(event interface{}, deliveryID string, logger *zap.Logger) (*plog.Logs, error) {
+	if deliveryID == "" {
+		return nil, fmt.Errorf("missing x-github-delivery")
+	}
+
 	switch e := event.(type) {
 	case *github.DeploymentEvent:
 		return deploymentCreatedToLogs(e, deliveryID, logger)
@@ -867,6 +932,7 @@ func deploymentCreatedToLogs(e *github.DeploymentEvent, deliveryID string, logge
 		DeliveryID: deliveryID,
 		Repo: e.GetRepo(),
 		Deployment: e.GetDeployment(),
+		WorkflowRun: e.GetWorkflowRun(),
 		State: "pending",
 		Result: "",
 		URL: "",
@@ -988,6 +1054,7 @@ type deploymentLogInput struct {
 	Repo             *github.Repository
 	Deployment      *github.Deployment
 	Status          *github.DeploymentStatus
+	WorkflowRun     *github.WorkflowRun
 	State           string
 	Result          string
 	URL             string
@@ -997,6 +1064,7 @@ type deploymentLogInput struct {
 func newDeploymentLogs(repo *github.Repository, environment string) (plog.Logs, plog.LogRecordSlice) {
 	logs := plog.NewLogs()
 	resourceLogs := logs.ResourceLogs().AppendEmpty()
+	resourceLogs.SetSchemaUrl(conventions.SchemaURL)
 	setDeploymentResourceAttributes(resourceLogs.Resource().Attributes(), repo, environment)
 	scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
 	scopeLogs.Scope().SetName("github-deployments")
@@ -1029,20 +1097,80 @@ func cdeventsSource(repo *github.Repository) string {
 }
 
 func cdeventsID(input deploymentLogInput) string {
-	if input.DeliveryID != "" {
-		if input.CDEventsIDSuffix != "" {
-			return fmt.Sprintf("%s-%s", input.DeliveryID, input.CDEventsIDSuffix)
-		}
-		return input.DeliveryID
+	if input.CDEventsIDSuffix != "" {
+		return fmt.Sprintf("%s-%s", input.DeliveryID, input.CDEventsIDSuffix)
 	}
+	return input.DeliveryID
+}
 
-	statusID := int64(0)
-	if input.Status != nil {
-		statusID = input.Status.GetID()
+func cdeventsSubjectType(eventType string) string {
+	if eventType == cdeventsServiceDeployed {
+		return "service"
 	}
+	return "pipelineRun"
+}
 
-	hash := sha256.Sum256([]byte(fmt.Sprintf("%s:%d:%d", input.EventType, input.Deployment.GetID(), statusID)))
-	return hex.EncodeToString(hash[:])
+func cdeventsSubjectID(input deploymentLogInput) string {
+	if input.EventType == cdeventsServiceDeployed {
+		return deploymentServiceName(input.Deployment.GetTask())
+	}
+	return fmt.Sprintf("github-deployment-%d", input.Deployment.GetID())
+}
+
+func artifactID(repo *github.Repository, sha string) string {
+	if repo == nil || repo.GetFullName() == "" || sha == "" {
+		return ""
+	}
+	return fmt.Sprintf("pkg:github/%s@%s", repo.GetFullName(), sha)
+}
+
+func deploymentContent(input deploymentLogInput) map[string]any {
+	repoFullName := ""
+	if input.Repo != nil {
+		repoFullName = input.Repo.GetFullName()
+	}
+	content := map[string]any{
+		"environment": map[string]string{
+			"id": input.Deployment.GetEnvironment(),
+			"name": input.Deployment.GetEnvironment(),
+		},
+		"deploymentId": fmt.Sprintf("%d", input.Deployment.GetID()),
+		"repository": repoFullName,
+		"sha": input.Deployment.GetSHA(),
+		"ref": input.Deployment.GetRef(),
+	}
+	if artifact := artifactID(input.Repo, input.Deployment.GetSHA()); artifact != "" {
+		content["artifactId"] = artifact
+	}
+	if input.URL != "" {
+		content["uri"] = input.URL
+	}
+	return content
+}
+
+func deploymentCDEventsBody(input deploymentLogInput) cdeventsBody {
+	return cdeventsBody{
+		Context: cdeventsContext{
+			Version: cdeventsSpecVersion,
+			ID: cdeventsID(input),
+			Source: cdeventsSource(input.Repo),
+			Type: input.EventType,
+			Timestamp: input.Time.UTC().Format(time.RFC3339Nano),
+		},
+		Subject: cdeventsSubject{
+			ID: cdeventsSubjectID(input),
+			Type: cdeventsSubjectType(input.EventType),
+			Source: cdeventsSource(input.Repo),
+			Content: deploymentContent(input),
+		},
+	}
+}
+
+func deploymentStatusValue(input deploymentLogInput) string {
+	if input.Status != nil && input.Status.GetState() != "" {
+		return input.Status.GetState()
+	}
+	return input.State
 }
 ```
 
@@ -1051,6 +1179,12 @@ Inside `fillDeploymentLogRecord(...)`, set:
 ```go
 record.SetEventName(input.EventType)
 record.SetTimestamp(pcommon.NewTimestampFromTime(input.Time))
+if input.WorkflowRun != nil && input.Repo != nil && input.Repo.GetID() > 0 && input.WorkflowRun.GetID() > 0 && input.WorkflowRun.GetRunAttempt() > 0 {
+	traceID, err := generateTraceID(input.Repo.GetID(), input.WorkflowRun.GetID(), input.WorkflowRun.GetRunAttempt())
+	if err == nil {
+		record.SetTraceID(traceID)
+	}
+}
 attrs := record.Attributes()
 attrs.PutStr(semconv.EverrGitHubDeliveryID, input.DeliveryID)
 if input.EventType != everrDeploySuperseded {
@@ -1060,24 +1194,41 @@ if input.EventType != everrDeploySuperseded {
 }
 attrs.PutStr(string(conventions.CICDPipelineRunIDKey), fmt.Sprintf("%d", input.Deployment.GetID()))
 attrs.PutStr(string(conventions.CICDPipelineNameKey), firstString(input.Deployment.GetTask(), "deploy"))
-attrs.PutStr("deployment.environment.name", input.Deployment.GetEnvironment())
 attrs.PutStr(string(conventions.VCSRefHeadRevisionKey), input.Deployment.GetSHA())
 attrs.PutStr(string(conventions.VCSRefHeadNameKey), input.Deployment.GetRef())
 attrs.PutStr(semconv.EverrDeployID, fmt.Sprintf("%d", input.Deployment.GetID()))
 attrs.PutStr(semconv.EverrDeployServiceName, deploymentServiceName(input.Deployment.GetTask()))
+attrs.PutStr(semconv.EverrDeployStatus, deploymentStatusValue(input))
 attrs.PutInt(semconv.EverrGitHubDeploymentID, input.Deployment.GetID())
 attrs.PutStr(semconv.EverrGitHubDeploymentCreatorLogin, input.Deployment.GetCreator().GetLogin())
+if input.Status != nil {
+	attrs.PutInt(semconv.EverrGitHubDeploymentStatusID, input.Status.GetID())
+}
+if input.WorkflowRun != nil {
+	attrs.PutInt(semconv.EverrGitHubWorkflowRunID, input.WorkflowRun.GetID())
+	attrs.PutInt(semconv.EverrGitHubWorkflowRunRunAttempt, int64(input.WorkflowRun.GetRunAttempt()))
+}
+if input.EventType == everrDeploySuperseded {
+	bodyBytes, _ := json.Marshal(map[string]any{
+		"deploymentId": fmt.Sprintf("%d", input.Deployment.GetID()),
+		"deploymentStatusId": fmt.Sprintf("%d", input.Status.GetID()),
+		"environment": input.Deployment.GetEnvironment(),
+		"githubDeliveryId": input.DeliveryID,
+	})
+	record.Body().SetStr(string(bodyBytes))
+} else {
+	bodyBytes, _ := json.Marshal(deploymentCDEventsBody(input))
+	record.Body().SetStr(string(bodyBytes))
+}
 ```
 
 Set `cicd.pipeline.run.state` only for `pending` and `executing`. Set `cicd.pipeline.result` only for `success`, `failure`, `error`, and `inactive`.
-
-For CDEvents records, marshal the CDEvents body and store it in `record.Body().SetStr(...)`. For `everr.deploy.superseded`, leave `cdevents.*` attributes empty and set a small JSON body with the deployment id, status id, environment, and raw GitHub delivery id.
 
 When building a CDEvents body, set `body.Context.ID = cdeventsID(input)` and `body.Context.Type = input.EventType`. The log attribute `cdevents.id` must always be copied from the same value used for `body.Context.ID`.
 
 - [ ] **Step 7: Add trace linkage test**
 
-Create `collector/receiver/githubactionsreceiver/testdata/deployment/deployment_status_success_with_workflow_run.json`:
+Create `collector/receiver/githubactionsreceiver/testdata/deployment/deployment_created_with_workflow_run.json`:
 
 ```json
 {
@@ -1091,15 +1242,6 @@ Create `collector/receiver/githubactionsreceiver/testdata/deployment/deployment_
     "created_at": "2026-05-17T10:00:00Z",
     "updated_at": "2026-05-17T10:00:00Z",
     "creator": { "login": "github-actions[bot]" }
-  },
-  "deployment_status": {
-    "id": 988,
-    "state": "success",
-    "environment_url": "https://app.everr.dev",
-    "target_url": "https://github.com/everr-labs/everr-deploy/actions/runs/1",
-    "description": "app rollout completed",
-    "created_at": "2026-05-17T10:04:00Z",
-    "updated_at": "2026-05-17T10:04:00Z"
   },
   "workflow_run": {
     "id": 456,
@@ -1120,10 +1262,10 @@ Create `collector/receiver/githubactionsreceiver/testdata/deployment/deployment_
 Add a test:
 
 ```go
-func TestDeploymentStatusUsesWorkflowTraceIDWhenPresent(t *testing.T) {
-	event := parseGitHubTestEvent[*github.DeploymentStatusEvent](t, "testdata/deployment/deployment_status_success_with_workflow_run.json", "deployment_status")
+func TestDeploymentEventUsesWorkflowTraceIDWhenPresent(t *testing.T) {
+	event := parseGitHubTestEvent[*github.DeploymentEvent](t, "testdata/deployment/deployment_created_with_workflow_run.json", "deployment")
 
-	logs, err := deploymentEventToLogs(event, "delivery-deploy-status-success-trace-1", zap.NewNop())
+	logs, err := deploymentEventToLogs(event, "delivery-deploy-created-trace-1", zap.NewNop())
 
 	require.NoError(t, err)
 	expected, err := generateTraceID(654321, 456, 2)
@@ -1133,7 +1275,7 @@ func TestDeploymentStatusUsesWorkflowTraceIDWhenPresent(t *testing.T) {
 }
 ```
 
-Implement a helper that checks `event.GetWorkflowRun()` on `github.DeploymentEvent` and `github.DeploymentStatusEvent`. If present and repo id is positive, set `TraceID` on every emitted record.
+Implement a helper that checks `event.GetWorkflowRun()` on `github.DeploymentEvent`. Verified against go-github v67.0.0: `DeploymentEvent` has `WorkflowRun`, while `DeploymentStatusEvent` does not. If a future go-github version exposes workflow linkage on status events, extend the helper then. If workflow run data is absent or the repo id is not positive, leave `TraceID` empty.
 
 - [ ] **Step 8: Run mapper tests**
 
@@ -1310,19 +1452,22 @@ SELECT
   TimestampTime,
   EventName,
   LogAttributes['everr.deploy.service.name'] AS deployed_service,
-  LogAttributes['deployment.environment.name'] AS environment,
+  ResourceAttributes['deployment.environment.name'] AS environment,
   LogAttributes['cicd.pipeline.result'] AS result,
   LogAttributes['everr.deploy.url'] AS deploy_url
 FROM app.logs
 WHERE ServiceName = 'github-deployments'
   AND TimestampTime >= now() - INTERVAL 7 DAY
 ORDER BY TimestampTime DESC
+LIMIT 1 BY if(LogAttributes['cdevents.id'] = '', LogAttributes['everr.github.delivery.id'], LogAttributes['cdevents.id'])
 LIMIT 100;
 ```
 
 Do not add `PREWHERE`.
 
 Do not add `tenant_id = toUInt64(getSetting('SQL_everr_tenant_id'))`; the row-level policy handles tenant filtering.
+
+V1 keeps ClickHouse append-only. If a retry creates duplicate rows, query surfaces deduplicate with `LIMIT 1 BY` on `cdevents.id`, falling back to `everr.github.delivery.id` for custom non-CDEvents rows.
 
 - [ ] **Step 3: Commit query doc change if any**
 
@@ -1564,6 +1709,8 @@ base="${1:-}"
 head="${2:-HEAD}"
 
 if [[ -z "$base" || "$base" == "0000000000000000000000000000000000000000" ]]; then
+  # workflow_dispatch has no reliable before SHA. Deploy all services so manual
+  # infra applies do not silently skip an ECS rollout wait.
   echo "app docs collector"
   exit 0
 fi
@@ -1662,9 +1809,10 @@ payload="$(
     '{
       state: $state,
       description: $description,
-      log_url: $log_url,
-      auto_inactive: true
-    } + if $environment_url == "" then {} else {environment_url: $environment_url} end'
+      log_url: $log_url
+    }
+    + if $state == "success" then {auto_inactive: true} else {} end
+    + if $environment_url == "" then {} else {environment_url: $environment_url} end'
 )"
 
 gh api \
@@ -1736,12 +1884,27 @@ Replace the current `Apply` step with:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          completed_services=()
+
+          service_completed() {
+            local needle="$1"
+            local completed
+            for completed in "${completed_services[@]}"; do
+              if [[ "$completed" == "$needle" ]]; then
+                return 0
+              fi
+            done
+            return 1
+          }
 
           mark_failed() {
-            status="$?"
+            local status="$?"
             for file in ../.deployments/*.id; do
               [ -f "$file" ] || continue
               service="$(basename "$file" .id)"
+              if service_completed "$service"; then
+                continue
+              fi
               deployment_id="$(cat "$file")"
               ../scripts/update-github-deployment-status.sh "$deployment_id" failure "${service} deploy failed"
             done
@@ -1781,12 +1944,15 @@ Replace the current `Apply` step with:
             ../scripts/wait-ecs-service-rollout.sh "$cluster" "$ecs_service" 1200 15
             deployment_id="$(cat "../.deployments/${service}.id")"
             ../scripts/update-github-deployment-status.sh "$deployment_id" success "${service} rollout completed" "$environment_url"
+            completed_services+=("$service")
           done
 
           trap - ERR
 ```
 
 Because the job default working directory is `./infra`, script paths in this step use `../scripts/...` and deployment id files live in `../.deployments`.
+
+The failure trap skips services already marked successful. If `app` completes and `docs` fails later, the trap must not emit a failure status for `app`.
 
 - [ ] **Step 8: Validate workflow YAML and shell scripts**
 
@@ -1795,6 +1961,11 @@ Run from `../everr-deploy`:
 ```bash
 chmod +x scripts/changed-ecs-services.sh scripts/create-github-deployment.sh scripts/update-github-deployment-status.sh scripts/wait-ecs-service-rollout.sh
 bash -n scripts/changed-ecs-services.sh scripts/create-github-deployment.sh scripts/update-github-deployment-status.sh scripts/wait-ecs-service-rollout.sh
+if command -v shellcheck >/dev/null; then
+  shellcheck scripts/changed-ecs-services.sh scripts/create-github-deployment.sh scripts/update-github-deployment-status.sh scripts/wait-ecs-service-rollout.sh
+else
+  echo "shellcheck not installed; skipped"
+fi
 python - <<'PY'
 import pathlib, yaml
 for path in pathlib.Path(".github/workflows").glob("*.yml"):
@@ -1803,7 +1974,7 @@ print("workflow yaml parsed")
 PY
 ```
 
-Expected: shell syntax passes and workflow YAML parses.
+Expected: shell syntax passes, shellcheck passes when installed, and workflow YAML parses.
 
 - [ ] **Step 9: Commit everr-deploy workflow changes**
 
@@ -1850,9 +2021,14 @@ Run:
 cd /Users/guidodorsi/workspace/everr-deploy
 scripts/tests/wait-ecs-service-rollout.test.sh
 bash -n scripts/*.sh
+if command -v shellcheck >/dev/null; then
+  shellcheck scripts/*.sh scripts/tests/*.sh
+else
+  echo "shellcheck not installed; skipped"
+fi
 ```
 
-Expected: tests and shell syntax checks pass.
+Expected: tests pass, shell syntax checks pass, and shellcheck passes when installed.
 
 - [ ] **Step 4: Confirm GitHub App configuration**
 
@@ -1890,12 +2066,13 @@ SELECT
   TimestampTime,
   EventName,
   LogAttributes['everr.deploy.service.name'] AS deployed_service,
-  LogAttributes['deployment.environment.name'] AS environment,
+  ResourceAttributes['deployment.environment.name'] AS environment,
   LogAttributes['cicd.pipeline.result'] AS result
 FROM app.logs
 WHERE ServiceName = 'github-deployments'
   AND TimestampTime >= now() - INTERVAL 1 DAY
 ORDER BY TimestampTime DESC
+LIMIT 1 BY if(LogAttributes['cdevents.id'] = '', LogAttributes['everr.github.delivery.id'], LogAttributes['cdevents.id'])
 LIMIT 20;
 ```
 

--- a/docs/superpowers/plans/2026-05-17-deploy-cdevents-ingest.md
+++ b/docs/superpowers/plans/2026-05-17-deploy-cdevents-ingest.md
@@ -1,0 +1,1887 @@
+# Deploy CDEvents Ingest Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ingest GitHub `deployment` and `deployment_status` webhooks into ClickHouse as OpenTelemetry log events with CDEvents-shaped bodies, then make `../everr-deploy` emit those GitHub deployment events and wait for ECS rollout completion.
+
+**Architecture:** Everr keeps GitHub Deployments as the public user contract. The app verifies GitHub webhooks, resolves the tenant from the installation, and forwards deploy webhooks to the collector-only queue. The collector maps deploy webhooks directly to OTel logs without fetching GitHub Actions log archives, and `../everr-deploy` becomes the first adopter by creating GitHub Deployment records and status updates from its deploy workflow.
+
+**Tech Stack:** TypeScript, TanStack Start file routes, pg-boss, Zod, Go collector receiver, OpenTelemetry Collector `plog`, ClickHouse `app.logs`, GitHub Deployments REST API, GitHub Actions, OpenTofu, AWS ECS `describe-services`.
+
+---
+
+## Context
+
+Current Everr flow:
+
+- `packages/app/src/routes/webhook/github.ts` exposes `/webhook/github`.
+- `packages/app/src/server/github-events/webhook.ts` verifies GitHub signatures and currently accepts only `workflow_run` and `workflow_job` for queueing.
+- `packages/app/src/server/github-events/runtime.ts` sends every queued webhook to both `gh-collector` and `gh-status`.
+- `gh-status` writes workflow state to Postgres. Deploy events must not go there in v1.
+- `gh-collector` resolves the tenant and forwards the raw webhook to `env.INGRESS_COLLECTOR_URL`, adding `x-everr-tenant-id`.
+- `collector/receiver/githubactionsreceiver/receiver.go` accepts GitHub webhook payloads, but its workflow log path initializes an installation GitHub client and downloads workflow log archives.
+- Deploy webhooks have no archive to fetch. They must be mapped directly from the webhook payload.
+- `clickhouse/init/10-create-mvs.sql` copies `ResourceAttributes['everr.tenant.id']` into `app.logs.tenant_id`. Deploy log resources must include that attribute through the existing collector resource processor.
+
+Current `../everr-deploy` flow:
+
+- `../everr-deploy/.github/workflows/image-update.yml` opens image tag update PRs.
+- `../everr-deploy/.github/workflows/deploy.yml` runs `tofu apply` on `main`, infra changes, and manual dispatch.
+- ECS service names are created in modules:
+  - app: `${var.name}-app`
+  - docs: `${var.name}-docs`
+  - collector: `${var.name}-everr-otel-collector`
+- Root outputs currently expose URLs and ECR repos, but not ECS cluster/service names.
+
+## Standards Locked For V1
+
+- GitHub Deployments are the user-facing source. GitHub says deployments are deploy requests, and statuses can be `error`, `failure`, `pending`, `in_progress`, `queued`, or `success`: https://docs.github.com/en/enterprise-cloud@latest/rest/deployments/deployments
+- CDEvents spec version is pinned to `0.5.0`: https://cdevents.dev/docs/
+- CDEvents event types stay pinned to:
+  - `dev.cdevents.pipelinerun.queued.0.3.0`
+  - `dev.cdevents.pipelinerun.started.0.3.0`
+  - `dev.cdevents.pipelinerun.finished.0.3.0`
+  - `dev.cdevents.service.deployed.0.3.0`
+- CDEvents versioning guidance says event versions live in event `type`, while spec version lives in `context.version`: https://cdevents.dev/docs/primer/#versioning-of-cdevents
+- OTel logs are the right signal because OTel treats events as a special type of log: https://opentelemetry.io/docs/concepts/signals/logs/
+- Use the OTel log record event-name field through `LogRecord.SetEventName(...)`; do not duplicate it in `LogAttributes['event.name']`.
+- Use stable OTel attributes where they match:
+  - `deployment.environment.name`: https://opentelemetry.io/docs/specs/semconv/registry/attributes/deployment/
+  - `service.name` and `service.version`: https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/
+  - `cicd.pipeline.run.id`, `cicd.pipeline.run.state`, and `cicd.pipeline.result`: https://opentelemetry.io/docs/specs/semconv/registry/attributes/cicd/
+- Do not use `url.full` for deployment URLs. `url.full` is generic URL semantic convention text, but this value is not the URL of a network call in this telemetry record: https://opentelemetry.io/docs/specs/semconv/registry/attributes/url/
+- OTel 1.41 lists `deployment.id`, `deployment.name`, and `deployment.status` as Development. V1 keeps the deploy run identifier in `cicd.pipeline.run.id` and custom query fields under `everr.*` to avoid changing meaning later.
+- AWS ECS `describe-services` exposes `deployments[].rolloutState`; AWS says it starts `IN_PROGRESS`, moves to `COMPLETED` at steady state, and moves to `FAILED` when circuit breaker marks failure: https://docs.aws.amazon.com/cli/latest/reference/ecs/describe-services.html
+
+## Non-Goals
+
+- No Postgres deploy table in v1.
+- No custom ClickHouse deploy table in v1.
+- No ClickHouse migration in this plan.
+- No custom Everr deploy ingestion endpoint for users in v1. Users adopt by creating GitHub Deployments and Deployment Statuses.
+- No capture for GitHub Actions jobs that only set `environment:` without creating a GitHub Deployment object, including `environment.deployment: false`.
+- No deploy phase model in v1. Later, phase events can use CDEvents `taskrun.started` and `taskrun.finished` plus `everr.deploy.phase`.
+
+## File Structure
+
+Everr app changes:
+
+- Modify `packages/app/src/server/github-events/webhook.ts`: accept `deployment` and `deployment_status`.
+- Modify `packages/app/src/server/github-events/runtime.ts`: route workflow events to both queues and deploy events only to `gh-collector`.
+- Modify `packages/app/src/server/github-events/payloads.ts`: parse minimal deploy webhook payloads and expose a shared installation-id helper.
+- Modify `packages/app/src/server/github-events/webhook.test.ts`: assert deploy webhooks are accepted and not sent to `gh-status`.
+- Add or modify runtime tests near `packages/app/src/server/github-events/runtime.test.ts` if the runtime queue split does not already have tests.
+
+Collector changes:
+
+- Add `collector/receiver/githubactionsreceiver/deploy_event_handling.go`: deploy webhook to OTel log mapping.
+- Add `collector/receiver/githubactionsreceiver/deploy_event_handling_test.go`: mapper tests for every event mapping.
+- Modify `collector/receiver/githubactionsreceiver/receiver.go`: dispatch deploy events before workflow trace, metric, and log archive processing.
+- Modify `collector/receiver/githubactionsreceiver/attributes.go` or add `deploy_attributes.go`: deploy-specific resource/log attribute helpers.
+- Modify `collector/semconv/cicd.go`: add Everr custom attribute constants for GitHub deployment fields.
+- Add `collector/receiver/githubactionsreceiver/testdata/deployment/*.json`: minimal deployment and deployment_status fixtures.
+
+ClickHouse/docs changes:
+
+- No SQL file changes.
+- Optional: add a small query example to the existing deploy spec if implementation finds a field name mismatch.
+
+`../everr-deploy` changes:
+
+- Modify `../everr-deploy/.github/workflows/deploy.yml`: create GitHub Deployment records, status updates, and ECS rollout wait.
+- Add `../everr-deploy/scripts/changed-ecs-services.sh`: map changed Terraform/image files to ECS services.
+- Add `../everr-deploy/scripts/create-github-deployment.sh`: create one GitHub Deployment per service and store IDs.
+- Add `../everr-deploy/scripts/update-github-deployment-status.sh`: set deployment statuses.
+- Add `../everr-deploy/scripts/wait-ecs-service-rollout.sh`: poll ECS until all rollout states are `COMPLETED`, fail on `FAILED`, and time out cleanly.
+- Add tests under `../everr-deploy/scripts/tests/` for the shell scripts.
+- Modify `../everr-deploy/infra/modules/*/outputs.tf` and `../everr-deploy/infra/outputs.tf`: expose ECS cluster and service names for the workflow.
+
+## Data Contract
+
+Every deploy OTel log record:
+
+- `EventName`: one of the CDEvents event types or `everr.deploy.superseded`.
+- `Body`: JSON CDEvents-shaped object.
+- `ResourceAttributes`:
+  - `everr.tenant.id`: set by the collector resource processor from `x-everr-tenant-id`.
+  - `service.name`: `github-deployments`.
+  - `deployment.environment.name`: GitHub deployment environment.
+  - `vcs.provider.name`: `github`.
+  - `vcs.repository.name`: GitHub repository full name.
+  - `vcs.owner.name`: GitHub repository owner login when available.
+- `LogAttributes`:
+  - `cdevents.type`
+  - `cdevents.id`
+  - `cdevents.source`
+  - `cicd.pipeline.run.id`
+  - `cicd.pipeline.name`
+  - `cicd.pipeline.run.state` for queued/started states
+  - `cicd.pipeline.result` for finished states
+  - `deployment.environment.name`
+  - `vcs.ref.head.revision`
+  - `vcs.ref.head.name`
+  - `everr.deploy.id`
+  - `everr.deploy.service.name`
+  - `everr.deploy.url` when GitHub status provides `environment_url` or `target_url`
+  - `everr.github.deployment.id`
+  - `everr.github.deployment_status.id` for deployment_status events
+  - `everr.github.deployment.creator.login`
+  - `everr.github.workflow_run.id` and `everr.github.workflow_run.run_attempt` when present
+
+Trace linkage:
+
+- When a deploy webhook includes `workflow_run`, set the log record `TraceID` with `generateTraceID(repository.id, workflow_run.id, workflow_run.run_attempt)`.
+- When `workflow_run` is absent, leave `TraceID` empty.
+
+`deployment_status: success` emits two log records:
+
+- `dev.cdevents.pipelinerun.finished.0.3.0`
+- `dev.cdevents.service.deployed.0.3.0`
+
+`deployment_status: inactive` emits one custom log record:
+
+- `everr.deploy.superseded`
+
+Do not map `inactive` to `service.removed`; GitHub can mark older deployments inactive when a newer successful deployment supersedes them.
+
+## Tasks
+
+### Task 1: App Accepts Deploy Webhooks
+
+**Files:**
+
+- Modify: `packages/app/src/server/github-events/webhook.ts`
+- Modify: `packages/app/src/server/github-events/webhook.test.ts`
+
+- [ ] **Step 1: Write failing webhook allowlist tests**
+
+Add these tests to `packages/app/src/server/github-events/webhook.test.ts`:
+
+```ts
+it("enqueues deployment events", async () => {
+  const secret = webhookSecret;
+  vi.stubEnv("GITHUB_APP_WEBHOOK_SECRET", secret);
+  const payload = JSON.stringify({
+    action: "created",
+    installation: { id: 123 },
+    repository: { id: 654321, full_name: "everr-labs/everr-deploy" },
+    deployment: {
+      id: 987,
+      sha: "abc123",
+      ref: "main",
+      task: "deploy:app",
+      environment: "production",
+      created_at: "2026-05-17T10:00:00Z",
+      updated_at: "2026-05-17T10:00:00Z",
+    },
+  });
+
+  const response = await handleGitHubWebhookRequest(
+    new Request("http://localhost/webhook/github", {
+      method: "POST",
+      headers: {
+        "x-github-event": "deployment",
+        "x-github-delivery": "delivery-deploy-1",
+        "x-hub-signature-256": sign(payload, secret),
+      },
+      body: payload,
+    }),
+  );
+
+  expect(response.status).toBe(202);
+  expect(webhookMocks.enqueueWebhookEvent).toHaveBeenCalledOnce();
+  expect(webhookMocks.enqueueWebhookEvent).toHaveBeenCalledWith(
+    "delivery-deploy-1",
+    {
+      headers: expect.objectContaining({
+        "x-github-event": ["deployment"],
+      }),
+      body: expect.any(String),
+    },
+    { statusQueue: false },
+  );
+});
+
+it("enqueues deployment_status events", async () => {
+  const secret = webhookSecret;
+  vi.stubEnv("GITHUB_APP_WEBHOOK_SECRET", secret);
+  const payload = JSON.stringify({
+    action: "created",
+    installation: { id: 123 },
+    repository: { id: 654321, full_name: "everr-labs/everr-deploy" },
+    deployment: {
+      id: 987,
+      sha: "abc123",
+      ref: "main",
+      task: "deploy:app",
+      environment: "production",
+    },
+    deployment_status: {
+      id: 988,
+      state: "success",
+      environment_url: "https://app.everr.dev",
+      target_url: "https://github.com/everr-labs/everr-deploy/actions/runs/1",
+      created_at: "2026-05-17T10:04:00Z",
+      updated_at: "2026-05-17T10:04:00Z",
+    },
+  });
+
+  const response = await handleGitHubWebhookRequest(
+    new Request("http://localhost/webhook/github", {
+      method: "POST",
+      headers: {
+        "x-github-event": "deployment_status",
+        "x-github-delivery": "delivery-deploy-status-1",
+        "x-hub-signature-256": sign(payload, secret),
+      },
+      body: payload,
+    }),
+  );
+
+  expect(response.status).toBe(202);
+  expect(webhookMocks.enqueueWebhookEvent).toHaveBeenCalledWith(
+    "delivery-deploy-status-1",
+    expect.any(Object),
+    { statusQueue: false },
+  );
+});
+```
+
+- [ ] **Step 2: Run the failing tests**
+
+Run:
+
+```bash
+pnpm --filter @everr/app test:ci src/server/github-events/webhook.test.ts
+```
+
+Expected: the new tests fail because deploy event types are currently ignored and `enqueueWebhookEvent` accepts only two arguments.
+
+- [ ] **Step 3: Add explicit collector-event allowlist**
+
+In `packages/app/src/server/github-events/webhook.ts`, add:
+
+```ts
+const collectorEventTypes = new Set([
+  "workflow_run",
+  "workflow_job",
+  "deployment",
+  "deployment_status",
+]);
+
+const workflowStatusEventTypes = new Set(["workflow_run", "workflow_job"]);
+```
+
+Replace the current ignored-event check with:
+
+```ts
+if (!collectorEventTypes.has(eventType)) {
+  return new Response(null, { status: 202 });
+}
+```
+
+Replace the queue call with:
+
+```ts
+await enqueueWebhookEvent(
+  eventId,
+  {
+    headers: headersToRecord(request.headers),
+    body: body.toString("base64"),
+  },
+  { statusQueue: workflowStatusEventTypes.has(eventType) },
+);
+```
+
+- [ ] **Step 4: Run the webhook tests again**
+
+Run:
+
+```bash
+pnpm --filter @everr/app test:ci src/server/github-events/webhook.test.ts
+```
+
+Expected: the new deployment tests still fail until Task 2 updates the queue function signature.
+
+### Task 2: App Routes Deploy Events Only To Collector
+
+**Files:**
+
+- Modify: `packages/app/src/server/github-events/runtime.ts`
+- Modify: `packages/app/src/server/github-events/payloads.ts`
+- Add or modify: `packages/app/src/server/github-events/runtime.test.ts`
+
+- [ ] **Step 1: Add runtime tests for queue selection**
+
+Create `packages/app/src/server/github-events/runtime.test.ts` if it does not exist. Mock `PgBoss` so the test can inspect `.send(...)` calls without connecting to Postgres.
+
+```ts
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { sends } = vi.hoisted(() => ({ sends: [] as unknown[][] }));
+
+vi.mock("pg-boss", () => ({
+  PgBoss: class {
+    on = vi.fn();
+    start = vi.fn().mockResolvedValue(undefined);
+    stop = vi.fn().mockResolvedValue(undefined);
+    createQueue = vi.fn().mockResolvedValue(undefined);
+    work = vi.fn();
+    send = vi.fn(async (...args: unknown[]) => {
+      sends.push(args);
+    });
+  },
+}));
+
+vi.mock("@/db/client", () => ({
+  db: {},
+  pool: { query: vi.fn() },
+}));
+
+import { enqueueWebhookEvent } from "./runtime";
+
+describe("enqueueWebhookEvent", () => {
+  beforeEach(() => {
+    sends.length = 0;
+  });
+
+  it("sends workflow events to collector and status queues", async () => {
+    await enqueueWebhookEvent(
+      "delivery-workflow",
+      { headers: {}, body: "e30=" },
+      { statusQueue: true },
+    );
+
+    expect(sends.map((call) => call[0])).toEqual(["gh-collector", "gh-status"]);
+  });
+
+  it("sends deploy events only to the collector queue", async () => {
+    await enqueueWebhookEvent(
+      "delivery-deploy",
+      { headers: {}, body: "e30=" },
+      { statusQueue: false },
+    );
+
+    expect(sends.map((call) => call[0])).toEqual(["gh-collector"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing runtime test**
+
+Run:
+
+```bash
+pnpm --filter @everr/app test:ci src/server/github-events/runtime.test.ts
+```
+
+Expected: TypeScript or runtime failure because `enqueueWebhookEvent` has no third argument.
+
+- [ ] **Step 3: Add the queue options type**
+
+In `packages/app/src/server/github-events/runtime.ts`, add:
+
+```ts
+type EnqueueWebhookEventOptions = {
+  statusQueue: boolean;
+};
+```
+
+Change the function signature:
+
+```ts
+export async function enqueueWebhookEvent(
+  eventId: string,
+  data: WebhookJobData,
+  options: EnqueueWebhookEventOptions = { statusQueue: true },
+): Promise<void> {
+```
+
+Replace the hard-coded queue list with:
+
+```ts
+const queues = options.statusQueue
+  ? (["gh-collector", "gh-status"] as const)
+  : (["gh-collector"] as const);
+
+await Promise.all(
+  queues.map((queue) =>
+    b.send(queue, data, {
+      id: eventId,
+      retryLimit: GH_EVENTS_CONFIG.maxAttempts,
+      retryBackoff: true,
+    }),
+  ),
+);
+```
+
+- [ ] **Step 4: Extend queued payload parsing for deploy events**
+
+In `packages/app/src/server/github-events/payloads.ts`, add schemas:
+
+```ts
+const deploymentSchema = z.object({
+  action: z.string().optional(),
+  installation: z.object({ id: z.number().int().positive().optional() }).optional(),
+  repository: repositorySchema,
+  deployment: z
+    .object({
+      id: z.number().int(),
+      sha: z.string().nullish(),
+      ref: z.string().nullish(),
+      task: z.string().nullish(),
+      environment: z.string().nullish(),
+      created_at: z.string().nullish(),
+      updated_at: z.string().nullish(),
+      creator: z.object({ login: z.string().optional() }).nullish(),
+    })
+    .optional(),
+  workflow_run: z
+    .object({
+      id: z.number().int(),
+      run_attempt: z.number().int().optional(),
+    })
+    .optional(),
+});
+
+const deploymentStatusSchema = deploymentSchema.extend({
+  deployment_status: z
+    .object({
+      id: z.number().int(),
+      state: z.string(),
+      environment_url: z.string().nullish(),
+      target_url: z.string().nullish(),
+      log_url: z.string().nullish(),
+      description: z.string().nullish(),
+      created_at: z.string().nullish(),
+      updated_at: z.string().nullish(),
+    })
+    .optional(),
+});
+```
+
+Extend the event union:
+
+```ts
+export type DeploymentPayload = z.infer<typeof deploymentSchema>;
+export type DeploymentStatusPayload = z.infer<typeof deploymentStatusSchema>;
+export type ParsedQueuedCollectorEvent =
+  | ParsedQueuedWorkflowEvent
+  | { eventType: "deployment"; payload: DeploymentPayload }
+  | { eventType: "deployment_status"; payload: DeploymentStatusPayload };
+```
+
+Add:
+
+```ts
+export function parseQueuedCollectorEvent(
+  eventType: string,
+  body: Buffer,
+): ParsedQueuedCollectorEvent {
+  if (eventType === "deployment") {
+    return {
+      eventType,
+      payload: parseJson(body, deploymentSchema, "deployment"),
+    };
+  }
+
+  if (eventType === "deployment_status") {
+    return {
+      eventType,
+      payload: parseJson(body, deploymentStatusSchema, "deployment_status"),
+    };
+  }
+
+  return parseQueuedWorkflowEvent(eventType, body);
+}
+```
+
+Change `installationIdFromQueuedEvent(...)` to accept `ParsedQueuedCollectorEvent` instead of only `ParsedQueuedWorkflowEvent`.
+
+- [ ] **Step 5: Use collector parser only in collector worker**
+
+In `packages/app/src/server/github-events/runtime.ts`, import `parseQueuedCollectorEvent` and use it only in `processCollectorJob`.
+
+Keep `processStatusJob` on `parseQueuedWorkflowEvent`:
+
+```ts
+const parsed = parseQueuedCollectorEvent(eventType, body);
+```
+
+The status worker remains:
+
+```ts
+const parsed = parseQueuedWorkflowEvent(eventType, body);
+```
+
+- [ ] **Step 6: Run app tests**
+
+Run:
+
+```bash
+pnpm --filter @everr/app test:ci src/server/github-events/webhook.test.ts src/server/github-events/runtime.test.ts
+pnpm --filter @everr/app typecheck
+```
+
+Expected: targeted tests pass and typecheck completes.
+
+- [ ] **Step 7: Commit app intake changes**
+
+Run:
+
+```bash
+git add packages/app/src/server/github-events/webhook.ts packages/app/src/server/github-events/webhook.test.ts packages/app/src/server/github-events/runtime.ts packages/app/src/server/github-events/runtime.test.ts packages/app/src/server/github-events/payloads.ts
+git commit -m "feat: accept GitHub deployment webhooks"
+```
+
+### Task 3: Collector Maps Deployment Events To OTel Logs
+
+**Files:**
+
+- Add: `collector/receiver/githubactionsreceiver/deploy_event_handling.go`
+- Add: `collector/receiver/githubactionsreceiver/deploy_event_handling_test.go`
+- Add: `collector/receiver/githubactionsreceiver/deploy_attributes.go`
+- Modify: `collector/semconv/cicd.go`
+- Add: `collector/receiver/githubactionsreceiver/testdata/deployment/deployment_created.json`
+- Add: `collector/receiver/githubactionsreceiver/testdata/deployment/deployment_status_success.json`
+- Add: `collector/receiver/githubactionsreceiver/testdata/deployment/deployment_status_inactive.json`
+
+- [ ] **Step 1: Add semconv constants**
+
+Append to `collector/semconv/cicd.go`:
+
+```go
+// Everr - CDEvents and deployment attributes with no stable OTel equivalent.
+const (
+	CDEventsType   = "cdevents.type"
+	CDEventsID     = "cdevents.id"
+	CDEventsSource = "cdevents.source"
+
+	EverrDeployID          = "everr.deploy.id"
+	EverrDeployServiceName = "everr.deploy.service.name"
+	EverrDeployURL         = "everr.deploy.url"
+
+	EverrGitHubDeploymentID           = "everr.github.deployment.id"
+	EverrGitHubDeploymentStatusID     = "everr.github.deployment_status.id"
+	EverrGitHubDeploymentCreatorLogin = "everr.github.deployment.creator.login"
+)
+```
+
+- [ ] **Step 2: Add minimal fixture files**
+
+Create `collector/receiver/githubactionsreceiver/testdata/deployment/deployment_created.json`:
+
+```json
+{
+  "action": "created",
+  "deployment": {
+    "id": 987,
+    "sha": "abc123",
+    "ref": "main",
+    "task": "deploy:app",
+    "environment": "production",
+    "created_at": "2026-05-17T10:00:00Z",
+    "updated_at": "2026-05-17T10:00:00Z",
+    "creator": { "login": "github-actions[bot]" }
+  },
+  "repository": {
+    "id": 654321,
+    "name": "everr-deploy",
+    "full_name": "everr-labs/everr-deploy",
+    "html_url": "https://github.com/everr-labs/everr-deploy",
+    "owner": { "login": "everr-labs" }
+  },
+  "installation": { "id": 123 },
+  "sender": { "login": "github-actions[bot]" }
+}
+```
+
+Create `collector/receiver/githubactionsreceiver/testdata/deployment/deployment_status_success.json`:
+
+```json
+{
+  "action": "created",
+  "deployment": {
+    "id": 987,
+    "sha": "abc123",
+    "ref": "main",
+    "task": "deploy:app",
+    "environment": "production",
+    "created_at": "2026-05-17T10:00:00Z",
+    "updated_at": "2026-05-17T10:00:00Z",
+    "creator": { "login": "github-actions[bot]" }
+  },
+  "deployment_status": {
+    "id": 988,
+    "state": "success",
+    "environment_url": "https://app.everr.dev",
+    "target_url": "https://github.com/everr-labs/everr-deploy/actions/runs/1",
+    "description": "app rollout completed",
+    "created_at": "2026-05-17T10:04:00Z",
+    "updated_at": "2026-05-17T10:04:00Z"
+  },
+  "repository": {
+    "id": 654321,
+    "name": "everr-deploy",
+    "full_name": "everr-labs/everr-deploy",
+    "html_url": "https://github.com/everr-labs/everr-deploy",
+    "owner": { "login": "everr-labs" }
+  },
+  "installation": { "id": 123 },
+  "sender": { "login": "github-actions[bot]" }
+}
+```
+
+Create `collector/receiver/githubactionsreceiver/testdata/deployment/deployment_status_inactive.json`:
+
+```json
+{
+  "action": "created",
+  "deployment": {
+    "id": 986,
+    "sha": "def456",
+    "ref": "main",
+    "task": "deploy:app",
+    "environment": "production",
+    "created_at": "2026-05-17T09:00:00Z",
+    "updated_at": "2026-05-17T09:00:00Z",
+    "creator": { "login": "github-actions[bot]" }
+  },
+  "deployment_status": {
+    "id": 989,
+    "state": "inactive",
+    "environment_url": "https://app.everr.dev",
+    "target_url": "https://github.com/everr-labs/everr-deploy/actions/runs/1",
+    "description": "superseded by a newer deployment",
+    "created_at": "2026-05-17T10:05:00Z",
+    "updated_at": "2026-05-17T10:05:00Z"
+  },
+  "repository": {
+    "id": 654321,
+    "name": "everr-deploy",
+    "full_name": "everr-labs/everr-deploy",
+    "html_url": "https://github.com/everr-labs/everr-deploy",
+    "owner": { "login": "everr-labs" }
+  },
+  "installation": { "id": 123 },
+  "sender": { "login": "github-actions[bot]" }
+}
+```
+
+- [ ] **Step 3: Write failing mapper tests**
+
+In `collector/receiver/githubactionsreceiver/deploy_event_handling_test.go`, add tests:
+
+```go
+func TestDeploymentEventToLogsMapsDeploymentCreated(t *testing.T) {
+	event := parseGitHubTestEvent[*github.DeploymentEvent](t, "testdata/deployment/deployment_created.json", "deployment")
+
+	logs, err := deploymentEventToLogs(event, zap.NewNop())
+
+	require.NoError(t, err)
+	require.NotNil(t, logs)
+	require.Equal(t, 1, logs.LogRecordCount())
+
+	record := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	require.Equal(t, "dev.cdevents.pipelinerun.queued.0.3.0", record.EventName())
+	require.Equal(t, "dev.cdevents.pipelinerun.queued.0.3.0", record.Attributes().AsRaw()[semconv.CDEventsType])
+	require.Equal(t, int64(987), record.Attributes().AsRaw()[semconv.EverrGitHubDeploymentID])
+	require.Equal(t, "987", record.Attributes().AsRaw()[string(conventions.CICDPipelineRunIDKey)])
+
+	resourceAttrs := logs.ResourceLogs().At(0).Resource().Attributes().AsRaw()
+	require.Equal(t, "github-deployments", resourceAttrs["service.name"])
+	require.Equal(t, "production", resourceAttrs["deployment.environment.name"])
+	require.Equal(t, "everr-labs/everr-deploy", resourceAttrs[string(conventions.VCSRepositoryNameKey)])
+}
+
+func TestDeploymentStatusSuccessEmitsPipelineFinishedAndServiceDeployed(t *testing.T) {
+	event := parseGitHubTestEvent[*github.DeploymentStatusEvent](t, "testdata/deployment/deployment_status_success.json", "deployment_status")
+
+	logs, err := deploymentEventToLogs(event, zap.NewNop())
+
+	require.NoError(t, err)
+	require.NotNil(t, logs)
+	require.Equal(t, 2, logs.LogRecordCount())
+
+	records := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords()
+	require.Equal(t, "dev.cdevents.pipelinerun.finished.0.3.0", records.At(0).EventName())
+	require.Equal(t, "success", records.At(0).Attributes().AsRaw()[string(conventions.CICDPipelineResultKey)])
+	require.Equal(t, "dev.cdevents.service.deployed.0.3.0", records.At(1).EventName())
+	require.Equal(t, "https://app.everr.dev", records.At(1).Attributes().AsRaw()[semconv.EverrDeployURL])
+}
+
+func TestDeploymentStatusInactiveEmitsSuperseded(t *testing.T) {
+	event := parseGitHubTestEvent[*github.DeploymentStatusEvent](t, "testdata/deployment/deployment_status_inactive.json", "deployment_status")
+
+	logs, err := deploymentEventToLogs(event, zap.NewNop())
+
+	require.NoError(t, err)
+	require.NotNil(t, logs)
+	require.Equal(t, 1, logs.LogRecordCount())
+	record := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	require.Equal(t, "everr.deploy.superseded", record.EventName())
+	require.NotContains(t, record.Body().Str(), "service.removed")
+}
+```
+
+If no generic `parseGitHubTestEvent` helper exists, add it at the top of the test file:
+
+```go
+func parseGitHubTestEvent[T any](t *testing.T, path string, eventType string) T {
+	t.Helper()
+	payload, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	event, err := github.ParseWebHook(eventType, payload)
+	require.NoError(t, err)
+
+	typed, ok := event.(T)
+	require.True(t, ok)
+	return typed
+}
+```
+
+- [ ] **Step 4: Run the failing mapper tests**
+
+Run:
+
+```bash
+cd collector/receiver/githubactionsreceiver
+go test ./... -run 'TestDeployment' -count=1
+```
+
+Expected: compile failure because `deploymentEventToLogs` does not exist.
+
+- [ ] **Step 5: Implement deploy resource attributes**
+
+Create `collector/receiver/githubactionsreceiver/deploy_attributes.go`:
+
+```go
+package githubactionsreceiver
+
+import (
+	"strings"
+
+	"github.com/google/go-github/v67/github"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	conventions "go.opentelemetry.io/otel/semconv/v1.38.0"
+)
+
+const githubDeploymentsServiceName = "github-deployments"
+
+func setDeploymentResourceAttributes(attrs pcommon.Map, repo *github.Repository, environment string) {
+	attrs.PutStr("service.name", githubDeploymentsServiceName)
+	if environment != "" {
+		attrs.PutStr("deployment.environment.name", environment)
+	}
+	attrs.PutStr(string(conventions.VCSProviderNameKey), "github")
+	if repo != nil {
+		attrs.PutStr(string(conventions.VCSRepositoryNameKey), repo.GetFullName())
+		attrs.PutStr(string(conventions.VCSOwnerNameKey), repo.GetOwner().GetLogin())
+	}
+}
+
+func deploymentServiceName(task string) string {
+	task = strings.TrimSpace(task)
+	if task == "" {
+		return "deploy"
+	}
+	if after, ok := strings.CutPrefix(task, "deploy:"); ok && strings.TrimSpace(after) != "" {
+		return strings.TrimSpace(after)
+	}
+	return task
+}
+```
+
+- [ ] **Step 6: Implement deploy event mapping**
+
+Create `collector/receiver/githubactionsreceiver/deploy_event_handling.go` with these constants and top-level dispatcher:
+
+```go
+package githubactionsreceiver
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/go-github/v67/github"
+	"github.com/everr-labs/everr/collector/semconv"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	conventions "go.opentelemetry.io/otel/semconv/v1.38.0"
+	"go.uber.org/zap"
+)
+
+const (
+	cdeventsSpecVersion        = "0.5.0"
+	cdeventsPipelineRunQueued  = "dev.cdevents.pipelinerun.queued.0.3.0"
+	cdeventsPipelineRunStarted = "dev.cdevents.pipelinerun.started.0.3.0"
+	cdeventsPipelineRunDone    = "dev.cdevents.pipelinerun.finished.0.3.0"
+	cdeventsServiceDeployed    = "dev.cdevents.service.deployed.0.3.0"
+	everrDeploySuperseded      = "everr.deploy.superseded"
+)
+
+func deploymentEventToLogs(event interface{}, logger *zap.Logger) (*plog.Logs, error) {
+	switch e := event.(type) {
+	case *github.DeploymentEvent:
+		return deploymentCreatedToLogs(e, logger)
+	case *github.DeploymentStatusEvent:
+		return deploymentStatusToLogs(e, logger)
+	default:
+		return nil, nil
+	}
+}
+```
+
+Implement `deploymentCreatedToLogs`, `deploymentStatusToLogs`, and helpers so:
+
+```go
+func deploymentCreatedToLogs(e *github.DeploymentEvent, logger *zap.Logger) (*plog.Logs, error) {
+	logs, records := newDeploymentLogs(e.GetRepo(), e.GetDeployment().GetEnvironment())
+	record := records.AppendEmpty()
+	fillDeploymentLogRecord(record, deploymentLogInput{
+		EventType: cdeventsPipelineRunQueued,
+		Repo: e.GetRepo(),
+		Deployment: e.GetDeployment(),
+		State: "pending",
+		Result: "",
+		URL: "",
+		Time: firstNonZeroTime(e.GetDeployment().GetCreatedAt().Time, e.GetDeployment().GetUpdatedAt().Time),
+	})
+	return &logs, nil
+}
+```
+
+```go
+func deploymentStatusToLogs(e *github.DeploymentStatusEvent, logger *zap.Logger) (*plog.Logs, error) {
+	status := e.GetDeploymentStatus()
+	state := status.GetState()
+	logs, records := newDeploymentLogs(e.GetRepo(), e.GetDeployment().GetEnvironment())
+
+	switch state {
+	case "in_progress", "queued", "pending":
+		record := records.AppendEmpty()
+		fillDeploymentLogRecord(record, deploymentLogInput{
+			EventType: cdeventsPipelineRunStarted,
+			Repo: e.GetRepo(),
+			Deployment: e.GetDeployment(),
+			Status: status,
+			State: "executing",
+			URL: firstString(status.GetEnvironmentURL(), status.GetTargetURL(), status.GetLogURL()),
+			Time: firstNonZeroTime(status.GetCreatedAt().Time, status.GetUpdatedAt().Time),
+		})
+	case "success":
+		finished := records.AppendEmpty()
+		fillDeploymentLogRecord(finished, deploymentLogInput{
+			EventType: cdeventsPipelineRunDone,
+			Repo: e.GetRepo(),
+			Deployment: e.GetDeployment(),
+			Status: status,
+			Result: "success",
+			URL: firstString(status.GetEnvironmentURL(), status.GetTargetURL(), status.GetLogURL()),
+			Time: firstNonZeroTime(status.GetCreatedAt().Time, status.GetUpdatedAt().Time),
+		})
+		deployed := records.AppendEmpty()
+		fillDeploymentLogRecord(deployed, deploymentLogInput{
+			EventType: cdeventsServiceDeployed,
+			Repo: e.GetRepo(),
+			Deployment: e.GetDeployment(),
+			Status: status,
+			Result: "success",
+			URL: firstString(status.GetEnvironmentURL(), status.GetTargetURL(), status.GetLogURL()),
+			Time: firstNonZeroTime(status.GetCreatedAt().Time, status.GetUpdatedAt().Time),
+		})
+	case "failure", "error":
+		record := records.AppendEmpty()
+		fillDeploymentLogRecord(record, deploymentLogInput{
+			EventType: cdeventsPipelineRunDone,
+			Repo: e.GetRepo(),
+			Deployment: e.GetDeployment(),
+			Status: status,
+			Result: state,
+			URL: firstString(status.GetEnvironmentURL(), status.GetTargetURL(), status.GetLogURL()),
+			Time: firstNonZeroTime(status.GetCreatedAt().Time, status.GetUpdatedAt().Time),
+		})
+	case "inactive":
+		record := records.AppendEmpty()
+		fillDeploymentLogRecord(record, deploymentLogInput{
+			EventType: everrDeploySuperseded,
+			Repo: e.GetRepo(),
+			Deployment: e.GetDeployment(),
+			Status: status,
+			Result: "inactive",
+			URL: firstString(status.GetEnvironmentURL(), status.GetTargetURL(), status.GetLogURL()),
+			Time: firstNonZeroTime(status.GetCreatedAt().Time, status.GetUpdatedAt().Time),
+		})
+	default:
+		logger.Debug("Skipping unsupported deployment_status state", zap.String("state", state))
+	}
+
+	if logs.LogRecordCount() == 0 {
+		return nil, nil
+	}
+	return &logs, nil
+}
+```
+
+Use a CDEvents body shape:
+
+```go
+type cdeventsBody struct {
+	Context cdeventsContext `json:"context"`
+	Subject cdeventsSubject `json:"subject"`
+}
+
+type cdeventsContext struct {
+	Version string `json:"version"`
+	ID string `json:"id"`
+	Source string `json:"source"`
+	Type string `json:"type"`
+	Timestamp string `json:"timestamp,omitempty"`
+}
+
+type cdeventsSubject struct {
+	ID string `json:"id"`
+	Type string `json:"type"`
+	Source string `json:"source,omitempty"`
+	Content map[string]any `json:"content,omitempty"`
+}
+```
+
+Use this input type and helper set:
+
+```go
+type deploymentLogInput struct {
+	EventType  string
+	Repo      *github.Repository
+	Deployment *github.Deployment
+	Status    *github.DeploymentStatus
+	State     string
+	Result    string
+	URL       string
+	Time      time.Time
+}
+
+func newDeploymentLogs(repo *github.Repository, environment string) (plog.Logs, plog.LogRecordSlice) {
+	logs := plog.NewLogs()
+	resourceLogs := logs.ResourceLogs().AppendEmpty()
+	setDeploymentResourceAttributes(resourceLogs.Resource().Attributes(), repo, environment)
+	scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
+	scopeLogs.Scope().SetName("github-deployments")
+	return logs, scopeLogs.LogRecords()
+}
+
+func firstString(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func firstNonZeroTime(values ...time.Time) time.Time {
+	for _, value := range values {
+		if !value.IsZero() {
+			return value
+		}
+	}
+	return time.Now().UTC()
+}
+
+func cdeventsSource(repo *github.Repository) string {
+	if repo == nil || repo.GetFullName() == "" {
+		return "/github/deployments"
+	}
+	return fmt.Sprintf("/github/%s/deployments", repo.GetFullName())
+}
+
+func cdeventsID(input deploymentLogInput) string {
+	statusID := int64(0)
+	if input.Status != nil {
+		statusID = input.Status.GetID()
+	}
+	hash := sha256.Sum256([]byte(fmt.Sprintf("%s:%d:%d", input.EventType, input.Deployment.GetID(), statusID)))
+	return hex.EncodeToString(hash[:])
+}
+```
+
+Inside `fillDeploymentLogRecord(...)`, set:
+
+```go
+record.SetEventName(input.EventType)
+record.SetTimestamp(pcommon.NewTimestampFromTime(input.Time))
+attrs := record.Attributes()
+attrs.PutStr(semconv.CDEventsType, input.EventType)
+attrs.PutStr(semconv.CDEventsID, cdeventsID(input))
+attrs.PutStr(semconv.CDEventsSource, cdeventsSource(input.Repo))
+attrs.PutStr(string(conventions.CICDPipelineRunIDKey), fmt.Sprintf("%d", input.Deployment.GetID()))
+attrs.PutStr(string(conventions.CICDPipelineNameKey), firstString(input.Deployment.GetTask(), "deploy"))
+attrs.PutStr("deployment.environment.name", input.Deployment.GetEnvironment())
+attrs.PutStr(string(conventions.VCSRefHeadRevisionKey), input.Deployment.GetSHA())
+attrs.PutStr(string(conventions.VCSRefHeadNameKey), input.Deployment.GetRef())
+attrs.PutStr(semconv.EverrDeployID, fmt.Sprintf("github-deployment-%d", input.Deployment.GetID()))
+attrs.PutStr(semconv.EverrDeployServiceName, deploymentServiceName(input.Deployment.GetTask()))
+attrs.PutInt(semconv.EverrGitHubDeploymentID, input.Deployment.GetID())
+attrs.PutStr(semconv.EverrGitHubDeploymentCreatorLogin, input.Deployment.GetCreator().GetLogin())
+```
+
+Set `cicd.pipeline.run.state` only for `pending` and `executing`. Set `cicd.pipeline.result` only for `success`, `failure`, `error`, and `inactive`.
+
+Marshal the CDEvents body and store it in `record.Body().SetStr(...)`.
+
+- [ ] **Step 7: Add trace linkage test**
+
+Create `collector/receiver/githubactionsreceiver/testdata/deployment/deployment_status_success_with_workflow_run.json`:
+
+```json
+{
+  "action": "created",
+  "deployment": {
+    "id": 987,
+    "sha": "abc123",
+    "ref": "main",
+    "task": "deploy:app",
+    "environment": "production",
+    "created_at": "2026-05-17T10:00:00Z",
+    "updated_at": "2026-05-17T10:00:00Z",
+    "creator": { "login": "github-actions[bot]" }
+  },
+  "deployment_status": {
+    "id": 988,
+    "state": "success",
+    "environment_url": "https://app.everr.dev",
+    "target_url": "https://github.com/everr-labs/everr-deploy/actions/runs/1",
+    "description": "app rollout completed",
+    "created_at": "2026-05-17T10:04:00Z",
+    "updated_at": "2026-05-17T10:04:00Z"
+  },
+  "workflow_run": {
+    "id": 456,
+    "run_attempt": 2
+  },
+  "repository": {
+    "id": 654321,
+    "name": "everr-deploy",
+    "full_name": "everr-labs/everr-deploy",
+    "html_url": "https://github.com/everr-labs/everr-deploy",
+    "owner": { "login": "everr-labs" }
+  },
+  "installation": { "id": 123 },
+  "sender": { "login": "github-actions[bot]" }
+}
+```
+
+Add a test:
+
+```go
+func TestDeploymentStatusUsesWorkflowTraceIDWhenPresent(t *testing.T) {
+	event := parseGitHubTestEvent[*github.DeploymentStatusEvent](t, "testdata/deployment/deployment_status_success_with_workflow_run.json", "deployment_status")
+
+	logs, err := deploymentEventToLogs(event, zap.NewNop())
+
+	require.NoError(t, err)
+	expected, err := generateTraceID(654321, 456, 2)
+	require.NoError(t, err)
+	record := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	require.Equal(t, expected, record.TraceID())
+}
+```
+
+Implement a helper that checks `event.GetWorkflowRun()` on `github.DeploymentEvent` and `github.DeploymentStatusEvent`. If present and repo id is positive, set `TraceID` on every emitted record.
+
+- [ ] **Step 8: Run mapper tests**
+
+Run:
+
+```bash
+cd collector/receiver/githubactionsreceiver
+go test ./... -run 'TestDeployment' -count=1
+```
+
+Expected: deploy mapper tests pass.
+
+### Task 4: Collector Dispatches Deploy Events Before Workflow Paths
+
+**Files:**
+
+- Modify: `collector/receiver/githubactionsreceiver/receiver.go`
+- Modify: `collector/receiver/githubactionsreceiver/receiver_test.go`
+
+- [ ] **Step 1: Add receiver test proving deploy path does not need GitHub API auth**
+
+Add a receiver test using a valid GitHub webhook signature and a `deployment_status` payload, but config with no GitHub API app id/private key. The logs consumer should receive logs and the response should be `202`.
+
+```go
+func TestReceiverDeploymentStatusDoesNotRequireGitHubAPIClient(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.Path = "/webhook/github"
+	cfg.Secret = "secret"
+	cfg.GitHubAPIConfig.Auth.AppID = 0
+	cfg.GitHubAPIConfig.Auth.PrivateKey = ""
+
+	consumer := newCapturingLogsConsumer()
+	rcv, err := newReceiver(receivertest.NewNopSettings(metadata.Type), cfg)
+	require.NoError(t, err)
+	rcv.logsConsumer = consumer
+
+	payload, err := os.ReadFile("testdata/deployment/deployment_status_success.json")
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/webhook/github", bytes.NewReader(payload))
+	signGitHubRequest(req, "secret", payload)
+	req.Header.Set("x-github-event", "deployment_status")
+	req.Header.Set("x-everr-tenant-id", "42")
+	rec := httptest.NewRecorder()
+
+	rcv.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusAccepted, rec.Code)
+	require.Len(t, consumer.logs, 1)
+	require.Equal(t, 2, consumer.logs[0].LogRecordCount())
+}
+```
+
+Use existing receiver test helpers where possible. If helper names differ, keep the same assertions and use the existing test style in `receiver_test.go`.
+
+- [ ] **Step 2: Run the failing receiver test**
+
+Run:
+
+```bash
+cd collector/receiver/githubactionsreceiver
+go test ./... -run 'TestReceiverDeploymentStatusDoesNotRequireGitHubAPIClient' -count=1
+```
+
+Expected: failure because current receiver rejects unsupported event types or initializes GitHub API auth before logs.
+
+- [ ] **Step 3: Add deploy event detection**
+
+In `collector/receiver/githubactionsreceiver/receiver.go`, add:
+
+```go
+func isDeploymentWebhookEvent(event interface{}) bool {
+	switch event.(type) {
+	case *github.DeploymentEvent, *github.DeploymentStatusEvent:
+		return true
+	default:
+		return false
+	}
+}
+```
+
+Extend the initial event switch:
+
+```go
+case *github.DeploymentEvent, *github.DeploymentStatusEvent:
+	// Deploy events are mapped directly to logs below.
+```
+
+- [ ] **Step 4: Dispatch deploy logs before installation client setup**
+
+After request metadata is copied into `client.Metadata`, add this block before `installationIDFromWebhookEvent(...)`:
+
+```go
+if isDeploymentWebhookEvent(event) {
+	if gar.logsConsumer == nil {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
+	ld, err := deploymentEventToLogs(event, gar.logger.Named("deploymentEventToLogs"))
+	if err != nil {
+		gar.logger.Error("Failed to process deployment event", zap.Error(err))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if ld != nil {
+		if err := gar.logsConsumer.ConsumeLogs(ctx, *ld); err != nil {
+			gar.logger.Error("Failed to consume deployment logs", zap.Error(err))
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+
+	w.WriteHeader(http.StatusAccepted)
+	return
+}
+```
+
+Leave the workflow-run and workflow-job path unchanged.
+
+- [ ] **Step 5: Keep installation helper workflow-only**
+
+Do not add deployment cases to `installationIDFromWebhookEvent(...)`. The deploy path returns before that helper and does not need a GitHub API client.
+
+- [ ] **Step 6: Run collector tests**
+
+Run:
+
+```bash
+cd collector/receiver/githubactionsreceiver
+go test ./... -count=1
+```
+
+Expected: all receiver tests pass.
+
+- [ ] **Step 7: Commit collector changes**
+
+Run:
+
+```bash
+git add collector/receiver/githubactionsreceiver collector/semconv/cicd.go
+git commit -m "feat: map GitHub deployment events to logs"
+```
+
+### Task 5: Query Contract Stays On Existing ClickHouse Logs
+
+**Files:**
+
+- No required SQL changes.
+- Optional modify: `docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-summary.md`
+
+- [ ] **Step 1: Verify no ClickHouse schema change is needed**
+
+Inspect:
+
+```bash
+rg -n "EventName|ResourceAttributes|app.logs_mv|ORDER BY" clickhouse/init/03-create-otel-tables.sql clickhouse/init/10-create-mvs.sql
+```
+
+Expected:
+
+- `otel.otel_logs` already has `EventName String`.
+- `app.logs_mv` copies `ResourceAttributes['everr.tenant.id']` to `tenant_id`.
+- `app.logs` orders by `(tenant_id, ServiceName, TimestampTime, Timestamp)`.
+
+- [ ] **Step 2: Add or verify query example**
+
+If the existing summary doc does not already show this, add a short query example:
+
+```sql
+SELECT
+  TimestampTime,
+  EventName,
+  LogAttributes['everr.deploy.service.name'] AS deployed_service,
+  LogAttributes['deployment.environment.name'] AS environment,
+  LogAttributes['cicd.pipeline.result'] AS result,
+  LogAttributes['everr.deploy.url'] AS deploy_url
+FROM app.logs
+WHERE ServiceName = 'github-deployments'
+  AND TimestampTime >= now() - INTERVAL 7 DAY
+ORDER BY TimestampTime DESC
+LIMIT 100;
+```
+
+Do not add `PREWHERE`.
+
+Do not add `tenant_id = toUInt64(getSetting('SQL_everr_tenant_id'))`; the row-level policy handles tenant filtering.
+
+- [ ] **Step 3: Commit query doc change if any**
+
+If the doc changed:
+
+```bash
+git add docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-summary.md
+git commit -m "docs: clarify deploy event query contract"
+```
+
+### Task 6: everr-deploy Exposes ECS Service Names
+
+**Files in `../everr-deploy`:**
+
+- Modify: `infra/modules/app_service/outputs.tf`
+- Modify: `infra/modules/docs_service/outputs.tf`
+- Modify: `infra/modules/everr_otel_collector/outputs.tf`
+- Modify: `infra/outputs.tf`
+
+- [ ] **Step 1: Add module service name outputs**
+
+Append to `../everr-deploy/infra/modules/app_service/outputs.tf`:
+
+```hcl
+output "ecs_service_name" {
+  value = aws_ecs_service.this.name
+}
+```
+
+Append to `../everr-deploy/infra/modules/docs_service/outputs.tf`:
+
+```hcl
+output "ecs_service_name" {
+  value = aws_ecs_service.this.name
+}
+```
+
+Append to `../everr-deploy/infra/modules/everr_otel_collector/outputs.tf`:
+
+```hcl
+output "ecs_service_name" {
+  value = aws_ecs_service.this.name
+}
+```
+
+- [ ] **Step 2: Add root outputs**
+
+Append to `../everr-deploy/infra/outputs.tf`:
+
+```hcl
+output "ecs_cluster_name" {
+  description = "ECS cluster name used by app, docs, and collector services."
+  value       = aws_ecs_cluster.main.name
+}
+
+output "app_ecs_service_name" {
+  description = "ECS service name for the Everr app service."
+  value       = module.app_service.ecs_service_name
+}
+
+output "docs_ecs_service_name" {
+  description = "ECS service name for the docs service."
+  value       = module.docs_service.ecs_service_name
+}
+
+output "collector_ecs_service_name" {
+  description = "ECS service name for the Everr OTel collector service."
+  value       = module.everr_otel_collector.ecs_service_name
+}
+```
+
+- [ ] **Step 3: Validate OpenTofu formatting**
+
+Run:
+
+```bash
+cd ../everr-deploy/infra
+tofu fmt -check -recursive
+tofu validate -no-color
+```
+
+Expected: both commands pass after `tofu init` has already been run in that workspace. If `tofu validate` asks for init, run `tofu init -input=false` and rerun validate.
+
+- [ ] **Step 4: Commit outputs**
+
+Run from `../everr-deploy`:
+
+```bash
+git add infra/modules/app_service/outputs.tf infra/modules/docs_service/outputs.tf infra/modules/everr_otel_collector/outputs.tf infra/outputs.tf
+git commit -m "deploy: expose ecs service outputs"
+```
+
+### Task 7: everr-deploy Adds ECS Rollout Polling Script
+
+**Files in `../everr-deploy`:**
+
+- Add: `scripts/wait-ecs-service-rollout.sh`
+- Add: `scripts/tests/wait-ecs-service-rollout.test.sh`
+
+- [ ] **Step 1: Create rollout wait script**
+
+Create `../everr-deploy/scripts/wait-ecs-service-rollout.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+cluster="${1:?usage: wait-ecs-service-rollout.sh <cluster> <service> [timeout_seconds] [interval_seconds]}"
+service="${2:?usage: wait-ecs-service-rollout.sh <cluster> <service> [timeout_seconds] [interval_seconds]}"
+timeout_seconds="${3:-1200}"
+interval_seconds="${4:-15}"
+deadline=$((SECONDS + timeout_seconds))
+
+while true; do
+  states_json="$(
+    aws ecs describe-services \
+      --cluster "$cluster" \
+      --services "$service" \
+      --query 'services[0].deployments[].rolloutState' \
+      --output json
+  )"
+
+  if jq -e 'length > 0 and any(.[]; . == "FAILED")' >/dev/null <<<"$states_json"; then
+    echo "ECS service $service has a failed deployment: $states_json" >&2
+    exit 1
+  fi
+
+  if jq -e 'length > 0 and all(.[]; . == "COMPLETED")' >/dev/null <<<"$states_json"; then
+    echo "ECS service $service rollout completed"
+    exit 0
+  fi
+
+  if (( SECONDS >= deadline )); then
+    echo "Timed out waiting for ECS service $service rollout states to become COMPLETED: $states_json" >&2
+    exit 124
+  fi
+
+  echo "Waiting for ECS service $service rollout states: $states_json"
+  sleep "$interval_seconds"
+done
+```
+
+- [ ] **Step 2: Add shell tests with fake AWS CLI**
+
+Create `../everr-deploy/scripts/tests/wait-ecs-service-rollout.test.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+cat >"$tmpdir/aws" <<'AWS'
+#!/usr/bin/env bash
+set -euo pipefail
+state_file="${FAKE_AWS_STATE_FILE:?missing FAKE_AWS_STATE_FILE}"
+call_file="${FAKE_AWS_CALL_FILE:?missing FAKE_AWS_CALL_FILE}"
+call="$(cat "$call_file")"
+call=$((call + 1))
+echo "$call" >"$call_file"
+sed -n "${call}p" "$state_file"
+AWS
+chmod +x "$tmpdir/aws"
+
+run_case() {
+  local name="$1"
+  local states="$2"
+  local expected="$3"
+  local call_file="$tmpdir/$name.calls"
+  local state_file="$tmpdir/$name.states"
+  printf '0' >"$call_file"
+  printf '%s\n' "$states" >"$state_file"
+  export FAKE_AWS_CALL_FILE="$call_file"
+  export FAKE_AWS_STATE_FILE="$state_file"
+  PATH="$tmpdir:$PATH" "$repo_root/scripts/wait-ecs-service-rollout.sh" cluster service 2 0
+  actual="$?"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "$name expected exit $expected, got $actual" >&2
+    exit 1
+  fi
+}
+
+run_case completed '["COMPLETED"]' 0
+
+set +e
+export FAKE_AWS_CALL_FILE="$tmpdir/failed.calls"
+export FAKE_AWS_STATE_FILE="$tmpdir/failed.states"
+printf '0' >"$FAKE_AWS_CALL_FILE"
+printf '%s\n' '["IN_PROGRESS","FAILED"]' >"$FAKE_AWS_STATE_FILE"
+PATH="$tmpdir:$PATH" "$repo_root/scripts/wait-ecs-service-rollout.sh" cluster service 2 0
+status="$?"
+set -e
+if [[ "$status" != "1" ]]; then
+  echo "failed case expected exit 1, got $status" >&2
+  exit 1
+fi
+```
+
+- [ ] **Step 3: Run the script tests**
+
+Run from `../everr-deploy`:
+
+```bash
+chmod +x scripts/wait-ecs-service-rollout.sh scripts/tests/wait-ecs-service-rollout.test.sh
+scripts/tests/wait-ecs-service-rollout.test.sh
+```
+
+Expected: test exits `0`.
+
+- [ ] **Step 4: Commit rollout script**
+
+Run from `../everr-deploy`:
+
+```bash
+git add scripts/wait-ecs-service-rollout.sh scripts/tests/wait-ecs-service-rollout.test.sh
+git commit -m "deploy: wait for ecs rollouts"
+```
+
+### Task 8: everr-deploy Emits GitHub Deployment Statuses
+
+**Files in `../everr-deploy`:**
+
+- Add: `scripts/changed-ecs-services.sh`
+- Add: `scripts/create-github-deployment.sh`
+- Add: `scripts/update-github-deployment-status.sh`
+- Modify: `.github/workflows/deploy.yml`
+
+- [ ] **Step 1: Add changed-service detection script**
+
+Create `../everr-deploy/scripts/changed-ecs-services.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+base="${1:-}"
+head="${2:-HEAD}"
+
+if [[ -z "$base" || "$base" == "0000000000000000000000000000000000000000" ]]; then
+  echo "app docs collector"
+  exit 0
+fi
+
+changed="$(git diff --name-only "$base" "$head")"
+services=()
+
+if grep -q '^infra/images\.auto\.tfvars$' <<<"$changed"; then
+  diff_text="$(git diff "$base" "$head" -- infra/images.auto.tfvars)"
+  grep -q 'app_image_tag' <<<"$diff_text" && services+=("app")
+  grep -q 'docs_image_tag' <<<"$diff_text" && services+=("docs")
+  grep -q 'collector_image_tag' <<<"$diff_text" && services+=("collector")
+fi
+
+if grep -q '^infra/' <<<"$changed"; then
+  if [[ "${#services[@]}" -eq 0 ]]; then
+    services=("app" "docs" "collector")
+  fi
+fi
+
+if [[ "${#services[@]}" -eq 0 ]]; then
+  echo "app docs collector"
+else
+  printf '%s\n' "${services[@]}" | awk '!seen[$0]++' | paste -sd' ' -
+fi
+```
+
+- [ ] **Step 2: Add deployment creation script**
+
+Create `../everr-deploy/scripts/create-github-deployment.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+service="${1:?usage: create-github-deployment.sh <service> <environment> <deployment-id-output-file>}"
+environment="${2:?usage: create-github-deployment.sh <service> <environment> <deployment-id-output-file>}"
+output_file="${3:?usage: create-github-deployment.sh <service> <environment> <deployment-id-output-file>}"
+
+payload="$(
+  jq -n \
+    --arg ref "$GITHUB_SHA" \
+    --arg environment "$environment" \
+    --arg task "deploy:$service" \
+    --arg service "$service" \
+    --arg workflow "$GITHUB_WORKFLOW" \
+    --arg run_id "$GITHUB_RUN_ID" \
+    --arg run_attempt "$GITHUB_RUN_ATTEMPT" \
+    '{
+      ref: $ref,
+      environment: $environment,
+      task: $task,
+      auto_merge: false,
+      required_contexts: [],
+      payload: {
+        service: $service,
+        workflow: $workflow,
+        workflow_run_id: $run_id,
+        workflow_run_attempt: $run_attempt
+      }
+    }'
+)"
+
+deployment_id="$(
+  gh api \
+    --method POST \
+    "repos/${GITHUB_REPOSITORY}/deployments" \
+    --input - \
+    --jq '.id' <<<"$payload"
+)"
+
+mkdir -p "$(dirname "$output_file")"
+printf '%s' "$deployment_id" >"$output_file"
+echo "Created GitHub deployment $deployment_id for $service"
+```
+
+- [ ] **Step 3: Add deployment status update script**
+
+Create `../everr-deploy/scripts/update-github-deployment-status.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+deployment_id="${1:?usage: update-github-deployment-status.sh <deployment-id> <state> <description> [environment-url]}"
+state="${2:?usage: update-github-deployment-status.sh <deployment-id> <state> <description> [environment-url]}"
+description="${3:?usage: update-github-deployment-status.sh <deployment-id> <state> <description> [environment-url]}"
+environment_url="${4:-}"
+
+payload="$(
+  jq -n \
+    --arg state "$state" \
+    --arg description "$description" \
+    --arg log_url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+    --arg environment_url "$environment_url" \
+    '{
+      state: $state,
+      description: $description,
+      log_url: $log_url,
+      auto_inactive: true
+    } + if $environment_url == "" then {} else {environment_url: $environment_url} end'
+)"
+
+gh api \
+  --method POST \
+  "repos/${GITHUB_REPOSITORY}/deployments/${deployment_id}/statuses" \
+  --input - >/dev/null <<<"$payload"
+
+echo "Set GitHub deployment $deployment_id to $state"
+```
+
+- [ ] **Step 4: Update deploy workflow permissions**
+
+In `../everr-deploy/.github/workflows/deploy.yml`, replace:
+
+```yaml
+permissions:
+  contents: read
+```
+
+with:
+
+```yaml
+permissions:
+  contents: read
+  deployments: write
+```
+
+- [ ] **Step 5: Add workflow environment variables**
+
+Add under workflow `env:`:
+
+```yaml
+  DEPLOY_ENVIRONMENT: production
+```
+
+- [ ] **Step 6: Add deployment creation before apply**
+
+In the `apply-infra` job, after `Init` and before `Apply`, add:
+
+```yaml
+      - name: Detect changed services
+        id: services
+        working-directory: .
+        run: |
+          SERVICES="$(scripts/changed-ecs-services.sh "${{ github.event.before }}" "${{ github.sha }}")"
+          echo "services=${SERVICES}" >> "$GITHUB_OUTPUT"
+          echo "Deploying services: ${SERVICES}"
+
+      - name: Create GitHub deployments
+        working-directory: .
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p .deployments
+          for service in ${{ steps.services.outputs.services }}; do
+            scripts/create-github-deployment.sh "$service" "$DEPLOY_ENVIRONMENT" ".deployments/${service}.id"
+            deployment_id="$(cat ".deployments/${service}.id")"
+            scripts/update-github-deployment-status.sh "$deployment_id" in_progress "${service} deploy started"
+          done
+```
+
+- [ ] **Step 7: Add failure trap around apply and rollout wait**
+
+Replace the current `Apply` step with:
+
+```yaml
+      - name: Apply and wait for ECS rollouts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          mark_failed() {
+            status="$?"
+            for file in ../.deployments/*.id; do
+              [ -f "$file" ] || continue
+              service="$(basename "$file" .id)"
+              deployment_id="$(cat "$file")"
+              ../scripts/update-github-deployment-status.sh "$deployment_id" failure "${service} deploy failed"
+            done
+            exit "$status"
+          }
+          trap mark_failed ERR
+
+          tofu apply -auto-approve -input=false
+
+          cluster="$(tofu output -raw ecs_cluster_name)"
+          app_service="$(tofu output -raw app_ecs_service_name)"
+          docs_service="$(tofu output -raw docs_ecs_service_name)"
+          collector_service="$(tofu output -raw collector_ecs_service_name)"
+          app_url="$(tofu output -raw app_url)"
+          docs_url="$(tofu output -raw docs_url)"
+
+          for service in ${{ steps.services.outputs.services }}; do
+            case "$service" in
+              app)
+                ecs_service="$app_service"
+                environment_url="$app_url"
+                ;;
+              docs)
+                ecs_service="$docs_service"
+                environment_url="$docs_url"
+                ;;
+              collector)
+                ecs_service="$collector_service"
+                environment_url=""
+                ;;
+              *)
+                echo "Unknown service: $service" >&2
+                exit 1
+                ;;
+            esac
+
+            ../scripts/wait-ecs-service-rollout.sh "$cluster" "$ecs_service" 1200 15
+            deployment_id="$(cat "../.deployments/${service}.id")"
+            ../scripts/update-github-deployment-status.sh "$deployment_id" success "${service} rollout completed" "$environment_url"
+          done
+
+          trap - ERR
+```
+
+Because the job default working directory is `./infra`, script paths in this step use `../scripts/...` and deployment id files live in `../.deployments`.
+
+- [ ] **Step 8: Validate workflow YAML and shell scripts**
+
+Run from `../everr-deploy`:
+
+```bash
+chmod +x scripts/changed-ecs-services.sh scripts/create-github-deployment.sh scripts/update-github-deployment-status.sh scripts/wait-ecs-service-rollout.sh
+bash -n scripts/changed-ecs-services.sh scripts/create-github-deployment.sh scripts/update-github-deployment-status.sh scripts/wait-ecs-service-rollout.sh
+python - <<'PY'
+import pathlib, yaml
+for path in pathlib.Path(".github/workflows").glob("*.yml"):
+    yaml.safe_load(path.read_text())
+print("workflow yaml parsed")
+PY
+```
+
+Expected: shell syntax passes and workflow YAML parses.
+
+- [ ] **Step 9: Commit everr-deploy workflow changes**
+
+Run from `../everr-deploy`:
+
+```bash
+git add .github/workflows/deploy.yml scripts/changed-ecs-services.sh scripts/create-github-deployment.sh scripts/update-github-deployment-status.sh
+git commit -m "deploy: emit github deployment statuses"
+```
+
+### Task 9: End-To-End Verification
+
+**Files:**
+
+- No required file changes.
+
+- [ ] **Step 1: Run Everr app tests**
+
+Run from `/Users/guidodorsi/workspace/everr`:
+
+```bash
+pnpm --filter @everr/app test:ci src/server/github-events/webhook.test.ts src/server/github-events/runtime.test.ts
+pnpm --filter @everr/app typecheck
+```
+
+Expected: tests pass and typecheck completes.
+
+- [ ] **Step 2: Run collector tests**
+
+Run:
+
+```bash
+cd /Users/guidodorsi/workspace/everr/collector/receiver/githubactionsreceiver
+go test ./... -count=1
+```
+
+Expected: tests pass.
+
+- [ ] **Step 3: Run everr-deploy script tests**
+
+Run:
+
+```bash
+cd /Users/guidodorsi/workspace/everr-deploy
+scripts/tests/wait-ecs-service-rollout.test.sh
+bash -n scripts/*.sh
+```
+
+Expected: tests and shell syntax checks pass.
+
+- [ ] **Step 4: Confirm GitHub App configuration**
+
+In the GitHub App settings used by Everr, confirm:
+
+- Webhook events include `deployment`.
+- Webhook events include `deployment_status`.
+- Repository permission includes Deployments read access.
+- The app is installed on `everr-labs/everr-deploy`.
+
+Expected: `../everr-deploy` deployment events can reach Everr's `/webhook/github` route.
+
+- [ ] **Step 5: Smoke test signed deploy webhook locally**
+
+Run the app test helper or a local script that signs `collector/receiver/githubactionsreceiver/testdata/deployment/deployment_status_success.json` with `GITHUB_APP_WEBHOOK_SECRET` and posts it to:
+
+```bash
+curl -i \
+  -X POST \
+  -H "x-github-event: deployment_status" \
+  -H "x-github-delivery: local-deploy-status-1" \
+  -H "x-hub-signature-256: sha256=<computed-signature>" \
+  --data-binary @collector/receiver/githubactionsreceiver/testdata/deployment/deployment_status_success.json \
+  http://localhost:5173/webhook/github
+```
+
+Expected: response is `202`.
+
+- [ ] **Step 6: Query ClickHouse after a real everr-deploy run**
+
+Run through the app's existing ClickHouse query path:
+
+```sql
+SELECT
+  TimestampTime,
+  EventName,
+  LogAttributes['everr.deploy.service.name'] AS deployed_service,
+  LogAttributes['deployment.environment.name'] AS environment,
+  LogAttributes['cicd.pipeline.result'] AS result
+FROM app.logs
+WHERE ServiceName = 'github-deployments'
+  AND TimestampTime >= now() - INTERVAL 1 DAY
+ORDER BY TimestampTime DESC
+LIMIT 20;
+```
+
+Expected:
+
+- At least one `dev.cdevents.pipelinerun.started.0.3.0` row per deployed service.
+- A `dev.cdevents.pipelinerun.finished.0.3.0` row per deployed service.
+- A `dev.cdevents.service.deployed.0.3.0` row per service that completed successfully.
+- `tenant_id` is populated by `app.logs_mv`.
+
+- [ ] **Step 7: Final commit if verification adjusts docs or tests**
+
+Run:
+
+```bash
+git status --short
+```
+
+If verification required small follow-up edits:
+
+```bash
+git add <changed-files>
+git commit -m "test: verify deployment event ingestion"
+```
+
+## Rollout Notes
+
+- `../everr-deploy` will create one GitHub Deployment per service. This makes deploy frequency per service queryable without guessing from a single umbrella infra deployment.
+- `tofu apply` still controls the actual infrastructure change. GitHub Deployment status is observability metadata around the deploy, not the deploy mechanism.
+- ECS polling waits for every reported deployment rollout state to be `COMPLETED`. A single `FAILED` state marks the GitHub Deployment as failed.
+- `deployment_status: inactive` rows are expected when GitHub auto-inactivates older deployments. Everr stores them as `everr.deploy.superseded`.
+- No user-facing Everr-specific deploy action is needed for v1. A user can adopt by creating GitHub Deployments and setting Deployment Statuses from any CI/CD system.

--- a/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-design.md
+++ b/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-design.md
@@ -1,0 +1,186 @@
+# GitHub Deploy CDEvents Ingest Design
+
+## Status
+
+Approved for implementation planning.
+
+## Context
+
+Everr currently ingests GitHub Actions `workflow_run` and `workflow_job` webhooks. The app verifies GitHub webhooks, resolves the tenant through the GitHub App installation, queues each event through pg-boss, writes workflow status to Postgres, and forwards CI telemetry to the collector so it lands in ClickHouse.
+
+Deploy tracking should start with GitHub's native `deployment` and `deployment_status` webhook events. Users who already use GitHub Actions environments or the GitHub Deployments API can adopt this without adding an Everr-specific action step.
+
+For v1, deployment events should be stored as OpenTelemetry logs with a CDEvents-shaped JSON body. There is no Postgres deploy table in v1. ClickHouse is the source for deploy history and deploy queries.
+
+## Goals
+
+- Accept GitHub `deployment` and `deployment_status` webhooks.
+- Convert those webhooks into OTel log records.
+- Store deploy events in the existing ClickHouse logs path.
+- Shape each log body as a CDEvents-style event so the event model is not GitHub-only.
+- Add query-friendly log attributes for common deploy filters.
+- Keep the first version small enough to support GitHub-native deploy tracking without custom YAML beyond GitHub environments.
+
+## Non-Goals
+
+- Do not add Postgres deploy state in v1.
+- Do not add a custom ClickHouse `deploy_events` table in v1.
+- Do not add `everr/action` deploy marker inputs in this slice.
+- Do not build deploy UI in this slice.
+- Do not try to infer deploys from workflow names.
+- Do not generate Drizzle migrations as part of the design step.
+
+## Event Model
+
+Each accepted GitHub deploy webhook becomes one or more OTel log records.
+
+The log body is JSON with a CDEvents-style shape:
+
+```json
+{
+  "context": {
+    "version": "0.5.0",
+    "id": "github-delivery-id",
+    "source": "github.com/acme/api",
+    "type": "dev.cdevents.service.deployed.0.2.0",
+    "timestamp": "2026-05-17T10:30:00.000Z"
+  },
+  "subject": {
+    "id": "github-deployment-123456",
+    "source": "github.com/acme/api",
+    "type": "service",
+    "content": {
+      "environment": {
+        "id": "production",
+        "name": "production"
+      },
+      "artifactId": "pkg:github/acme/api@abc123",
+      "uri": "https://github.com/acme/api/deployments/123456"
+    }
+  }
+}
+```
+
+The exact CDEvents event type depends on the GitHub event:
+
+| GitHub event | GitHub state | CDEvents-style log event |
+| --- | --- | --- |
+| `deployment` | created/requested | `dev.cdevents.pipelinerun.queued.*` |
+| `deployment_status` | `in_progress` | `dev.cdevents.pipelinerun.started.*` |
+| `deployment_status` | `success` | `dev.cdevents.pipelinerun.finished.*` and `dev.cdevents.service.deployed.*` |
+| `deployment_status` | `failure` or `error` | `dev.cdevents.pipelinerun.finished.*` |
+| `deployment_status` | `inactive` | `dev.cdevents.service.removed.*` when GitHub marks an old environment deployment inactive |
+
+For `deployment_status: success`, emit both:
+
+1. a pipeline completion event, because the deployment run finished; and
+2. a service deployed event, because the service is now running in the environment.
+
+## Query Attributes
+
+The CDEvents JSON body is useful for portability, but common filters should not require JSON parsing. Duplicate important fields into OTel log attributes:
+
+- `event.name`
+- `cdevents.type`
+- `cdevents.id`
+- `deployment.id`
+- `deployment.environment.name`
+- `deployment.status`
+- `service.name`
+- `vcs.repository.name`
+- `vcs.ref.head.revision`
+- `url.full`
+- `everr.github.deployment_status.id`
+- `everr.github.deployment_status.environment_url`
+- `everr.github.deployment.creator.login`
+
+Use empty strings for missing optional fields instead of nullable values.
+
+## Data Flow
+
+1. GitHub sends `deployment` or `deployment_status` to Everr's existing `/webhook/github` route.
+2. The webhook route verifies the signature and keeps ignoring unsupported events.
+3. The allowlist expands to accept `deployment` and `deployment_status`.
+4. The existing event queue stores the raw payload once and sends it to the worker path.
+5. The tenant resolver uses `installation.id`, the same as workflow events.
+6. The app forwards the raw webhook payload to the collector through the existing `gh-collector` path.
+7. The collector's GitHub Actions receiver accepts `deployment` and `deployment_status` events in addition to workflow events.
+8. A new deploy event mapper in the collector parses the GitHub payload and builds OTel log records.
+9. The collector exports the logs into ClickHouse.
+10. Query surfaces can find deploys by filtering `app.logs`.
+
+The existing `gh-status` Postgres-writing path remains workflow-only. Deployment events do not create Postgres rows in v1.
+
+## ClickHouse Query Shape
+
+Deploy history queries read from `app.logs`:
+
+```sql
+SELECT
+  TimestampTime,
+  LogAttributes['event.name'] AS event_name,
+  LogAttributes['deployment.environment.name'] AS environment,
+  LogAttributes['deployment.status'] AS status,
+  LogAttributes['service.name'] AS service,
+  LogAttributes['vcs.repository.name'] AS repository,
+  LogAttributes['vcs.ref.head.revision'] AS sha,
+  Body
+FROM logs
+WHERE ServiceName = 'github-deployments'
+  AND TimestampTime >= now() - INTERVAL 7 DAY
+ORDER BY TimestampTime DESC
+LIMIT 100;
+```
+
+The existing `app.logs` table orders by tenant, service, and time. That is a reasonable v1 fit if deploy logs use a stable service name such as `github-deployments`. It keeps deploy queries time-bounded and service-filtered.
+
+Per `schema-pk-plan-before-creation`, avoid creating a custom deploy table until the query patterns are better proven, because ClickHouse `ORDER BY` is hard to change later. Per `schema-pk-prioritize-filters`, if a custom table is added later, its key should be driven by the most common filters: tenant, environment, service, repository, and time. Per `schema-types-lowcardinality`, repeated strings like environment, status, service, and event name should be LowCardinality if they become typed columns later. Per `schema-types-avoid-nullable`, optional fields should prefer empty defaults over nullable columns.
+
+Do not add `tenant_id = toUInt64(getSetting('SQL_everr_tenant_id'))` to queries. Existing row-level policy handles tenant filtering.
+
+## Error Handling
+
+- Invalid JSON or unsupported deploy payload shape is a terminal event error and should not retry.
+- Missing `installation.id` is terminal because Everr cannot resolve a tenant.
+- Missing deployment id, repo, or SHA should not crash if GitHub allows the payload; emit the log with empty query attributes and preserve the raw CDEvents body where possible.
+- Collector or ClickHouse failures remain retryable through the existing queue behavior.
+- Duplicate GitHub delivery ids should stay idempotent through the existing pg-boss job id behavior.
+
+## Deployment Phases
+
+CDEvents does not model deploy phases as one `phase` field on `service.deployed`. Richer phases should be modeled as task runs:
+
+- `dev.cdevents.taskrun.started.*`
+- `dev.cdevents.taskrun.finished.*`
+
+GitHub native deployment events do not provide phase detail like `migrate`, `canary`, `rollout`, or `verify`. That should be a later `everr/action` feature. When added, Everr can emit task-run CDEvents and include a query-friendly attribute such as `everr.deploy.phase`.
+
+## Testing
+
+- Webhook tests:
+  - accepts `deployment`
+  - accepts `deployment_status`
+  - still ignores unrelated GitHub events
+  - still rejects bad signatures
+- Payload parser tests:
+  - parses minimal GitHub deployment payloads
+  - parses minimal GitHub deployment status payloads
+  - rejects missing installation id
+- Mapper tests:
+  - maps `deployment` to a pipeline event
+  - maps `deployment_status: in_progress` to pipeline started
+  - maps `deployment_status: success` to pipeline finished plus service deployed
+  - maps `deployment_status: failure` and `error` to pipeline finished with failure
+  - preserves repository, SHA, environment, URL, and sender fields as log attributes
+- ClickHouse query tests:
+  - deploy logs can be selected from `logs` using service name, event name, environment, and time filters
+- End-to-end smoke:
+  - send signed GitHub-like deployment payloads to `/webhook/github`
+  - verify deploy CDEvents-shaped logs appear in ClickHouse
+
+## References
+
+- CDEvents documentation: https://cdevents.dev/docs/
+- CDEvents primer and observability use case: https://cdevents.dev/docs/primer/
+- GitHub deployment webhooks: https://docs.github.com/en/webhooks/webhook-events-and-payloads
+- GitHub deployment statuses API states: https://docs.github.com/en/rest/deployments/statuses

--- a/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-design.md
+++ b/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-design.md
@@ -69,7 +69,9 @@ The exact CDEvents event type depends on the GitHub event:
 | `deployment_status` | `in_progress` | `dev.cdevents.pipelinerun.started.*` |
 | `deployment_status` | `success` | `dev.cdevents.pipelinerun.finished.*` and `dev.cdevents.service.deployed.*` |
 | `deployment_status` | `failure` or `error` | `dev.cdevents.pipelinerun.finished.*` |
-| `deployment_status` | `inactive` | `dev.cdevents.service.removed.*` when GitHub marks an old environment deployment inactive |
+| `deployment_status` | `inactive` | `everr.deploy.superseded` custom OTel log event |
+
+Do not map GitHub `inactive` to `dev.cdevents.service.removed.*`. In GitHub, `inactive` usually means an older deployment was superseded by a newer one, not that the service stopped running.
 
 For `deployment_status: success`, emit both:
 
@@ -80,19 +82,23 @@ For `deployment_status: success`, emit both:
 
 The CDEvents JSON body is useful for portability, but common filters should not require JSON parsing. Duplicate important fields into OTel log attributes:
 
-- `event.name`
 - `cdevents.type`
 - `cdevents.id`
-- `deployment.id`
 - `deployment.environment.name`
-- `deployment.status`
-- `service.name`
 - `vcs.repository.name`
 - `vcs.ref.head.revision`
-- `url.full`
+- `everr.deploy.id`
+- `everr.deploy.service.name`
+- `everr.deploy.status`
+- `everr.deploy.url`
 - `everr.github.deployment_status.id`
-- `everr.github.deployment_status.environment_url`
 - `everr.github.deployment.creator.login`
+
+Set the OTel log record event name with `SetEventName(...)`, so ClickHouse stores it in the dedicated `EventName` column. Do not also write `event.name` into `LogAttributes`.
+
+Keep custom attributes under `everr.*`. Use standard OTel attributes only when the attribute already has the same meaning, such as `deployment.environment.name` and `vcs.ref.head.revision`.
+
+Use `ServiceName = 'github-deployments'` for the OTel resource service name and ClickHouse column. Use `everr.deploy.service.name` for the service being deployed.
 
 Use empty strings for missing optional fields instead of nullable values.
 
@@ -111,6 +117,8 @@ Use empty strings for missing optional fields instead of nullable values.
 
 The existing `gh-status` Postgres-writing path remains workflow-only. Deployment events do not create Postgres rows in v1.
 
+The collector dispatch must keep deploy mapping structurally separate from the existing workflow log path. `eventToLogs` is workflow-run specific: it expects a `WorkflowRunEvent` and fetches a GitHub Actions log archive with an installation GitHub client. Deploy webhooks do not have an archive to fetch. Add a deploy-specific mapper, for example `deploymentEventToLogs`, and dispatch `deployment` and `deployment_status` before the workflow trace, metric, and log archive logic. The deploy path must not call `getInstallationClient()` or `Actions.GetWorkflowRunAttemptLogs(...)`.
+
 ## ClickHouse Query Shape
 
 Deploy history queries read from `app.logs`:
@@ -118,21 +126,24 @@ Deploy history queries read from `app.logs`:
 ```sql
 SELECT
   TimestampTime,
-  LogAttributes['event.name'] AS event_name,
+  EventName AS event_name,
   LogAttributes['deployment.environment.name'] AS environment,
-  LogAttributes['deployment.status'] AS status,
-  LogAttributes['service.name'] AS service,
+  LogAttributes['everr.deploy.status'] AS status,
+  LogAttributes['everr.deploy.service.name'] AS service,
   LogAttributes['vcs.repository.name'] AS repository,
   LogAttributes['vcs.ref.head.revision'] AS sha,
   Body
-FROM logs
+FROM app.logs
 WHERE ServiceName = 'github-deployments'
   AND TimestampTime >= now() - INTERVAL 7 DAY
+  AND (startsWith(EventName, 'dev.cdevents.') OR EventName = 'everr.deploy.superseded')
 ORDER BY TimestampTime DESC
 LIMIT 100;
 ```
 
 The existing `app.logs` table orders by tenant, service, and time. That is a reasonable v1 fit if deploy logs use a stable service name such as `github-deployments`. It keeps deploy queries time-bounded and service-filtered.
+
+Per `schema-pk-filter-on-orderby`, keep deploy queries anchored on the existing `ORDER BY` prefix through the tenant row policy, `ServiceName`, and time. `EventName` is cheaper to read than `LogAttributes['event.name']`, but it is not part of the `ORDER BY`, so it should not replace the service and time filters. Per `query-index-skipping-indices`, do not add a skipping index for `EventName` in v1; consider it later only if real deploy queries are hot and `EXPLAIN indexes = 1` shows useful skipping.
 
 Per `schema-pk-plan-before-creation`, avoid creating a custom deploy table until the query patterns are better proven, because ClickHouse `ORDER BY` is hard to change later. Per `schema-pk-prioritize-filters`, if a custom table is added later, its key should be driven by the most common filters: tenant, environment, service, repository, and time. Per `schema-types-lowcardinality`, repeated strings like environment, status, service, and event name should be LowCardinality if they become typed columns later. Per `schema-types-avoid-nullable`, optional fields should prefer empty defaults over nullable columns.
 
@@ -171,9 +182,15 @@ GitHub native deployment events do not provide phase detail like `migrate`, `can
   - maps `deployment_status: in_progress` to pipeline started
   - maps `deployment_status: success` to pipeline finished plus service deployed
   - maps `deployment_status: failure` and `error` to pipeline finished with failure
+  - maps `deployment_status: inactive` to `everr.deploy.superseded`, not service removed
   - preserves repository, SHA, environment, URL, and sender fields as log attributes
+  - sets the OTel `EventName` field instead of writing `event.name` to `LogAttributes`
+- Receiver dispatch tests:
+  - deploy events use the deploy mapper before the workflow log path
+  - deploy events do not require an installation GitHub client
+  - deploy events do not call `GetWorkflowRunAttemptLogs`
 - ClickHouse query tests:
-  - deploy logs can be selected from `logs` using service name, event name, environment, and time filters
+  - deploy logs can be selected from `app.logs` using service name, event name, environment, and time filters
 - End-to-end smoke:
   - send signed GitHub-like deployment payloads to `/webhook/github`
   - verify deploy CDEvents-shaped logs appear in ClickHouse

--- a/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-design.md
+++ b/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-design.md
@@ -41,7 +41,7 @@ The log body is JSON with a CDEvents-style shape:
 {
   "context": {
     "version": "0.5.0",
-    "id": "github-delivery-id",
+    "id": "github-delivery-id-service-deployed",
     "source": "github.com/acme/api",
     "type": "dev.cdevents.service.deployed.0.3.0",
     "timestamp": "2026-05-17T10:30:00.000Z"
@@ -71,7 +71,13 @@ V1 pins the body to CDEvents spec `0.5.0` and this event type subset:
 
 For CDEvents records, the `context.version` field must be `0.5.0`, and the `context.type` field must use one of the exact event types above. Do not silently move to a newer CDEvents spec or event type version later; that is an ingestion format change and needs an explicit migration or dual-read plan.
 
-`everr.deploy.superseded` is an Everr custom OTel log event, not part of the pinned CDEvents subset. Set its OTel `EventName` to `everr.deploy.superseded` and leave `cdevents.type` empty.
+`everr.deploy.superseded` is an Everr custom OTel log event, not part of the pinned CDEvents subset. Set its OTel `EventName` to `everr.deploy.superseded` and leave `cdevents.*` attributes empty.
+
+For CDEvents records, `cdevents.id` must equal the CDEvents body's `context.id`. Base the id on GitHub's `x-github-delivery` header because that is the source webhook event id:
+
+- For webhooks that emit one CDEvents record, set `context.id = cdevents.id = <x-github-delivery>`.
+- For `deployment_status: success`, set the pipeline-finished record to `<x-github-delivery>` and the service-deployed record to `<x-github-delivery>-service-deployed`. CDEvents builds on CloudEvents, where `source + id` identifies a distinct event, so two CDEvents records from one webhook must not share the same `context.id`.
+- Store the raw GitHub delivery id separately in `everr.github.delivery.id` on every emitted deploy row, including custom rows such as `everr.deploy.superseded`.
 
 The exact CDEvents event type depends on the GitHub event:
 
@@ -96,6 +102,7 @@ The CDEvents JSON body is useful for portability, but common filters should not 
 
 - `cdevents.type`
 - `cdevents.id`
+- `everr.github.delivery.id`
 - `cicd.pipeline.name`
 - `cicd.pipeline.result`
 - `cicd.pipeline.run.id`
@@ -127,6 +134,8 @@ Map OTel CI/CD attributes when they fit the GitHub deployment lifecycle:
 - `cicd.pipeline.name`: GitHub deployment task, defaulting to `deploy`.
 - `cicd.pipeline.run.state`: `pending` for deployment creation, `executing` for `in_progress`.
 - `cicd.pipeline.result`: `success`, `failure`, or `error` on finished deployment status events.
+
+Set `everr.deploy.id` to the same GitHub deployment id string used by `cicd.pipeline.run.id`. This deliberate duplicate gives future `everr/action` task-run or phase events a stable Everr-owned deploy join key without depending on OTel CI/CD semantic convention evolution. Keep `everr.github.deployment.id` as the source-specific raw GitHub id as well.
 
 Use `everr.github.repository.full_name` for GitHub's `owner/repo` value because OTel `vcs.repository.name` is only the repository name.
 
@@ -270,6 +279,7 @@ GitHub native deployment events do not provide phase detail like `migrate`, `can
 
 - CDEvents documentation: https://cdevents.dev/docs/
 - CDEvents primer and observability use case: https://cdevents.dev/docs/primer/
+- CloudEvents `source + id` uniqueness rule inherited by CDEvents context ids: https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#id
 - GitHub Actions environment deployment tracking: https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments
 - GitHub deployment webhooks: https://docs.github.com/en/webhooks/webhook-events-and-payloads
 - GitHub deployment statuses API states: https://docs.github.com/en/rest/deployments/statuses

--- a/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-design.md
+++ b/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-design.md
@@ -49,14 +49,12 @@ The log body is JSON with a CDEvents-style shape:
   "subject": {
     "id": "github-deployment-123456",
     "source": "github.com/acme/api",
-    "type": "service",
     "content": {
       "environment": {
         "id": "production",
         "name": "production"
       },
-      "artifactId": "pkg:github/acme/api@abc123",
-      "uri": "https://github.com/acme/api/deployments/123456"
+      "artifactId": "pkg:github/acme/api@abc123"
     }
   }
 }
@@ -98,13 +96,20 @@ The CDEvents JSON body is useful for portability, but common filters should not 
 
 - `cdevents.type`
 - `cdevents.id`
+- `cicd.pipeline.name`
+- `cicd.pipeline.result`
+- `cicd.pipeline.run.id`
+- `cicd.pipeline.run.state`
 - `deployment.environment.name`
 - `vcs.repository.name`
+- `vcs.repository.url.full`
 - `vcs.ref.head.revision`
 - `everr.deploy.id`
 - `everr.deploy.service.name`
 - `everr.deploy.status`
 - `everr.deploy.url`
+- `everr.github.repository.full_name`
+- `everr.github.repository.owner.login`
 - `everr.github.deployment_status.id`
 - `everr.github.deployment.creator.login`
 - `everr.github.workflow_run.id`
@@ -116,6 +121,15 @@ Keep custom attributes under `everr.*`. Use standard OTel attributes only when t
 
 Use `ServiceName = 'github-deployments'` for the OTel resource service name and ClickHouse column. Use `everr.deploy.service.name` for the service being deployed.
 
+Map OTel CI/CD attributes when they fit the GitHub deployment lifecycle:
+
+- `cicd.pipeline.run.id`: GitHub deployment id.
+- `cicd.pipeline.name`: GitHub deployment task, defaulting to `deploy`.
+- `cicd.pipeline.run.state`: `pending` for deployment creation, `executing` for `in_progress`.
+- `cicd.pipeline.result`: `success`, `failure`, or `error` on finished deployment status events.
+
+Use `everr.github.repository.full_name` for GitHub's `owner/repo` value because OTel `vcs.repository.name` is only the repository name.
+
 Use empty strings for missing optional fields instead of nullable values.
 
 ## Resource Attributes
@@ -125,9 +139,12 @@ Every deploy log record must be emitted under an OTel resource. These attributes
 - `everr.tenant.id`: the tenant id resolved from the GitHub App installation. This is required because `app.logs_mv` copies `ResourceAttributes['everr.tenant.id']` into `app.logs.tenant_id`.
 - `service.name`: `github-deployments`. The ClickHouse exporter copies this into the `ServiceName` column, which deploy queries use for the primary filter.
 - `deployment.environment.name`: GitHub deployment environment name.
-- `vcs.provider.name`: `github`.
-- `vcs.owner.name`: repository owner or organization login.
-- `vcs.repository.name`: full repository name, such as `acme/api`.
+- `vcs.repository.name`: repository name only, such as `api`.
+- `vcs.repository.url.full`: canonical repository URL, such as `https://github.com/acme/api`.
+- `everr.github.repository.full_name`: GitHub full repository name, such as `acme/api`.
+- `everr.github.repository.owner.login`: repository owner or organization login.
+
+Do not use `vcs.owner.name` or `vcs.provider.name`; they are not in the OTel VCS semantic conventions. Keep those GitHub-specific fields under `everr.github.*`.
 
 Set the `ResourceLogs.SchemaUrl` to the OTel semantic convention schema URL used by the receiver, for example `https://opentelemetry.io/schemas/1.38.0` while the receiver uses semconv v1.38.0.
 
@@ -178,7 +195,7 @@ SELECT
   LogAttributes['deployment.environment.name'] AS environment,
   LogAttributes['everr.deploy.status'] AS status,
   LogAttributes['everr.deploy.service.name'] AS service,
-  LogAttributes['vcs.repository.name'] AS repository,
+  LogAttributes['everr.github.repository.full_name'] AS repository,
   LogAttributes['vcs.ref.head.revision'] AS sha,
   Body
 FROM app.logs

--- a/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-design.md
+++ b/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-design.md
@@ -102,6 +102,21 @@ Use `ServiceName = 'github-deployments'` for the OTel resource service name and 
 
 Use empty strings for missing optional fields instead of nullable values.
 
+## Resource Attributes
+
+Every deploy log record must be emitted under an OTel resource. These attributes are required on `ResourceAttributes`, not just on individual log records:
+
+- `everr.tenant.id`: the tenant id resolved from the GitHub App installation. This is required because `app.logs_mv` copies `ResourceAttributes['everr.tenant.id']` into `app.logs.tenant_id`.
+- `service.name`: `github-deployments`. The ClickHouse exporter copies this into the `ServiceName` column, which deploy queries use for the primary filter.
+- `deployment.environment.name`: GitHub deployment environment name.
+- `vcs.provider.name`: `github`.
+- `vcs.owner.name`: repository owner or organization login.
+- `vcs.repository.name`: full repository name, such as `acme/api`.
+
+Set the `ResourceLogs.SchemaUrl` to the OTel semantic convention schema URL used by the receiver, for example `https://opentelemetry.io/schemas/1.38.0` while the receiver uses semconv v1.38.0.
+
+If one GitHub webhook emits multiple log records, such as `deployment_status: success`, put those records under the same resource so they share the tenant, storage service, environment, and repository identity.
+
 ## Data Flow
 
 1. GitHub sends `deployment` or `deployment_status` to Everr's existing `/webhook/github` route.
@@ -109,7 +124,7 @@ Use empty strings for missing optional fields instead of nullable values.
 3. The allowlist expands to accept `deployment` and `deployment_status`.
 4. The existing event queue stores the raw payload once and sends it to the worker path.
 5. The tenant resolver uses `installation.id`, the same as workflow events.
-6. The app forwards the raw webhook payload to the collector through the existing `gh-collector` path.
+6. The app forwards the raw webhook payload and resolved tenant id to the collector through the existing `gh-collector` path.
 7. The collector's GitHub Actions receiver accepts `deployment` and `deployment_status` events in addition to workflow events.
 8. A new deploy event mapper in the collector parses the GitHub payload and builds OTel log records.
 9. The collector exports the logs into ClickHouse.
@@ -143,7 +158,7 @@ LIMIT 100;
 
 The existing `app.logs` table orders by tenant, service, and time. That is a reasonable v1 fit if deploy logs use a stable service name such as `github-deployments`. It keeps deploy queries time-bounded and service-filtered.
 
-Per `schema-pk-filter-on-orderby`, keep deploy queries anchored on the existing `ORDER BY` prefix through the tenant row policy, `ServiceName`, and time. `EventName` is cheaper to read than `LogAttributes['event.name']`, but it is not part of the `ORDER BY`, so it should not replace the service and time filters. Per `query-index-skipping-indices`, do not add a skipping index for `EventName` in v1; consider it later only if real deploy queries are hot and `EXPLAIN indexes = 1` shows useful skipping.
+Per `query-mv-incremental`, remember that `app.logs_mv` transforms inserted `otel.otel_logs` rows as they arrive. That means `everr.tenant.id` must already be present on `ResourceAttributes` before insert time. Per `schema-pk-filter-on-orderby`, keep deploy queries anchored on the existing `ORDER BY` prefix through the tenant row policy, `ServiceName`, and time. `EventName` is cheaper to read than `LogAttributes['event.name']`, but it is not part of the `ORDER BY`, so it should not replace the service and time filters. Per `query-index-skipping-indices`, do not add a skipping index for `EventName` in v1; consider it later only if real deploy queries are hot and `EXPLAIN indexes = 1` shows useful skipping.
 
 Per `schema-pk-plan-before-creation`, avoid creating a custom deploy table until the query patterns are better proven, because ClickHouse `ORDER BY` is hard to change later. Per `schema-pk-prioritize-filters`, if a custom table is added later, its key should be driven by the most common filters: tenant, environment, service, repository, and time. Per `schema-types-lowcardinality`, repeated strings like environment, status, service, and event name should be LowCardinality if they become typed columns later. Per `schema-types-avoid-nullable`, optional fields should prefer empty defaults over nullable columns.
 
@@ -185,12 +200,15 @@ GitHub native deployment events do not provide phase detail like `migrate`, `can
   - maps `deployment_status: inactive` to `everr.deploy.superseded`, not service removed
   - preserves repository, SHA, environment, URL, and sender fields as log attributes
   - sets the OTel `EventName` field instead of writing `event.name` to `LogAttributes`
+  - sets resource attributes for tenant id, storage service name, environment, and repository identity
+  - sets `ResourceLogs.SchemaUrl`
 - Receiver dispatch tests:
   - deploy events use the deploy mapper before the workflow log path
   - deploy events do not require an installation GitHub client
   - deploy events do not call `GetWorkflowRunAttemptLogs`
 - ClickHouse query tests:
   - deploy logs can be selected from `app.logs` using service name, event name, environment, and time filters
+  - deploy logs include `app.logs.tenant_id` through `ResourceAttributes['everr.tenant.id']`
 - End-to-end smoke:
   - send signed GitHub-like deployment payloads to `/webhook/github`
   - verify deploy CDEvents-shaped logs appear in ClickHouse

--- a/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-design.md
+++ b/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-design.md
@@ -98,7 +98,7 @@ For `deployment_status: success`, emit both:
 
 ## Query Attributes
 
-The CDEvents JSON body is useful for portability, but common filters should not require JSON parsing. Duplicate important fields into OTel log attributes:
+The CDEvents JSON body is useful for portability, but common filters should not require JSON parsing. Duplicate event-specific fields into OTel log attributes:
 
 - `cdevents.type`
 - `cdevents.id`
@@ -107,24 +107,22 @@ The CDEvents JSON body is useful for portability, but common filters should not 
 - `cicd.pipeline.result`
 - `cicd.pipeline.run.id`
 - `cicd.pipeline.run.state`
-- `deployment.environment.name`
-- `vcs.repository.name`
-- `vcs.repository.url.full`
 - `vcs.ref.head.revision`
+- `vcs.ref.head.name`
 - `everr.deploy.id`
 - `everr.deploy.service.name`
 - `everr.deploy.status`
 - `everr.deploy.url`
-- `everr.github.repository.full_name`
-- `everr.github.repository.owner.login`
 - `everr.github.deployment_status.id`
 - `everr.github.deployment.creator.login`
 - `everr.github.workflow_run.id`
 - `everr.github.workflow_run.run_attempt`
 
+Repository identity lives on `ResourceAttributes`, because it describes the source resource shared by all records emitted from the same GitHub webhook.
+
 Set the OTel log record event name with `SetEventName(...)`, so ClickHouse stores it in the dedicated `EventName` column. Do not also write `event.name` into `LogAttributes`.
 
-Keep custom attributes under `everr.*`. Use standard OTel attributes only when the attribute already has the same meaning, such as `deployment.environment.name` and `vcs.ref.head.revision`.
+Keep custom attributes under `everr.*`. Use standard OTel attributes only when the attribute already has the same meaning, such as resource-level `deployment.environment.name` and log-level `vcs.ref.head.revision`.
 
 Use `ServiceName = 'github-deployments'` for the OTel resource service name and ClickHouse column. Use `everr.deploy.service.name` for the service being deployed.
 
@@ -153,7 +151,7 @@ Every deploy log record must be emitted under an OTel resource. These attributes
 - `everr.github.repository.full_name`: GitHub full repository name, such as `acme/api`.
 - `everr.github.repository.owner.login`: repository owner or organization login.
 
-Do not use `vcs.owner.name` or `vcs.provider.name`; they are not in the OTel VCS semantic conventions. Keep those GitHub-specific fields under `everr.github.*`.
+Do not use `vcs.owner.name` or `vcs.provider.name` in v1. Store GitHub-specific owner and provider identity under `everr.github.*` so the resource identity stays aligned with the query contract.
 
 Set the `ResourceLogs.SchemaUrl` to the OTel semantic convention schema URL used by the receiver, for example `https://opentelemetry.io/schemas/1.38.0` while the receiver uses semconv v1.38.0.
 
@@ -161,7 +159,7 @@ If one GitHub webhook emits multiple log records, such as `deployment_status: su
 
 ## Trace Linkage
 
-If a `deployment` or `deployment_status` payload includes GitHub `workflow_run` data, set each emitted deploy log record's OTel `TraceID` to the same deterministic trace id used by workflow telemetry:
+If a parsed deploy webhook includes GitHub `workflow_run` data, set each emitted deploy log record's OTel `TraceID` to the same deterministic trace id used by workflow telemetry:
 
 ```text
 generateTraceID(repository.id, workflow_run.id, workflow_run.run_attempt)
@@ -169,7 +167,7 @@ generateTraceID(repository.id, workflow_run.id, workflow_run.run_attempt)
 
 This links deploy logs to the CI trace for queries and trace views. It uses the existing receiver trace id shape from workflow logs and spans.
 
-Only set this trace id when `repository.id`, `workflow_run.id`, and `workflow_run.run_attempt` are all present. If the webhook does not include workflow run linkage, leave the deploy log `TraceID` empty in v1. Do not call the GitHub API just to discover missing linkage.
+Only set this trace id when `repository.id`, `workflow_run.id`, and `workflow_run.run_attempt` are all present. In go-github v67.0.0, `DeploymentEvent` exposes `WorkflowRun`, but `DeploymentStatusEvent` does not. If the parsed event does not expose workflow run linkage, leave the deploy log `TraceID` empty in v1. Do not call the GitHub API just to discover missing linkage.
 
 Also copy the linkage into log attributes:
 
@@ -201,10 +199,10 @@ Deploy history queries read from `app.logs`:
 SELECT
   TimestampTime,
   EventName AS event_name,
-  LogAttributes['deployment.environment.name'] AS environment,
+  ResourceAttributes['deployment.environment.name'] AS environment,
   LogAttributes['everr.deploy.status'] AS status,
   LogAttributes['everr.deploy.service.name'] AS service,
-  LogAttributes['everr.github.repository.full_name'] AS repository,
+  ResourceAttributes['everr.github.repository.full_name'] AS repository,
   LogAttributes['vcs.ref.head.revision'] AS sha,
   Body
 FROM app.logs
@@ -212,10 +210,11 @@ WHERE ServiceName = 'github-deployments'
   AND TimestampTime >= now() - INTERVAL 7 DAY
   AND (startsWith(EventName, 'dev.cdevents.') OR EventName = 'everr.deploy.superseded')
 ORDER BY TimestampTime DESC
+LIMIT 1 BY if(LogAttributes['cdevents.id'] = '', LogAttributes['everr.github.delivery.id'], LogAttributes['cdevents.id'])
 LIMIT 100;
 ```
 
-The existing `app.logs` table orders by tenant, service, and time. That is a reasonable v1 fit if deploy logs use a stable service name such as `github-deployments`. It keeps deploy queries time-bounded and service-filtered.
+The existing `app.logs` table orders by tenant, service, and time. That is a reasonable v1 fit if deploy logs use a stable service name such as `github-deployments`. It keeps deploy queries time-bounded and service-filtered. ClickHouse remains append-only for v1; if a retry produces duplicate rows, query surfaces deduplicate with `LIMIT 1 BY` on `cdevents.id`, falling back to `everr.github.delivery.id` for custom non-CDEvents rows.
 
 Per `query-mv-incremental`, remember that `app.logs_mv` transforms inserted `otel.otel_logs` rows as they arrive. That means `everr.tenant.id` must already be present on `ResourceAttributes` before insert time. Per `schema-pk-filter-on-orderby`, keep deploy queries anchored on the existing `ORDER BY` prefix through the tenant row policy, `ServiceName`, and time. `EventName` is cheaper to read than `LogAttributes['event.name']`, but it is not part of the `ORDER BY`, so it should not replace the service and time filters. Per `query-index-skipping-indices`, do not add a skipping index for `EventName` in v1; consider it later only if real deploy queries are hot and `EXPLAIN indexes = 1` shows useful skipping.
 

--- a/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-design.md
+++ b/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-design.md
@@ -28,6 +28,7 @@ For v1, deployment events should be stored as OpenTelemetry logs with a CDEvents
 - Do not add `everr/action` deploy marker inputs in this slice.
 - Do not build deploy UI in this slice.
 - Do not try to infer deploys from workflow names.
+- Do not capture GitHub Actions environment usage that does not create a GitHub Deployment object, such as jobs configured with `environment.deployment: false`.
 - Do not generate Drizzle migrations as part of the design step.
 
 ## Event Model
@@ -42,7 +43,7 @@ The log body is JSON with a CDEvents-style shape:
     "version": "0.5.0",
     "id": "github-delivery-id",
     "source": "github.com/acme/api",
-    "type": "dev.cdevents.service.deployed.0.2.0",
+    "type": "dev.cdevents.service.deployed.0.3.0",
     "timestamp": "2026-05-17T10:30:00.000Z"
   },
   "subject": {
@@ -61,17 +62,30 @@ The log body is JSON with a CDEvents-style shape:
 }
 ```
 
+## CDEvents Version Pin
+
+V1 pins the body to CDEvents spec `0.5.0` and this event type subset:
+
+- `dev.cdevents.pipelinerun.queued.0.3.0`
+- `dev.cdevents.pipelinerun.started.0.3.0`
+- `dev.cdevents.pipelinerun.finished.0.3.0`
+- `dev.cdevents.service.deployed.0.3.0`
+
+For CDEvents records, the `context.version` field must be `0.5.0`, and the `context.type` field must use one of the exact event types above. Do not silently move to a newer CDEvents spec or event type version later; that is an ingestion format change and needs an explicit migration or dual-read plan.
+
+`everr.deploy.superseded` is an Everr custom OTel log event, not part of the pinned CDEvents subset. Set its OTel `EventName` to `everr.deploy.superseded` and leave `cdevents.type` empty.
+
 The exact CDEvents event type depends on the GitHub event:
 
 | GitHub event | GitHub state | CDEvents-style log event |
 | --- | --- | --- |
-| `deployment` | created/requested | `dev.cdevents.pipelinerun.queued.*` |
-| `deployment_status` | `in_progress` | `dev.cdevents.pipelinerun.started.*` |
-| `deployment_status` | `success` | `dev.cdevents.pipelinerun.finished.*` and `dev.cdevents.service.deployed.*` |
-| `deployment_status` | `failure` or `error` | `dev.cdevents.pipelinerun.finished.*` |
+| `deployment` | created/requested | `dev.cdevents.pipelinerun.queued.0.3.0` |
+| `deployment_status` | `in_progress` | `dev.cdevents.pipelinerun.started.0.3.0` |
+| `deployment_status` | `success` | `dev.cdevents.pipelinerun.finished.0.3.0` and `dev.cdevents.service.deployed.0.3.0` |
+| `deployment_status` | `failure` or `error` | `dev.cdevents.pipelinerun.finished.0.3.0` |
 | `deployment_status` | `inactive` | `everr.deploy.superseded` custom OTel log event |
 
-Do not map GitHub `inactive` to `dev.cdevents.service.removed.*`. In GitHub, `inactive` usually means an older deployment was superseded by a newer one, not that the service stopped running.
+Do not map GitHub `inactive` to a CDEvents `service.removed` event. In GitHub, `inactive` usually means an older deployment was superseded by a newer one, not that the service stopped running.
 
 For `deployment_status: success`, emit both:
 
@@ -93,6 +107,8 @@ The CDEvents JSON body is useful for portability, but common filters should not 
 - `everr.deploy.url`
 - `everr.github.deployment_status.id`
 - `everr.github.deployment.creator.login`
+- `everr.github.workflow_run.id`
+- `everr.github.workflow_run.run_attempt`
 
 Set the OTel log record event name with `SetEventName(...)`, so ClickHouse stores it in the dedicated `EventName` column. Do not also write `event.name` into `LogAttributes`.
 
@@ -116,6 +132,23 @@ Every deploy log record must be emitted under an OTel resource. These attributes
 Set the `ResourceLogs.SchemaUrl` to the OTel semantic convention schema URL used by the receiver, for example `https://opentelemetry.io/schemas/1.38.0` while the receiver uses semconv v1.38.0.
 
 If one GitHub webhook emits multiple log records, such as `deployment_status: success`, put those records under the same resource so they share the tenant, storage service, environment, and repository identity.
+
+## Trace Linkage
+
+If a `deployment` or `deployment_status` payload includes GitHub `workflow_run` data, set each emitted deploy log record's OTel `TraceID` to the same deterministic trace id used by workflow telemetry:
+
+```text
+generateTraceID(repository.id, workflow_run.id, workflow_run.run_attempt)
+```
+
+This links deploy logs to the CI trace for queries and trace views. It uses the existing receiver trace id shape from workflow logs and spans.
+
+Only set this trace id when `repository.id`, `workflow_run.id`, and `workflow_run.run_attempt` are all present. If the webhook does not include workflow run linkage, leave the deploy log `TraceID` empty in v1. Do not call the GitHub API just to discover missing linkage.
+
+Also copy the linkage into log attributes:
+
+- `everr.github.workflow_run.id`
+- `everr.github.workflow_run.run_attempt`
 
 ## Data Flow
 
@@ -176,8 +209,8 @@ Do not add `tenant_id = toUInt64(getSetting('SQL_everr_tenant_id'))` to queries.
 
 CDEvents does not model deploy phases as one `phase` field on `service.deployed`. Richer phases should be modeled as task runs:
 
-- `dev.cdevents.taskrun.started.*`
-- `dev.cdevents.taskrun.finished.*`
+- `dev.cdevents.taskrun.started.0.3.0`
+- `dev.cdevents.taskrun.finished.0.3.0`
 
 GitHub native deployment events do not provide phase detail like `migrate`, `canary`, `rollout`, or `verify`. That should be a later `everr/action` feature. When added, Everr can emit task-run CDEvents and include a query-friendly attribute such as `everr.deploy.phase`.
 
@@ -198,10 +231,13 @@ GitHub native deployment events do not provide phase detail like `migrate`, `can
   - maps `deployment_status: success` to pipeline finished plus service deployed
   - maps `deployment_status: failure` and `error` to pipeline finished with failure
   - maps `deployment_status: inactive` to `everr.deploy.superseded`, not service removed
+  - uses `context.version = "0.5.0"` and only the pinned CDEvents `0.3.0` event types
   - preserves repository, SHA, environment, URL, and sender fields as log attributes
   - sets the OTel `EventName` field instead of writing `event.name` to `LogAttributes`
   - sets resource attributes for tenant id, storage service name, environment, and repository identity
   - sets `ResourceLogs.SchemaUrl`
+  - sets the same `TraceID` as workflow telemetry when `workflow_run` linkage is present
+  - leaves `TraceID` empty when workflow linkage is absent
 - Receiver dispatch tests:
   - deploy events use the deploy mapper before the workflow log path
   - deploy events do not require an installation GitHub client
@@ -217,5 +253,6 @@ GitHub native deployment events do not provide phase detail like `migrate`, `can
 
 - CDEvents documentation: https://cdevents.dev/docs/
 - CDEvents primer and observability use case: https://cdevents.dev/docs/primer/
+- GitHub Actions environment deployment tracking: https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments
 - GitHub deployment webhooks: https://docs.github.com/en/webhooks/webhook-events-and-payloads
 - GitHub deployment statuses API states: https://docs.github.com/en/rest/deployments/statuses

--- a/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-summary.md
+++ b/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-summary.md
@@ -50,13 +50,20 @@ Each log should include these attributes so SQL queries do not need to parse JSO
 
 - `cdevents.type`
 - `cdevents.id`
+- `cicd.pipeline.name`
+- `cicd.pipeline.result`
+- `cicd.pipeline.run.id`
+- `cicd.pipeline.run.state`
 - `deployment.environment.name`
 - `vcs.repository.name`
+- `vcs.repository.url.full`
 - `vcs.ref.head.revision`
 - `everr.deploy.id`
 - `everr.deploy.service.name`
 - `everr.deploy.status`
 - `everr.deploy.url`
+- `everr.github.repository.full_name`
+- `everr.github.repository.owner.login`
 - `everr.github.deployment_status.id`
 - `everr.github.deployment.creator.login`
 - `everr.github.workflow_run.id`
@@ -68,6 +75,10 @@ Keep custom deploy fields under `everr.*`. Use standard OTel fields only when th
 
 Use `ServiceName = 'github-deployments'` for storage and `everr.deploy.service.name` for the service being deployed.
 
+Use `cicd.pipeline.run.id` for the GitHub deployment id, `cicd.pipeline.name` for the deployment task, `cicd.pipeline.run.state` for pending/executing, and `cicd.pipeline.result` for success/failure/error.
+
+Use `everr.github.repository.full_name` for GitHub's `owner/repo` value because OTel `vcs.repository.name` is only the repository name.
+
 Use empty strings for optional missing values.
 
 ## Resource Attributes
@@ -77,9 +88,10 @@ Each deploy log must also set resource-level data:
 - `everr.tenant.id`: resolved tenant id from the GitHub App installation
 - `service.name`: `github-deployments`
 - `deployment.environment.name`
-- `vcs.provider.name`: `github`
-- `vcs.owner.name`
-- `vcs.repository.name`
+- `vcs.repository.name`: repository name only
+- `vcs.repository.url.full`
+- `everr.github.repository.full_name`
+- `everr.github.repository.owner.login`
 
 Set `ResourceLogs.SchemaUrl` to the OTel semantic convention schema URL used by the receiver. This matters because `app.logs_mv` reads the tenant from `ResourceAttributes['everr.tenant.id']`.
 
@@ -121,3 +133,16 @@ When we add Everr-specific deploy markers, phases should be represented as CDEve
 - `dev.cdevents.taskrun.finished.0.3.0`
 
 Those logs can also include `everr.deploy.phase` for easy filtering.
+
+## Standards Links
+
+The summary follows these standards contracts:
+
+- OTel logs data model for `Body`, `Resource`, `Attributes`, `TraceId`, and `EventName`: https://opentelemetry.io/docs/specs/otel/logs/data-model/
+- OTel custom attribute naming, which is why Everr-specific fields stay under `everr.*`: https://opentelemetry.io/docs/specs/semconv/general/naming/
+- OTel resource/service conventions for `service.name`: https://opentelemetry.io/docs/specs/semconv/resource/
+- OTel deployment attributes for `deployment.environment.name`: https://opentelemetry.io/docs/specs/semconv/registry/attributes/deployment/
+- OTel CI/CD attributes for `cicd.pipeline.*`: https://opentelemetry.io/docs/specs/semconv/registry/attributes/cicd/
+- OTel VCS attributes for `vcs.repository.name`, `vcs.repository.url.full`, and `vcs.ref.head.revision`: https://opentelemetry.io/docs/specs/semconv/registry/entities/vcs/
+- CDEvents v0.5.0 docs and event versioning model: https://cdevents.dev/docs/ and https://cdevents.dev/docs/primer/#versioning-of-cdevents
+- CDEvents Go SDK v0.5 schema surface used to pin event types to `0.3.0`: https://pkg.go.dev/github.com/cdevents/sdk-go/pkg/api/v05

--- a/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-summary.md
+++ b/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-summary.md
@@ -48,7 +48,7 @@ For CDEvents records, `cdevents.id` equals the CDEvents body `context.id`. Use G
 
 ## Query Attributes
 
-CDEvents log records should include these attributes so SQL queries do not need to parse JSON:
+CDEvents log records should include these event-specific attributes so SQL queries do not need to parse JSON:
 
 - `cdevents.type`
 - `cdevents.id`
@@ -57,26 +57,24 @@ CDEvents log records should include these attributes so SQL queries do not need 
 - `cicd.pipeline.result`
 - `cicd.pipeline.run.id`
 - `cicd.pipeline.run.state`
-- `deployment.environment.name`
-- `vcs.repository.name`
-- `vcs.repository.url.full`
 - `vcs.ref.head.revision`
+- `vcs.ref.head.name`
 - `everr.deploy.id`
 - `everr.deploy.service.name`
 - `everr.deploy.status`
 - `everr.deploy.url`
-- `everr.github.repository.full_name`
-- `everr.github.repository.owner.login`
 - `everr.github.deployment_status.id`
 - `everr.github.deployment.creator.login`
 - `everr.github.workflow_run.id`
 - `everr.github.workflow_run.run_attempt`
 
+Repository identity is resource-level data, so queries should read it from `ResourceAttributes`.
+
 Set the OTel log record event name with `SetEventName(...)`. ClickHouse stores it in the dedicated `EventName` column, so do not duplicate it as `event.name` inside `LogAttributes`.
 
 Keep custom deploy fields under `everr.*`. Use standard OTel fields only when they already mean the same thing.
 
-Use `ServiceName = 'github-deployments'` for storage and `everr.deploy.service.name` for the service being deployed.
+Use `ServiceName = 'github-deployments'` for storage and `everr.deploy.service.name` for the service being deployed. Query environment from `ResourceAttributes['deployment.environment.name']`, not from log attributes.
 
 Use `cicd.pipeline.run.id` for the GitHub deployment id, `cicd.pipeline.name` for the deployment task, `cicd.pipeline.run.state` for pending/executing, and `cicd.pipeline.result` for success/failure/error.
 
@@ -102,9 +100,9 @@ Set `ResourceLogs.SchemaUrl` to the OTel semantic convention schema URL used by 
 
 ## Trace Linkage
 
-When the GitHub payload includes `workflow_run`, set the deploy log `TraceID` with the existing workflow formula: `generateTraceID(repository.id, workflow_run.id, workflow_run.run_attempt)`.
+When the parsed GitHub payload includes `workflow_run`, set the deploy log `TraceID` with the existing workflow formula: `generateTraceID(repository.id, workflow_run.id, workflow_run.run_attempt)`.
 
-If the payload does not include workflow run linkage, leave `TraceID` empty in v1. Do not call the GitHub API just to fill it in.
+In go-github v67.0.0, `DeploymentEvent` exposes `WorkflowRun`, but `DeploymentStatusEvent` does not. If the parsed event does not expose workflow run linkage, leave `TraceID` empty in v1. Do not call the GitHub API just to fill it in.
 
 ## Data Flow
 

--- a/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-summary.md
+++ b/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-summary.md
@@ -32,15 +32,17 @@ V1 tracks deploy history in ClickHouse only. It does not add a Postgres deploy t
 
 | GitHub event | GitHub state | OTel log event |
 | --- | --- | --- |
-| `deployment` | created/requested | `dev.cdevents.pipelinerun.queued.*` |
-| `deployment_status` | `in_progress` | `dev.cdevents.pipelinerun.started.*` |
-| `deployment_status` | `success` | `dev.cdevents.pipelinerun.finished.*` plus `dev.cdevents.service.deployed.*` |
-| `deployment_status` | `failure` or `error` | `dev.cdevents.pipelinerun.finished.*` |
+| `deployment` | created/requested | `dev.cdevents.pipelinerun.queued.0.3.0` |
+| `deployment_status` | `in_progress` | `dev.cdevents.pipelinerun.started.0.3.0` |
+| `deployment_status` | `success` | `dev.cdevents.pipelinerun.finished.0.3.0` plus `dev.cdevents.service.deployed.0.3.0` |
+| `deployment_status` | `failure` or `error` | `dev.cdevents.pipelinerun.finished.0.3.0` |
 | `deployment_status` | `inactive` | `everr.deploy.superseded` custom OTel log event |
 
 On successful deploys, emit both a pipeline finished event and a service deployed event. The first says the deploy process completed; the second says the service is now deployed.
 
 Do not map GitHub `inactive` to `service.removed`. GitHub usually marks an old deployment inactive when a newer one supersedes it, while the service can still be running.
+
+Pin CDEvents output to `context.version = "0.5.0"` and the exact `0.3.0` event types above. Changing the CDEvents spec or event type versions later is an ingestion format change. `everr.deploy.superseded` is a custom OTel log event outside that CDEvents subset.
 
 ## Query Attributes
 
@@ -57,6 +59,8 @@ Each log should include these attributes so SQL queries do not need to parse JSO
 - `everr.deploy.url`
 - `everr.github.deployment_status.id`
 - `everr.github.deployment.creator.login`
+- `everr.github.workflow_run.id`
+- `everr.github.workflow_run.run_attempt`
 
 Set the OTel log record event name with `SetEventName(...)`. ClickHouse stores it in the dedicated `EventName` column, so do not duplicate it as `event.name` inside `LogAttributes`.
 
@@ -79,6 +83,12 @@ Each deploy log must also set resource-level data:
 
 Set `ResourceLogs.SchemaUrl` to the OTel semantic convention schema URL used by the receiver. This matters because `app.logs_mv` reads the tenant from `ResourceAttributes['everr.tenant.id']`.
 
+## Trace Linkage
+
+When the GitHub payload includes `workflow_run`, set the deploy log `TraceID` with the existing workflow formula: `generateTraceID(repository.id, workflow_run.id, workflow_run.run_attempt)`.
+
+If the payload does not include workflow run linkage, leave `TraceID` empty in v1. Do not call the GitHub API just to fill it in.
+
 ## Data Flow
 
 1. GitHub sends `deployment` or `deployment_status` to `/webhook/github`.
@@ -98,6 +108,7 @@ Implementation detail: deploy mapping must be a separate collector path from wor
 - No deploy UI in this slice.
 - No `everr/action` deploy marker inputs in this slice.
 - No deploy inference from workflow names.
+- No capture for GitHub Actions environment usage that does not create a GitHub Deployment object, such as `environment.deployment: false`.
 - No detailed phase tracking from GitHub alone.
 
 ## Later Extension
@@ -106,7 +117,7 @@ GitHub native deploy events do not include detailed phases like `migrate`, `cana
 
 When we add Everr-specific deploy markers, phases should be represented as CDEvents task-run logs:
 
-- `dev.cdevents.taskrun.started.*`
-- `dev.cdevents.taskrun.finished.*`
+- `dev.cdevents.taskrun.started.0.3.0`
+- `dev.cdevents.taskrun.finished.0.3.0`
 
 Those logs can also include `everr.deploy.phase` for easy filtering.

--- a/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-summary.md
+++ b/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-summary.md
@@ -1,0 +1,91 @@
+# GitHub Deploy CDEvents Ingest Summary
+
+## Purpose
+
+Add first-class deploy event ingestion for users who already use GitHub Deployments or GitHub Actions environments.
+
+V1 tracks deploy history in ClickHouse only. It does not add a Postgres deploy table.
+
+## Core Design Choices
+
+1. **Use GitHub native deploy webhooks**
+
+   Accept `deployment` and `deployment_status` events in the existing GitHub webhook route.
+
+2. **Store deploys as OTel logs**
+
+   Convert each deploy webhook into one or more OpenTelemetry log records. The log body is a CDEvents-shaped JSON event. Common query fields are duplicated into log attributes.
+
+3. **Use existing ClickHouse logs storage**
+
+   Deploy events land in the existing `app.logs` path. V1 does not create a custom `deploy_events` table.
+
+4. **Keep Postgres workflow state unchanged**
+
+   The existing `gh-status` path remains workflow-only. Deploy webhooks do not write Postgres rows in v1.
+
+5. **Keep the model standards-shaped**
+
+   CDEvents gives us a deploy event shape that is not tied only to GitHub. Later, `everr/action` can emit the same event shape for richer deploy phases.
+
+## Event Mapping
+
+| GitHub event | GitHub state | OTel log event |
+| --- | --- | --- |
+| `deployment` | created/requested | `dev.cdevents.pipelinerun.queued.*` |
+| `deployment_status` | `in_progress` | `dev.cdevents.pipelinerun.started.*` |
+| `deployment_status` | `success` | `dev.cdevents.pipelinerun.finished.*` plus `dev.cdevents.service.deployed.*` |
+| `deployment_status` | `failure` or `error` | `dev.cdevents.pipelinerun.finished.*` |
+| `deployment_status` | `inactive` | `dev.cdevents.service.removed.*` |
+
+On successful deploys, emit both a pipeline finished event and a service deployed event. The first says the deploy process completed; the second says the service is now deployed.
+
+## Query Attributes
+
+Each log should include these attributes so SQL queries do not need to parse JSON:
+
+- `event.name`
+- `cdevents.type`
+- `cdevents.id`
+- `deployment.id`
+- `deployment.environment.name`
+- `deployment.status`
+- `service.name`
+- `vcs.repository.name`
+- `vcs.ref.head.revision`
+- `url.full`
+- `everr.github.deployment_status.id`
+- `everr.github.deployment_status.environment_url`
+- `everr.github.deployment.creator.login`
+
+Use empty strings for optional missing values.
+
+## Data Flow
+
+1. GitHub sends `deployment` or `deployment_status` to `/webhook/github`.
+2. The app verifies the webhook signature.
+3. The app resolves the tenant from `installation.id`.
+4. The raw webhook is queued and forwarded through the existing collector path.
+5. The collector accepts deploy webhooks and maps them into OTel logs.
+6. The collector exports those logs to ClickHouse.
+7. Deploy history is queried from `app.logs`.
+
+## Non-Goals
+
+- No Postgres deploy table in v1.
+- No custom ClickHouse deploy table in v1.
+- No deploy UI in this slice.
+- No `everr/action` deploy marker inputs in this slice.
+- No deploy inference from workflow names.
+- No detailed phase tracking from GitHub alone.
+
+## Later Extension
+
+GitHub native deploy events do not include detailed phases like `migrate`, `canary`, `rollout`, or `verify`.
+
+When we add Everr-specific deploy markers, phases should be represented as CDEvents task-run logs:
+
+- `dev.cdevents.taskrun.started.*`
+- `dev.cdevents.taskrun.finished.*`
+
+Those logs can also include `everr.deploy.phase` for easy filtering.

--- a/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-summary.md
+++ b/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-summary.md
@@ -42,14 +42,17 @@ On successful deploys, emit both a pipeline finished event and a service deploye
 
 Do not map GitHub `inactive` to `service.removed`. GitHub usually marks an old deployment inactive when a newer one supersedes it, while the service can still be running.
 
-Pin CDEvents output to `context.version = "0.5.0"` and the exact `0.3.0` event types above. Changing the CDEvents spec or event type versions later is an ingestion format change. `everr.deploy.superseded` is a custom OTel log event outside that CDEvents subset.
+Pin CDEvents output to `context.version = "0.5.0"` and the exact `0.3.0` event types above. Changing the CDEvents spec or event type versions later is an ingestion format change. `everr.deploy.superseded` is a custom OTel log event outside that CDEvents subset, so it leaves `cdevents.*` attributes empty.
+
+For CDEvents records, `cdevents.id` equals the CDEvents body `context.id`. Use GitHub's `x-github-delivery` header as the base id. If one webhook emits two CDEvents records, as `deployment_status: success` does, the second record must get a distinct id: `<x-github-delivery>-service-deployed`. Keep the raw delivery id in `everr.github.delivery.id` on every deploy row.
 
 ## Query Attributes
 
-Each log should include these attributes so SQL queries do not need to parse JSON:
+CDEvents log records should include these attributes so SQL queries do not need to parse JSON:
 
 - `cdevents.type`
 - `cdevents.id`
+- `everr.github.delivery.id`
 - `cicd.pipeline.name`
 - `cicd.pipeline.result`
 - `cicd.pipeline.run.id`
@@ -76,6 +79,8 @@ Keep custom deploy fields under `everr.*`. Use standard OTel fields only when th
 Use `ServiceName = 'github-deployments'` for storage and `everr.deploy.service.name` for the service being deployed.
 
 Use `cicd.pipeline.run.id` for the GitHub deployment id, `cicd.pipeline.name` for the deployment task, `cicd.pipeline.run.state` for pending/executing, and `cicd.pipeline.result` for success/failure/error.
+
+Set `everr.deploy.id` to the same GitHub deployment id string used by `cicd.pipeline.run.id`. It duplicates the id under the `everr.*` namespace so future `everr/action` task-run or phase events have a stable Everr-owned deploy join key without depending on OTel CI/CD semantic convention evolution.
 
 Use `everr.github.repository.full_name` for GitHub's `owner/repo` value because OTel `vcs.repository.name` is only the repository name.
 
@@ -145,4 +150,5 @@ The summary follows these standards contracts:
 - OTel CI/CD attributes for `cicd.pipeline.*`: https://opentelemetry.io/docs/specs/semconv/registry/attributes/cicd/
 - OTel VCS attributes for `vcs.repository.name`, `vcs.repository.url.full`, and `vcs.ref.head.revision`: https://opentelemetry.io/docs/specs/semconv/registry/entities/vcs/
 - CDEvents v0.5.0 docs and event versioning model: https://cdevents.dev/docs/ and https://cdevents.dev/docs/primer/#versioning-of-cdevents
+- CloudEvents `source + id` uniqueness rule inherited by CDEvents context ids: https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#id
 - CDEvents Go SDK v0.5 schema surface used to pin event types to `0.3.0`: https://pkg.go.dev/github.com/cdevents/sdk-go/pkg/api/v05

--- a/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-summary.md
+++ b/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-summary.md
@@ -36,27 +36,33 @@ V1 tracks deploy history in ClickHouse only. It does not add a Postgres deploy t
 | `deployment_status` | `in_progress` | `dev.cdevents.pipelinerun.started.*` |
 | `deployment_status` | `success` | `dev.cdevents.pipelinerun.finished.*` plus `dev.cdevents.service.deployed.*` |
 | `deployment_status` | `failure` or `error` | `dev.cdevents.pipelinerun.finished.*` |
-| `deployment_status` | `inactive` | `dev.cdevents.service.removed.*` |
+| `deployment_status` | `inactive` | `everr.deploy.superseded` custom OTel log event |
 
 On successful deploys, emit both a pipeline finished event and a service deployed event. The first says the deploy process completed; the second says the service is now deployed.
+
+Do not map GitHub `inactive` to `service.removed`. GitHub usually marks an old deployment inactive when a newer one supersedes it, while the service can still be running.
 
 ## Query Attributes
 
 Each log should include these attributes so SQL queries do not need to parse JSON:
 
-- `event.name`
 - `cdevents.type`
 - `cdevents.id`
-- `deployment.id`
 - `deployment.environment.name`
-- `deployment.status`
-- `service.name`
 - `vcs.repository.name`
 - `vcs.ref.head.revision`
-- `url.full`
+- `everr.deploy.id`
+- `everr.deploy.service.name`
+- `everr.deploy.status`
+- `everr.deploy.url`
 - `everr.github.deployment_status.id`
-- `everr.github.deployment_status.environment_url`
 - `everr.github.deployment.creator.login`
+
+Set the OTel log record event name with `SetEventName(...)`. ClickHouse stores it in the dedicated `EventName` column, so do not duplicate it as `event.name` inside `LogAttributes`.
+
+Keep custom deploy fields under `everr.*`. Use standard OTel fields only when they already mean the same thing.
+
+Use `ServiceName = 'github-deployments'` for storage and `everr.deploy.service.name` for the service being deployed.
 
 Use empty strings for optional missing values.
 
@@ -69,6 +75,8 @@ Use empty strings for optional missing values.
 5. The collector accepts deploy webhooks and maps them into OTel logs.
 6. The collector exports those logs to ClickHouse.
 7. Deploy history is queried from `app.logs`.
+
+Implementation detail: deploy mapping must be a separate collector path from workflow log archive ingestion. The existing workflow log mapper expects a `workflow_run` event and fetches a GitHub Actions log archive with an installation client. Deploy events should map directly from webhook payload to logs and should not call the GitHub Actions log API.
 
 ## Non-Goals
 

--- a/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-summary.md
+++ b/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-summary.md
@@ -66,12 +66,25 @@ Use `ServiceName = 'github-deployments'` for storage and `everr.deploy.service.n
 
 Use empty strings for optional missing values.
 
+## Resource Attributes
+
+Each deploy log must also set resource-level data:
+
+- `everr.tenant.id`: resolved tenant id from the GitHub App installation
+- `service.name`: `github-deployments`
+- `deployment.environment.name`
+- `vcs.provider.name`: `github`
+- `vcs.owner.name`
+- `vcs.repository.name`
+
+Set `ResourceLogs.SchemaUrl` to the OTel semantic convention schema URL used by the receiver. This matters because `app.logs_mv` reads the tenant from `ResourceAttributes['everr.tenant.id']`.
+
 ## Data Flow
 
 1. GitHub sends `deployment` or `deployment_status` to `/webhook/github`.
 2. The app verifies the webhook signature.
 3. The app resolves the tenant from `installation.id`.
-4. The raw webhook is queued and forwarded through the existing collector path.
+4. The raw webhook and resolved tenant id are queued and forwarded through the existing collector path.
 5. The collector accepts deploy webhooks and maps them into OTel logs.
 6. The collector exports those logs to ClickHouse.
 7. Deploy history is queried from `app.logs`.

--- a/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-summary.md
+++ b/docs/superpowers/specs/2026-05-17-github-deploy-cdevents-ingest-summary.md
@@ -104,6 +104,26 @@ When the parsed GitHub payload includes `workflow_run`, set the deploy log `Trac
 
 In go-github v67.0.0, `DeploymentEvent` exposes `WorkflowRun`, but `DeploymentStatusEvent` does not. If the parsed event does not expose workflow run linkage, leave `TraceID` empty in v1. Do not call the GitHub API just to fill it in.
 
+## Query Example
+
+```sql
+SELECT
+  TimestampTime,
+  EventName,
+  LogAttributes['everr.deploy.service.name'] AS deployed_service,
+  ResourceAttributes['deployment.environment.name'] AS environment,
+  LogAttributes['cicd.pipeline.result'] AS result,
+  LogAttributes['everr.deploy.url'] AS deploy_url
+FROM app.logs
+WHERE ServiceName = 'github-deployments'
+  AND TimestampTime >= now() - INTERVAL 7 DAY
+ORDER BY TimestampTime DESC
+LIMIT 1 BY if(LogAttributes['cdevents.id'] = '', LogAttributes['everr.github.delivery.id'], LogAttributes['cdevents.id'])
+LIMIT 100;
+```
+
+V1 keeps ClickHouse append-only. Retries can produce duplicate rows; dedupe at query time with `LIMIT 1 BY` on `cdevents.id`, falling back to `everr.github.delivery.id` for custom non-CDEvents rows. The row-level policy handles tenant filtering, so do not add an explicit `tenant_id` predicate.
+
 ## Data Flow
 
 1. GitHub sends `deployment` or `deployment_status` to `/webhook/github`.

--- a/packages/app/src/server/github-events/payloads.ts
+++ b/packages/app/src/server/github-events/payloads.ts
@@ -91,11 +91,58 @@ const workflowJobSchema = z.object({
   repository: repositorySchema,
 });
 
+const deploymentSchema = z.object({
+  action: z.string().optional(),
+  installation: z
+    .object({ id: z.number().int().positive().optional() })
+    .optional(),
+  repository: repositorySchema,
+  deployment: z
+    .object({
+      id: z.number().int(),
+      sha: z.string().nullish(),
+      ref: z.string().nullish(),
+      task: z.string().nullish(),
+      environment: z.string().nullish(),
+      created_at: z.string().nullish(),
+      updated_at: z.string().nullish(),
+      creator: z.object({ login: z.string().optional() }).nullish(),
+    })
+    .optional(),
+  workflow_run: z
+    .object({
+      id: z.number().int(),
+      run_attempt: z.number().int().optional(),
+    })
+    .optional(),
+});
+
+const deploymentStatusSchema = deploymentSchema.extend({
+  deployment_status: z
+    .object({
+      id: z.number().int(),
+      state: z.string(),
+      environment_url: z.string().nullish(),
+      target_url: z.string().nullish(),
+      log_url: z.string().nullish(),
+      description: z.string().nullish(),
+      created_at: z.string().nullish(),
+      updated_at: z.string().nullish(),
+    })
+    .optional(),
+});
+
 export type WorkflowRunPayload = z.infer<typeof workflowRunSchema>;
 export type WorkflowJobPayload = z.infer<typeof workflowJobSchema>;
+export type DeploymentPayload = z.infer<typeof deploymentSchema>;
+export type DeploymentStatusPayload = z.infer<typeof deploymentStatusSchema>;
 export type ParsedQueuedWorkflowEvent =
   | { eventType: "workflow_run"; payload: WorkflowRunPayload }
   | { eventType: "workflow_job"; payload: WorkflowJobPayload };
+export type ParsedQueuedCollectorEvent =
+  | ParsedQueuedWorkflowEvent
+  | { eventType: "deployment"; payload: DeploymentPayload }
+  | { eventType: "deployment_status"; payload: DeploymentStatusPayload };
 
 function parseJson<T>(body: Buffer, schema: z.ZodSchema<T>, label: string): T {
   let parsedBody: unknown;
@@ -136,8 +183,29 @@ export function parseQueuedWorkflowEvent(
   );
 }
 
+export function parseQueuedCollectorEvent(
+  eventType: string,
+  body: Buffer,
+): ParsedQueuedCollectorEvent {
+  if (eventType === "deployment") {
+    return {
+      eventType,
+      payload: parseJson(body, deploymentSchema, "deployment"),
+    };
+  }
+
+  if (eventType === "deployment_status") {
+    return {
+      eventType,
+      payload: parseJson(body, deploymentStatusSchema, "deployment_status"),
+    };
+  }
+
+  return parseQueuedWorkflowEvent(eventType, body);
+}
+
 export function installationIdFromQueuedEvent(
-  event: ParsedQueuedWorkflowEvent,
+  event: ParsedQueuedCollectorEvent,
 ): number {
   const installationId =
     event.payload.installation?.id && event.payload.installation.id > 0

--- a/packages/app/src/server/github-events/runtime.test.ts
+++ b/packages/app/src/server/github-events/runtime.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { sends } = vi.hoisted(() => ({ sends: [] as unknown[][] }));
+
+vi.mock("pg-boss", () => ({
+  PgBoss: class {
+    on = vi.fn();
+    start = vi.fn().mockResolvedValue(undefined);
+    stop = vi.fn().mockResolvedValue(undefined);
+    createQueue = vi.fn().mockResolvedValue(undefined);
+    work = vi.fn();
+    send = vi.fn(async (...args: unknown[]) => {
+      sends.push(args);
+    });
+  },
+}));
+
+vi.mock("@/db/client", () => ({
+  db: {},
+  pool: { query: vi.fn() },
+}));
+
+import { enqueueWebhookEvent } from "./runtime";
+
+describe("enqueueWebhookEvent", () => {
+  beforeEach(() => {
+    sends.length = 0;
+  });
+
+  it("sends workflow events to collector and status queues", async () => {
+    await enqueueWebhookEvent(
+      "delivery-workflow",
+      { headers: {}, body: "e30=" },
+      { statusQueue: true },
+    );
+
+    expect(sends.map((call) => call[0])).toEqual(["gh-collector", "gh-status"]);
+  });
+
+  it("sends deploy events only to the collector queue", async () => {
+    await enqueueWebhookEvent(
+      "delivery-deploy",
+      { headers: {}, body: "e30=" },
+      { statusQueue: false },
+    );
+
+    expect(sends.map((call) => call[0])).toEqual(["gh-collector"]);
+  });
+});

--- a/packages/app/src/server/github-events/runtime.ts
+++ b/packages/app/src/server/github-events/runtime.ts
@@ -5,6 +5,7 @@ import { GH_EVENTS_CONFIG } from "./config";
 import { firstHeader } from "./headers";
 import {
   installationIdFromQueuedEvent,
+  parseQueuedCollectorEvent,
   parseQueuedWorkflowEvent,
 } from "./payloads";
 import { handleStatusEvent } from "./status-writer";
@@ -31,7 +32,7 @@ function createBoss(): PgBoss {
 async function processCollectorJob(job: Job<WebhookJobData>): Promise<void> {
   const eventType = firstHeader(job.data.headers, "x-github-event") ?? "";
   const body = Buffer.from(job.data.body, "base64");
-  const parsed = parseQueuedWorkflowEvent(eventType, body);
+  const parsed = parseQueuedCollectorEvent(eventType, body);
   const installationId = installationIdFromQueuedEvent(parsed);
   const organizationId = await resolveOrganizationId(installationId);
   await replayWebhookToCollector(
@@ -108,17 +109,26 @@ async function startGitHubEventsRuntime(): Promise<PgBoss> {
   return boss;
 }
 
+type EnqueueWebhookEventOptions = {
+  statusQueue: boolean;
+};
+
 export async function enqueueWebhookEvent(
   eventId: string,
   data: WebhookJobData,
+  options: EnqueueWebhookEventOptions = { statusQueue: true },
 ): Promise<void> {
   let b = getBoss();
   if (!b) {
     b = await startGitHubEventsRuntime();
   }
 
+  const queues = options.statusQueue
+    ? (["gh-collector", "gh-status"] as const)
+    : (["gh-collector"] as const);
+
   await Promise.all(
-    (["gh-collector", "gh-status"] as const).map((queue) =>
+    queues.map((queue) =>
       b.send(queue, data, {
         id: eventId,
         retryLimit: GH_EVENTS_CONFIG.maxAttempts,

--- a/packages/app/src/server/github-events/webhook.test.ts
+++ b/packages/app/src/server/github-events/webhook.test.ts
@@ -112,6 +112,7 @@ describe("handleGitHubWebhookRequest", () => {
         }),
         body: expect.any(String),
       },
+      { statusQueue: true },
     );
   });
 
@@ -263,5 +264,98 @@ describe("handleGitHubWebhookRequest", () => {
 
     expect(response.status).toBe(202);
     expect(webhookMocks.enqueueWebhookEvent).toHaveBeenCalledOnce();
+    expect(webhookMocks.enqueueWebhookEvent).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Object),
+      { statusQueue: true },
+    );
+  });
+
+  it("enqueues deployment events", async () => {
+    const secret = webhookSecret;
+    vi.stubEnv("GITHUB_APP_WEBHOOK_SECRET", secret);
+    const payload = JSON.stringify({
+      action: "created",
+      installation: { id: 123 },
+      repository: { id: 654321, full_name: "everr-labs/everr-deploy" },
+      deployment: {
+        id: 987,
+        sha: "abc123",
+        ref: "main",
+        task: "deploy:app",
+        environment: "production",
+        created_at: "2026-05-17T10:00:00Z",
+        updated_at: "2026-05-17T10:00:00Z",
+      },
+    });
+
+    const response = await handleGitHubWebhookRequest(
+      new Request("http://localhost/webhook/github", {
+        method: "POST",
+        headers: {
+          "x-github-event": "deployment",
+          "x-github-delivery": "delivery-deploy-1",
+          "x-hub-signature-256": sign(payload, secret),
+        },
+        body: payload,
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    expect(webhookMocks.enqueueWebhookEvent).toHaveBeenCalledOnce();
+    expect(webhookMocks.enqueueWebhookEvent).toHaveBeenCalledWith(
+      "delivery-deploy-1",
+      {
+        headers: expect.objectContaining({
+          "x-github-event": ["deployment"],
+        }),
+        body: expect.any(String),
+      },
+      { statusQueue: false },
+    );
+  });
+
+  it("enqueues deployment_status events", async () => {
+    const secret = webhookSecret;
+    vi.stubEnv("GITHUB_APP_WEBHOOK_SECRET", secret);
+    const payload = JSON.stringify({
+      action: "created",
+      installation: { id: 123 },
+      repository: { id: 654321, full_name: "everr-labs/everr-deploy" },
+      deployment: {
+        id: 987,
+        sha: "abc123",
+        ref: "main",
+        task: "deploy:app",
+        environment: "production",
+      },
+      deployment_status: {
+        id: 988,
+        state: "success",
+        environment_url: "https://app.everr.dev",
+        target_url: "https://github.com/everr-labs/everr-deploy/actions/runs/1",
+        created_at: "2026-05-17T10:04:00Z",
+        updated_at: "2026-05-17T10:04:00Z",
+      },
+    });
+
+    const response = await handleGitHubWebhookRequest(
+      new Request("http://localhost/webhook/github", {
+        method: "POST",
+        headers: {
+          "x-github-event": "deployment_status",
+          "x-github-delivery": "delivery-deploy-status-1",
+          "x-hub-signature-256": sign(payload, secret),
+        },
+        body: payload,
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    expect(webhookMocks.enqueueWebhookEvent).toHaveBeenCalledWith(
+      "delivery-deploy-status-1",
+      expect.any(Object),
+      { statusQueue: false },
+    );
   });
 });

--- a/packages/app/src/server/github-events/webhook.ts
+++ b/packages/app/src/server/github-events/webhook.ts
@@ -7,6 +7,15 @@ import { env } from "@/env";
 import { headersToRecord } from "./headers";
 import { enqueueWebhookEvent } from "./runtime";
 
+const collectorEventTypes = new Set([
+  "workflow_run",
+  "workflow_job",
+  "deployment",
+  "deployment_status",
+]);
+
+const workflowStatusEventTypes = new Set(["workflow_run", "workflow_job"]);
+
 const installationEventSchema = z.object({
   action: z.string().optional(),
   installation: z
@@ -98,16 +107,20 @@ export async function handleGitHubWebhookRequest(
     return handleInstallationEvent({ eventType, bodyText });
   }
 
-  if (eventType !== "workflow_run" && eventType !== "workflow_job") {
+  if (!collectorEventTypes.has(eventType)) {
     return new Response(null, { status: 202 });
   }
 
   const body = Buffer.from(bodyText, "utf8");
 
-  await enqueueWebhookEvent(eventId, {
-    headers: headersToRecord(request.headers),
-    body: body.toString("base64"),
-  });
+  await enqueueWebhookEvent(
+    eventId,
+    {
+      headers: headersToRecord(request.headers),
+      body: body.toString("base64"),
+    },
+    { statusQueue: workflowStatusEventTypes.has(eventType) },
+  );
 
   return new Response(null, { status: 202 });
 }


### PR DESCRIPTION
## Summary

- Add the full design for ingesting GitHub `deployment` and `deployment_status` webhooks as CDEvents-shaped OpenTelemetry logs.
- Add a shorter peer-review summary focused on core design choices, event mapping, data flow, non-goals, and standards links.
- Add an implementation plan covering app webhook intake, collector deploy-log mapping, ClickHouse query behavior, and the `../everr-deploy` adoption path using GitHub Deployments plus ECS rollout polling.
- Align the spec and plan on review feedback: CDEvents ids come from `x-github-delivery`, raw delivery ids are stored in `everr.github.delivery.id`, repository identity is resource-level, `everr.deploy.superseded` is not a CDEvents row, `ResourceLogs.SchemaUrl` is required, trace linkage follows the go-github v67 payload shape, query dedupe stays append-only in ClickHouse, and the everr-deploy failure trap skips services already marked successful.
- Tighten the deployment-status plan: only `in_progress` maps to started, queued/pending statuses are skipped, inactive does not set `cicd.pipeline.result`, missing deployment ids become empty string query attributes instead of `0`, and the mapper snippet now writes state/result/url attributes directly.
- Fix changed-service detection reliability by requiring `actions/checkout@v6` with `fetch-depth: 0` before running the `git diff` based service detector.
- Clarify collector routing details: verify the tenant resource processor covers GitHub deploy logs, assert tenant header metadata survives receiver dispatch, add deployment cases to the existing top-level receiver switch before the default `204`, and keep `installationIdFromQueuedEvent(...)` body unchanged while switching collector jobs to `parseQueuedCollectorEvent(...)`.

## Validation

- `git diff --check`
- `python3` config validation that `collector/config.yml` and `collector/config.example.yml` map `metadata.x-everr-tenant-id` into `everr.tenant.id` on the GitHub logs pipeline before `batch`.
- Scanned plan/spec docs for placeholders, non-ASCII drift, old `queued/pending -> started` mapping, inactive pipeline-result mapping, old deployment-id `0` formatting, missing checkout `fetch-depth`, incorrect log-level deploy environment usage, incorrect log-level repository identity usage, old CDEvents hash-id code, and forbidden VCS owner/provider setters.
- Checked local go-github v67 types: `DeploymentEvent` has `WorkflowRun`; `DeploymentStatusEvent` does not.
- Verified the `actions/checkout` README says only one commit is fetched by default and `fetch-depth: 0` fetches all history.
- Pre-commit hook ran for the docs commits; code hooks were skipped because only markdown docs changed.