### PR TITLE
Remove Enter shortcut from setup auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,15 +595,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
-name = "convert_case"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -695,34 +686,6 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crossterm"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
-dependencies = [
- "bitflags 2.11.0",
- "crossterm_winapi",
- "derive_more 2.1.1",
- "document-features",
- "futures-core",
- "mio",
- "parking_lot",
- "rustix",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "crunchy"
@@ -887,7 +850,7 @@ version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
- "convert_case 0.4.0",
+ "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -909,7 +872,6 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -1030,15 +992,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "document-features"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
-dependencies = [
- "litrs",
 ]
 
 [[package]]
@@ -1194,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "everr-app"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1238,7 +1191,6 @@ dependencies = [
  "chrono",
  "clap",
  "cliclack",
- "crossterm",
  "dialoguer",
  "dirs 6.0.0",
  "everr-core",
@@ -2597,12 +2549,6 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
-
-[[package]]
-name = "litrs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -4753,27 +4699,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "signal-hook"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-mio"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
-dependencies = [
- "libc",
- "mio",
- "signal-hook",
-]
 
 [[package]]
 name = "signal-hook-registry"

--- a/packages/desktop-app/src-cli/Cargo.toml
+++ b/packages/desktop-app/src-cli/Cargo.toml
@@ -12,7 +12,6 @@ anyhow = "1.0.98"
 chrono = "0.4"
 clap = { version = "4.5.38", features = ["derive"] }
 cliclack = "0.5.2"
-crossterm = { version = "0.29", features = ["event-stream"] }
 dialoguer = "0.11.0"
 dirs = "6.0.0"
 everr-core = { path = "../../../crates/everr-core" }

--- a/packages/desktop-app/src-cli/src/auth.rs
+++ b/packages/desktop-app/src-cli/src/auth.rs
@@ -1,10 +1,6 @@
-use std::future::Future;
-use std::io::{self, IsTerminal};
 use std::time::{Duration, Instant};
 
-use anyhow::{Context, Result, anyhow, bail};
-use crossterm::event::{Event, EventStream, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
-use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
+use anyhow::{Result, anyhow, bail};
 use everr_core::api::ApiClient;
 use everr_core::auth::{
     AuthConfig, DeviceAuthorization, DevicePollStatus, build_auth_http_client, login_with_prompt,
@@ -12,7 +8,6 @@ use everr_core::auth::{
 };
 use everr_core::build;
 use everr_core::state::{AppStateStore, Session};
-use futures_util::StreamExt;
 use tokio::time::sleep;
 
 use crate::cli::LoginArgs;
@@ -59,24 +54,15 @@ pub(crate) fn identity_summary_lines(email: Option<&str>, org_name: Option<&str>
     lines
 }
 
-pub async fn login_with_enter_to_open_browser(
+pub async fn login_with_device_authorization(
     config: &AuthConfig,
     store: &AppStateStore,
 ) -> Result<Session> {
     let client = build_auth_http_client()?;
     let authorization = start_device_authorization(&client, config).await?;
     show_device_sign_in_note(&authorization.verification_url, &authorization.user_code)?;
-    cliclack::log::remark("Press Enter to open in your browser")?;
 
-    complete_setup_device_authorization_with_enter_prompt(
-        config,
-        store,
-        &client,
-        authorization,
-        wait_for_browser_prompt_action(),
-        open_browser_with_warning,
-    )
-    .await
+    complete_setup_device_authorization(config, store, &client, authorization).await
 }
 
 fn show_device_sign_in_note(verification_url: &str, user_code: &str) -> Result<()> {
@@ -87,127 +73,35 @@ fn show_device_sign_in_note(verification_url: &str, user_code: &str) -> Result<(
     Ok(())
 }
 
-async fn complete_setup_device_authorization_with_enter_prompt<Enter, OpenBrowser>(
+async fn complete_setup_device_authorization(
     config: &AuthConfig,
     store: &AppStateStore,
     client: &reqwest::Client,
     authorization: DeviceAuthorization,
-    enter_prompt: Enter,
-    mut open_browser: OpenBrowser,
-) -> Result<Session>
-where
-    Enter: Future<Output = BrowserPromptAction>,
-    OpenBrowser: FnMut(&str) -> Result<()>,
-{
+) -> Result<Session> {
     let deadline = Instant::now() + Duration::from_secs(authorization.expires_in);
     let mut poll_interval = authorization.interval;
-    let mut enter_prompt = Box::pin(enter_prompt);
-    let mut listen_for_enter = true;
 
     loop {
         if Instant::now() >= deadline {
             bail!("device authentication expired before completion");
         }
 
-        tokio::select! {
-            action = &mut enter_prompt, if listen_for_enter => {
-                listen_for_enter = false;
-                match action {
-                    BrowserPromptAction::OpenBrowser => {
-                        open_browser(&authorization.verification_url)?;
-                    }
-                    BrowserPromptAction::Cancel => bail!("cancelled"),
-                    BrowserPromptAction::Unavailable => {}
-                }
+        sleep(Duration::from_secs(poll_interval)).await;
+        match poll_device_authorization(client, config, &authorization).await? {
+            DevicePollStatus::Authorized(token) => {
+                let session = session_from_device_token(config, token)?;
+                store.save_session(&session)?;
+                return Ok(session);
             }
-            _ = sleep(Duration::from_secs(poll_interval)) => {
-                match poll_device_authorization(client, config, &authorization).await? {
-                    DevicePollStatus::Authorized(token) => {
-                        let session = session_from_device_token(config, token)?;
-                        store.save_session(&session)?;
-                        return Ok(session);
-                    }
-                    DevicePollStatus::Pending => {}
-                    DevicePollStatus::SlowDown => {
-                        poll_interval += 5;
-                    }
-                    DevicePollStatus::Denied => bail!("device authentication was denied"),
-                    DevicePollStatus::Expired => bail!("device authentication token expired"),
-                }
+            DevicePollStatus::Pending => {}
+            DevicePollStatus::SlowDown => {
+                poll_interval += 5;
             }
+            DevicePollStatus::Denied => bail!("device authentication was denied"),
+            DevicePollStatus::Expired => bail!("device authentication token expired"),
         }
     }
-}
-
-async fn wait_for_browser_prompt_action() -> BrowserPromptAction {
-    if !io::stdin().is_terminal() {
-        return BrowserPromptAction::Unavailable;
-    }
-
-    let _raw_mode = match RawModeGuard::enable() {
-        Ok(guard) => guard,
-        Err(_) => return BrowserPromptAction::Unavailable,
-    };
-
-    let mut events = EventStream::new();
-    while let Some(event) = events.next().await {
-        match event {
-            Ok(Event::Key(key)) => {
-                if let Some(action) = browser_prompt_action_for_key(key) {
-                    return action;
-                }
-            }
-            Ok(_) => {}
-            Err(_) => return BrowserPromptAction::Unavailable,
-        }
-    }
-
-    BrowserPromptAction::Unavailable
-}
-
-fn browser_prompt_action_for_key(key: KeyEvent) -> Option<BrowserPromptAction> {
-    if key.kind != KeyEventKind::Press {
-        return None;
-    }
-
-    match key.code {
-        KeyCode::Enter => Some(BrowserPromptAction::OpenBrowser),
-        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-            Some(BrowserPromptAction::Cancel)
-        }
-        _ => None,
-    }
-}
-
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-enum BrowserPromptAction {
-    OpenBrowser,
-    Cancel,
-    Unavailable,
-}
-
-struct RawModeGuard;
-
-impl RawModeGuard {
-    fn enable() -> Result<Self> {
-        enable_raw_mode().context("failed to enable terminal raw mode")?;
-        Ok(Self)
-    }
-}
-
-impl Drop for RawModeGuard {
-    fn drop(&mut self) {
-        let _ = disable_raw_mode();
-    }
-}
-
-fn open_browser_with_warning(verification_url: &str) -> Result<()> {
-    if let Err(error) = webbrowser::open(verification_url) {
-        cliclack::log::warning(format!(
-            "Could not open browser automatically.\nOpen this URL manually: {verification_url} ({error})"
-        ))?;
-    }
-    Ok(())
 }
 
 pub async fn open_browser_immediately(verification_url: String, user_code: String) {
@@ -302,10 +196,8 @@ fn current_api_base_url() -> Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use std::future;
     use std::sync::Mutex;
 
-    use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
     use everr_core::auth::{AuthConfig, DeviceAuthorization};
     use everr_core::build;
     use mockito::Server;
@@ -380,7 +272,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn setup_login_finishes_when_enter_is_never_pressed() {
+    async fn setup_login_waits_for_authorization_polling() {
         let _guard = ENV_LOCK
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -407,68 +299,14 @@ mod tests {
             interval: 0,
         };
 
-        let session = super::complete_setup_device_authorization_with_enter_prompt(
-            &config,
-            &store,
-            &client,
-            authorization,
-            future::pending(),
-            |_| Ok(()),
-        )
-        .await
-        .expect("setup login should finish");
+        let session =
+            super::complete_setup_device_authorization(&config, &store, &client, authorization)
+                .await
+                .expect("setup login should finish");
 
         token_mock.assert_async().await;
         assert_eq!(session.api_base_url, config.api_base_url);
         assert_eq!(session.token, "token-123");
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn setup_login_opens_browser_once_when_enter_is_pressed() {
-        let _guard = ENV_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let mut server = Server::new_async().await;
-        let token_mock = server
-            .mock("POST", "/api/auth/device/token")
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(r#"{"access_token":"token-123"}"#)
-            .create_async()
-            .await;
-        let config = AuthConfig {
-            api_base_url: server.url(),
-        };
-        let temp_dir = tempdir().expect("temp dir");
-        let _env = TempConfigEnv::set(temp_dir.path());
-        let store = everr_core::state::AppStateStore::for_namespace("everr-auth-test");
-        let client = everr_core::auth::build_auth_http_client().expect("http client");
-        let authorization = DeviceAuthorization {
-            device_code: "device-123".to_string(),
-            user_code: "CODE-123".to_string(),
-            verification_url: "https://example.com/device".to_string(),
-            expires_in: 60,
-            interval: 0,
-        };
-        let mut opened_urls = Vec::new();
-
-        let session = super::complete_setup_device_authorization_with_enter_prompt(
-            &config,
-            &store,
-            &client,
-            authorization,
-            future::ready(super::BrowserPromptAction::OpenBrowser),
-            |url| {
-                opened_urls.push(url.to_string());
-                Ok(())
-            },
-        )
-        .await
-        .expect("setup login should finish");
-
-        token_mock.assert_async().await;
-        assert_eq!(session.token, "token-123");
-        assert_eq!(opened_urls, vec!["https://example.com/device"]);
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -499,44 +337,12 @@ mod tests {
             interval: 0,
         };
 
-        let error = super::complete_setup_device_authorization_with_enter_prompt(
-            &config,
-            &store,
-            &client,
-            authorization,
-            future::pending(),
-            |_| Ok(()),
-        )
-        .await
-        .expect_err("denied auth should fail");
+        let error =
+            super::complete_setup_device_authorization(&config, &store, &client, authorization)
+                .await
+                .expect_err("denied auth should fail");
 
         token_mock.assert_async().await;
         assert_eq!(error.to_string(), "device authentication was denied");
-    }
-
-    #[test]
-    fn enter_key_opens_browser_and_ctrl_c_cancels() {
-        assert_eq!(
-            super::browser_prompt_action_for_key(
-                KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE,)
-            ),
-            Some(super::BrowserPromptAction::OpenBrowser)
-        );
-        assert_eq!(
-            super::browser_prompt_action_for_key(KeyEvent::new(
-                KeyCode::Char('c'),
-                KeyModifiers::CONTROL,
-            )),
-            Some(super::BrowserPromptAction::Cancel)
-        );
-        assert_eq!(
-            super::browser_prompt_action_for_key(KeyEvent {
-                code: KeyCode::Enter,
-                modifiers: KeyModifiers::NONE,
-                kind: KeyEventKind::Release,
-                state: KeyEventState::NONE,
-            }),
-            None
-        );
     }
 }

--- a/packages/desktop-app/src-cli/src/onboarding.rs
+++ b/packages/desktop-app/src-cli/src/onboarding.rs
@@ -106,7 +106,7 @@ async fn step_authenticate() -> Result<Session> {
             Ok(session)
         }
         Err(_) => {
-            let session = auth::login_with_enter_to_open_browser(&config, &store).await?;
+            let session = auth::login_with_device_authorization(&config, &store).await?;
             Ok(session)
         }
     }

--- a/packages/desktop-app/src-cli/tests/skills_commands.rs
+++ b/packages/desktop-app/src-cli/tests/skills_commands.rs
@@ -219,7 +219,7 @@ fn setup_authenticates_without_enter_when_polling_succeeds() {
         .arg("setup")
         .assert()
         .success()
-        .stderr(contains("Press Enter to open in your browser"))
+        .stderr(contains("Press Enter to open in your browser").not())
         .stderr(contains("Logged in as user@example.com"))
         .stderr(contains("Using organization: Acme"));
 


### PR DESCRIPTION
## Summary

- Remove the optional "Press Enter to open in your browser" listener from `everr setup` device auth.
- Keep setup auth focused on printing the device code/URL and polling until auth succeeds or fails.
- Drop the CLI crate's `crossterm` dependency and update the lockfile.

## Root Cause

The install-script setup path could panic inside `crossterm::EventStream` while trying to initialize terminal input handling for the optional Enter shortcut. The shortcut is not required for device auth, so removing it avoids that terminal-event failure mode entirely.

## Validation

- `cargo test -p everr-cli -- --test-threads=1`
