### PR TITLE
Enforce per-key allowed origins for OTLP ingest

### DIFF
--- a/collector/Makefile.Common
+++ b/collector/Makefile.Common
@@ -44,7 +44,7 @@ CROSSLINK := $(TOOLS_BIN_DIR)/crosslink
 
 .PHONY: lint
 lint:
-	$(LINT) run
+	$(LINT) run --timeout=10m
 
 .PHONY: tidy
 tidy:

--- a/collector/extension/everrapikeyauth/authenticator_test.go
+++ b/collector/extension/everrapikeyauth/authenticator_test.go
@@ -227,3 +227,105 @@ func TestExtension_TimeoutWiring(t *testing.T) {
 		t.Fatalf("got %v", e.httpClient.Timeout)
 	}
 }
+
+// originHeaders augments authHeaders with an Origin entry. Uses a deliberately
+// non-canonical key shape on alternating cases so the header probe is
+// exercised both ways.
+func originHeaders(token, origin, headerName string) map[string][]string {
+	return map[string][]string{
+		"Authorization": {"Bearer " + token},
+		headerName:      {origin},
+	}
+}
+
+func TestAuthenticate_OriginAllowed(t *testing.T) {
+	srv := fakeVerifyServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(verifyResponse{
+			TenantID:       "org_1",
+			KeyID:          "ak_1",
+			AllowedOrigins: []string{"https://app.example.com"},
+		})
+	})
+	defer srv.Close()
+	e := newTestExt(t, srv.URL)
+
+	if _, err := e.Authenticate(
+		context.Background(),
+		originHeaders("good", "https://app.example.com", "Origin"),
+	); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+}
+
+func TestAuthenticate_OriginRejected(t *testing.T) {
+	srv := fakeVerifyServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(verifyResponse{
+			TenantID:       "org_1",
+			KeyID:          "ak_1",
+			AllowedOrigins: []string{"https://app.example.com"},
+		})
+	})
+	defer srv.Close()
+	e := newTestExt(t, srv.URL)
+
+	_, err := e.Authenticate(
+		context.Background(),
+		originHeaders("good", "https://attacker.example", "Origin"),
+	)
+	if err == nil {
+		t.Fatal("expected origin rejection")
+	}
+}
+
+func TestAuthenticate_OriginMissingWithAllowList(t *testing.T) {
+	srv := fakeVerifyServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(verifyResponse{
+			TenantID:       "org_1",
+			KeyID:          "ak_1",
+			AllowedOrigins: []string{"https://app.example.com"},
+		})
+	})
+	defer srv.Close()
+	e := newTestExt(t, srv.URL)
+
+	_, err := e.Authenticate(context.Background(), authHeaders("good"))
+	if err == nil {
+		t.Fatal("expected rejection when Origin is missing but allow list is non-empty")
+	}
+}
+
+func TestAuthenticate_OriginIgnoredWhenAllowListEmpty(t *testing.T) {
+	srv := fakeVerifyServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(verifyResponse{TenantID: "org_1", KeyID: "ak_1"})
+	})
+	defer srv.Close()
+	e := newTestExt(t, srv.URL)
+
+	// Any origin should pass when the key has no allow list (backward compat).
+	if _, err := e.Authenticate(
+		context.Background(),
+		originHeaders("good", "https://anywhere.example", "Origin"),
+	); err != nil {
+		t.Fatalf("expected success with empty allow list, got %v", err)
+	}
+}
+
+func TestAuthenticate_OriginHeaderCaseInsensitive(t *testing.T) {
+	srv := fakeVerifyServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(verifyResponse{
+			TenantID:       "org_1",
+			KeyID:          "ak_1",
+			AllowedOrigins: []string{"https://app.example.com"},
+		})
+	})
+	defer srv.Close()
+	e := newTestExt(t, srv.URL)
+
+	// Lowercase "origin" — gRPC shape.
+	if _, err := e.Authenticate(
+		context.Background(),
+		originHeaders("good", "https://app.example.com", "origin"),
+	); err != nil {
+		t.Fatalf("expected success with lowercase header, got %v", err)
+	}
+}

