### PR TITLE
Restore check-run-id input on @everr/action; drop API self-discovery

### DIFF
--- a/.changeset/restore-check-run-id.md
+++ b/.changeset/restore-check-run-id.md
@@ -1,0 +1,9 @@
+---
+"@everr/action": minor
+---
+
+Revert the API-based self-discovery added in 0.1.0 and bring back the
+`check-run-id` input. Workflows that use the action pass
+`${{ job.check_run_id }}` explicitly, the way they did before
+self-discovery. Drops the `github-token` input and removes the
+`actions: read` permission requirement on calling workflows.

--- a/.github/actions/everr-action/action.yml
+++ b/.github/actions/everr-action/action.yml
@@ -8,8 +8,9 @@ inputs:
     default: "true"
   check-run-id:
     description: |
-      Check run id for the current workflow job, e.g. ${{ job.check_run_id }}.
-      Required when resource-usage is enabled; the action no-ops with a warning
+      Check run id for the current workflow job. Pass the workflow
+      expression `job.check_run_id` from the calling workflow. Required
+      when resource-usage is enabled; the action no-ops with a warning
       if it is missing.
     required: false
     default: ""

--- a/.github/actions/everr-action/action.yml
+++ b/.github/actions/everr-action/action.yml
@@ -6,13 +6,13 @@ inputs:
     description: Collect per-job machine resource usage and upload a best-effort artifact. Set to "false" to opt out.
     required: false
     default: "true"
-  github-token:
+  check-run-id:
     description: |
-      Token used to look up the current job's check_run_id via the GitHub API
-      when resource-usage is enabled. The default uses the workflow-provided
-      GITHUB_TOKEN; the calling workflow must grant `actions: read`.
+      Check run id for the current workflow job, e.g. ${{ job.check_run_id }}.
+      Required when resource-usage is enabled; the action no-ops with a warning
+      if it is missing.
     required: false
-    default: ${{ github.token }}
+    default: ""
 
 runs:
   using: node24

