### PR TITLE
Emit job ids on CI log scopes

### DIFF
--- a/collector/Makefile.Common
+++ b/collector/Makefile.Common
@@ -44,7 +44,7 @@ CROSSLINK := $(TOOLS_BIN_DIR)/crosslink
 
 .PHONY: lint
 lint:
-	$(LINT) run
+	$(LINT) run --timeout 5m
 
 .PHONY: tidy
 tidy:

--- a/collector/receiver/githubactionsreceiver/log_event_handling.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling.go
@@ -473,6 +473,10 @@ func resolveLogJobMetadata(ctx context.Context, zipJobNames []string, stepTiming
 		runAttempt: e.GetWorkflowRun().GetRunAttempt(),
 	}
 
+	// Job logs arrive from the workflow_run archive, whose file paths only
+	// include job names. The stable GitHub job ID comes from completed
+	// workflow_job events cached with step timings; if that event was missed,
+	// ListWorkflowJobs provides the same ID/name mapping before we emit logs.
 	if stepTimingsCache != nil {
 		if cachedJobs := stepTimingsCache.GetSteps(key); cachedJobs != nil {
 			addJobTimingsMetadata(result, cachedJobs)

--- a/collector/receiver/githubactionsreceiver/log_event_handling.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling.go
@@ -169,6 +169,8 @@ func eventToLogs(ctx context.Context, event interface{}, config *Config, ghClien
 
 	logger.Debug("Extracted jobs from zip", zap.Strings("jobs", jobs), zap.Int("file_count", len(stepFiles)))
 
+	jobMetadataByZipName := resolveLogJobMetadata(ctx, jobs, stepTimingsCache, ghClient, e, logger)
+
 	// Resolve sanitized ZIP directory names to original job names.
 	// GitHub sanitizes "/" to "_" in ZIP paths, causing span ID mismatches
 	// for matrix/sharded jobs like "test (1/2)" → "test (1_2)".
@@ -183,9 +185,14 @@ func eventToLogs(ctx context.Context, event interface{}, config *Config, ghClien
 				jobName = resolved
 			}
 		}
+		jobID := int64(0)
+		if metadata, ok := jobMetadataByZipName[zipJobName]; ok {
+			jobName = metadata.jobName
+			jobID = metadata.jobID
+		}
 
 		jobLogsScope := allLogs.ScopeLogs().AppendEmpty()
-		jobLogsScope.Scope().Attributes().PutStr(string(conventions.CICDPipelineTaskNameKey), jobName)
+		setJobScopeAttributes(jobLogsScope, jobName, jobID)
 
 		for _, logFile := range stepFiles {
 			// File matching uses the ZIP directory name
@@ -322,7 +329,7 @@ func processCombinedLogs(
 		jobName := jst.jobName
 
 		jobLogsScope := allLogs.ScopeLogs().AppendEmpty()
-		jobLogsScope.Scope().Attributes().PutStr(string(conventions.CICDPipelineTaskNameKey), jobName)
+		setJobScopeAttributes(jobLogsScope, jobName, jst.jobID)
 
 		// Pre-generate span IDs for each step
 		steps := make([]stepInfo, 0, len(jst.steps))
@@ -445,6 +452,73 @@ func minDuration(a, b time.Duration) time.Duration {
 	return b
 }
 
+type logJobMetadata struct {
+	jobID   int64
+	jobName string
+}
+
+func setJobScopeAttributes(scopeLogs plog.ScopeLogs, jobName string, jobID int64) {
+	attrs := scopeLogs.Scope().Attributes()
+	attrs.PutStr(string(conventions.CICDPipelineTaskNameKey), jobName)
+	if jobID != 0 {
+		attrs.PutInt(string(conventions.CICDPipelineTaskRunIDKey), jobID)
+	}
+}
+
+func resolveLogJobMetadata(ctx context.Context, zipJobNames []string, stepTimingsCache *stepTimingCache, ghClient *github.Client, e *github.WorkflowRunEvent, logger *zap.Logger) map[string]logJobMetadata {
+	result := make(map[string]logJobMetadata)
+	key := runKey{
+		repoID:     e.GetRepo().GetID(),
+		runID:      e.GetWorkflowRun().GetID(),
+		runAttempt: e.GetWorkflowRun().GetRunAttempt(),
+	}
+
+	if stepTimingsCache != nil {
+		if cachedJobs := stepTimingsCache.GetSteps(key); cachedJobs != nil {
+			addJobTimingsMetadata(result, cachedJobs)
+			stepTimingsCache.Delete(key)
+		}
+	}
+
+	if hasMetadataForAllJobs(result, zipJobNames) {
+		return result
+	}
+
+	addJobMetadata(result, listWorkflowJobMetadata(ctx, ghClient, e, logger))
+	return result
+}
+
+func hasMetadataForAllJobs(metadata map[string]logJobMetadata, zipJobNames []string) bool {
+	for _, jobName := range zipJobNames {
+		if _, ok := metadata[jobName]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func addJobTimingsMetadata(dst map[string]logJobMetadata, jobs []jobStepTimings) {
+	metadata := make([]logJobMetadata, 0, len(jobs))
+	for _, job := range jobs {
+		metadata = append(metadata, logJobMetadata{
+			jobID:   job.jobID,
+			jobName: job.jobName,
+		})
+	}
+	addJobMetadata(dst, metadata)
+}
+
+func addJobMetadata(dst map[string]logJobMetadata, jobs []logJobMetadata) {
+	for _, job := range jobs {
+		if job.jobName == "" {
+			continue
+		}
+		dst[job.jobName] = job
+		sanitized := strings.ReplaceAll(job.jobName, "/", "_")
+		dst[sanitized] = job
+	}
+}
+
 // fetchStepTimingsFromAPI calls the GitHub API to get step timing data
 // when the cache doesn't have it.
 func fetchStepTimingsFromAPI(ctx context.Context, ghClient *github.Client, e *github.WorkflowRunEvent, logger *zap.Logger) []jobStepTimings {
@@ -483,10 +557,48 @@ func fetchStepTimingsFromAPI(ctx context.Context, ghClient *github.Client, e *gi
 			}
 			if len(timings) > 0 {
 				result = append(result, jobStepTimings{
+					jobID:   job.GetID(),
 					jobName: job.GetName(),
 					steps:   timings,
 				})
 			}
+		}
+
+		if resp == nil || resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	return result
+}
+
+func listWorkflowJobMetadata(ctx context.Context, ghClient *github.Client, e *github.WorkflowRunEvent, logger *zap.Logger) []logJobMetadata {
+	owner := e.GetRepo().GetOwner().GetLogin()
+	repo := e.GetRepo().GetName()
+	runID := e.GetWorkflowRun().GetID()
+
+	opts := &github.ListWorkflowJobsOptions{
+		Filter:      "latest",
+		ListOptions: github.ListOptions{PerPage: 100},
+	}
+
+	var result []logJobMetadata
+	for {
+		jobsResp, resp, err := ghClient.Actions.ListWorkflowJobs(ctx, owner, repo, runID, opts)
+		if err != nil {
+			logger.Warn("Failed to list workflow jobs for log metadata", zap.Error(err))
+			return nil
+		}
+
+		for _, job := range jobsResp.Jobs {
+			if job.GetStatus() != "completed" {
+				continue
+			}
+			result = append(result, logJobMetadata{
+				jobID:   job.GetID(),
+				jobName: job.GetName(),
+			})
 		}
 
 		if resp == nil || resp.NextPage == 0 {

--- a/collector/receiver/githubactionsreceiver/log_event_handling.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling.go
@@ -581,15 +581,13 @@ func listWorkflowJobMetadata(ctx context.Context, ghClient *github.Client, e *gi
 	owner := e.GetRepo().GetOwner().GetLogin()
 	repo := e.GetRepo().GetName()
 	runID := e.GetWorkflowRun().GetID()
+	runAttempt := int64(e.GetWorkflowRun().GetRunAttempt())
 
-	opts := &github.ListWorkflowJobsOptions{
-		Filter:      "latest",
-		ListOptions: github.ListOptions{PerPage: 100},
-	}
+	opts := &github.ListOptions{PerPage: 100}
 
 	var result []logJobMetadata
 	for {
-		jobsResp, resp, err := ghClient.Actions.ListWorkflowJobs(ctx, owner, repo, runID, opts)
+		jobsResp, resp, err := ghClient.Actions.ListWorkflowJobsAttempt(ctx, owner, repo, runID, runAttempt, opts)
 		if err != nil {
 			logger.Warn("Failed to list workflow jobs for log metadata", zap.Error(err))
 			return nil

--- a/collector/receiver/githubactionsreceiver/log_event_handling.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling.go
@@ -461,7 +461,7 @@ func setJobScopeAttributes(scopeLogs plog.ScopeLogs, jobName string, jobID int64
 	attrs := scopeLogs.Scope().Attributes()
 	attrs.PutStr(string(conventions.CICDPipelineTaskNameKey), jobName)
 	if jobID != 0 {
-		attrs.PutInt(string(conventions.CICDPipelineTaskRunIDKey), jobID)
+		attrs.PutStr(string(conventions.CICDPipelineTaskRunIDKey), strconv.FormatInt(jobID, 10))
 	}
 }
 

--- a/collector/receiver/githubactionsreceiver/log_event_handling_test.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"strconv"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -502,94 +501,6 @@ func TestEventToLogsNormalFormatUnchanged(t *testing.T) {
 	sn, ok := records.At(0).Attributes().Get(semconv.EverrGitHubWorkflowJobStepNumber)
 	require.True(t, ok)
 	require.Equal(t, int64(1), sn.Int())
-}
-
-func TestEventToLogsNormalFormatUsesCachedJobMetadata(t *testing.T) {
-	logger := zaptest.NewLogger(t)
-
-	runPayload, err := os.ReadFile("./testdata/completed/8_workflow_run_completed.json")
-	require.NoError(t, err)
-	runEvent, err := github.ParseWebHook("workflow_run", runPayload)
-	require.NoError(t, err)
-	wre := runEvent.(*github.WorkflowRunEvent)
-
-	normalLog := "2023-10-13T10:11:33Z Setting up the job\n"
-	var buf bytes.Buffer
-	w := zip.NewWriter(&buf)
-	f, err := w.Create("pre-commit/1_Set up job.txt")
-	require.NoError(t, err)
-	_, err = f.Write([]byte(normalLog))
-	require.NoError(t, err)
-	require.NoError(t, w.Close())
-	zipData := buf.Bytes()
-
-	zipServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/zip")
-		_, _ = w.Write(zipData)
-	}))
-	defer zipServer.Close()
-
-	var jobsAPIHits atomic.Int32
-	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		expectedSuffix := fmt.Sprintf("/repos/%s/%s/actions/runs/%d/attempts/%d/logs",
-			wre.GetRepo().GetOwner().GetLogin(),
-			wre.GetRepo().GetName(),
-			wre.GetWorkflowRun().GetID(),
-			wre.GetWorkflowRun().GetRunAttempt())
-		if r.URL.Path == expectedSuffix || r.URL.Path == "/api/v3"+expectedSuffix {
-			http.Redirect(w, r, zipServer.URL, http.StatusFound)
-			return
-		}
-		jobsSuffix := fmt.Sprintf("/repos/%s/%s/actions/runs/%d/jobs",
-			wre.GetRepo().GetOwner().GetLogin(),
-			wre.GetRepo().GetName(),
-			wre.GetWorkflowRun().GetID())
-		if r.URL.Path == jobsSuffix || r.URL.Path == "/api/v3"+jobsSuffix {
-			jobsAPIHits.Add(1)
-			http.Error(w, "unexpected jobs API call", http.StatusInternalServerError)
-			return
-		}
-		http.NotFound(w, r)
-	}))
-	defer apiServer.Close()
-
-	ghClient, err := github.NewClient(nil).WithEnterpriseURLs(apiServer.URL+"/", apiServer.URL+"/")
-	require.NoError(t, err)
-
-	jnCache := newJobNameCache(100, 30*time.Minute)
-	stCache := newStepTimingCache(100, 30*time.Minute)
-	key := runKey{
-		repoID:     wre.GetRepo().GetID(),
-		runID:      wre.GetWorkflowRun().GetID(),
-		runAttempt: wre.GetWorkflowRun().GetRunAttempt(),
-	}
-	stCache.AddJob(key, 12345, "pre-commit", []stepTiming{
-		{
-			Number:      1,
-			Name:        "Set up job",
-			StartedAt:   time.Date(2023, 10, 13, 10, 11, 33, 0, time.UTC),
-			CompletedAt: time.Date(2023, 10, 13, 10, 11, 35, 0, time.UTC),
-		},
-	})
-
-	logs, err := eventToLogs(
-		context.Background(),
-		wre,
-		&Config{},
-		ghClient,
-		logger,
-		true,
-		jnCache,
-		stCache,
-	)
-	require.NoError(t, err)
-	require.NotNil(t, logs)
-	require.Equal(t, int32(0), jobsAPIHits.Load())
-
-	scope := logs.ResourceLogs().At(0).ScopeLogs().At(0)
-	scopeJobID, ok := scope.Scope().Attributes().Get(string(conventions.CICDPipelineTaskRunIDKey))
-	require.True(t, ok)
-	require.Equal(t, "12345", scopeJobID.Str())
 }
 
 func makeTestWorkflowRunEvent(repoID, runID int64, runAttempt int) *github.WorkflowRunEvent {

--- a/collector/receiver/githubactionsreceiver/log_event_handling_test.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/go-github/v67/github"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	conventions "go.opentelemetry.io/otel/semconv/v1.38.0"
 	"go.uber.org/zap/zaptest"
 
 	"github.com/everr-labs/everr/collector/semconv"
@@ -208,7 +209,7 @@ func TestStepTimingCache(t *testing.T) {
 		{Number: 2, Name: "Build", StartedAt: base.Add(5 * time.Second), CompletedAt: base.Add(30 * time.Second)},
 	}
 
-	cache.AddJob(key, "build", steps)
+	cache.AddJob(key, 101, "build", steps)
 
 	t.Run("cache hit", func(t *testing.T) {
 		result := cache.GetSteps(key)
@@ -218,7 +219,7 @@ func TestStepTimingCache(t *testing.T) {
 	})
 
 	t.Run("multiple jobs same run", func(t *testing.T) {
-		cache.AddJob(key, "test", []stepTiming{
+		cache.AddJob(key, 102, "test", []stepTiming{
 			{Number: 1, Name: "Run tests", StartedAt: base, CompletedAt: base.Add(60 * time.Second)},
 		})
 		result := cache.GetSteps(key)
@@ -294,7 +295,7 @@ func TestProcessCombinedLogsWithRealWebhook(t *testing.T) {
 			CompletedAt: s.GetCompletedAt().Time,
 		})
 	}
-	stCache.AddJob(key, job.GetName(), timings)
+	stCache.AddJob(key, job.GetID(), job.GetName(), timings)
 
 	// Build a combined-format zip with log lines spanning multiple steps.
 	// Steps from the real payload:
@@ -366,6 +367,9 @@ func TestProcessCombinedLogsWithRealWebhook(t *testing.T) {
 	scopeJobName, ok := scope.Scope().Attributes().Get(string("cicd.pipeline.task.name"))
 	require.True(t, ok)
 	require.Equal(t, "pre-commit", scopeJobName.Str())
+	scopeJobID, ok := scope.Scope().Attributes().Get(string(conventions.CICDPipelineTaskRunIDKey))
+	require.True(t, ok)
+	require.Equal(t, job.GetID(), scopeJobID.Int())
 
 	records := scope.LogRecords()
 	require.Equal(t, 5, records.Len(), "expected 5 log lines")
@@ -448,6 +452,15 @@ func TestEventToLogsNormalFormatUnchanged(t *testing.T) {
 			http.Redirect(w, r, zipServer.URL, http.StatusFound)
 			return
 		}
+		jobsSuffix := fmt.Sprintf("/repos/%s/%s/actions/runs/%d/jobs",
+			wre.GetRepo().GetOwner().GetLogin(),
+			wre.GetRepo().GetName(),
+			wre.GetWorkflowRun().GetID())
+		if r.URL.Path == jobsSuffix || r.URL.Path == "/api/v3"+jobsSuffix {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"total_count":1,"jobs":[{"id":12345,"name":"pre-commit","status":"completed"}]}`))
+			return
+		}
 		http.NotFound(w, r)
 	}))
 	defer apiServer.Close()
@@ -479,6 +492,10 @@ func TestEventToLogsNormalFormatUnchanged(t *testing.T) {
 
 	records := sl.At(0).LogRecords()
 	require.Equal(t, 1, records.Len())
+
+	scopeJobID, ok := sl.At(0).Scope().Attributes().Get(string(conventions.CICDPipelineTaskRunIDKey))
+	require.True(t, ok)
+	require.Equal(t, int64(12345), scopeJobID.Int())
 
 	sn, ok := records.At(0).Attributes().Get(semconv.EverrGitHubWorkflowJobStepNumber)
 	require.True(t, ok)

--- a/collector/receiver/githubactionsreceiver/log_event_handling_test.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling_test.go
@@ -453,13 +453,22 @@ func TestEventToLogsNormalFormatUnchanged(t *testing.T) {
 			http.Redirect(w, r, zipServer.URL, http.StatusFound)
 			return
 		}
-		jobsSuffix := fmt.Sprintf("/repos/%s/%s/actions/runs/%d/jobs",
+		jobsSuffix := fmt.Sprintf("/repos/%s/%s/actions/runs/%d/attempts/%d/jobs",
 			wre.GetRepo().GetOwner().GetLogin(),
 			wre.GetRepo().GetName(),
-			wre.GetWorkflowRun().GetID())
+			wre.GetWorkflowRun().GetID(),
+			wre.GetWorkflowRun().GetRunAttempt())
 		if r.URL.Path == jobsSuffix || r.URL.Path == "/api/v3"+jobsSuffix {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"total_count":1,"jobs":[{"id":12345,"name":"pre-commit","status":"completed"}]}`))
+			return
+		}
+		latestJobsSuffix := fmt.Sprintf("/repos/%s/%s/actions/runs/%d/jobs",
+			wre.GetRepo().GetOwner().GetLogin(),
+			wre.GetRepo().GetName(),
+			wre.GetWorkflowRun().GetID())
+		if r.URL.Path == latestJobsSuffix || r.URL.Path == "/api/v3"+latestJobsSuffix {
+			http.Error(w, "unexpected latest-attempt jobs API call", http.StatusInternalServerError)
 			return
 		}
 		http.NotFound(w, r)

--- a/collector/receiver/githubactionsreceiver/log_event_handling_test.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -369,7 +370,7 @@ func TestProcessCombinedLogsWithRealWebhook(t *testing.T) {
 	require.Equal(t, "pre-commit", scopeJobName.Str())
 	scopeJobID, ok := scope.Scope().Attributes().Get(string(conventions.CICDPipelineTaskRunIDKey))
 	require.True(t, ok)
-	require.Equal(t, job.GetID(), scopeJobID.Int())
+	require.Equal(t, strconv.FormatInt(job.GetID(), 10), scopeJobID.Str())
 
 	records := scope.LogRecords()
 	require.Equal(t, 5, records.Len(), "expected 5 log lines")
@@ -495,7 +496,7 @@ func TestEventToLogsNormalFormatUnchanged(t *testing.T) {
 
 	scopeJobID, ok := sl.At(0).Scope().Attributes().Get(string(conventions.CICDPipelineTaskRunIDKey))
 	require.True(t, ok)
-	require.Equal(t, int64(12345), scopeJobID.Int())
+	require.Equal(t, "12345", scopeJobID.Str())
 
 	sn, ok := records.At(0).Attributes().Get(semconv.EverrGitHubWorkflowJobStepNumber)
 	require.True(t, ok)

--- a/collector/receiver/githubactionsreceiver/log_event_handling_test.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -501,6 +502,94 @@ func TestEventToLogsNormalFormatUnchanged(t *testing.T) {
 	sn, ok := records.At(0).Attributes().Get(semconv.EverrGitHubWorkflowJobStepNumber)
 	require.True(t, ok)
 	require.Equal(t, int64(1), sn.Int())
+}
+
+func TestEventToLogsNormalFormatUsesCachedJobMetadata(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	runPayload, err := os.ReadFile("./testdata/completed/8_workflow_run_completed.json")
+	require.NoError(t, err)
+	runEvent, err := github.ParseWebHook("workflow_run", runPayload)
+	require.NoError(t, err)
+	wre := runEvent.(*github.WorkflowRunEvent)
+
+	normalLog := "2023-10-13T10:11:33Z Setting up the job\n"
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	f, err := w.Create("pre-commit/1_Set up job.txt")
+	require.NoError(t, err)
+	_, err = f.Write([]byte(normalLog))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	zipData := buf.Bytes()
+
+	zipServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		_, _ = w.Write(zipData)
+	}))
+	defer zipServer.Close()
+
+	var jobsAPIHits atomic.Int32
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		expectedSuffix := fmt.Sprintf("/repos/%s/%s/actions/runs/%d/attempts/%d/logs",
+			wre.GetRepo().GetOwner().GetLogin(),
+			wre.GetRepo().GetName(),
+			wre.GetWorkflowRun().GetID(),
+			wre.GetWorkflowRun().GetRunAttempt())
+		if r.URL.Path == expectedSuffix || r.URL.Path == "/api/v3"+expectedSuffix {
+			http.Redirect(w, r, zipServer.URL, http.StatusFound)
+			return
+		}
+		jobsSuffix := fmt.Sprintf("/repos/%s/%s/actions/runs/%d/jobs",
+			wre.GetRepo().GetOwner().GetLogin(),
+			wre.GetRepo().GetName(),
+			wre.GetWorkflowRun().GetID())
+		if r.URL.Path == jobsSuffix || r.URL.Path == "/api/v3"+jobsSuffix {
+			jobsAPIHits.Add(1)
+			http.Error(w, "unexpected jobs API call", http.StatusInternalServerError)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer apiServer.Close()
+
+	ghClient, err := github.NewClient(nil).WithEnterpriseURLs(apiServer.URL+"/", apiServer.URL+"/")
+	require.NoError(t, err)
+
+	jnCache := newJobNameCache(100, 30*time.Minute)
+	stCache := newStepTimingCache(100, 30*time.Minute)
+	key := runKey{
+		repoID:     wre.GetRepo().GetID(),
+		runID:      wre.GetWorkflowRun().GetID(),
+		runAttempt: wre.GetWorkflowRun().GetRunAttempt(),
+	}
+	stCache.AddJob(key, 12345, "pre-commit", []stepTiming{
+		{
+			Number:      1,
+			Name:        "Set up job",
+			StartedAt:   time.Date(2023, 10, 13, 10, 11, 33, 0, time.UTC),
+			CompletedAt: time.Date(2023, 10, 13, 10, 11, 35, 0, time.UTC),
+		},
+	})
+
+	logs, err := eventToLogs(
+		context.Background(),
+		wre,
+		&Config{},
+		ghClient,
+		logger,
+		true,
+		jnCache,
+		stCache,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, logs)
+	require.Equal(t, int32(0), jobsAPIHits.Load())
+
+	scope := logs.ResourceLogs().At(0).ScopeLogs().At(0)
+	scopeJobID, ok := scope.Scope().Attributes().Get(string(conventions.CICDPipelineTaskRunIDKey))
+	require.True(t, ok)
+	require.Equal(t, "12345", scopeJobID.Str())
 }
 
 func makeTestWorkflowRunEvent(repoID, runID int64, runAttempt int) *github.WorkflowRunEvent {

--- a/collector/receiver/githubactionsreceiver/receiver.go
+++ b/collector/receiver/githubactionsreceiver/receiver.go
@@ -271,6 +271,9 @@ func (gar *githubActionsReceiver) ServeHTTP(w http.ResponseWriter, r *http.Reque
 				})
 			}
 			if len(timings) > 0 {
+				// The workflow_run log archive only names jobs by ZIP path. Keep the
+				// workflow_job event's stable GitHub job ID here so later log records
+				// can be enriched without relying on display names.
 				gar.stepTimings.AddJob(key, e.GetWorkflowJob().GetID(), jobName, timings)
 			}
 		}

--- a/collector/receiver/githubactionsreceiver/receiver.go
+++ b/collector/receiver/githubactionsreceiver/receiver.go
@@ -271,7 +271,7 @@ func (gar *githubActionsReceiver) ServeHTTP(w http.ResponseWriter, r *http.Reque
 				})
 			}
 			if len(timings) > 0 {
-				gar.stepTimings.AddJob(key, jobName, timings)
+				gar.stepTimings.AddJob(key, e.GetWorkflowJob().GetID(), jobName, timings)
 			}
 		}
 	case *github.WorkflowRunEvent:

--- a/collector/receiver/githubactionsreceiver/receiver_test.go
+++ b/collector/receiver/githubactionsreceiver/receiver_test.go
@@ -322,6 +322,10 @@ func TestGitHubActionsServiceResourceAttributes(t *testing.T) {
 		serviceNamespace, found := attrs.Get("service.namespace")
 		require.True(t, found)
 		require.Equal(t, "cicd", serviceNamespace.Str())
+
+		jobID, found := attrs.Get(string(conventions.CICDPipelineTaskRunIDKey))
+		require.True(t, found)
+		require.Equal(t, strconv.FormatInt(event.(*github.WorkflowJobEvent).GetWorkflowJob().GetID(), 10), jobID.Str())
 	})
 }
 

