### PR TITLE
perf(clickhouse): raise idle_socket_ttl so TLS handshakes are reused

### DIFF
--- a/packages/app/src/lib/clickhouse.ts
+++ b/packages/app/src/lib/clickhouse.ts
@@ -2,11 +2,17 @@ import { createHmac } from "node:crypto";
 import { env } from "@/env";
 import { createClient } from "@/lib/clickhouse-client";
 
+// The client default of 2500ms forces a fresh TLS handshake on most queries
+// against ClickHouse Cloud (server keep-alive ~10s). Set just under the server
+// timeout so idle sockets are reused instead of reconnected.
+const clickhouseKeepAlive = { idle_socket_ttl: 8000 } as const;
+
 const clickhouse = createClient({
   url: env.CLICKHOUSE_URL,
   username: env.CLICKHOUSE_USERNAME,
   password: env.CLICKHOUSE_PASSWORD,
   database: env.CLICKHOUSE_DATABASE,
+  keep_alive: clickhouseKeepAlive,
 });
 
 export type ClickhouseQuery = <T>(
@@ -103,6 +109,7 @@ const clickhouseAdmin = createClient({
   username: env.CLICKHOUSE_ADMIN_USERNAME,
   password: env.CLICKHOUSE_ADMIN_PASSWORD,
   database: env.CLICKHOUSE_DATABASE,
+  keep_alive: clickhouseKeepAlive,
 });
 
 export async function upsertTenantRetention(row: {


### PR DESCRIPTION
## Summary
- Pass `keep_alive: { idle_socket_ttl: 8000 }` to both `@clickhouse/client` instances in `packages/app/src/lib/clickhouse.ts`.
- The library default is 2500ms, which forces a fresh TLS handshake on most queries against ClickHouse Cloud (server keep-alive ~10s). 8000ms keeps idle sockets reusable while staying under the server timeout.

## Why
Cloud traces over the last 24h:
- ~64% of POSTs to ClickHouse included a `tls.connect` child (393/618).
- TLS handshake averaged ~42ms, ~21% of total POST time.
- Handshake itself is healthy (p95 55ms, p99 74ms) — the problem is that it happens almost every query.

## Test plan
- [ ] Deploy and re-run the ratio query (POSTs with `tls.connect` child vs. total) — expect the share to drop sharply.
- [ ] Spot-check overall ClickHouse POST p50/p95 latency for a downward shift of ~40ms.