--- a/.github/actions/everr-action/scripts/build-readme.mjs
+++ b/.github/actions/everr-action/scripts/build-readme.mjs
@@ -32,18 +32,12 @@ ${actionYml.description}
 ## Usage
 
 \`\`\`yaml
-permissions:
-  contents: read
-  actions: read
-
 steps:
   - uses: everr-labs/everr-action@v0
+    with:
+      check-run-id: \${{ job.check_run_id }}
 \`\`\`
 
-> The action needs \`actions: read\` so it can look up its own job via
-> the GitHub Jobs API to derive a \`check_run_id\`. The default
-> \`github-token\` input uses the workflow's GITHUB_TOKEN.
->
 > Resource usage collection is on by default. To opt out, pass
 > \`resource-usage: "false"\`.
 

--- a/.github/actions/everr-action/src/index.test.ts
+++ b/.github/actions/everr-action/src/index.test.ts
@@ -8,60 +8,17 @@ import { fileURLToPath } from "node:url";
 import {
   artifactNameForCheckRun,
   buildRuntimePaths,
-  checkRunIdFromUrl,
-  discoverCurrentCheckRunId,
   finalizeAndUploadResourceUsage,
   isResourceUsageEnabled,
   normalizeCheckRunId,
   resolveActionRoot,
+  resolveCheckRunIdInput,
   startResourceUsage,
 } from "./index.ts";
 
 function inputResolver(values: Record<string, string>): (name: string) => string {
   return (name: string) => values[name] ?? "";
 }
-
-function jsonResponse(status: number, body: unknown) {
-  return {
-    json: async () => body,
-    ok: status >= 200 && status < 300,
-    status,
-  };
-}
-
-function mockFetch(
-  responses: Array<{ body: unknown; status: number }>,
-): {
-  calls: Array<{ headers: Record<string, string>; url: string }>;
-  fetch: (
-    input: string,
-    init: { headers: Record<string, string> },
-  ) => Promise<ReturnType<typeof jsonResponse>>;
-} {
-  const calls: Array<{ headers: Record<string, string>; url: string }> = [];
-  let i = 0;
-  return {
-    calls,
-    fetch: async (
-      input: string,
-      init: { headers: Record<string, string> },
-    ) => {
-      calls.push({ headers: init.headers, url: input });
-      const next = responses[i++];
-      if (!next) {
-        throw new Error("no more mocked responses");
-      }
-      return jsonResponse(next.status, next.body);
-    },
-  };
-}
-
-const defaultEnvForDiscovery = {
-  GITHUB_REPOSITORY: "everr-labs/everr",
-  GITHUB_RUN_ATTEMPT: "1",
-  GITHUB_RUN_ID: "12",
-  RUNNER_NAME: "runner-7",
-};
 
 test("artifactNameForCheckRun uses the direct per-job naming contract", () => {
   assert.equal(artifactNameForCheckRun("123"), "everr-resource-usage-v2-123");
@@ -97,114 +54,16 @@ test("normalizeCheckRunId trims valid ids and rejects malformed values", () => {
   assert.equal(normalizeCheckRunId("abc"), null);
 });
 
-test("checkRunIdFromUrl extracts the trailing id and rejects malformed values", () => {
-  assert.equal(
-    checkRunIdFromUrl("https://api.github.com/repos/o/r/check-runs/12345"),
-    "12345",
-  );
-  assert.equal(checkRunIdFromUrl("https://api.github.com/repos/o/r/check-runs/"), null);
-  assert.equal(checkRunIdFromUrl(""), null);
-});
-
-test("discoverCurrentCheckRunId returns the in_progress job on this runner", async () => {
-  const { calls, fetch } = mockFetch([
-    {
-      status: 200,
-      body: {
-        total_count: 2,
-        jobs: [
-          {
-            name: "Build",
-            runner_name: "runner-9",
-            status: "in_progress",
-            check_run_url: "https://api.github.com/repos/everr-labs/everr/check-runs/9999",
-          },
-          {
-            name: "Lint",
-            runner_name: "runner-7",
-            status: "in_progress",
-            check_run_url: "https://api.github.com/repos/everr-labs/everr/check-runs/4242",
-          },
-        ],
-      },
-    },
-  ]);
-
-  const result = await discoverCurrentCheckRunId({
-    env: defaultEnvForDiscovery,
-    fetchImpl: fetch,
-    token: "ghs_xyz",
-    warning: () => {},
-  });
-
-  assert.equal(result, "4242");
-  assert.equal(calls.length, 1);
-  assert.match(
-    calls[0].url,
-    /\/repos\/everr-labs\/everr\/actions\/runs\/12\/attempts\/1\/jobs/,
-  );
-  assert.equal(calls[0].headers.Authorization, "Bearer ghs_xyz");
-});
-
-test("discoverCurrentCheckRunId warns and returns null when the API rejects the request", async () => {
+test("resolveCheckRunIdInput warns when the workflow does not provide a valid id", () => {
   const warnings: string[] = [];
-  const { fetch } = mockFetch([{ status: 403, body: { message: "no" } }]);
 
-  const result = await discoverCurrentCheckRunId({
-    env: defaultEnvForDiscovery,
-    fetchImpl: fetch,
-    token: "ghs_xyz",
+  const checkRunId = resolveCheckRunIdInput({
+    getInput: () => "not-a-number",
     warning: (message: string) => warnings.push(message),
   });
 
-  assert.equal(result, null);
-  assert.match(warnings[0], /jobs API returned 403/);
-});
-
-test("discoverCurrentCheckRunId warns when no in_progress job matches the runner", async () => {
-  const warnings: string[] = [];
-  const { fetch } = mockFetch([
-    {
-      status: 200,
-      body: {
-        total_count: 1,
-        jobs: [
-          {
-            name: "Build",
-            runner_name: "runner-9",
-            status: "in_progress",
-            check_run_url: "https://api.github.com/repos/o/r/check-runs/9999",
-          },
-        ],
-      },
-    },
-  ]);
-
-  const result = await discoverCurrentCheckRunId({
-    env: defaultEnvForDiscovery,
-    fetchImpl: fetch,
-    token: "ghs_xyz",
-    warning: (message: string) => warnings.push(message),
-  });
-
-  assert.equal(result, null);
-  assert.match(warnings[0], /no in_progress job on runner 'runner-7'/);
-});
-
-test("discoverCurrentCheckRunId warns when required env vars are missing", async () => {
-  const warnings: string[] = [];
-  const { fetch, calls } = mockFetch([]);
-
-  const result = await discoverCurrentCheckRunId({
-    env: { GITHUB_RUN_ID: "12" },
-    fetchImpl: fetch,
-    token: "ghs_xyz",
-    warning: (message: string) => warnings.push(message),
-  });
-
-  assert.equal(result, null);
-  assert.equal(calls.length, 0);
-  assert.match(warnings[0], /GITHUB_REPOSITORY, GITHUB_RUN_ID, or RUNNER_NAME is missing/);
+  assert.equal(checkRunId, null);
+  assert.match(warnings[0], /missing or invalid check-run-id input/);
 });
 
 test("isResourceUsageEnabled accepts only the literal string 'true'", () => {
@@ -224,7 +83,7 @@ test("startResourceUsage no-ops when resource-usage input is not enabled", async
     env: {
       RUNNER_OS: "Linux",
     },
-    getInput: inputResolver({ "resource-usage": "false", "github-token": "ghs_xyz" }),
+    getInput: inputResolver({ "resource-usage": "false", "check-run-id": "123" }),
     saveState: (key: string, value: string) => savedState.set(key, value),
     info: (message: string) => infoMessages.push(message),
     warning: () => {},
@@ -243,7 +102,7 @@ test("startResourceUsage no-ops on non-linux runners", async () => {
     env: {
       RUNNER_OS: "Windows",
     },
-    getInput: inputResolver({ "resource-usage": "true", "github-token": "ghs_xyz" }),
+    getInput: inputResolver({ "resource-usage": "true", "check-run-id": "123" }),
     saveState: (key: string, value: string) => savedState.set(key, value),
     info: (message: string) => infoMessages.push(message),
     warning: () => {},
@@ -254,7 +113,7 @@ test("startResourceUsage no-ops on non-linux runners", async () => {
   assert.match(infoMessages[0], /supported only on Linux runners/);
 });
 
-test("startResourceUsage skips sampling when github-token is missing", async () => {
+test("startResourceUsage skips sampling when check-run-id is missing", async () => {
   const savedState = new Map<string, string>();
   const warnings: string[] = [];
 
@@ -262,7 +121,7 @@ test("startResourceUsage skips sampling when github-token is missing", async () 
     env: {
       RUNNER_OS: "Linux",
     },
-    getInput: inputResolver({ "resource-usage": "true", "github-token": "" }),
+    getInput: inputResolver({ "resource-usage": "true", "check-run-id": "" }),
     saveState: (key: string, value: string) => savedState.set(key, value),
     info: () => {},
     warning: (message: string) => warnings.push(message),
@@ -270,46 +129,26 @@ test("startResourceUsage skips sampling when github-token is missing", async () 
 
   assert.equal(result.enabled, false);
   assert.equal(savedState.get("enabled"), "0");
-  assert.match(warnings[0], /no github-token/);
+  assert.match(warnings[0], /missing or invalid check-run-id input/);
 });
-
-function jobsApiResponseFor(checkRunId: string, runnerName: string) {
-  return {
-    status: 200,
-    body: {
-      total_count: 1,
-      jobs: [
-        {
-          name: "lint",
-          runner_name: runnerName,
-          status: "in_progress",
-          check_run_url: `https://api.github.com/repos/everr-labs/everr/check-runs/${checkRunId}`,
-        },
-      ],
-    },
-  };
-}
 
 test("startResourceUsage downgrades sampler startup failures to warnings", async () => {
   const savedState = new Map<string, string>();
   const warnings: string[] = [];
   const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "everr-ru-start-"));
