### PR TITLE
Remove local endpoint command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Breaking changes - CLI command groups
 
-- Moved commands under grouped namespaces: `everr cloud login/logout`, `everr ci status/watch/runs/show/logs`, and `everr local start/status/query/endpoint`.
+- Moved commands under grouped namespaces: `everr cloud login/logout`, `everr ci status/watch/runs/show/logs`, and `everr local start/status/query`.
 - Removed the retired CLI commands `everr test-history`, `everr slowest-tests`, `everr slowest-jobs`, `everr workflows`, and `everr ci grep`, along with their `/api/cli/*` backend routes.
 
 ### Breaking changes - `everr local`

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/SKILL.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/SKILL.md
@@ -13,7 +13,7 @@ Prefer real OpenTelemetry for runtime services. Use `everr wrap` only for bounde
 
 1. Run `everr local status`.
 2. If the collector is stopped, run `everr local start` or ask the user to open Everr Desktop.
-3. Run `everr local endpoint` and use that OTLP/HTTP URL in exporters.
+3. Use the `otlp:` URL from `everr local status` in exporters.
 4. Inspect the app before adding packages: framework, runtime, existing OTel setup, startup path, logger, and test runner.
 5. Add the smallest standard OTel setup for the stack: `service.name`, traces, logs, useful resource attributes, automatic error capture, and an OTLP/HTTP exporter.
 6. Gate local-only exporters so local collector URLs do not ship in production bundles.
@@ -26,7 +26,7 @@ Prefer real OpenTelemetry for runtime services. Use `everr wrap` only for bounde
 | --- | --- |
 | Check collector state | `everr local status` |
 | Start the CLI collector | `everr local start` |
-| Get the OTLP/HTTP endpoint | `everr local endpoint` |
+| Get the OTLP/HTTP endpoint | `everr local status` |
 | Verify telemetry arrived | `everr local query "<SQL>"` |
 | Capture build/lint output | `everr wrap -- <command>` |
 

--- a/docs/cli-guidelines.md
+++ b/docs/cli-guidelines.md
@@ -36,7 +36,7 @@ Commands that help an agent understand or investigate CI/local telemetry must be
 
 | Category | Commands |
 |---|---|
-| Agent-useful (document in a skill) | `ci status`, `ci watch`, `ci runs`, `ci show`, `ci logs`, `local query`, `local endpoint`, `wrap` |
+| Agent-useful (document in a skill) | `ci status`, `ci watch`, `ci runs`, `ci show`, `ci logs`, `local status`, `local query`, `wrap` |
 | Human-only (exclude from skills) | `setup`, `init`, `cloud login`, `cloud logout`, `uninstall` |
 
 **Why:** Skills are the source of truth for what an agent can use. Including setup/auth commands adds noise and risks an agent attempting to run interactive flows.

--- a/packages/desktop-app/src-cli/src/cli.rs
+++ b/packages/desktop-app/src-cli/src/cli.rs
@@ -93,8 +93,6 @@ pub enum LocalSubcommand {
     Query(TelemetryQueryArgs),
     /// Check whether the local collector is running.
     Status,
-    /// Print the local collector URL.
-    Endpoint,
 }
 
 #[derive(Args, Debug)]
@@ -391,11 +389,11 @@ mod tests {
             Cli::try_parse_from(["everr", "wrap", "--", "cargo", "test"]).expect("wrap command");
         assert!(matches!(wrap.command, Commands::Wrap(_)));
 
-        let local = Cli::try_parse_from(["everr", "local", "endpoint"]).expect("local command");
+        let local = Cli::try_parse_from(["everr", "local", "status"]).expect("local command");
         let Commands::Local(local) = local.command else {
             panic!("expected local command");
         };
-        assert!(matches!(local.command, LocalSubcommand::Endpoint));
+        assert!(matches!(local.command, LocalSubcommand::Status));
     }
 
     #[test]

--- a/packages/desktop-app/src-cli/src/telemetry/commands.rs
+++ b/packages/desktop-app/src-cli/src/telemetry/commands.rs
@@ -15,7 +15,6 @@ pub async fn run(args: LocalArgs) -> Result<()> {
             .await
             .context("telemetry query task failed")?,
         LocalSubcommand::Status => run_status().await,
-        LocalSubcommand::Endpoint => run_endpoint(),
     }
 }
 
