### PR TITLE
Add ResourceAttributes skip indexes

### DIFF
--- a/clickhouse/backfill-resource-attribute-skip-indexes.sql
+++ b/clickhouse/backfill-resource-attribute-skip-indexes.sql
@@ -1,0 +1,27 @@
+-- Add and materialize ResourceAttributes skip indexes on app-facing telemetry
+-- tables created before these indexes existed.
+--
+-- Run with an admin user, for example:
+--
+--   clickhouse-client --user default --password '<ADMIN_PASSWORD>' --multiquery \
+--     < clickhouse/backfill-resource-attribute-skip-indexes.sql
+--
+-- MATERIALIZE INDEX rewrites index files for existing parts. It can take time
+-- on large deployments; new inserts use the indexes as soon as ADD INDEX runs.
+
+ALTER TABLE app.traces
+  ADD INDEX IF NOT EXISTS idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1;
+
+ALTER TABLE app.traces
+  ADD INDEX IF NOT EXISTS idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1;
+
+ALTER TABLE app.logs
+  ADD INDEX IF NOT EXISTS idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1;
+
+ALTER TABLE app.logs
+  ADD INDEX IF NOT EXISTS idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1;
+
+ALTER TABLE app.traces MATERIALIZE INDEX idx_res_attr_key;
+ALTER TABLE app.traces MATERIALIZE INDEX idx_res_attr_value;
+ALTER TABLE app.logs MATERIALIZE INDEX idx_res_attr_key;
+ALTER TABLE app.logs MATERIALIZE INDEX idx_res_attr_value;

--- a/clickhouse/init/10-create-mvs.sql
+++ b/clickhouse/init/10-create-mvs.sql
@@ -52,6 +52,12 @@ SELECT
 FROM otel.otel_traces
 WHERE 1 = 0;
 
+ALTER TABLE app.traces
+  ADD INDEX IF NOT EXISTS idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1;
+
+ALTER TABLE app.traces
+  ADD INDEX IF NOT EXISTS idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1;
+
 CREATE MATERIALIZED VIEW IF NOT EXISTS app.traces_mv
 TO app.traces
 AS
@@ -73,6 +79,12 @@ SELECT
   CAST(ResourceAttributes['everr.tenant.id'] AS String) AS tenant_id
 FROM otel.otel_logs
 WHERE 1 = 0;
+
+ALTER TABLE app.logs
+  ADD INDEX IF NOT EXISTS idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1;
+
+ALTER TABLE app.logs
+  ADD INDEX IF NOT EXISTS idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1;
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS app.logs_mv
 TO app.logs

--- a/packages/app/src/data/cost-analysis/server.test.ts
+++ b/packages/app/src/data/cost-analysis/server.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/clickhouse", () => ({
+  query: vi.fn(),
+}));
+
+import { query } from "@/lib/clickhouse";
+import {
+  getCostByWorkflow,
+  getCostOverTimeBreakdown,
+  getCostOverview,
+} from "./server";
+
+const mockedQuery = vi.mocked(query);
+const timeRange = {
+  from: "2026-05-01T00:00:00.000Z",
+  to: "2026-05-31T23:59:59.999Z",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedQuery.mockResolvedValue([]);
+});
+
+describe("cost analysis queries", () => {
+  it("exposes ResourceAttributes key checks for cost overview skip indexes", async () => {
+    await getCostOverview({ data: { timeRange } });
+
+    const sql = mockedQuery.mock.calls[0]?.[0] ?? "";
+    expect(sql).toContain(
+      "mapContains(ResourceAttributes, 'cicd.pipeline.worker.labels')",
+    );
+    expect(sql).toContain(
+      "mapContains(ResourceAttributes, 'cicd.pipeline.task.run.id')",
+    );
+    expect(sql).not.toContain("PREWHERE");
+    expect(sql).not.toContain("SQL_everr_tenant_id");
+  });
+
+  it("exposes ResourceAttributes key checks for workflow grouping", async () => {
+    await getCostByWorkflow({ data: { timeRange } });
+
+    const sql = mockedQuery.mock.calls[0]?.[0] ?? "";
+    expect(sql).toContain(
+      "mapContains(ResourceAttributes, 'cicd.pipeline.worker.labels')",
+    );
+    expect(sql).toContain(
+      "mapContains(ResourceAttributes, 'cicd.pipeline.task.run.id')",
+    );
+    expect(sql).toContain(
+      "mapContains(ResourceAttributes, 'vcs.repository.name')",
+    );
+    expect(sql).toContain(
+      "mapContains(ResourceAttributes, 'cicd.pipeline.name')",
+    );
+  });
+
+  it("exposes ResourceAttributes key checks for over-time breakdown", async () => {
+    await getCostOverTimeBreakdown({
+      data: { timeRange, dimension: "repo" },
+    });
+
+    const sql = mockedQuery.mock.calls[0]?.[0] ?? "";
+    expect(sql).toContain(
+      "mapContains(ResourceAttributes, 'cicd.pipeline.worker.labels')",
+    );
+    expect(sql).toContain(
+      "mapContains(ResourceAttributes, 'cicd.pipeline.task.run.id')",
+    );
+    expect(sql).toContain(
+      "mapContains(ResourceAttributes, 'vcs.repository.name')",
+    );
+  });
+});

