### PR TITLE
Set GitHub Actions service identity

### DIFF
--- a/collector/receiver/githubactionsreceiver/README.md
+++ b/collector/receiver/githubactionsreceiver/README.md
@@ -89,31 +89,16 @@ Several helper files are leveraged to provide additional capabilities automatica
 - [HTTP server settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/confighttp/README.md#server-configuration) including CORS
 - [TLS and mTLS settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md)
 
-### Service Name Generation
+### Service Identity
 
-The GitHub Actions Receiver dynamically generates the `service.name` attribute, which is crucial for identifying the source of telemetry data in observability platforms. This name helps in categorising and filtering traces originating from different GitHub repositories or actions workflows.
+The GitHub Actions Receiver sets the OpenTelemetry service identity to:
 
-#### Default Service Name
-
-By default, the service name is derived from the **GitHub repository's full name** (e.g., org/repo-name) provided in the payload. This name is then formatted to be all lowercase and to have slashes (/) and underscores (\_) replaced with dashes (-), ensuring a clean, URL-friendly identifier.
-
-#### Customisation Options
-
-While the default naming convention should suffice for most use cases, there might be scenarios where a more descriptive or specific service name is required. For such cases, the receiver's configuration provides options for customization:
-
-- **Custom Service Name**: A completely custom service.name that overrides the default naming convention. This is useful when you want to assign a specific, recognisable name to the telemetry data from a particular GitHub repository or workflow.
-
-- **Service Name Prefix and Suffix**: These allow for the addition of prefixes or suffixes to the automatically generated service name, offering a balance between automatic naming and customization.
-
-Here's an example snippet from a configuration file (config.yaml) demonstrating how to set these options:
-
-```yaml
-receivers:
-  githubactionsreceiver:
-    custom_service_name: 'github-com-myorg' # Completely overrides the default service name
-    service_name_prefix: 'foo-' # Prepended to the default service name (ignored if custom_service_name is set)
-    service_name_suffix: '-bar' # Appended to the default service name (ignored if custom_service_name is set)
+```text
+service.namespace = "ci"
+service.name = "github-actions"
 ```
+
+Repository, workflow, run, and job details are recorded with `vcs.*` and `cicd.*` attributes instead of being encoded into `service.name`.
 
 ## GitHub webhooks
 

--- a/collector/receiver/githubactionsreceiver/README.md
+++ b/collector/receiver/githubactionsreceiver/README.md
@@ -94,7 +94,7 @@ Several helper files are leveraged to provide additional capabilities automatica
 The GitHub Actions Receiver sets the OpenTelemetry service identity to:
 
 ```text
-service.namespace = "ci"
+service.namespace = "cicd"
 service.name = "github-actions"
 ```
 

--- a/collector/receiver/githubactionsreceiver/attributes.go
+++ b/collector/receiver/githubactionsreceiver/attributes.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	githubActionsServiceName      = "github-actions"
-	githubActionsServiceNamespace = "ci"
+	githubActionsServiceNamespace = "cicd"
 )
 
 func setGitHubActionsServiceAttributes(attrs pcommon.Map) {

--- a/collector/receiver/githubactionsreceiver/attributes.go
+++ b/collector/receiver/githubactionsreceiver/attributes.go
@@ -17,9 +17,18 @@ import (
 	"github.com/everr-labs/everr/collector/semconv"
 )
 
+const (
+	githubActionsServiceName      = "github-actions"
+	githubActionsServiceNamespace = "ci"
+)
+
+func setGitHubActionsServiceAttributes(attrs pcommon.Map) {
+	attrs.PutStr(string(conventions.ServiceNameKey), githubActionsServiceName)
+	attrs.PutStr(string(conventions.ServiceNamespaceKey), githubActionsServiceNamespace)
+}
+
 func setWorkflowRunEventAttributes(attrs pcommon.Map, e *github.WorkflowRunEvent, config *Config) {
-	serviceName := generateServiceName(config, e.GetRepo().GetFullName())
-	attrs.PutStr("service.name", serviceName)
+	setGitHubActionsServiceAttributes(attrs)
 
 	attrs.PutInt(semconv.EverrGitHubWorkflowID, e.GetWorkflowRun().GetWorkflowID())
 	attrs.PutStr(semconv.EverrGitHubWorkflowRunActorLogin, e.GetWorkflowRun().GetActor().GetLogin())

--- a/collector/receiver/githubactionsreceiver/config.go
+++ b/collector/receiver/githubactionsreceiver/config.go
@@ -39,9 +39,9 @@ type Config struct {
 	confighttp.ServerConfig `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 	Path                    string                   `mapstructure:"path"`                // path for data collection. Default is <host>:<port>/events
 	Secret                  string                   `mapstructure:"secret"`              // github webhook hash signature. Default is empty
-	CustomServiceName       string                   `mapstructure:"custom_service_name"` // custom service name. Default is empty
-	ServiceNamePrefix       string                   `mapstructure:"service_name_prefix"` // service name prefix. Default is empty
-	ServiceNameSuffix       string                   `mapstructure:"service_name_suffix"` // service name suffix. Default is empty
+	CustomServiceName       string                   `mapstructure:"custom_service_name"` // deprecated: ignored; service.name is github-actions
+	ServiceNamePrefix       string                   `mapstructure:"service_name_prefix"` // deprecated: ignored; service.name is github-actions
+	ServiceNameSuffix       string                   `mapstructure:"service_name_suffix"` // deprecated: ignored; service.name is github-actions
 	GitHubAPIConfig         GitHubAPIConfig          `mapstructure:"gh_api"`              // github api configuration
 }
 