@@ -40,11 +39,6 @@ async fn run_status() -> Result<()> {
     println!("collector: stopped");
     eprintln!("telemetry collector isn't running - run `everr local start` or open Everr Desktop");
     std::process::exit(2);
-}
-
-fn run_endpoint() -> Result<()> {
-    println!("{}", everr_core::build::otlp_http_origin());
-    Ok(())
 }
 
 fn run_query(args: TelemetryQueryArgs) -> Result<()> {

--- a/packages/desktop-app/src-cli/tests/help_output.rs
+++ b/packages/desktop-app/src-cli/tests/help_output.rs
@@ -124,7 +124,7 @@ fn telemetry_help_lists_start_command() {
         .stdout(contains("start"))
         .stdout(contains("query"))
         .stdout(contains("status"))
-        .stdout(contains("endpoint"));
+        .stdout(predicates::str::contains("endpoint").not());
 
     env.command()
         .args(["local", "start", "--help"])

--- a/packages/desktop-app/src-cli/tests/telemetry_commands.rs
+++ b/packages/desktop-app/src-cli/tests/telemetry_commands.rs
@@ -8,16 +8,15 @@ use predicates::str::{contains, diff};
 use support::CliTestEnv;
 
 #[test]
-fn endpoint_prints_only_collector_url() {
+fn endpoint_is_not_a_local_subcommand() {
     let env = CliTestEnv::new();
-    let collector_url = format!("{}\n", everr_core::build::otlp_http_origin());
 
     env.command()
         .args(["local", "endpoint"])
         .assert()
-        .success()
-        .stdout(diff(collector_url))
-        .stderr(diff(""));
+        .failure()
+        .stderr(contains("unrecognized subcommand"))
+        .stderr(contains("endpoint"));
 }
 
 #[test]

--- a/packages/docs/content/docs/cli/commands.mdx
+++ b/packages/docs/content/docs/cli/commands.mdx
@@ -49,9 +49,8 @@ Collection-style commands accept `--limit <n>` and `--offset <n>` for pagination
 ## Local Telemetry
 
 - `everr local start` — start the local OpenTelemetry collector
-- `everr local status` — check whether the local OpenTelemetry collector is running
+- `everr local status` — check whether the local OpenTelemetry collector is running and print local OTLP/SQL URLs
 - `everr local query "<SQL>"` — query local telemetry with read-only SQL
-- `everr local endpoint` — print the current local collector URL
 - `everr wrap -- <command>` — run a command normally and mirror stdout/stderr into local telemetry
   - Requires a running collector; if unavailable, the command is not run
   - Preserves the wrapped command's non-zero exit code

--- a/packages/docs/content/docs/cli/telemetry.mdx
+++ b/packages/docs/content/docs/cli/telemetry.mdx
@@ -27,13 +27,13 @@ Useful flags:
 
 ### `everr local status`
 
-Checks whether the local collector healthcheck is reachable.
+Checks whether the local collector healthcheck is reachable and prints the local OTLP/HTTP and SQL URLs when it is running.
 
 ```shell
 everr local status
 ```
 
-It exits with code `0` when the collector is running and code `2` when it is stopped.
+It exits with code `0` when the collector is running and code `2` when it is stopped. Use the `otlp:` URL from this output when configuring local OpenTelemetry exporters.
 
 ### `everr local query`
 
@@ -46,14 +46,6 @@ everr local query "SELECT Timestamp, ServiceName, SpanName FROM otel_traces ORDE
 Useful flags:
 
 - `--format <table|json|ndjson>` — default `table` on TTY, `ndjson` otherwise.
-
-### `everr local endpoint`
-
-Prints the collector URL for the current build.
-
-```shell
-everr local endpoint
-```
 
 ### `everr wrap`
 


### PR DESCRIPTION
## Summary

- Remove the redundant `everr local endpoint` CLI subcommand.
- Keep `everr local status` as the place to read local OTLP and SQL URLs.
- Update CLI tests, command docs, changelog, CLI guidelines, and bundled telemetry setup guidance.

## Validation

- `cargo fmt --package everr-cli -- --check`
- `cargo test -p everr-cli`
- `git diff --check`
- `rg -n "everr local endpoint|LocalSubcommand::Endpoint|endpoint_prints_only_collector_url|local endpoint" packages/desktop-app/src-cli crates/everr-core/assets/skills docs packages/docs CHANGELOG.md -S` returned no matches