### PR TITLE
feat(cost-analysis): show billed minutes computed in ClickHouse

### DIFF
--- a/packages/app/src/components/panel-shell.tsx
+++ b/packages/app/src/components/panel-shell.tsx
@@ -7,8 +7,13 @@ import {
   CardTitle,
 } from "@everr/ui/components/card";
 import { Skeleton } from "@everr/ui/components/skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@everr/ui/components/tooltip";
 import { cn } from "@everr/ui/lib/utils";
-import { AlertCircle } from "lucide-react";
+import { AlertCircle, CircleHelp } from "lucide-react";
 import type { ReactNode } from "react";
 import type { PanelChromeProps } from "./panel-types";
 
@@ -17,8 +22,38 @@ export interface PanelShellProps extends PanelChromeProps {
   children?: ReactNode;
 }
 
+function StatTitle({
+  title,
+  titleHint,
+}: {
+  title: string;
+  titleHint?: ReactNode;
+}) {
+  if (!titleHint) return <CardDescription>{title}</CardDescription>;
+  return (
+    <CardDescription className="inline-flex items-center gap-1">
+      {title}
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <button
+              type="button"
+              className="text-muted-foreground hover:text-foreground"
+              aria-label={`What is ${title}?`}
+            />
+          }
+        >
+          <CircleHelp className="size-3.5" />
+        </TooltipTrigger>
+        <TooltipContent className="max-w-64">{titleHint}</TooltipContent>
+      </Tooltip>
+    </CardDescription>
+  );
+}
+
 export function PanelShell({
   title,
+  titleHint,
   description,
   status,
   variant = "default",
@@ -34,7 +69,7 @@ export function PanelShell({
       return (
         <Card inset={inset} className={className}>
           <CardHeader className="pb-1">
-            {title && <CardDescription>{title}</CardDescription>}
+            {title && <StatTitle title={title} titleHint={titleHint} />}
             <Skeleton className="h-9 w-24" />
           </CardHeader>
         </Card>
@@ -60,7 +95,7 @@ export function PanelShell({
       return (
         <Card inset={inset} className={className}>
           <CardHeader className="pb-1">
-            {title && <CardDescription>{title}</CardDescription>}
+            {title && <StatTitle title={title} titleHint={titleHint} />}
             <CardTitle className="text-3xl tabular-nums">--</CardTitle>
           </CardHeader>
         </Card>
@@ -87,7 +122,7 @@ export function PanelShell({
       <Card inset={inset} className={cn(className)}>
         <CardHeader className="relative pb-2">
           <div className="flex items-center justify-between">
-            {title && <CardDescription>{title}</CardDescription>}
+            {title && <StatTitle title={title} titleHint={titleHint} />}
             {Icon && <Icon className="text-muted-foreground size-4" />}
           </div>
           <CardTitle className="text-3xl tabular-nums">{children}</CardTitle>

--- a/packages/app/src/components/panel-types.ts
+++ b/packages/app/src/components/panel-types.ts
@@ -33,6 +33,7 @@ export type InferFactoriesData<T extends readonly unknown[]> = {
 /** Shared chrome props for all panel variants. */
 export interface PanelChromeProps {
   title?: string;
+  titleHint?: ReactNode;
   description?: string;
   variant?: "default" | "stat";
   skeleton?: ReactNode;

--- a/packages/app/src/data/cost-analysis/schemas.ts
+++ b/packages/app/src/data/cost-analysis/schemas.ts
@@ -7,6 +7,7 @@ export const BREAKDOWN_OTHER_KEY = "__other__";
 export interface CostSummary {
   totalCost: number;
   totalMinutes: number;
+  billedMinutes: number;
   totalJobs: number;
   costByOs: { os: string; cost: number; jobs: number }[];
   selfHostedMinutes: number;

--- a/packages/app/src/data/cost-analysis/server.ts
+++ b/packages/app/src/data/cost-analysis/server.ts
@@ -51,7 +51,8 @@ export const getCostOverview = createAuthenticatedServerFn({
         ResourceAttributes['cicd.pipeline.worker.labels'] as labels,
         count(*) as totalJobs,
         sum(Duration) / 1000000 as totalDurationMs,
-        sum(ceil(Duration / 60000000000.0)) as roundedMinutes
+        sum(ceil(Duration / 60000000000.0)) as roundedMinutes,
+        sum(sum(ceil(Duration / 60000000000.0))) OVER () as totalBilledMinutes
       FROM traces
       WHERE Timestamp >= {fromTime:String} AND Timestamp <= {toTime:String}
         AND ResourceAttributes['cicd.pipeline.worker.labels'] != ''
@@ -67,11 +68,13 @@ export const getCostOverview = createAuthenticatedServerFn({
       totalJobs: string;
       totalDurationMs: string;
       roundedMinutes: string;
+      totalBilledMinutes: string;
     }>(sql, { fromTime: fromISO, toTime: toISO });
 
     const summary: CostSummary = {
       totalCost: 0,
       totalMinutes: 0,
+      billedMinutes: Number(rows[0]?.totalBilledMinutes ?? 0),
       totalJobs: 0,
       costByOs: [],
       selfHostedMinutes: 0,

--- a/packages/app/src/routes/_authenticated/_dashboard/cost-analysis.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/cost-analysis.tsx
@@ -3,7 +3,7 @@ import {
   ToggleGroupItem,
 } from "@everr/ui/components/toggle-group";
 import { createFileRoute } from "@tanstack/react-router";
-import { Clock, DollarSign, Server } from "lucide-react";
+import { Clock, DollarSign, Receipt, Server } from "lucide-react";
 import { useState } from "react";
 import {
   ActionsUsageChart,
@@ -111,7 +111,7 @@ function CostAnalysisPage() {
         </div>
       </div>
 
-      <div className="grid gap-4 md:grid-cols-3">
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
         <TimeRangePanel
           title="Estimated Cost"
           queries={[costOverviewOptions]}
@@ -130,6 +130,15 @@ function CostAnalysisPage() {
           {(overview) =>
             Math.round(overview.summary.totalMinutes).toLocaleString()
           }
+        </TimeRangePanel>
+
+        <TimeRangePanel
+          title="Billed Minutes"
+          queries={[costOverviewOptions]}
+          variant="stat"
+          icon={Receipt}
+        >
+          {(overview) => overview.summary.billedMinutes.toLocaleString()}
         </TimeRangePanel>
 
         <TimeRangePanel

--- a/packages/app/src/routes/_authenticated/_dashboard/cost-analysis.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/cost-analysis.tsx
@@ -123,6 +123,7 @@ function CostAnalysisPage() {
 
         <TimeRangePanel
           title="Total Minutes"
+          titleHint="Actual elapsed runner time across all jobs, summed second-by-second. Useful for measuring real usage and pipeline duration."
           queries={[costOverviewOptions]}
           variant="stat"
           icon={Clock}
@@ -134,6 +135,7 @@ function CostAnalysisPage() {
 
         <TimeRangePanel
           title="Billed Minutes"
+          titleHint="What GitHub actually charges for: each job's duration rounded up to the next whole minute, then summed. Always ≥ Total Minutes."
           queries={[costOverviewOptions]}
           variant="stat"
           icon={Receipt}

--- a/packages/app/src/routes/_authenticated/_dashboard/cost-analysis.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/cost-analysis.tsx
@@ -145,6 +145,7 @@ function CostAnalysisPage() {
 
         <TimeRangePanel
           title="Self-Hosted Minutes"
+          titleHint="Actual elapsed minutes for jobs running on self-hosted runners (no GitHub-hosted runner charges). Subset of Total Minutes."
           queries={[costOverviewOptions]}
           variant="stat"
           icon={Server}


### PR DESCRIPTION
## Summary
- Adds a fourth stat card, **Billed Minutes**, to the Cost Analysis page (grid now `md:grid-cols-2 lg:grid-cols-4`).
- The total is produced entirely in ClickHouse via a window aggregate (`sum(sum(ceil(Duration / 60s))) OVER ()`) on the existing `getCostOverview` query — no extra round-trip and no JS-side reduction. Per-job ceiling already lived in SQL; this extends it to the grand total.
- Extends `CostSummary` with `billedMinutes: number`.

<img width="406" height="202" alt="Screenshot 2026-05-19 at 09 58 17" src="https://github.com/user-attachments/assets/91998210-48bb-48d0-a803-174c864fe283" />
