### PR TITLE
Import runs from any branch

### DIFF
--- a/packages/app/src/server/github-events/backfill.test.ts
+++ b/packages/app/src/server/github-events/backfill.test.ts
@@ -346,9 +346,9 @@ describe("backfillRepo", () => {
     expect(result.jobsReplayed).toBe(1);
   });
 
-  it("stops after 100 jobs per repo", async () => {
-    // 25 runs with 5 jobs each = 125 jobs, should stop at 100 (20 runs)
-    const runs = Array.from({ length: 25 }, (_, i) =>
+  it("stops after 250 jobs per repo", async () => {
+    // 60 runs with 5 jobs each = 300 jobs, should stop at 250 (50 runs)
+    const runs = Array.from({ length: 60 }, (_, i) =>
       makeRun({ id: i + 1, run_number: i + 1 }),
     );
     const jobsPerRun = runs.map((r) =>
@@ -360,8 +360,8 @@ describe("backfillRepo", () => {
 
     const { result } = await drainBackfill(999, "org-1", TEST_REPO);
 
-    expect(result.jobsReplayed).toBe(100);
-    expect(result.runsReplayed).toBe(20);
+    expect(result.jobsReplayed).toBe(250);
+    expect(result.runsReplayed).toBe(50);
   });
 
   it("imports workflow runs from any branch", async () => {
@@ -464,18 +464,18 @@ describe("backfillRepo", () => {
     // 1 initial + 3 per-run + 1 done = 5
     expect(progressEvents.length).toBe(5);
 
-    // First event should be "importing" with runsProcessed 0 and jobsQuota 100
+    // First event should be "importing" with runsProcessed 0 and jobsQuota 250
     const first = progressEvents[0];
     expect(first.status).toBe("importing");
     expect(first.runsProcessed).toBe(0);
-    expect(first.jobsQuota).toBe(100);
+    expect(first.jobsQuota).toBe(250);
 
     // Last event should be "done"
     const last = progressEvents[progressEvents.length - 1];
     expect(last.status).toBe("done");
     expect(last.runsProcessed).toBe(3);
     expect(last.jobsEnqueued).toBe(3);
-    expect(last.jobsQuota).toBe(100);
+    expect(last.jobsQuota).toBe(250);
 
     // Incremental events should show increasing runsProcessed
     const importingEvents = progressEvents.filter(

--- a/packages/app/src/server/github-events/backfill.test.ts
+++ b/packages/app/src/server/github-events/backfill.test.ts
@@ -303,11 +303,11 @@ describe("backfillRepo", () => {
       if (url.includes("/access_tokens")) {
         return mockTokenResponse();
       }
-      if (url.includes("/actions/runs?") && url.includes("branch=main")) {
-        return mockGitHubList("workflow_runs", runs);
-      }
       if (url.includes("/actions/runs?")) {
-        return mockGitHubList("workflow_runs", []);
+        return mockGitHubList(
+          "workflow_runs",
+          url.includes("branch=") ? [] : runs,
+        );
       }
       if (url.includes("/jobs")) {
         const runId = Number(url.match(/runs\/(\d+)\/jobs/)?.[1]);
@@ -364,16 +364,49 @@ describe("backfillRepo", () => {
     expect(result.runsReplayed).toBe(20);
   });
 
-  it("falls back to no branch filter when main and master have no runs", async () => {
-    const { runs, jobs } = makeSingleRunWithJob();
+  it("imports workflow runs from any branch", async () => {
+    const runs = [
+      makeRun({ id: 1, head_branch: "main" }),
+      makeRun({ id: 2, head_branch: "feature/import-me" }),
+    ];
+    const jobs = [
+      [makeJob({ id: 101, run_id: 1, head_branch: "main" })],
+      [makeJob({ id: 201, run_id: 2, head_branch: "feature/import-me" })],
+    ];
+    const runListUrls: string[] = [];
 
     mockFetch.mockImplementation(async (url: string) => {
       if (url.includes("/access_tokens")) return mockTokenResponse();
-      // main and master return empty, unfiltered returns runs
-      if (url.includes("/actions/runs?") && url.includes("branch=")) {
-        return mockGitHubList("workflow_runs", []);
-      }
       if (url.includes("/actions/runs?")) {
+        runListUrls.push(url);
+        if (url.includes("branch=")) {
+          return mockGitHubList("workflow_runs", [runs[0]]);
+        }
+        return mockGitHubList("workflow_runs", runs);
+      }
+      if (url.includes("/jobs")) {
+        const runId = Number(url.match(/runs\/(\d+)\/jobs/)?.[1]);
+        const idx = runs.findIndex((r) => r.id === runId);
+        return mockGitHubList("jobs", idx >= 0 ? jobs[idx] : []);
+      }
+      return mockGitHubList("workflow_runs", []);
+    });
+
+    const { result } = await drainBackfill(999, "org-1", TEST_REPO);
+
+    expect(result.runsReplayed).toBe(2);
+    expect(result.jobsReplayed).toBe(2);
+    expect(runListUrls.every((url) => !url.includes("branch="))).toBe(true);
+  });
+
+  it("uses no branch filter when listing runs", async () => {
+    const { runs, jobs } = makeSingleRunWithJob();
+    const runListUrls: string[] = [];
+
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url.includes("/access_tokens")) return mockTokenResponse();
+      if (url.includes("/actions/runs?")) {
+        runListUrls.push(url);
         return mockGitHubList("workflow_runs", runs);
       }
       if (url.includes("/jobs")) {
@@ -386,6 +419,7 @@ describe("backfillRepo", () => {
 
     expect(result.runsReplayed).toBe(1);
     expect(result.jobsReplayed).toBe(1);
+    expect(runListUrls.every((url) => !url.includes("branch="))).toBe(true);
   });
 
   it("handles repos with no workflow runs", async () => {

--- a/packages/app/src/server/github-events/backfill.ts
+++ b/packages/app/src/server/github-events/backfill.ts
@@ -7,7 +7,7 @@
  *
  * Scope constraints (from spec):
  * - User-selected repos (one or more)
- * - 100 jobs per repo (soft quota — a run that pushes past 100 is fully included)
+ * - 250 jobs per repo (soft quota — a run that pushes past 250 is fully included)
  * - Branch selection: no branch filter; import completed runs from any branch
  * - Only runs with conclusion "success" or "failure"
  *
@@ -32,7 +32,7 @@ const logger = logs.getLogger("@everr/app/github-events/backfill");
 // Constants
 // ---------------------------------------------------------------------------
 
-export const JOB_QUOTA_PER_REPO = 100;
+export const JOB_QUOTA_PER_REPO = 250;
 const VALID_CONCLUSIONS = new Set(["success", "failure"]);
 
 // ---------------------------------------------------------------------------
@@ -396,7 +396,7 @@ export async function listInstallationRepos(
  * Backfills historical GitHub Actions data for a single repo.
  *
  * Replays completed runs and their jobs from any branch through the collector
- * pipeline. Stops at 100 jobs per repo (soft quota).
+ * pipeline. Stops at 250 jobs per repo (soft quota).
  */
 export async function* backfillRepo(
   installationId: number,

--- a/packages/app/src/server/github-events/backfill.ts
+++ b/packages/app/src/server/github-events/backfill.ts
@@ -8,7 +8,7 @@
  * Scope constraints (from spec):
  * - User-selected repos (one or more)
  * - 100 jobs per repo (soft quota — a run that pushes past 100 is fully included)
- * - Branch selection: main → master → no filter (picks first with runs)
+ * - Branch selection: no branch filter; import completed runs from any branch
  * - Only runs with conclusion "success" or "failure"
  *
  * All GitHub API calls (repos, runs, jobs) are made sequentially on purpose to
@@ -33,8 +33,6 @@ const logger = logs.getLogger("@everr/app/github-events/backfill");
 // ---------------------------------------------------------------------------
 
 export const JOB_QUOTA_PER_REPO = 100;
-/** Try main, then master, then no branch filter. Stop at the first with runs. */
-const BRANCH_CANDIDATES: (string | null)[] = ["main", "master", null];
 const VALID_CONCLUSIONS = new Set(["success", "failure"]);
 
 // ---------------------------------------------------------------------------
@@ -397,9 +395,8 @@ export async function listInstallationRepos(
 /**
  * Backfills historical GitHub Actions data for a single repo.
  *
- * Tries main, then master, then no branch filter — stops at the first
- * that returns runs. Replays completed runs and their jobs through the
- * collector pipeline. Stops at 100 jobs per repo (soft quota).
+ * Replays completed runs and their jobs from any branch through the collector
+ * pipeline. Stops at 100 jobs per repo (soft quota).
  */
 export async function* backfillRepo(
   installationId: number,
@@ -432,28 +429,23 @@ export async function* backfillRepo(
   let jobCount = 0;
   let runsProcessed = 0;
 
-  for (const branch of BRANCH_CANDIDATES) {
-    if (jobCount >= JOB_QUOTA_PER_REPO) break;
+  const runsUrl = `https://api.github.com/repos/${repo.full_name}/actions/runs?status=completed&per_page=100`;
 
-    const branchParam = branch ? `&branch=${branch}` : "";
-    const runsUrl = `https://api.github.com/repos/${repo.full_name}/actions/runs?status=completed${branchParam}&per_page=100`;
+  try {
+    const token = await getInstallationToken(installationId);
 
-    try {
-      const token = await getInstallationToken(installationId);
+    // Collect all valid runs, then dedup in one query
+    const candidateRuns: ApiWorkflowRun[] = [];
+    for await (const run of paginate<ApiWorkflowRun>(
+      token,
+      runsUrl,
+      "workflow_runs",
+    )) {
+      if (!VALID_CONCLUSIONS.has(run.conclusion ?? "")) continue;
+      candidateRuns.push(run);
+    }
 
-      // Collect all valid runs, then dedup in one query
-      const candidateRuns: ApiWorkflowRun[] = [];
-      for await (const run of paginate<ApiWorkflowRun>(
-        token,
-        runsUrl,
-        "workflow_runs",
-      )) {
-        if (!VALID_CONCLUSIONS.has(run.conclusion ?? "")) continue;
-        candidateRuns.push(run);
-      }
-
-      if (candidateRuns.length === 0) continue;
-
+    if (candidateRuns.length > 0) {
       const traceIds = candidateRuns.map((run) =>
         generateWorkflowTraceId(repo.id, run.id, run.run_attempt),
       );
@@ -528,16 +520,10 @@ export async function* backfillRepo(
           result.errors.push(`run ${run.id}: ${msg}`);
         }
       }
-
-      // Found runs on this branch — don't try the next candidate
-      break;
-    } catch (err) {
-      // Branch may not exist (404) — try next
-      const msg = err instanceof Error ? err.message : String(err);
-      if (!msg.includes("status=404")) {
-        result.errors.push(`branch ${branch ?? "all"}: ${msg}`);
-      }
     }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    result.errors.push(`runs: ${msg}`);
   }
 
   result.durationMs = Date.now() - started;


### PR DESCRIPTION
## Summary

- Change GitHub Actions backfill to list completed runs without a branch filter.
- Increase the per-repo import job quota from 100 to 250 while keeping success/failure filtering, deduplication, and job replay behavior.
- Add coverage proving imports include runs from both default and feature branches, the run-list request does not send `branch=`, and quota progress reports `250`.

## Validation

- `pnpm --filter @everr/app exec vitest run src/server/github-events/backfill.test.ts`
- `pnpm exec biome check packages/app/src/server/github-events/backfill.ts packages/app/src/server/github-events/backfill.test.ts`
- `pnpm --filter @everr/app typecheck`
- `git diff --check`