### PR TITLE
Add cursor pagination for trace search

### DIFF
--- a/packages/telemetry-explorer/src/traces/data/options.test.ts
+++ b/packages/telemetry-explorer/src/traces/data/options.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { tracesSearchOptions } from "./options";
+import { tracesSearchInfiniteOptions } from "./options";
 import type { TracesRepositoryLike } from "./repository";
 import type { TraceSummary } from "./types";
 
@@ -19,6 +19,7 @@ const baseInput = {
   minMs: undefined,
   maxMs: undefined,
   status: "all" as const,
+  limit: 50,
 };
 
 const rows: TraceSummary[] = [
@@ -36,36 +37,27 @@ const rows: TraceSummary[] = [
   },
 ];
 
-describe("tracesSearchOptions", () => {
-  it("keeps previous rows only when increasing the limit", () => {
-    const previousOptions = tracesSearchOptions({ ...baseInput, limit: 50 });
-    const nextOptions = tracesSearchOptions({ ...baseInput, limit: 100 });
+describe("tracesSearchInfiniteOptions", () => {
+  it("uses the last row as the next cursor when the page is full", () => {
+    const options = tracesSearchInfiniteOptions({ ...baseInput, limit: 1 });
+    const getNextPageParam = options.getNextPageParam as (
+      lastPage: TraceSummary[] | undefined,
+      allPages: TraceSummary[][],
+    ) => unknown;
 
-    const placeholderData = nextOptions.placeholderData as (
-      previousData: TraceSummary[] | undefined,
-      previousQuery: { queryKey: readonly unknown[] },
-    ) => TraceSummary[] | undefined;
-
-    expect(placeholderData(rows, { queryKey: previousOptions.queryKey })).toBe(
-      rows,
-    );
+    expect(getNextPageParam(rows, [rows])).toEqual({
+      startTs: "2026-05-20 12:00:00.000",
+      traceId: "trace-1",
+    });
   });
 
-  it("does not keep previous rows when filters change", () => {
-    const previousOptions = tracesSearchOptions({ ...baseInput, limit: 50 });
-    const nextOptions = tracesSearchOptions({
-      ...baseInput,
-      service: ["api"],
-      limit: 50,
-    });
+  it("stops pagination when the last page is shorter than the page size", () => {
+    const options = tracesSearchInfiniteOptions({ ...baseInput, limit: 2 });
+    const getNextPageParam = options.getNextPageParam as (
+      lastPage: TraceSummary[] | undefined,
+      allPages: TraceSummary[][],
+    ) => unknown;
 
-    const placeholderData = nextOptions.placeholderData as (
-      previousData: TraceSummary[] | undefined,
-      previousQuery: { queryKey: readonly unknown[] },
-    ) => TraceSummary[] | undefined;
-
-    expect(
-      placeholderData(rows, { queryKey: previousOptions.queryKey }),
-    ).toBeUndefined();
+    expect(getNextPageParam(rows, [rows])).toBeUndefined();
   });
 });

--- a/packages/telemetry-explorer/src/traces/data/options.ts
+++ b/packages/telemetry-explorer/src/traces/data/options.ts
@@ -4,9 +4,10 @@ import {
   type TimeRange,
   toClickHouseDateTime,
 } from "@everr/ui/lib/time-range";
-import { queryOptions } from "@tanstack/react-query";
+import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 import type { TracesRepositoryLike } from "./repository";
 import type { SpanStatusFilter } from "./schemas";
+import type { TraceSummary } from "./types";
 import type { DetailWindow } from "./window";
 
 export type TraceSearchOptionsInput = {
@@ -22,19 +23,26 @@ export type TraceSearchOptionsInput = {
   limit: number;
 };
 
+type TraceSearchCursor = {
+  startTs: string;
+  traceId: string;
+};
+
 const MS_TO_NS = 1_000_000n;
 
-export function tracesSearchOptions(input: TraceSearchOptionsInput) {
+export function tracesSearchInfiniteOptions(input: TraceSearchOptionsInput) {
   const { repo, refresh, ...key } = input;
   const refreshMs = getRefreshIntervalMs(refresh);
-  const queryKey = ["traces", "search", key] as const;
-  return queryOptions({
+  const queryKey = ["traces", "search", "infinite", key] as const;
+  return infiniteQueryOptions({
     queryKey,
-    queryFn: async () => {
+    queryFn: async ({ pageParam }: { pageParam: TraceSearchCursor | null }) => {
       const { fromDate, toDate } = resolveTimeRange(input.timeRange);
       return repo.search({
         fromTs: toClickHouseDateTime(fromDate),
         toTs: toClickHouseDateTime(toDate),
+        cursorStartTs: pageParam?.startTs,
+        cursorTraceId: pageParam?.traceId,
         namespace: input.namespace,
         service: input.service,
         name: input.name,
@@ -50,58 +58,15 @@ export function tracesSearchOptions(input: TraceSearchOptionsInput) {
         limit: input.limit,
       });
     },
-    placeholderData: (previousData, previousQuery) =>
-      shouldKeepPreviousSearchRows(queryKey, previousQuery?.queryKey)
-        ? previousData
-        : undefined,
+    initialPageParam: null,
+    getNextPageParam: (lastPage: TraceSummary[] | undefined) => {
+      if (!lastPage || lastPage.length < input.limit) return undefined;
+      const lastRow = lastPage.at(-1);
+      if (!lastRow) return undefined;
+      return { startTs: lastRow.startTs, traceId: lastRow.traceId };
+    },
     refetchInterval: refreshMs && refreshMs > 0 ? refreshMs : false,
   });
-}
-
-type TraceSearchKey = Omit<TraceSearchOptionsInput, "repo" | "refresh">;
-type TraceSearchQueryKey = readonly ["traces", "search", TraceSearchKey];
-
-function shouldKeepPreviousSearchRows(
-  current: TraceSearchQueryKey,
-  previous: readonly unknown[] | undefined,
-): boolean {
-  if (!isTraceSearchQueryKey(previous)) return false;
-  const currentKey = current[2];
-  const previousKey = previous[2];
-  return (
-    currentKey.limit > previousKey.limit &&
-    currentKey.timeRange.from === previousKey.timeRange.from &&
-    currentKey.timeRange.to === previousKey.timeRange.to &&
-    arraysEqual(currentKey.namespace, previousKey.namespace) &&
-    arraysEqual(currentKey.service, previousKey.service) &&
-    currentKey.name === previousKey.name &&
-    currentKey.minMs === previousKey.minMs &&
-    currentKey.maxMs === previousKey.maxMs &&
-    currentKey.status === previousKey.status
-  );
-}
-
-function isTraceSearchQueryKey(
-  key: readonly unknown[] | undefined,
-): key is TraceSearchQueryKey {
-  return key?.[0] === "traces" && key[1] === "search" && isSearchKey(key[2]);
-}
-
-function isSearchKey(value: unknown): value is TraceSearchKey {
-  if (!value || typeof value !== "object") return false;
-  const candidate = value as Partial<TraceSearchKey>;
-  return (
-    typeof candidate.timeRange?.from === "string" &&
-    typeof candidate.timeRange.to === "string" &&
-    Array.isArray(candidate.namespace) &&
-    Array.isArray(candidate.service) &&
-    typeof candidate.name === "string" &&
-    typeof candidate.limit === "number"
-  );
-}
-
-function arraysEqual(a: string[], b: string[]): boolean {
-  return a.length === b.length && a.every((value, i) => value === b[i]);
 }
 
 export type GetTraceOptionsInput = {

--- a/packages/telemetry-explorer/src/traces/data/repository.test.ts
+++ b/packages/telemetry-explorer/src/traces/data/repository.test.ts
@@ -13,6 +13,21 @@ function makeRepo() {
   return new TracesRepository(client);
 }
 
+function traceRows(count: number): TraceSummary[] {
+  return Array.from({ length: count }, (_, i) => ({
+    traceId: `t${i}`,
+    rootName: "GET",
+    rootService: "web",
+    rootNamespace: "",
+    rootStatus: "Ok",
+    startTs: `2026-05-27 21:15:${String(50 - i).padStart(2, "0")}.000`,
+    durationNs: "1500000",
+    spanCount: 3,
+    errorCount: 0,
+    services: ["web"],
+  }));
+}
+
 describe("TracesRepository.search", () => {
   it("returns rows from ClickHouse and forwards the time window + paging", async () => {
     const row: TraceSummary = {
@@ -30,7 +45,7 @@ describe("TracesRepository.search", () => {
     query.mockResolvedValueOnce([row]);
 
     const result = await makeRepo().search({
-      fromTs: "2026-05-20 11:00:00.000",
+      fromTs: "2026-05-20 12:30:00.000",
       toTs: "2026-05-20 13:00:00.000",
       namespace: [],
       service: [],
@@ -46,9 +61,80 @@ describe("TracesRepository.search", () => {
     expect(sql).toContain("parseDateTime64BestEffort({fromTs:String}, 9)");
     expect(sql).toContain("parseDateTime64BestEffort({toTs:String}, 9)");
     expect(params).toMatchObject({
-      fromTs: "2026-05-20 11:00:00.000",
+      fromTs: "2026-05-20 12:30:00.000",
       toTs: "2026-05-20 13:00:00.000",
       limit: 25,
+    });
+  });
+
+  it("uses the selected time range without adaptive narrowing", async () => {
+    query.mockResolvedValueOnce(traceRows(2));
+
+    await makeRepo().search({
+      fromTs: "2026-05-13 21:15:54.183",
+      toTs: "2026-05-27 21:15:54.183",
+      namespace: [],
+      service: [],
+      name: "",
+      status: "all",
+      limit: 2,
+    });
+
+    expect(query).toHaveBeenCalledTimes(1);
+    const [, params] = query.mock.calls[0] ?? [];
+    expect(params).toMatchObject({
+      fromTs: "2026-05-13 21:15:54.183",
+      toTs: "2026-05-27 21:15:54.183",
+      limit: 2,
+    });
+  });
+
+  it("does not retry wider windows when a page is short", async () => {
+    query.mockResolvedValueOnce(traceRows(1));
+
+    await makeRepo().search({
+      fromTs: "2026-05-13 21:15:54.183",
+      toTs: "2026-05-27 21:15:54.183",
+      namespace: [],
+      service: [],
+      name: "",
+      status: "all",
+      limit: 2,
+    });
+
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query.mock.calls[0]?.[1]).toMatchObject({
+      fromTs: "2026-05-13 21:15:54.183",
+      toTs: "2026-05-27 21:15:54.183",
+    });
+  });
+
+  it("uses the cursor as the next page upper bound and tie breaker", async () => {
+    query.mockResolvedValueOnce(traceRows(2));
+
+    await makeRepo().search({
+      fromTs: "2026-05-13 21:15:54.183",
+      toTs: "2026-05-27 21:15:54.183",
+      cursorStartTs: "2026-05-27 21:00:00.000",
+      cursorTraceId: "trace-z",
+      namespace: [],
+      service: [],
+      name: "",
+      status: "all",
+      limit: 2,
+    });
+
+    const [sql, params] = query.mock.calls[0] ?? [];
+    expect(sql).toContain(
+      "startTsRaw < parseDateTime64BestEffort({cursorStartTs:String}, 9)",
+    );
+    expect(sql).toContain("TraceId < {cursorTraceId:String}");
+    expect(sql).toContain("ORDER BY startTsRaw DESC, TraceId DESC");
+    expect(params).toMatchObject({
+      fromTs: "2026-05-13 21:15:54.183",
+      toTs: "2026-05-27 21:00:00.000",
+      cursorStartTs: "2026-05-27 21:00:00.000",
+      cursorTraceId: "trace-z",
     });
   });
 

--- a/packages/telemetry-explorer/src/traces/data/repository.ts
+++ b/packages/telemetry-explorer/src/traces/data/repository.ts
@@ -46,11 +46,11 @@ export class TracesRepository {
     // matching span. Without this, span-level HAVING via countIf forces a
     // full in-window scan + group-by on every tenant span.
     const spanPreds: string[] = [];
-    // Aggregate-level predicates that can't be pushed to WHERE.
-    const havingParts: string[] = [];
+    const aggregateHavingParts: string[] = [];
+    const hasCursor = Boolean(input.cursorStartTs && input.cursorTraceId);
     const params: Record<string, unknown> = {
       fromTs: input.fromTs,
-      toTs: input.toTs,
+      toTs: hasCursor ? input.cursorStartTs : input.toTs,
       limit: input.limit,
     };
 
@@ -75,11 +75,11 @@ export class TracesRepository {
     // exposes it as a string. Filter on the raw int to avoid a double
     // toString → toUInt64 round-trip per row.
     if (input.minDurationNs !== undefined) {
-      havingParts.push("durationNsRaw >= {minDurationNs:UInt64}");
+      aggregateHavingParts.push("durationNsRaw >= {minDurationNs:UInt64}");
       params.minDurationNs = input.minDurationNs;
     }
     if (input.maxDurationNs !== undefined) {
-      havingParts.push("durationNsRaw <= {maxDurationNs:UInt64}");
+      aggregateHavingParts.push("durationNsRaw <= {maxDurationNs:UInt64}");
       params.maxDurationNs = input.maxDurationNs;
     }
     // Span-level, matching the rest of the filters: 'error' = trace contains
@@ -87,10 +87,27 @@ export class TracesRepository {
     // Unset everywhere). Filtering on the root span alone hides traces whose
     // failure lives in a child.
     if (input.status === "error") {
-      havingParts.push("countIf(StatusCode = 'Error') > 0");
+      aggregateHavingParts.push("countIf(StatusCode = 'Error') > 0");
     } else if (input.status === "ok") {
-      havingParts.push("countIf(StatusCode = 'Error') = 0");
+      aggregateHavingParts.push("countIf(StatusCode = 'Error') = 0");
     }
+
+    const cursorHaving = hasCursor
+      ? `(
+            startTsRaw < parseDateTime64BestEffort({cursorStartTs:String}, 9)
+            OR (
+              startTsRaw = parseDateTime64BestEffort({cursorStartTs:String}, 9)
+              AND TraceId < {cursorTraceId:String}
+            )
+          )`
+      : "";
+    if (hasCursor) {
+      params.cursorStartTs = input.cursorStartTs;
+      params.cursorTraceId = input.cursorTraceId;
+    }
+    const havingParts = cursorHaving
+      ? [...aggregateHavingParts, cursorHaving]
+      : aggregateHavingParts;
 
     // Two-pass when span-level filters are present: the inner subquery uses
     // WHERE to prune spans before reading, then the outer aggregates the full
@@ -135,7 +152,7 @@ export class TracesRepository {
           ${candidateFilter}
         GROUP BY TraceId
         ${havingParts.length > 0 ? `HAVING ${havingParts.join(" AND ")}` : ""}
-        ORDER BY startTsRaw DESC
+        ORDER BY startTsRaw DESC, TraceId DESC
         LIMIT {limit:UInt32}
       )
       SELECT

--- a/packages/telemetry-explorer/src/traces/data/schemas.ts
+++ b/packages/telemetry-explorer/src/traces/data/schemas.ts
@@ -32,6 +32,8 @@ export function toTraceListSearch(
 export const SearchTracesInputSchema = z.object({
   fromTs: z.string().min(1),
   toTs: z.string().min(1),
+  cursorStartTs: z.string().min(1).optional(),
+  cursorTraceId: z.string().min(1).optional(),
   namespace: z.array(z.string()).default([]),
   service: z.array(z.string()).default([]),
   name: z.string().default(""),

--- a/packages/telemetry-explorer/src/traces/ui/trace-results-list.test.tsx
+++ b/packages/telemetry-explorer/src/traces/ui/trace-results-list.test.tsx
@@ -1,4 +1,3 @@
-import type { UseQueryResult } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
@@ -40,18 +39,6 @@ function row(
   };
 }
 
-function queryResult(data: TraceSummary[]): UseQueryResult<TraceSummary[]> {
-  return {
-    data,
-    isPending: false,
-    isFetching: false,
-    isPlaceholderData: false,
-    isError: false,
-    error: null,
-    refetch: vi.fn(),
-  } as unknown as UseQueryResult<TraceSummary[]>;
-}
-
 function renderTraceLink({
   traceId,
   className,
@@ -81,8 +68,13 @@ describe("TraceResultsList", () => {
     ];
     render(
       <TraceResultsList
-        query={queryResult(rows)}
-        limit={50}
+        rows={rows}
+        isPending={false}
+        isError={false}
+        error={null}
+        refetch={() => {}}
+        hasMore={false}
+        isLoadingMore={false}
         renderTraceLink={renderTraceLink}
         onLoadMore={() => {}}
         onClearFilters={() => {}}
@@ -102,8 +94,13 @@ describe("TraceResultsList", () => {
     ];
     const { container } = render(
       <TraceResultsList
-        query={queryResult(rows)}
-        limit={50}
+        rows={rows}
+        isPending={false}
+        isError={false}
+        error={null}
+        refetch={() => {}}
+        hasMore={false}
+        isLoadingMore={false}
         renderTraceLink={renderTraceLink}
         onLoadMore={() => {}}
         onClearFilters={() => {}}
@@ -121,8 +118,13 @@ describe("TraceResultsList", () => {
     const rows = [row({ traceId: "abc123", rootName: "GET /home" })];
     render(
       <TraceResultsList
-        query={queryResult(rows)}
-        limit={50}
+        rows={rows}
+        isPending={false}
+        isError={false}
+        error={null}
+        refetch={() => {}}
+        hasMore={false}
+        isLoadingMore={false}
         renderTraceLink={renderTraceLink}
         onLoadMore={() => {}}
         onClearFilters={() => {}}
@@ -139,8 +141,13 @@ describe("TraceResultsList", () => {
     const onClearFilters = vi.fn();
     render(
       <TraceResultsList
-        query={queryResult([])}
-        limit={50}
+        rows={[]}
+        isPending={false}
+        isError={false}
+        error={null}
+        refetch={() => {}}
+        hasMore={false}
+        isLoadingMore={false}
         renderTraceLink={renderTraceLink}
         onLoadMore={() => {}}
         onClearFilters={onClearFilters}
@@ -154,16 +161,16 @@ describe("TraceResultsList", () => {
     const user = userEvent.setup();
     const onLoadMore = vi.fn();
     const rows = [row({ traceId: "a", rootName: "GET /a" })];
-    const query = {
-      ...queryResult(rows),
-      isFetching: true,
-      isPlaceholderData: true,
-    } as unknown as UseQueryResult<TraceSummary[]>;
 
     render(
       <TraceResultsList
-        query={query}
-        limit={50}
+        rows={rows}
+        isPending={false}
+        isError={false}
+        error={null}
+        refetch={() => {}}
+        hasMore={true}
+        isLoadingMore={true}
         renderTraceLink={renderTraceLink}
         onLoadMore={onLoadMore}
         onClearFilters={() => {}}

--- a/packages/telemetry-explorer/src/traces/ui/trace-results-list.tsx
+++ b/packages/telemetry-explorer/src/traces/ui/trace-results-list.tsx
@@ -8,7 +8,6 @@ import {
 import { RetryError } from "@everr/ui/components/retry-error";
 import { Skeleton } from "@everr/ui/components/skeleton";
 import { formatDuration } from "@everr/ui/lib/formatting";
-import type { UseQueryResult } from "@tanstack/react-query";
 import { type ReactNode, useMemo } from "react";
 import { Virtuoso } from "react-virtuoso";
 import type { TraceSummary } from "../data/types";
@@ -20,8 +19,13 @@ import { serviceColor } from "./shared/service-color";
 const SKELETON_DELAY_MS = 1000;
 
 type Props = {
-  query: UseQueryResult<TraceSummary[]>;
-  limit: number;
+  rows: TraceSummary[];
+  isPending: boolean;
+  isError: boolean;
+  error: Error | null;
+  refetch: () => void;
+  hasMore: boolean;
+  isLoadingMore: boolean;
   renderTraceLink: (props: TraceLinkRenderProps) => ReactNode;
   onLoadMore: () => void;
   onClearFilters: () => void;
@@ -36,13 +40,17 @@ export type TraceLinkRenderProps = {
 };
 
 export function TraceResultsList({
-  query,
-  limit,
+  rows,
+  isPending,
+  isError,
+  error,
+  refetch,
+  hasMore,
+  isLoadingMore,
   renderTraceLink,
   onLoadMore,
   onClearFilters,
 }: Props) {
-  const rows = query.data ?? [];
   const maxDuration = useMemo(() => {
     let max = 0n;
     for (const r of rows) {
@@ -52,14 +60,14 @@ export function TraceResultsList({
     return max;
   }, [rows]);
 
-  const showSkeleton = useDelayedFlag(query.isPending, SKELETON_DELAY_MS);
-  if (query.isPending) return showSkeleton ? <ResultsSkeleton /> : null;
-  if (query.isError) {
+  const showSkeleton = useDelayedFlag(isPending, SKELETON_DELAY_MS);
+  if (isPending) return showSkeleton ? <ResultsSkeleton /> : null;
+  if (isError) {
     return (
       <RetryError
         title="Failed to load traces"
-        message={(query.error as Error).message}
-        onRetry={() => query.refetch()}
+        message={error?.message ?? "Unknown error"}
+        onRetry={refetch}
       />
     );
   }
@@ -67,8 +75,6 @@ export function TraceResultsList({
     return <EmptyState onClearFilters={onClearFilters} />;
   }
 
-  const isLoadingMore = query.isFetching && query.isPlaceholderData;
-  const hasMore = rows.length >= limit || isLoadingMore;
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <Virtuoso

--- a/packages/telemetry-explorer/src/traces/ui/traces-search-page.tsx
+++ b/packages/telemetry-explorer/src/traces/ui/traces-search-page.tsx
@@ -1,9 +1,13 @@
 import type { TimeRange } from "@everr/ui/lib/time-range";
-import { useQuery } from "@tanstack/react-query";
-import type { ReactNode } from "react";
+import {
+  keepPreviousData,
+  useInfiniteQuery,
+  useQuery,
+} from "@tanstack/react-query";
+import { type ReactNode, useMemo } from "react";
 import {
   listServiceIdentitiesOptions,
-  tracesSearchOptions,
+  tracesSearchInfiniteOptions,
 } from "../data/options";
 import type { TracesRepositoryLike } from "../data/repository";
 import type { SpanStatusFilter } from "../data/schemas";
@@ -45,8 +49,17 @@ export function TracesSearch({
   const identitiesQuery = useQuery(
     listServiceIdentitiesOptions(repo, { timeRange, refresh }),
   );
-  const tracesQuery = useQuery(
-    tracesSearchOptions({
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isPending,
+    isError,
+    error,
+    refetch,
+  } = useInfiniteQuery({
+    ...tracesSearchInfiniteOptions({
       repo,
       timeRange,
       refresh,
@@ -58,7 +71,9 @@ export function TracesSearch({
       status: search.status,
       limit: search.limit,
     }),
-  );
+    placeholderData: keepPreviousData,
+  });
+  const rows = useMemo(() => data?.pages.flat() ?? [], [data]);
 
   return (
     <div className="flex h-full min-h-0 flex-col gap-3 p-4">
@@ -75,12 +90,15 @@ export function TracesSearch({
         onChange={onSearchChange}
       />
       <TraceResultsList
-        query={tracesQuery}
-        limit={search.limit}
+        rows={rows}
+        isPending={isPending}
+        isError={isError}
+        error={error}
+        refetch={refetch}
+        hasMore={hasNextPage}
+        isLoadingMore={isFetchingNextPage}
         renderTraceLink={renderTraceLink}
-        onLoadMore={() =>
-          onSearchChange({ limit: Math.min(search.limit + 50, 500) })
-        }
+        onLoadMore={() => fetchNextPage()}
         onClearFilters={() =>
           onSearchChange({
             namespace: [],


### PR DESCRIPTION
## Summary
- Add cursor fields to trace search requests.
- Switch trace search results to infinite-query pagination.
- Page by `(startTs, traceId)` instead of increasing the URL limit and refetching the full result set.
- Keep the selected time range intact; no adaptive trailing-window narrowing is included.

## Testing
- `pnpm --filter @everr/telemetry-explorer test -- --runInBand packages/telemetry-explorer/src/traces/data/repository.test.ts packages/telemetry-explorer/src/traces/data/options.test.ts packages/telemetry-explorer/src/traces/ui/trace-results-list.test.tsx`
- `pnpm --filter @everr/telemetry-explorer typecheck`
- `pnpm --filter @everr/app typecheck`
- `pnpm check packages/telemetry-explorer/src/traces/data/repository.ts packages/telemetry-explorer/src/traces/data/repository.test.ts packages/telemetry-explorer/src/traces/data/options.ts packages/telemetry-explorer/src/traces/data/options.test.ts packages/telemetry-explorer/src/traces/data/schemas.ts packages/telemetry-explorer/src/traces/ui/traces-search-page.tsx packages/telemetry-explorer/src/traces/ui/trace-results-list.tsx packages/telemetry-explorer/src/traces/ui/trace-results-list.test.tsx`