--- a/collector/receiver/githubactionsreceiver/receiver_test.go
+++ b/collector/receiver/githubactionsreceiver/receiver_test.go
@@ -278,6 +278,53 @@ func TestResourceAndSpanAttributesCreation(t *testing.T) {
 	}
 }
 
+func TestGitHubActionsServiceResourceAttributes(t *testing.T) {
+	config := &Config{
+		CustomServiceName: "custom-service",
+		ServiceNamePrefix: "prefix-",
+		ServiceNameSuffix: "-suffix",
+	}
+
+	t.Run("workflow run", func(t *testing.T) {
+		payload, err := os.ReadFile("./testdata/completed/8_workflow_run_completed.json")
+		require.NoError(t, err)
+
+		event, err := github.ParseWebHook("workflow_run", payload)
+		require.NoError(t, err)
+
+		attrs := pcommon.NewMap()
+		setWorkflowRunEventAttributes(attrs, event.(*github.WorkflowRunEvent), config)
+
+		serviceName, found := attrs.Get("service.name")
+		require.True(t, found)
+		require.Equal(t, "github-actions", serviceName.Str())
+
+		serviceNamespace, found := attrs.Get("service.namespace")
+		require.True(t, found)
+		require.Equal(t, "ci", serviceNamespace.Str())
+	})
+
+	t.Run("workflow job", func(t *testing.T) {
+		payload, err := os.ReadFile("./testdata/completed/5_workflow_job_completed.json")
+		require.NoError(t, err)
+
+		event, err := github.ParseWebHook("workflow_job", payload)
+		require.NoError(t, err)
+
+		resource := pcommon.NewResource()
+		createResourceAttributes(resource, event, config, zaptest.NewLogger(t))
+		attrs := resource.Attributes()
+
+		serviceName, found := attrs.Get("service.name")
+		require.True(t, found)
+		require.Equal(t, "github-actions", serviceName.Str())
+
+		serviceNamespace, found := attrs.Get("service.namespace")
+		require.True(t, found)
+		require.Equal(t, "ci", serviceNamespace.Str())
+	})
+}
+
 // attributeValueToString converts an attribute value to a string regardless of its actual type
 func attributeValueToString(attr pcommon.Value) string {
 	switch attr.Type() {

--- a/collector/receiver/githubactionsreceiver/receiver_test.go
+++ b/collector/receiver/githubactionsreceiver/receiver_test.go
@@ -301,7 +301,7 @@ func TestGitHubActionsServiceResourceAttributes(t *testing.T) {
 
 		serviceNamespace, found := attrs.Get("service.namespace")
 		require.True(t, found)
-		require.Equal(t, "ci", serviceNamespace.Str())
+		require.Equal(t, "cicd", serviceNamespace.Str())
 	})
 
 	t.Run("workflow job", func(t *testing.T) {
@@ -321,7 +321,7 @@ func TestGitHubActionsServiceResourceAttributes(t *testing.T) {
 
 		serviceNamespace, found := attrs.Get("service.namespace")
 		require.True(t, found)
-		require.Equal(t, "ci", serviceNamespace.Str())
+		require.Equal(t, "cicd", serviceNamespace.Str())
 	})
 }
 

--- a/collector/receiver/githubactionsreceiver/testdata/build/config.yaml
+++ b/collector/receiver/githubactionsreceiver/testdata/build/config.yaml
@@ -1,9 +1,6 @@
 receivers:
   githubactions:
     # secret: my-secret
-    # custom_service_name: github // default org-repo-name
-    # service_name_prefix: foo-   // ignored if custom_service_name set
-    # service_name_suffix: -bar   // ignored if custom_service_name set
     # gh_api:
     #   base_url: https://gh_enterprise.base.url      // Enterprise GitHub base URL. Omit for github.com
     #   upload_url: https://gh_enterprise.upload.url  // Enterprise GitHub upload URL. Omit for github.com

--- a/collector/receiver/githubactionsreceiver/testdata/example_config.yaml
+++ b/collector/receiver/githubactionsreceiver/testdata/example_config.yaml
@@ -1,9 +1,6 @@
 receivers:
   githubactions:
     # secret: my-secret
-    # custom_service_name: github-foo // default org-repo-name (github)
-    # service_name_prefix: foo- // ignored if custom_service_name set
-    # service_name_suffix: -bar // ignored if custom_service_name set
     cors:
       allowed_origins: ["*"]
       allowed_headers: ["*"]

--- a/collector/receiver/githubactionsreceiver/trace_attributes.go
+++ b/collector/receiver/githubactionsreceiver/trace_attributes.go
@@ -24,8 +24,7 @@ func createResourceAttributes(resource pcommon.Resource, event interface{}, conf
 
 	switch e := event.(type) {
 	case *github.WorkflowJobEvent:
-		serviceName := generateServiceName(config, e.GetRepo().GetFullName())
-		attrs.PutStr("service.name", serviceName)
+		setGitHubActionsServiceAttributes(attrs)
 
 		attrs.PutStr(string(conventions.CICDPipelineNameKey), e.GetWorkflowJob().GetWorkflowName())
 

--- a/collector/receiver/githubactionsreceiver/trace_event_handling.go
+++ b/collector/receiver/githubactionsreceiver/trace_event_handling.go
@@ -291,14 +291,6 @@ func generateParentSpanID(runID int64, runAttempt int) (pcommon.SpanID, error) {
 	return spanID, nil
 }
 
-func generateServiceName(config *Config, fullName string) string {
-	if config.CustomServiceName != "" {
-		return config.CustomServiceName
-	}
-	formattedName := strings.ToLower(strings.ReplaceAll(strings.ReplaceAll(fullName, "/", "-"), "_", "-"))
-	return fmt.Sprintf("%s%s%s", config.ServiceNamePrefix, formattedName, config.ServiceNameSuffix)
-}
-
 func generateStepSpanID(runID int64, runAttempt int, jobName string, stepNumber int64) (pcommon.SpanID, error) {
 	input := fmt.Sprintf("%d%d%s%d", runID, runAttempt, jobName, stepNumber)
 	hash := sha256.Sum256([]byte(input))


### PR DESCRIPTION
## Summary

- Set GitHub Actions telemetry resources to `service.namespace = "cicd"` and `service.name = "github-actions"`.
- Keep repository, workflow, run, and job identity in `vcs.*` and `cicd.*` attributes instead of encoding them into `service.name`.
- Mark the old service-name config fields as deprecated/ignored and update the receiver docs/examples.

## Why

GitHub Actions logs are emitted by the CI integration, while the repository and workflow are separate resource attributes. Using a fixed service identity keeps the OpenTelemetry resource model cleaner and makes the log service filter less overloaded.

## Validation

- `go test . -count=1` from `collector/receiver/githubactionsreceiver`
- Pre-commit hook ran collector fmt, tidy, and lint during commit