--- a/collector/receiver/githubactionsreceiver/step_timing_cache.go
+++ b/collector/receiver/githubactionsreceiver/step_timing_cache.go
@@ -15,6 +15,7 @@ type stepTiming struct {
 
 // jobStepTimings holds step timing information for a single job within a run.
 type jobStepTimings struct {
+	jobID   int64
 	jobName string
 	steps   []stepTiming
 }
@@ -45,7 +46,7 @@ func newStepTimingCache(maxSize int, ttl time.Duration) *stepTimingCache {
 
 // AddJob records step timing data for a job. Called when a workflow_job event
 // arrives with completed status.
-func (c *stepTimingCache) AddJob(key runKey, jobName string, steps []stepTiming) {
+func (c *stepTimingCache) AddJob(key runKey, jobID int64, jobName string, steps []stepTiming) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -61,6 +62,7 @@ func (c *stepTimingCache) AddJob(key runKey, jobName string, steps []stepTiming)
 		c.order = append(c.order, key)
 	}
 	entry.jobs = append(entry.jobs, jobStepTimings{
+		jobID:   jobID,
 		jobName: jobName,
 		steps:   steps,
 	})

--- a/collector/receiver/githubactionsreceiver/trace_attributes.go
+++ b/collector/receiver/githubactionsreceiver/trace_attributes.go
@@ -8,6 +8,7 @@ package githubactionsreceiver
 
 import (
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -35,7 +36,7 @@ func createResourceAttributes(resource pcommon.Resource, event interface{}, conf
 		attrs.PutStr(string(conventions.VCSRefHeadTypeKey), "branch")
 		attrs.PutStr(string(conventions.VCSRefHeadRevisionKey), e.GetWorkflowJob().GetHeadSHA())
 		attrs.PutStr(string(conventions.CICDPipelineTaskRunURLFullKey), e.GetWorkflowJob().GetHTMLURL())
-		attrs.PutInt(string(conventions.CICDPipelineTaskRunIDKey), e.GetWorkflowJob().GetID())
+		attrs.PutStr(string(conventions.CICDPipelineTaskRunIDKey), strconv.FormatInt(e.GetWorkflowJob().GetID(), 10))
 
 		if len(e.WorkflowJob.Labels) > 0 {
 			labels := e.GetWorkflowJob().Labels

--- a/packages/app/src/data/runs.test.ts
+++ b/packages/app/src/data/runs.test.ts
@@ -314,23 +314,4 @@ describe("getStepLogs", () => {
     expect(mockedQuery.mock.calls[0]?.[0]).not.toContain("match(Body");
     expect(mockedQuery.mock.calls[1]?.[0]).not.toContain("match(Body");
   });
-
-  it("filters job id logs using scope attributes", async () => {
-    mockedQuery
-      .mockResolvedValueOnce([{ cnt: "1" }])
-      .mockResolvedValueOnce([
-        { timestamp: "2026-03-09 12:00:00", body: "ok" },
-      ]);
-
-    await getStepLogs({
-      data: { traceId: "trace-1", jobId: "777", stepNumber: "16" },
-    });
-
-    expect(mockedQuery.mock.calls[0]?.[0]).toContain(
-      "ScopeAttributes['cicd.pipeline.task.run.id'] = {jobId:String}",
-    );
-    expect(mockedQuery.mock.calls[1]?.[0]).toContain(
-      "ScopeAttributes['cicd.pipeline.task.run.id'] = {jobId:String}",
-    );
-  });
 });

--- a/packages/app/src/data/runs.test.ts
+++ b/packages/app/src/data/runs.test.ts
@@ -314,4 +314,23 @@ describe("getStepLogs", () => {
     expect(mockedQuery.mock.calls[0]?.[0]).not.toContain("match(Body");
     expect(mockedQuery.mock.calls[1]?.[0]).not.toContain("match(Body");
   });
+
+  it("filters job id logs using scope attributes", async () => {
+    mockedQuery
+      .mockResolvedValueOnce([{ cnt: "1" }])
+      .mockResolvedValueOnce([
+        { timestamp: "2026-03-09 12:00:00", body: "ok" },
+      ]);
+
+    await getStepLogs({
+      data: { traceId: "trace-1", jobId: "777", stepNumber: "16" },
+    });
+
+    expect(mockedQuery.mock.calls[0]?.[0]).toContain(
+      "ScopeAttributes['cicd.pipeline.task.run.id'] = {jobId:String}",
+    );
+    expect(mockedQuery.mock.calls[1]?.[0]).toContain(
+      "ScopeAttributes['cicd.pipeline.task.run.id'] = {jobId:String}",
+    );
+  });
 });

--- a/packages/app/src/data/runs/server.ts
+++ b/packages/app/src/data/runs/server.ts
@@ -40,16 +40,16 @@ function buildJobFilterClause(params: StepLogsJobFilter): {
   clause: string;
   queryParam: Record<string, string>;
 } {
-  if (params.jobId !== undefined) {
+  if (params.jobName !== undefined) {
     return {
       clause:
-        "AND ResourceAttributes['cicd.pipeline.task.run.id'] = {jobId:String}",
-      queryParam: { jobId: params.jobId },
+        "AND ScopeAttributes['cicd.pipeline.task.name'] = {jobName:String}",
+      queryParam: { jobName: params.jobName },
     };
   }
   return {
-    clause: "AND ScopeAttributes['cicd.pipeline.task.name'] = {jobName:String}",
-    queryParam: { jobName: params.jobName! },
+    clause: "AND ScopeAttributes['cicd.pipeline.task.run.id'] = {jobId:String}",
+    queryParam: { jobId: params.jobId },
   };
 }
 
@@ -339,10 +339,14 @@ export const getStepLogs = createAuthenticatedServerFn({
     }),
   )
   .handler(async ({ data, context }) => {
-    const jobFilter: StepLogsJobFilter =
-      data.jobId !== undefined
-        ? { jobId: data.jobId }
-        : { jobName: data.jobName! };
+    let jobFilter: StepLogsJobFilter;
+    if (data.jobId !== undefined) {
+      jobFilter = { jobId: data.jobId };
+    } else if (data.jobName !== undefined) {
+      jobFilter = { jobName: data.jobName };
+    } else {
+      throw new Error("Provide either jobName or jobId.");
+    }
 
     const totalCount = await countStepLogs(context.clickhouse, {
       traceId: data.traceId,


### PR DESCRIPTION
## Summary
- Add GitHub workflow job ids to CI log scope attributes during collector ingestion.
- Carry job ids through the step timing cache and GitHub job metadata lookup for normal and compacted log archives.
- Update everr ci logs --job-id lookup to query the log scope job id used by future ingested logs.

## Root Cause
Trace spans had cicd.pipeline.task.run.id, but log records only carried the job name on scope attributes. As a result, job-name log lookup worked while job-id lookup could not match future logs unless ingestion emitted the same job id on log scopes.

## Validation
- go test -count=1 ./... in collector/receiver/githubactionsreceiver
- pnpm --filter @everr/app test:ci src/data/runs.test.ts
- pnpm --filter @everr/app typecheck
- pnpm exec biome check packages/app/src/data/runs/server.ts packages/app/src/data/runs.test.ts
- pre-commit hooks: Biome check, fallow, collector fmt/tidy/lint