### PR TITLE
perf(tests-overview): filter by ServiceName to hit traces primary key

### DIFF
--- a/packages/app/src/data/sql-helpers.ts
+++ b/packages/app/src/data/sql-helpers.ts
@@ -1,4 +1,13 @@
 /**
+ * Spans carrying `everr.test.*` attributes only come from CI runners.
+ * Filtering by ServiceName aligns with the `traces` ORDER BY prefix
+ * `(tenant_id, ServiceName, …)` and lets ClickHouse use the primary index
+ * instead of scanning every span in the time window.
+ */
+export const TEST_SPAN_SERVICE_FILTER =
+  "ServiceName IN ('github-actions', 'everr-labs-everr')";
+
+/**
  * SQL expression to build the full test name from parent_test and test name.
  * Uses "/" as the join separator for deduplication purposes.
  *
@@ -50,7 +59,8 @@ export function leafTestFilter(
   return `${leftExpr} NOT IN (
     SELECT DISTINCT ${rightExpr}
     FROM traces
-    WHERE SpanAttributes['everr.test.parent_test'] != ''
+    WHERE ${TEST_SPAN_SERVICE_FILTER}
+      AND SpanAttributes['everr.test.parent_test'] != ''
       AND Timestamp >= {${fromParam}:String} AND Timestamp <= {${toParam}:String}
       ${scopedConditions}
   )`;

--- a/packages/app/src/data/test-performance/children.ts
+++ b/packages/app/src/data/test-performance/children.ts
@@ -6,7 +6,7 @@ import {
   type TimeRange,
   TimeRangeSchema,
 } from "@/lib/time-range";
-import { testFullNameExpr } from "../sql-helpers";
+import { TEST_SPAN_SERVICE_FILTER, testFullNameExpr } from "../sql-helpers";
 
 // Filter options (repos + branches that have test data)
 interface TestPerfFilterOptions {
@@ -28,7 +28,8 @@ const getTestPerfFilterOptions = createAuthenticatedServerFn({
       clickhouse.query<{ repo: string }>(
         `SELECT DISTINCT ResourceAttributes['vcs.repository.name'] as repo
       FROM traces
-      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+      WHERE ${TEST_SPAN_SERVICE_FILTER}
+        AND Timestamp >= {from:String} AND Timestamp <= {to:String}
         AND ResourceAttributes['vcs.repository.name'] != ''
         AND SpanAttributes['everr.test.name'] != ''
       ORDER BY repo
@@ -38,7 +39,8 @@ const getTestPerfFilterOptions = createAuthenticatedServerFn({
       clickhouse.query<{ branch: string }>(
         `SELECT DISTINCT ResourceAttributes['vcs.ref.head.name'] as branch
       FROM traces
-      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+      WHERE ${TEST_SPAN_SERVICE_FILTER}
+        AND Timestamp >= {from:String} AND Timestamp <= {to:String}
         AND ResourceAttributes['vcs.ref.head.name'] != ''
         AND SpanAttributes['everr.test.name'] != ''
       ORDER BY branch
@@ -98,6 +100,7 @@ const getTestPerfChildren = createAuthenticatedServerFn({
     const { fromISO, toISO } = resolveTimeRange(data.timeRange);
 
     const baseConditions = [
+      TEST_SPAN_SERVICE_FILTER,
       "Timestamp >= {fromTime:String} AND Timestamp <= {toTime:String}",
       "SpanAttributes['everr.test.name'] != ''",
       "SpanAttributes['everr.test.result'] IN ('pass', 'fail')",

--- a/packages/app/src/data/test-performance/filters.ts
+++ b/packages/app/src/data/test-performance/filters.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 import { resolveTimeRange, TimeRangeSchema } from "@/lib/time-range";
-import { leafTestFilter, testFullNameExpr } from "../sql-helpers";
+import {
+  leafTestFilter,
+  TEST_SPAN_SERVICE_FILTER,
+  testFullNameExpr,
+} from "../sql-helpers";
 
 // Filter input for test performance
 export const TestPerformanceFilterSchema = z.object({
@@ -34,6 +38,7 @@ export function buildFilterConditions(
 ): BuildFilterResult {
   const includeSkipResults = options?.includeSkipResults ?? false;
   const conditions: string[] = [
+    TEST_SPAN_SERVICE_FILTER,
     "Timestamp >= {fromTime:String} AND Timestamp <= {toTime:String}",
     "SpanAttributes['everr.test.name'] != ''",
     includeSkipResults


### PR DESCRIPTION
## Summary

The `/tests-overview` page was bottlenecked on two ClickHouse queries (package rollup and totals) that scanned the `traces` table filtered only by `Timestamp` plus map lookups into `SpanAttributes`. That skipped the `(tenant_id, ServiceName, ...)` ORDER BY prefix and forced a partition scan.

Test result spans only come from CI services (`github-actions`, current; `everr-labs-everr`, legacy). Adding `ServiceName IN (...)` aligns the WHERE clause with the primary key — `EXPLAIN indexes=1` now shows `ServiceName` in the `PrimaryKey` condition for both the main scan and the leaf-filter `NOT IN` subquery.

A new shared constant `TEST_SPAN_SERVICE_FILTER` is applied in:
- `leafTestFilter` (the `NOT IN` parents subquery)
- `buildFilterConditions` (covers the `test-results.ts` totals)
- `children.ts` `baseConditions` + the repo/branch filter-option queries

## Numbers

Median ClickHouse query duration on prod (24h window, measured via the `clickhouse.query` spans):

| Query | Before | After | Speedup |
| --- | --- | --- | --- |
| Package rollup (`WITH executions …`) | 1024 ms | 131 ms | ~7.8x |
| Totals (`uniqExact(test_full_name) …`) | 676 ms | 61 ms | ~11x |

Worst-case prod trace before this change was 3.7s; the same shape now runs under ~650 ms.

## Test plan

- [x] `pnpm --filter @everr/app exec vitest run src/data/sql-helpers.test.ts src/data/test-performance/filters.test.ts` — 7/7 pass
- [x] Compared results before/after on prod (24h and 30-day windows) — identical row sets, only float-precision noise in aggregations
- [x] `EXPLAIN indexes=1` confirms `ServiceName` is now used in the `PrimaryKey` condition
- [ ] Smoke-test `/tests-overview` once deployed to staging

## Notes / follow-ups

While investigating I noticed a pre-existing semantic quirk in the package-rollup join in `children.ts`: `replaceAll(' > ', '/')` is applied to `parent_test` when building `executions.normalized_full_name`, but not to `direct_children.child_full_name` (which uses the raw test `name`). For Vitest tests (which use `" > "` as the separator) the `startsWith` clause therefore never matches, and nested test durations are silently excluded from the rollup. Fixing this changes the displayed durations (~2x larger for files with nested describes), so it's not in this PR — happy to follow up separately.