-  const { fetch } = mockFetch([jobsApiResponseFor("111", "runner-7")]);
 
   try {
     const result = await startResourceUsage({
       env: {
         RUNNER_OS: "Linux",
         RUNNER_TEMP: tempDir,
-        RUNNER_NAME: "runner-7",
         GITHUB_RUN_ID: "12",
         GITHUB_RUN_ATTEMPT: "1",
         GITHUB_JOB: "lint",
         GITHUB_REPOSITORY: "everr-labs/everr",
         GITHUB_WORKSPACE: tempDir,
       },
-      getInput: inputResolver({ "resource-usage": "true", "github-token": "ghs_xyz" }),
-      fetchImpl: fetch,
+      getInput: inputResolver({ "resource-usage": "true", "check-run-id": "111" }),
       saveState: (key: string, value: string) => savedState.set(key, value),
       warning: (message: string) => warnings.push(message),
       spawnImpl: () => {
@@ -329,7 +168,6 @@ test("startResourceUsage downgrades sampler startup failures to warnings", async
 test("startResourceUsage resolves sampler path without GITHUB_ACTION_PATH", async () => {
   const savedState = new Map<string, string>();
   const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "everr-ru-spawn-"));
-  const { fetch } = mockFetch([jobsApiResponseFor("222", "runner-7")]);
   let spawnInvocation:
     | {
         args: readonly string[];
@@ -342,15 +180,13 @@ test("startResourceUsage resolves sampler path without GITHUB_ACTION_PATH", asyn
       env: {
         RUNNER_OS: "Linux",
         RUNNER_TEMP: tempDir,
-        RUNNER_NAME: "runner-7",
         GITHUB_RUN_ID: "12",
         GITHUB_RUN_ATTEMPT: "1",
         GITHUB_JOB: "lint",
         GITHUB_REPOSITORY: "everr-labs/everr",
         GITHUB_WORKSPACE: tempDir,
       },
-      getInput: inputResolver({ "resource-usage": "true", "github-token": "ghs_xyz" }),
-      fetchImpl: fetch,
+      getInput: inputResolver({ "resource-usage": "true", "check-run-id": "222" }),
       saveState: (key: string, value: string) => savedState.set(key, value),
       info: () => {},
       warning: () => {},

--- a/.github/actions/everr-action/src/index.ts
+++ b/.github/actions/everr-action/src/index.ts
@@ -40,32 +40,10 @@ type UploadArtifactImpl = (
   options: { retentionDays: number },
 ) => Promise<unknown>;
 
-interface JobsApiResponse {
-  jobs: Array<{
-    check_run_url: string;
-    name: string;
-    runner_name: string | null;
-    status: string;
-  }>;
-  total_count: number;
-}
-
-interface FetchResponseLike {
-  json: () => Promise<unknown>;
-  ok: boolean;
-  status: number;
-}
-
-type FetchImpl = (
-  input: string,
-  init: { headers: Record<string, string> },
-) => Promise<FetchResponseLike>;
-
 const defaultSampleIntervalSeconds = "5";
 
 interface StartResourceUsageOptions {
   env?: Env;
-  fetchImpl?: FetchImpl;
   fsModule?: typeof fs;
   fspModule?: typeof fsp;
   getInput?: GetInput;
@@ -122,83 +100,16 @@ function normalizeCheckRunId(rawCheckRunId: string): string | null {
   return checkRunId;
 }
 
-function checkRunIdFromUrl(checkRunUrl: string): string | null {
-  const tail = checkRunUrl.split("/").pop() || "";
-  return normalizeCheckRunId(tail);
-}
-
-async function discoverCurrentCheckRunId({
-  env,
-  fetchImpl = globalThis.fetch as unknown as FetchImpl,
-  token,
+function resolveCheckRunIdInput({
+  getInput = core.getInput,
   warning = core.warning,
 }: {
-  env: Env;
-  fetchImpl?: FetchImpl;
-  token: string;
+  getInput?: GetInput;
   warning?: Log;
-}): Promise<string | null> {
-  const repo = env.GITHUB_REPOSITORY;
-  const runId = env.GITHUB_RUN_ID;
-  const attempt = env.GITHUB_RUN_ATTEMPT || "1";
-  const runnerName = env.RUNNER_NAME;
-  const apiUrl = env.GITHUB_API_URL || "https://api.github.com";
-
-  if (!repo || !runId || !runnerName) {
-    warning(
-      "resource-usage skipped: GITHUB_REPOSITORY, GITHUB_RUN_ID, or RUNNER_NAME is missing",
-    );
-    return null;
-  }
-
-  const url = `${apiUrl}/repos/${repo}/actions/runs/${runId}/attempts/${attempt}/jobs?per_page=100`;
-
-  let response: FetchResponseLike;
-  try {
-    response = await fetchImpl(url, {
-      headers: {
-        Accept: "application/vnd.github+json",
-        Authorization: `Bearer ${token}`,
-        "User-Agent": "everr-action",
-        "X-GitHub-Api-Version": "2022-11-28",
-      },
-    });
-  } catch (error) {
-    warning(
-      `resource-usage skipped: GitHub jobs API request failed: ${formatError(error)}`,
-    );
-    return null;
-  }
-
-  if (!response.ok) {
-    warning(
-      `resource-usage skipped: GitHub jobs API returned ${response.status}`,
-    );
-    return null;
-  }
-
-  const body = (await response.json()) as JobsApiResponse;
-  if (body.total_count > body.jobs.length) {
-    warning(
-      `resource-usage: only fetched ${body.jobs.length} of ${body.total_count} jobs; matching may be incomplete`,
-    );
-  }
-
-  const match = body.jobs.find(
-    (job) => job.runner_name === runnerName && job.status === "in_progress",
-  );
-  if (!match) {
-    warning(
-      `resource-usage skipped: no in_progress job on runner '${runnerName}'`,
-    );
-    return null;
-  }
-
-  const checkRunId = checkRunIdFromUrl(match.check_run_url);
+} = {}): string | null {
+  const checkRunId = normalizeCheckRunId(getInput("check-run-id"));
   if (!checkRunId) {
-    warning(
-      `resource-usage skipped: could not parse check_run_id from '${match.check_run_url}'`,
-    );
+    warning("resource-usage skipped: missing or invalid check-run-id input");
     return null;
   }
 
@@ -211,7 +122,6 @@ function isResourceUsageEnabled(getInput: GetInput): boolean {
 
 async function startResourceUsage({
   env = process.env,
-  fetchImpl,
   fsModule = fs,
   fspModule = fsp,
   saveState = core.saveState,
@@ -238,21 +148,7 @@ async function startResourceUsage({
     return { enabled: false };
   }
 
-  const token = getInput("github-token");
-  if (!token) {
-    warning(
-      "resource-usage skipped: no github-token; ensure the workflow grants actions: read and exposes GITHUB_TOKEN",
-    );
-    saveState("enabled", "0");
-    return { enabled: false };
-  }
-
-  const checkRunId = await discoverCurrentCheckRunId({
-    env,
-    fetchImpl,
-    token,
-    warning,
-  });
+  const checkRunId = resolveCheckRunIdInput({ getInput, warning });
   if (!checkRunId) {
     saveState("enabled", "0");
     return { enabled: false };
@@ -524,14 +420,13 @@ if (entrypointPath === fileURLToPath(import.meta.url)) {
 export {
   artifactNameForCheckRun,
   buildRuntimePaths,
-  checkRunIdFromUrl,
-  discoverCurrentCheckRunId,
   ensureSamplesFile,
   finalizeAndUploadResourceUsage,
   formatError,
   isResourceUsageEnabled,
   normalizeCheckRunId,
   resolveActionRoot,
+  resolveCheckRunIdInput,
   resolveWorkspaceFilesystemInfo,
   startResourceUsage,
   stopSampler,

--- a/.github/workflows/build-and-push-images.yml
+++ b/.github/workflows/build-and-push-images.yml
@@ -16,7 +16,6 @@ on:
 
 permissions:
   contents: read
-  actions: read
 
 concurrency:
   group: build-and-push-images
@@ -75,6 +74,8 @@ jobs:
 
       - name: Collect resource usage
         uses: ./.github/actions/everr-action
+        with:
+          check-run-id: ${{ job.check_run_id }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -108,6 +109,8 @@ jobs:
 
       - name: Collect resource usage
         uses: ./.github/actions/everr-action
+        with:
+          check-run-id: ${{ job.check_run_id }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -141,6 +144,8 @@ jobs:
 
       - name: Collect resource usage
         uses: ./.github/actions/everr-action
+        with:
+          check-run-id: ${{ job.check_run_id }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/build-and-test-app.yml
+++ b/.github/workflows/build-and-test-app.yml
@@ -2,7 +2,6 @@ name: Build & Test App
 
 permissions:
   contents: read
-  actions: read
 
 concurrency:
   # For pushes, this lets concurrent runs happen, so each push gets a result.
@@ -48,6 +47,8 @@ jobs:
 
       - name: Collect resource usage
         uses: ./.github/actions/everr-action
+        with:
+          check-run-id: ${{ job.check_run_id }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/build-and-test-collector.yml
+++ b/.github/workflows/build-and-test-collector.yml
@@ -11,7 +11,6 @@ concurrency:
 
 permissions:
   contents: read
-  actions: read
 
 on:
   pull_request:
@@ -35,6 +34,8 @@ jobs:
 
       - name: Collect resource usage
         uses: ./.github/actions/everr-action
+        with:
+          check-run-id: ${{ job.check_run_id }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -73,6 +74,8 @@ jobs:
 
       - name: Collect resource usage
         uses: ./.github/actions/everr-action
+        with:
+          check-run-id: ${{ job.check_run_id }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -130,6 +133,8 @@ jobs:
 
       - name: Collect resource usage
         uses: ./.github/actions/everr-action
+        with:
+          check-run-id: ${{ job.check_run_id }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -167,6 +172,8 @@ jobs:
 
       - name: Collect resource usage
         uses: ./.github/actions/everr-action
+        with:
+          check-run-id: ${{ job.check_run_id }}
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/build-and-test-desktop-app.yml
+++ b/.github/workflows/build-and-test-desktop-app.yml
@@ -2,7 +2,6 @@ name: Build & Test Desktop App
 
 permissions:
   contents: read
-  actions: read
 
 concurrency:
   # For pushes, this lets concurrent runs happen, so each push gets a result.
@@ -48,6 +47,8 @@ jobs:
 
       - name: Collect resource usage
         uses: ./.github/actions/everr-action
+        with:
+          check-run-id: ${{ job.check_run_id }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/build-everr-cli.yml
+++ b/.github/workflows/build-everr-cli.yml
@@ -2,7 +2,6 @@ name: Everr CLI CI
 
 permissions:
   contents: read
-  actions: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -41,6 +40,8 @@ jobs:
 
       - name: Collect resource usage
         uses: ./.github/actions/everr-action
+        with:
+          check-run-id: ${{ job.check_run_id }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/deploy-desktop-app.yml
+++ b/.github/workflows/deploy-desktop-app.yml
@@ -2,7 +2,6 @@ name: Deploy Desktop App
 
 permissions:
   contents: read
-  actions: read
   id-token: write
   attestations: write
 
@@ -27,6 +26,8 @@ jobs:
 
       - name: Collect resource usage
         uses: ./.github/actions/everr-action
+        with:
+          check-run-id: ${{ job.check_run_id }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/packages/docs/content/docs/github-action/index.mdx
+++ b/packages/docs/content/docs/github-action/index.mdx
@@ -1,0 +1,92 @@
+---
+title: GitHub Action
+description: Drop the everr-action into a workflow to capture per-job runner metrics and ship them to Everr.
+---
+
+The Everr GitHub Action runs alongside your CI jobs and uploads
+per-job runner metrics (CPU, memory, network, disk) as a workflow
+artifact. Everr ingests the artifact and stitches the samples onto the
+matching check run so you can see resource pressure next to the rest of
+your CI signal.
+
+The action is published from this monorepo to
+[`everr-labs/everr-action`](https://github.com/everr-labs/everr-action)
+and tagged with semver. Use the floating major tag (`@v0`) in your
+workflows so patches are picked up automatically.
+
+## Quick start
+
+Add the action as the first step of any job whose resource usage you
+want to track. Pass `${{ job.check_run_id }}` so Everr can stitch the
+uploaded samples onto the matching check run.
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: everr-labs/everr-action@v0
+        with:
+          check-run-id: ${{ job.check_run_id }}
+
+      # ...the rest of your job
+```
+
+That's it — the action samples while your job runs and uploads the
+artifact in its post-step.
+
+## How it works
+
+- **Pre-step.** Validates the `check-run-id` input, then spawns a
+  detached background sampler script that writes one NDJSON line every
+  five seconds.
+- **During the job.** Your job runs normally; the sampler does not
+  block, and a failed sampler never fails the job.
+- **Post-step.** Stops the sampler, normalizes the samples, writes
+  `metadata.json` + `samples.ndjson`, and uploads them as a workflow
+  artifact named `everr-resource-usage-v2-{check_run_id}` (7-day
+  retention).
+
+Sampling currently runs only on Linux runners. macOS and Windows jobs
+get a no-op start and a warning at finalize time.
+
+## Inputs
+
+| Name             | Required | Default  | Description                                                                                                                            |
+| ---------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `resource-usage` | no       | `"true"` | Whether to sample per-job resource usage. Set to `"false"` to opt out without removing the step.                                       |
+| `check-run-id`   | no       | `""`     | Check run id for the current workflow job, e.g. `${{ job.check_run_id }}`. The action no-ops with a warning when it is missing.        |
+
+## Opting out
+
+To disable resource sampling on a specific job without removing the
+step:
+
+```yaml
+- uses: everr-labs/everr-action@v0
+  with:
+    resource-usage: "false"
+```
+
+## Versioning
+
+- `v0` — floating major tag. Recommended for most consumers; picks up
+  every backwards-compatible release.
+- `v0.X.Y` — exact version. Use if you need a reproducible pin.
+
+Releases are managed via [Changesets](https://github.com/changesets/changesets);
+each release ships a CHANGELOG on the mirror repo's GitHub Release.
+
+## Failure modes
+
+The action is designed to never fail the host job. Each of the
+following downgrades to a `warning::` annotation:
+
+- `check-run-id` is missing or malformed.
+- The sampler script fails to start or exits early.
+- The finalize step can't read its sample file or the upload fails.
+- The runner is not Linux.
+
+The host job continues as if the action wasn't present.

--- a/packages/docs/content/docs/github-action/meta.json
+++ b/packages/docs/content/docs/github-action/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "GitHub Action",
+  "pages": ["index"]
+}

--- a/packages/docs/content/docs/meta.json
+++ b/packages/docs/content/docs/meta.json
@@ -1,3 +1,3 @@
 {
-  "pages": ["app", "features", "cli", "sending-telemetry", "reference"]
+  "pages": ["app", "features", "cli", "sending-telemetry", "github-action", "reference"]
 }


### PR DESCRIPTION
## Summary
- Bring back \`check-run-id\` and drop \`github-token\`. The \`actions: read\` permission that self-discovery required is a worse ergonomic trade than just passing \`\${{ job.check_run_id }}\` at call sites.
- Remove the API discovery code, mock-fetch test fixtures, and \`actions: read\` from the six workflows that grew it.
- Restore \`with: check-run-id: \${{ job.check_run_id }}\` at the 11 in-repo call sites.
- Rewrite the docs page (was open in #128) to match the restored shape.
- Resource sampling stays default-on; opt out with \`resource-usage: "false"\`.

Closes #128.

## Test plan
- [ ] verify-action-dist CI passes (17/17 locally)
- [ ] After merge, release-pr opens a Version Packages PR bumping \`@everr/action\` to 0.3.0
- [ ] After that PR merges, \`everr-labs/everr-action@v0\` resolves the new bundle and existing in-repo workflows continue to upload artifacts named \`everr-resource-usage-v2-{check_run_id}\`