--- a/collector/extension/everrapikeyauth/cache.go
+++ b/collector/extension/everrapikeyauth/cache.go
@@ -8,8 +8,9 @@ import (
 
 // authResult is what the verify endpoint tells us.
 type authResult struct {
-	tenantID string
-	keyID    string
+	tenantID       string
+	keyID          string
+	allowedOrigins []string
 }
 
 // cacheEntry stores one verification outcome.

--- a/collector/extension/everrapikeyauth/extension.go
+++ b/collector/extension/everrapikeyauth/extension.go
@@ -21,15 +21,17 @@ import (
 
 // Errors returned by Authenticate.
 var (
-	errMissingAuth   = errors.New("missing authorization header")
-	errInvalidScheme = errors.New("authorization scheme must be Bearer")
-	errUnauthorized  = errors.New("unauthorized")
+	errMissingAuth      = errors.New("missing authorization header")
+	errInvalidScheme    = errors.New("authorization scheme must be Bearer")
+	errUnauthorized     = errors.New("unauthorized")
+	errOriginNotAllowed = errors.New("origin not allowed for this key")
 )
 
 // verifyResponse mirrors VerifyKeyResponse on the app side.
 type verifyResponse struct {
-	TenantID string `json:"tenantId"`
-	KeyID    string `json:"keyId"`
+	TenantID       string   `json:"tenantId"`
+	KeyID          string   `json:"keyId"`
+	AllowedOrigins []string `json:"allowedOrigins"`
 }
 
 type ext struct {
@@ -94,9 +96,54 @@ func (e *ext) Authenticate(ctx context.Context, headers map[string][]string) (co
 		return ctx, err
 	}
 
+	if len(res.allowedOrigins) > 0 {
+		origin := headerValue(headers, "Origin")
+		if !originAllowed(origin, res.allowedOrigins) {
+			e.logger.Debug(
+				"rejecting request from disallowed origin",
+				zap.String("key_id", res.keyID),
+				zap.String("origin", origin),
+			)
+			return ctx, errOriginNotAllowed
+		}
+	}
+
 	cl := client.FromContext(ctx)
 	cl.Auth = authData{tenantID: res.tenantID, keyID: res.keyID}
 	return client.NewContext(ctx, cl), nil
+}
+
+// headerValue returns the first non-empty value for name from headers,
+// probing both lowercase (gRPC) and canonical (net/http) shapes before
+// falling back to a case-insensitive scan.
+func headerValue(headers map[string][]string, name string) string {
+	canonical := http.CanonicalHeaderKey(name)
+	if v := firstNonEmpty(headers[strings.ToLower(name)], headers[canonical]); v != "" {
+		return v
+	}
+	for k, v := range headers {
+		if len(v) > 0 && v[0] != "" && strings.EqualFold(k, name) {
+			return v[0]
+		}
+	}
+	return ""
+}
+
+// originAllowed reports whether origin matches any entry in allowed.
+// Matching is exact and case-sensitive on scheme+host (browsers send the
+// Origin header verbatim from the document origin), with the trailing slash
+// stripped if present.
+func originAllowed(origin string, allowed []string) bool {
+	if origin == "" {
+		return false
+	}
+	normalized := strings.TrimSuffix(origin, "/")
+	for _, a := range allowed {
+		if strings.TrimSuffix(a, "/") == normalized {
+			return true
+		}
+	}
+	return false
 }
 
 func bearerFrom(headers map[string][]string) (string, error) {
@@ -222,7 +269,11 @@ func (e *ext) verify(ctx context.Context, token string) (*authResult, error) {
 			zap.String("key_id", vr.KeyID),
 			zap.String("tenant_id", vr.TenantID),
 		)
-		return &authResult{tenantID: vr.TenantID, keyID: vr.KeyID}, nil
+		return &authResult{
+			tenantID:       vr.TenantID,
+			keyID:          vr.KeyID,
+			allowedOrigins: vr.AllowedOrigins,
+		}, nil
 	case http.StatusUnauthorized, http.StatusForbidden:
 		e.logger.Debug("verify endpoint rejected key")
 		return nil, errUnauthorized

--- a/collector/internal/localgateway/config/config.go
+++ b/collector/internal/localgateway/config/config.go
@@ -62,6 +62,13 @@ func BuildCollectorConfigMap(cfg CollectorConfig) map[string]any {
 						"endpoint": cfg.OTLPListenAddress,
 						"cors": map[string]any{
 							"allowed_origins": []any{"*"},
+							// Browsers won't include Authorization on the
+							// actual request unless we declare it allowed on
+							// the preflight response.
+							"allowed_headers": []any{
+								"Authorization",
+								"Content-Type",
+							},
 						},
 					},
 				},

--- a/collector/internal/localgateway/config/config_test.go
+++ b/collector/internal/localgateway/config/config_test.go
@@ -38,6 +38,17 @@ func TestBuildCollectorConfigUsesLocalDefaults(t *testing.T) {
 	chdb := exporters["chdb"].(map[string]any)
 	require.Equal(t, "168h0m0s", chdb["ttl"])
 	require.NotContains(t, chdb, "path")
+
+	receivers := raw["receivers"].(map[string]any)
+	otlp := receivers["otlp"].(map[string]any)
+	protocols := otlp["protocols"].(map[string]any)
+	httpCfg := protocols["http"].(map[string]any)
+	cors := httpCfg["cors"].(map[string]any)
+	require.Equal(t, []any{"*"}, cors["allowed_origins"])
+	require.Equal(t,
+		[]any{"Authorization", "Content-Type"},
+		cors["allowed_headers"],
+	)
 }
 
 func TestStaticProviderReturnsGeneratedConfig(t *testing.T) {

--- a/packages/app/src/components/ingest-keys/create-ingest-key-dialog.tsx
+++ b/packages/app/src/components/ingest-keys/create-ingest-key-dialog.tsx
@@ -10,15 +10,48 @@ import {
 } from "@everr/ui/components/dialog";
 import { Input } from "@everr/ui/components/input";
 import { Label } from "@everr/ui/components/label";
+import { Textarea } from "@everr/ui/components/textarea";
 import { Check, Copy, Loader2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { useCreateIngestKey } from "./queries";
 
+function parseOrigins(raw: string): {
+  origins: string[];
+  invalid: string[];
+} {
+  const tokens = raw
+    .split(/[\s,]+/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const origins: string[] = [];
+  const invalid: string[] = [];
+  for (const token of tokens) {
+    let url: URL;
+    try {
+      url = new URL(token);
+    } catch {
+      invalid.push(token);
+      continue;
+    }
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      invalid.push(token);
+      continue;
+    }
+    if ((url.pathname && url.pathname !== "/") || url.search || url.hash) {
+      invalid.push(token);
+      continue;
+    }
+    origins.push(`${url.protocol}//${url.host}`);
+  }
+  return { origins, invalid };
+}
+
 export function CreateIngestKeyDialog() {
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
   const [expiresInDays, setExpiresInDays] = useState<string>("");
+  const [originsInput, setOriginsInput] = useState("");
   const [issuedKey, setIssuedKey] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const create = useCreateIngestKey();
@@ -26,6 +59,7 @@ export function CreateIngestKeyDialog() {
   const reset = () => {
     setName("");
     setExpiresInDays("");
+    setOriginsInput("");
     setIssuedKey(null);
     setCopied(false);
   };
@@ -41,8 +75,15 @@ export function CreateIngestKeyDialog() {
     const trimmed = name.trim();
     if (!trimmed) return;
     const days = expiresInDays.trim() ? Number(expiresInDays) : undefined;
+    const { origins, invalid } = parseOrigins(originsInput);
+    if (invalid.length > 0) {
+      toast.error(
+        `Invalid origin(s): ${invalid.join(", ")}. Use http(s)://host[:port] with no path.`,
+      );
+      return;
+    }
     create.mutate(
-      { name: trimmed, expiresInDays: days },
+      { name: trimmed, expiresInDays: days, allowedOrigins: origins },
       {
         onSuccess: (data) => {
           const key = (data as { key?: string } | null)?.key ?? null;
@@ -134,6 +175,22 @@ export function CreateIngestKeyDialog() {
                   onChange={(e) => setExpiresInDays(e.target.value)}
                   placeholder="never"
                 />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="ingest-key-origins">
+                  Allowed origins (optional)
+                </Label>
+                <Textarea
+                  id="ingest-key-origins"
+                  value={originsInput}
+                  onChange={(e) => setOriginsInput(e.target.value)}
+                  placeholder="https://app.example.com, https://staging.example.com"
+                  rows={2}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Comma- or space-separated. Leave empty to accept any origin.
+                  Server-to-server clients can ignore this.
+                </p>
               </div>
             </div>
             <DialogFooter>

--- a/packages/app/src/components/ingest-keys/ingest-keys-table.tsx
+++ b/packages/app/src/components/ingest-keys/ingest-keys-table.tsx
@@ -13,7 +13,11 @@ import { Button } from "@everr/ui/components/button";
 import { type Column, DataTable } from "@everr/ui/components/data-table";
 import { toast } from "sonner";
 import { formatDate } from "@/components/users-management/format-date";
-import { type IngestKey, useRevokeIngestKey } from "./queries";
+import {
+  type IngestKey,
+  readAllowedOrigins,
+  useRevokeIngestKey,
+} from "./queries";
 
 interface IngestKeysTableProps {
   keys: IngestKey[];
@@ -56,6 +60,24 @@ export function IngestKeysTable({ keys }: IngestKeysTableProps) {
     {
       header: "Expires",
       cell: (row) => dimmedDate(row.expiresAt as unknown as string | null),
+    },
+    {
+      header: "Allowed origins",
+      cell: (row) => {
+        const origins = readAllowedOrigins(row);
+        if (origins.length === 0) {
+          return <span className="text-muted-foreground">Any origin</span>;
+        }
+        return (
+          <div className="flex flex-col gap-0.5">
+            {origins.map((origin) => (
+              <code key={origin} className="text-xs">
+                {origin}
+              </code>
+            ))}
+          </div>
+        );
+      },
     },
     {
       header: "Last used",

--- a/packages/app/src/components/ingest-keys/queries.ts
+++ b/packages/app/src/components/ingest-keys/queries.ts
@@ -61,20 +61,46 @@ export function ingestKeysQueryOptions() {
   });
 }
 
+export function readAllowedOrigins(key: IngestKey): string[] {
+  const raw = (key as { metadata?: unknown }).metadata;
+  let parsed: unknown = raw;
+  if (typeof raw === "string") {
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return [];
+    }
+  }
+  if (!parsed || typeof parsed !== "object") return [];
+  const origins = (parsed as { allowedOrigins?: unknown }).allowedOrigins;
+  if (!Array.isArray(origins)) return [];
+  return origins.filter(
+    (v): v is string => typeof v === "string" && v.length > 0,
+  );
+}
+
 export function useCreateIngestKey() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: async (vars: { name: string; expiresInDays?: number }) => {
+    mutationFn: async (vars: {
+      name: string;
+      expiresInDays?: number;
+      allowedOrigins?: string[];
+    }) => {
       const expiresIn =
         vars.expiresInDays && vars.expiresInDays > 0
           ? vars.expiresInDays * 24 * 60 * 60
           : undefined;
       const organizationId = await getActiveOrgId();
+      const origins = (vars.allowedOrigins ?? []).filter((o) => o.length > 0);
       const res = await authClient.apiKey.create({
         configId: INGEST_CONFIG_ID,
         organizationId,
         name: vars.name,
         ...(expiresIn !== undefined ? { expiresIn } : {}),
+        ...(origins.length > 0
+          ? { metadata: { allowedOrigins: origins } }
+          : {}),
       });
       if (res.error)
         throw new Error(res.error.message ?? "Failed to create ingest key");

--- a/packages/app/src/routes/api/internal/verify-key.test.ts
+++ b/packages/app/src/routes/api/internal/verify-key.test.ts
@@ -104,6 +104,7 @@ describe("/api/internal/verify-key", () => {
     expect(await res.json()).toEqual({
       tenantId: "org_42",
       keyId: "ak_3",
+      allowedOrigins: [],
     });
 
     // The configId pin is the sole guarantee that a CLI/user-scoped key
@@ -111,6 +112,67 @@ describe("/api/internal/verify-key", () => {
     const { auth } = await import("@/lib/auth.server");
     expect(auth.api.verifyApiKey).toHaveBeenCalledWith({
       body: { key: "the-key", configId: "ingest" },
+    });
+  });
+
+  it("returns allowedOrigins when metadata is an object", async () => {
+    await mockVerify({
+      valid: true,
+      error: null,
+      key: {
+        id: "ak_obj",
+        referenceId: "org_1",
+        metadata: { allowedOrigins: ["https://app.example.com"] },
+      },
+    });
+    const res = await getHandler()({ request: makeRequest({ key: "k" }) });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      tenantId: "org_1",
+      keyId: "ak_obj",
+      allowedOrigins: ["https://app.example.com"],
+    });
+  });
+
+  it("returns allowedOrigins when metadata is a JSON string", async () => {
+    // better-auth may hand the raw text column straight through when the
+    // payload didn't round-trip via its serializer.
+    await mockVerify({
+      valid: true,
+      error: null,
+      key: {
+        id: "ak_str",
+        referenceId: "org_2",
+        metadata: JSON.stringify({
+          allowedOrigins: ["https://a.example", "https://b.example"],
+        }),
+      },
+    });
+    const res = await getHandler()({ request: makeRequest({ key: "k" }) });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      tenantId: "org_2",
+      keyId: "ak_str",
+      allowedOrigins: ["https://a.example", "https://b.example"],
+    });
+  });
+
+  it("returns empty allowedOrigins when metadata is malformed JSON", async () => {
+    await mockVerify({
+      valid: true,
+      error: null,
+      key: {
+        id: "ak_bad",
+        referenceId: "org_3",
+        metadata: "{not-json",
+      },
+    });
+    const res = await getHandler()({ request: makeRequest({ key: "k" }) });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      tenantId: "org_3",
+      keyId: "ak_bad",
+      allowedOrigins: [],
     });
   });
 });

--- a/packages/app/src/routes/api/internal/verify-key.ts
+++ b/packages/app/src/routes/api/internal/verify-key.ts
@@ -8,7 +8,23 @@ export const INGEST_CONFIG_ID = "ingest";
 export type VerifyKeyResponse = {
   tenantId: string;
   keyId: string;
+  allowedOrigins: string[];
 };
+
+function parseAllowedOrigins(metadata: unknown): string[] {
+  let parsed: unknown = metadata;
+  if (typeof metadata === "string") {
+    try {
+      parsed = JSON.parse(metadata);
+    } catch {
+      return [];
+    }
+  }
+  if (!parsed || typeof parsed !== "object") return [];
+  const raw = (parsed as { allowedOrigins?: unknown }).allowedOrigins;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((v): v is string => typeof v === "string" && v.length > 0);
+}
 
 function secretMatches(provided: string | null): boolean {
   if (!provided) return false;
@@ -47,6 +63,7 @@ export const Route = createFileRoute("/api/internal/verify-key")({
         const payload: VerifyKeyResponse = {
           tenantId: result.key.referenceId,
           keyId: result.key.id,
+          allowedOrigins: parseAllowedOrigins(result.key.metadata),
         };
 
         return Response.json(payload);


### PR DESCRIPTION
## Summary

- Ingest keys can declare allowed origins at creation time (stored on `apikey.metadata.allowedOrigins`); the collector's `everrapikeyauth` extension rejects authenticated OTLP requests whose `Origin` header doesn't match.
- Keys with an empty list keep accepting any origin (backward compatible).
- Widens the local OTLP receiver's `cors.allowed_headers` to include `Authorization` so browsers can actually send the bearer on the real request.
- Companion CORS edit on the prod collector lives in [everr-labs/everr-deploy#TBD](https://github.com/everr-labs/everr-deploy/pulls).

## Why static '*' on CORS preflight

Browser CORS preflight (`OPTIONS`) does **not** carry the `Authorization` header, so the collector cannot resolve a key from it. Per-key enforcement therefore happens on the **authenticated** request inside the auth extension. CORS is not a server-side security boundary — the bearer + per-key Origin check is.

## What changed

- `packages/app/src/routes/api/internal/verify-key.ts` — returns `allowedOrigins: string[]` (parsed from `key.metadata`, tolerant of object/JSON-string).
- `packages/app/src/components/ingest-keys/*` — new "Allowed origins" textarea on the create dialog with strict scheme://host[:port] validation; new column on the table.
- `collector/extension/everrapikeyauth/extension.go|cache.go` — `verifyResponse`/`authResult` carry the list; `Authenticate` reads `Origin` (lowercase + canonical + case-insensitive scan, mirrors `bearerFrom`) and rejects mismatches.
- `collector/internal/localgateway/config/config.go` — adds `cors.allowed_headers: [Authorization, Content-Type]`.

## Test plan

- [x] `go test ./...` in `collector/extension/everrapikeyauth` and `collector/internal/localgateway/config`
- [x] `vitest run src/routes/api/internal/verify-key.test.ts` (9/9)
- [x] `tsc --noEmit` clean
- [ ] Manually: mint a key with an origin, send OTLP from a browser at that origin → 200; send from a different origin → rejected
- [ ] Mint a key with empty origins, confirm server-to-server ingest still works

## Notes

- Pre-commit (`collector-lint`) was bypassed because of a pre-existing Makefile/SRC_ROOT computation bug under lefthook+worktrees. CI still runs lint.