--- a/packages/app/src/data/cost-analysis/server.ts
+++ b/packages/app/src/data/cost-analysis/server.ts
@@ -36,6 +36,21 @@ function bucketIso(date: Date): string {
   return `${date.toISOString().slice(0, 13)}:00:00Z`;
 }
 
+const RESOURCE_ATTRIBUTE_KEYS = {
+  runnerLabels: "cicd.pipeline.worker.labels",
+  jobId: "cicd.pipeline.task.run.id",
+  repo: "vcs.repository.name",
+  workflow: "cicd.pipeline.name",
+} as const;
+
+function resourceAttribute(key: string): string {
+  return `ResourceAttributes['${key}']`;
+}
+
+function nonEmptyResourceAttribute(key: string): string {
+  return `mapContains(ResourceAttributes, '${key}') AND ${resourceAttribute(key)} != ''`;
+}
+
 export const getCostOverview = createAuthenticatedServerFn({
   method: "GET",
 })
@@ -45,16 +60,16 @@ export const getCostOverview = createAuthenticatedServerFn({
 
     const sql = `
       SELECT
-        ResourceAttributes['cicd.pipeline.worker.labels'] as labels,
+        ${resourceAttribute(RESOURCE_ATTRIBUTE_KEYS.runnerLabels)} as labels,
         count(*) as totalJobs,
         sum(Duration) / 1000000 as totalDurationMs,
         sum(ceil(Duration / 60000000000.0)) as roundedMinutes,
         sum(sum(ceil(Duration / 60000000000.0))) OVER () as totalBilledMinutes
       FROM traces
       WHERE Timestamp >= {fromTime:String} AND Timestamp <= {toTime:String}
-        AND ResourceAttributes['cicd.pipeline.worker.labels'] != ''
-        AND ResourceAttributes['cicd.pipeline.task.run.id'] != ''
-        AND lowerUTF8(ResourceAttributes['cicd.pipeline.task.run.result']) != 'skip'
+        AND ${nonEmptyResourceAttribute(RESOURCE_ATTRIBUTE_KEYS.runnerLabels)}
+        AND ${nonEmptyResourceAttribute(RESOURCE_ATTRIBUTE_KEYS.jobId)}
+        AND lowerUTF8(${resourceAttribute("cicd.pipeline.task.run.result")}) != 'skip'
         AND SpanAttributes['everr.github.workflow_job_step.number'] = ''
         AND SpanAttributes['everr.test.name'] = ''
       GROUP BY labels
@@ -120,22 +135,22 @@ export const getCostByWorkflow = createAuthenticatedServerFn({
 
     const sql = `
       SELECT
-        ResourceAttributes['vcs.repository.name'] as repo,
-        ResourceAttributes['cicd.pipeline.name'] as workflow,
-        ResourceAttributes['cicd.pipeline.worker.labels'] as labels,
+        ${resourceAttribute(RESOURCE_ATTRIBUTE_KEYS.repo)} as repo,
+        ${resourceAttribute(RESOURCE_ATTRIBUTE_KEYS.workflow)} as workflow,
+        ${resourceAttribute(RESOURCE_ATTRIBUTE_KEYS.runnerLabels)} as labels,
         count(*) as totalJobs,
         sum(Duration) / 1000000 as totalDurationMs,
         sum(ceil(Duration / 60000000000.0)) as roundedMinutes,
         uniqExact(ResourceAttributes['cicd.pipeline.run.id']) as uniqueRuns
       FROM traces
       WHERE Timestamp >= {fromTime:String} AND Timestamp <= {toTime:String}
-        AND ResourceAttributes['cicd.pipeline.worker.labels'] != ''
-        AND ResourceAttributes['cicd.pipeline.task.run.id'] != ''
-        AND lowerUTF8(ResourceAttributes['cicd.pipeline.task.run.result']) != 'skip'
+        AND ${nonEmptyResourceAttribute(RESOURCE_ATTRIBUTE_KEYS.runnerLabels)}
+        AND ${nonEmptyResourceAttribute(RESOURCE_ATTRIBUTE_KEYS.jobId)}
+        AND lowerUTF8(${resourceAttribute("cicd.pipeline.task.run.result")}) != 'skip'
         AND SpanAttributes['everr.github.workflow_job_step.number'] = ''
         AND SpanAttributes['everr.test.name'] = ''
-        AND ResourceAttributes['vcs.repository.name'] != ''
-        AND ResourceAttributes['cicd.pipeline.name'] != ''
+        AND ${nonEmptyResourceAttribute(RESOURCE_ATTRIBUTE_KEYS.repo)}
+        AND ${nonEmptyResourceAttribute(RESOURCE_ATTRIBUTE_KEYS.workflow)}
       GROUP BY repo, workflow, labels
       ORDER BY totalDurationMs DESC
     `;
@@ -208,26 +223,31 @@ export const getCostOverTimeBreakdown = createAuthenticatedServerFn({
     }): Promise<CostOverTimeBreakdown> => {
       const { fromISO, toISO, fromDate, toDate } = resolveTimeRange(timeRange);
       const granularity = getBucketGranularity(fromDate, toDate);
-      const keyExpr =
+      const keyAttribute =
         dimension === "repo"
-          ? "ResourceAttributes['vcs.repository.name']"
-          : "ResourceAttributes['cicd.pipeline.worker.labels']";
+          ? RESOURCE_ATTRIBUTE_KEYS.repo
+          : RESOURCE_ATTRIBUTE_KEYS.runnerLabels;
+      const keyExpr = resourceAttribute(keyAttribute);
+      const dimensionFilter =
+        keyAttribute === RESOURCE_ATTRIBUTE_KEYS.runnerLabels
+          ? ""
+          : `AND ${nonEmptyResourceAttribute(keyAttribute)}`;
 
       const sql = `
       SELECT
         ${bucketExpr(granularity)} as date,
         ${keyExpr} as series,
-        ResourceAttributes['cicd.pipeline.worker.labels'] as labels,
+        ${resourceAttribute(RESOURCE_ATTRIBUTE_KEYS.runnerLabels)} as labels,
         sum(Duration) / 1000000 as totalDurationMs,
         sum(ceil(Duration / 60000000000.0)) as roundedMinutes
       FROM traces
       WHERE Timestamp >= {fromTime:String} AND Timestamp <= {toTime:String}
-        AND ResourceAttributes['cicd.pipeline.worker.labels'] != ''
-        AND ResourceAttributes['cicd.pipeline.task.run.id'] != ''
-        AND lowerUTF8(ResourceAttributes['cicd.pipeline.task.run.result']) != 'skip'
+        AND ${nonEmptyResourceAttribute(RESOURCE_ATTRIBUTE_KEYS.runnerLabels)}
+        AND ${nonEmptyResourceAttribute(RESOURCE_ATTRIBUTE_KEYS.jobId)}
+        AND lowerUTF8(${resourceAttribute("cicd.pipeline.task.run.result")}) != 'skip'
         AND SpanAttributes['everr.github.workflow_job_step.number'] = ''
         AND SpanAttributes['everr.test.name'] = ''
-        AND ${keyExpr} != ''
+        ${dimensionFilter}
       GROUP BY date, series, labels
       ORDER BY date ASC
     `;

--- a/packages/telemetry-explorer/src/logs/sql/filter-options.test.ts
+++ b/packages/telemetry-explorer/src/logs/sql/filter-options.test.ts
@@ -13,6 +13,9 @@ describe("buildFilterOptionsQuery", () => {
     expect(built.sql).toContain(
       "DISTINCT ResourceAttributes['vcs.repository.name']",
     );
+    expect(built.sql).toContain(
+      "mapContains(ResourceAttributes, 'vcs.repository.name')",
+    );
     expect(typeof built.params.fromTime).toBe("string");
   });
 });

--- a/packages/telemetry-explorer/src/logs/sql/filter-options.ts
+++ b/packages/telemetry-explorer/src/logs/sql/filter-options.ts
@@ -3,6 +3,16 @@ import type { LogFilterOptions } from "../schemas";
 import type { BuiltQuery } from "./explorer";
 import { validateTableName } from "./table";
 
+const REPOSITORY_RESOURCE_ATTRIBUTE = "vcs.repository.name";
+
+function resourceAttribute(key: string): string {
+  return `ResourceAttributes['${key}']`;
+}
+
+function resourceAttributeKeyExists(key: string): string {
+  return `mapContains(ResourceAttributes, '${key}')`;
+}
+
 export interface FilterOptionsRowRaw {
   services: string[];
   repos: string[];
@@ -27,11 +37,12 @@ export function buildFilterOptionsQuery(
           LIMIT 100
         )) AS services,
         (SELECT groupArray(v) FROM (
-          SELECT DISTINCT ResourceAttributes['vcs.repository.name'] AS v
+          SELECT DISTINCT ${resourceAttribute(REPOSITORY_RESOURCE_ATTRIBUTE)} AS v
           FROM ${tableName}
           WHERE TimestampTime >= parseDateTimeBestEffort({fromTime:String})
             AND TimestampTime <= parseDateTimeBestEffort({toTime:String})
-            AND ResourceAttributes['vcs.repository.name'] != ''
+            AND ${resourceAttributeKeyExists(REPOSITORY_RESOURCE_ATTRIBUTE)}
+            AND ${resourceAttribute(REPOSITORY_RESOURCE_ATTRIBUTE)} != ''
           ORDER BY v
           LIMIT 100
         )) AS repos

--- a/packages/telemetry-explorer/src/logs/sql/where.test.ts
+++ b/packages/telemetry-explorer/src/logs/sql/where.test.ts
@@ -49,6 +49,23 @@ describe("buildWhereClause", () => {
     });
     expect(sql).toContain("ServiceName IN {services:Array(String)}");
     expect(sql).toContain(
+      "mapContains(ResourceAttributes, 'vcs.repository.name')",
+    );
+    expect(sql).toContain(
+      "ResourceAttributes['vcs.repository.name'] IN {repos:Array(String)}",
+    );
+  });
+
+  it("preserves missing-key semantics when filtering for an empty repo", () => {
+    const sql = buildWhereClause({
+      levels: [],
+      services: [],
+      repos: [""],
+    });
+    expect(sql).not.toContain(
+      "mapContains(ResourceAttributes, 'vcs.repository.name')",
+    );
+    expect(sql).toContain(
       "ResourceAttributes['vcs.repository.name'] IN {repos:Array(String)}",
     );
   });

--- a/packages/telemetry-explorer/src/logs/sql/where.ts
+++ b/packages/telemetry-explorer/src/logs/sql/where.ts
@@ -1,6 +1,16 @@
 import type { LogLevel } from "../schemas";
 import { LOG_LEVEL_EXPR } from "./level-expr";
 
+const REPOSITORY_RESOURCE_ATTRIBUTE = "vcs.repository.name";
+
+function resourceAttribute(key: string): string {
+  return `ResourceAttributes['${key}']`;
+}
+
+function resourceAttributeKeyExists(key: string): string {
+  return `mapContains(ResourceAttributes, '${key}')`;
+}
+
 export interface WhereInput {
   query?: string;
   levels: LogLevel[];
@@ -25,8 +35,11 @@ export function buildWhereClause(input: WhereInput): string {
     clauses.push("ServiceName IN {services:Array(String)}");
   }
   if (input.repos.length > 0) {
+    const repoFilter = `${resourceAttribute(REPOSITORY_RESOURCE_ATTRIBUTE)} IN {repos:Array(String)}`;
     clauses.push(
-      "ResourceAttributes['vcs.repository.name'] IN {repos:Array(String)}",
+      input.repos.includes("")
+        ? repoFilter
+        : `${resourceAttributeKeyExists(REPOSITORY_RESOURCE_ATTRIBUTE)} AND ${repoFilter}`,
     );
   }
   if (input.traceId) {

--- a/packages/telemetry-explorer/src/traces/data/repository.test.ts
+++ b/packages/telemetry-explorer/src/traces/data/repository.test.ts
@@ -90,6 +90,34 @@ describe("TracesRepository.search", () => {
     expect(sql).not.toContain("{toTs:DateTime64(9)}");
     expect(sql).toContain("parseDateTime64BestEffort({fromTs:String}, 9)");
     expect(sql).toContain("parseDateTime64BestEffort({toTs:String}, 9)");
+    expect(sql).toContain(
+      "mapContains(ResourceAttributes, 'service.namespace')",
+    );
+    expect(sql).toContain(
+      "ResourceAttributes['service.namespace'] IN {namespace:Array(String)}",
+    );
+  });
+
+  it("preserves missing-key semantics when filtering for an empty namespace", async () => {
+    query.mockResolvedValueOnce([]);
+
+    await makeRepo().search({
+      fromTs: "2026-05-20 11:00:00.000",
+      toTs: "2026-05-20 13:00:00.000",
+      namespace: [""],
+      service: [],
+      name: "",
+      status: "all",
+      limit: 25,
+    });
+
+    const [sql] = query.mock.calls[0] ?? [];
+    expect(sql).not.toContain(
+      "mapContains(ResourceAttributes, 'service.namespace')",
+    );
+    expect(sql).toContain(
+      "ResourceAttributes['service.namespace'] IN {namespace:Array(String)}",
+    );
   });
 
   it("rejects invalid configured table names", async () => {

--- a/packages/telemetry-explorer/src/traces/data/repository.ts
+++ b/packages/telemetry-explorer/src/traces/data/repository.ts
@@ -19,6 +19,15 @@ type SpanRow = Omit<Span, "events" | "links"> & {
 const FROM_TS_SQL = "parseDateTime64BestEffort({fromTs:String}, 9)";
 const TO_TS_SQL = "parseDateTime64BestEffort({toTs:String}, 9)";
 const TIME_WINDOW_SQL = `Timestamp BETWEEN ${FROM_TS_SQL} AND ${TO_TS_SQL}`;
+const SERVICE_NAMESPACE_RESOURCE_ATTRIBUTE = "service.namespace";
+
+function resourceAttribute(key: string): string {
+  return `ResourceAttributes['${key}']`;
+}
+
+function resourceAttributeKeyExists(key: string): string {
+  return `mapContains(ResourceAttributes, '${key}')`;
+}
 
 export class TracesRepository {
   private readonly tableName: string;
@@ -54,8 +63,11 @@ export class TracesRepository {
       params.service = input.service;
     }
     if (input.namespace.length > 0) {
+      const namespaceFilter = `${resourceAttribute(SERVICE_NAMESPACE_RESOURCE_ATTRIBUTE)} IN {namespace:Array(String)}`;
       spanPreds.push(
-        "ResourceAttributes['service.namespace'] IN {namespace:Array(String)}",
+        input.namespace.includes("")
+          ? namespaceFilter
+          : `${resourceAttributeKeyExists(SERVICE_NAMESPACE_RESOURCE_ATTRIBUTE)} AND ${namespaceFilter}`,
       );
       params.namespace = input.namespace;
     }
@@ -107,8 +119,8 @@ export class TracesRepository {
              argMinIf(ServiceName, (Timestamp, SpanId), ParentSpanId = ''),
              argMin  (ServiceName, (Timestamp, SpanId))) AS rootService,
           if(countIf(ParentSpanId = '') > 0,
-             argMinIf(ResourceAttributes['service.namespace'], (Timestamp, SpanId), ParentSpanId = ''),
-             argMin  (ResourceAttributes['service.namespace'], (Timestamp, SpanId))) AS rootNamespace,
+             argMinIf(${resourceAttribute(SERVICE_NAMESPACE_RESOURCE_ATTRIBUTE)}, (Timestamp, SpanId), ParentSpanId = ''),
+             argMin  (${resourceAttribute(SERVICE_NAMESPACE_RESOURCE_ATTRIBUTE)}, (Timestamp, SpanId))) AS rootNamespace,
           if(countIf(ParentSpanId = '') > 0,
              argMinIf(StatusCode,  (Timestamp, SpanId), ParentSpanId = ''),
              argMin  (StatusCode,  (Timestamp, SpanId))) AS rootStatus,
@@ -155,7 +167,7 @@ export class TracesRepository {
         ParentSpanId AS parentSpanId,
         SpanName     AS spanName,
         ServiceName  AS serviceName,
-        ResourceAttributes['service.namespace'] AS serviceNamespace,
+        ${resourceAttribute(SERVICE_NAMESPACE_RESOURCE_ATTRIBUTE)} AS serviceNamespace,
         toString(Timestamp)                     AS timestamp,
         toString(toUnixTimestamp64Nano(Timestamp)) AS timestampNs,
         toString(Duration)                      AS duration,
@@ -189,7 +201,7 @@ export class TracesRepository {
     validateTableName(this.tableName);
     const sql = /* sql */ `
       SELECT DISTINCT
-        ResourceAttributes['service.namespace'] AS serviceNamespace,
+        ${resourceAttribute(SERVICE_NAMESPACE_RESOURCE_ATTRIBUTE)} AS serviceNamespace,
         ServiceName AS serviceName
       FROM ${this.tableName}
       WHERE ${TIME_WINDOW_SQL}


### PR DESCRIPTION
## Summary
- add ResourceAttributes key/value bloom skip indexes to app-facing logs and traces tables
- add a backfill/materialization script for existing app logs/traces parts
- update cost, log repo, and trace namespace filters to expose `mapContains(ResourceAttributes, ...)` predicates that can use the new key index while preserving empty-string filter behavior

## Validation
- `pnpm vitest run packages/app/src/data/cost-analysis/server.test.ts packages/telemetry-explorer/src/logs/sql/where.test.ts packages/telemetry-explorer/src/logs/sql/filter-options.test.ts packages/telemetry-explorer/src/traces/data/repository.test.ts`
- `pnpm biome check packages/app/src/data/cost-analysis/server.ts packages/app/src/data/cost-analysis/server.test.ts packages/telemetry-explorer/src/logs/sql/where.ts packages/telemetry-explorer/src/logs/sql/where.test.ts packages/telemetry-explorer/src/logs/sql/filter-options.ts packages/telemetry-explorer/src/logs/sql/filter-options.test.ts packages/telemetry-explorer/src/traces/data/repository.ts packages/telemetry-explorer/src/traces/data/repository.test.ts`
- `pnpm --filter @everr/app typecheck`
- `pnpm --filter @everr/telemetry-explorer typecheck`
