### PR TITLE
Add otel_metrics_histogram table

### DIFF
--- a/clickhouse/backfill-sql-api-access.sql
+++ b/clickhouse/backfill-sql-api-access.sql
@@ -68,6 +68,7 @@ GRANT SELECT ON app.metrics_gauge TO sql_api_role;
 GRANT SELECT ON app.metrics_sum       TO sql_api_role;
 GRANT SELECT ON app.metrics_histogram              TO sql_api_role;
 GRANT SELECT ON app.metrics_exponential_histogram TO sql_api_role;
+GRANT SELECT ON app.metrics_summary              TO sql_api_role;
 
 -- Clean up accidental/manual system grants. SHOW TABLES handles schema
 -- discovery without exposing storage counters from system.tables or the
@@ -108,3 +109,5 @@ CREATE ROW POLICY IF NOT EXISTS sql_api_default_deny_metrics_histogram
   ON app.metrics_histogram              FOR SELECT USING 0 TO sql_api_role;
 CREATE ROW POLICY IF NOT EXISTS sql_api_default_deny_metrics_exponential_histogram
   ON app.metrics_exponential_histogram FOR SELECT USING 0 TO sql_api_role;
+CREATE ROW POLICY IF NOT EXISTS sql_api_default_deny_metrics_summary
+  ON app.metrics_summary               FOR SELECT USING 0 TO sql_api_role;

--- a/clickhouse/backfill-sql-api-access.sql
+++ b/clickhouse/backfill-sql-api-access.sql
@@ -66,7 +66,8 @@ GRANT SELECT ON app.traces        TO sql_api_role;
 GRANT SELECT ON app.logs          TO sql_api_role;
 GRANT SELECT ON app.metrics_gauge TO sql_api_role;
 GRANT SELECT ON app.metrics_sum       TO sql_api_role;
-GRANT SELECT ON app.metrics_histogram TO sql_api_role;
+GRANT SELECT ON app.metrics_histogram              TO sql_api_role;
+GRANT SELECT ON app.metrics_exponential_histogram TO sql_api_role;
 
 -- Clean up accidental/manual system grants. SHOW TABLES handles schema
 -- discovery without exposing storage counters from system.tables or the
@@ -104,4 +105,6 @@ CREATE ROW POLICY IF NOT EXISTS sql_api_default_deny_metrics_gauge
 CREATE ROW POLICY IF NOT EXISTS sql_api_default_deny_metrics_sum
   ON app.metrics_sum       FOR SELECT USING 0 TO sql_api_role;
 CREATE ROW POLICY IF NOT EXISTS sql_api_default_deny_metrics_histogram
-  ON app.metrics_histogram FOR SELECT USING 0 TO sql_api_role;
+  ON app.metrics_histogram              FOR SELECT USING 0 TO sql_api_role;
+CREATE ROW POLICY IF NOT EXISTS sql_api_default_deny_metrics_exponential_histogram
+  ON app.metrics_exponential_histogram FOR SELECT USING 0 TO sql_api_role;

--- a/clickhouse/backfill-sql-api-access.sql
+++ b/clickhouse/backfill-sql-api-access.sql
@@ -65,7 +65,8 @@ CREATE ROLE IF NOT EXISTS sql_api_role SETTINGS PROFILE 'sql_api_profile';
 GRANT SELECT ON app.traces        TO sql_api_role;
 GRANT SELECT ON app.logs          TO sql_api_role;
 GRANT SELECT ON app.metrics_gauge TO sql_api_role;
-GRANT SELECT ON app.metrics_sum   TO sql_api_role;
+GRANT SELECT ON app.metrics_sum       TO sql_api_role;
+GRANT SELECT ON app.metrics_histogram TO sql_api_role;
 
 -- Clean up accidental/manual system grants. SHOW TABLES handles schema
 -- discovery without exposing storage counters from system.tables or the
@@ -101,4 +102,6 @@ CREATE ROW POLICY IF NOT EXISTS sql_api_default_deny_logs
 CREATE ROW POLICY IF NOT EXISTS sql_api_default_deny_metrics_gauge
   ON app.metrics_gauge FOR SELECT USING 0 TO sql_api_role;
 CREATE ROW POLICY IF NOT EXISTS sql_api_default_deny_metrics_sum
-  ON app.metrics_sum   FOR SELECT USING 0 TO sql_api_role;
+  ON app.metrics_sum       FOR SELECT USING 0 TO sql_api_role;
+CREATE ROW POLICY IF NOT EXISTS sql_api_default_deny_metrics_histogram
+  ON app.metrics_histogram FOR SELECT USING 0 TO sql_api_role;

--- a/clickhouse/init/03-create-otel-tables.sql
+++ b/clickhouse/init/03-create-otel-tables.sql
@@ -225,3 +225,36 @@ CREATE TABLE IF NOT EXISTS otel.otel_metrics_exponential_histogram (
 PARTITION BY toDate(TimeUnix)
 ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+
+CREATE TABLE IF NOT EXISTS otel.otel_metrics_summary (
+    ResourceAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    ResourceSchemaUrl String CODEC(ZSTD(1)),
+    ScopeName String CODEC(ZSTD(1)),
+    ScopeVersion String CODEC(ZSTD(1)),
+    ScopeAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    ScopeDroppedAttrCount UInt32 CODEC(ZSTD(1)),
+    ScopeSchemaUrl String CODEC(ZSTD(1)),
+    ServiceName LowCardinality(String) CODEC(ZSTD(1)),
+    MetricName String CODEC(ZSTD(1)),
+    MetricDescription String CODEC(ZSTD(1)),
+    MetricUnit String CODEC(ZSTD(1)),
+    Attributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    StartTimeUnix DateTime64(9) CODEC(Delta, ZSTD(1)),
+    TimeUnix DateTime64(9) CODEC(Delta, ZSTD(1)),
+    Count UInt64 CODEC(Delta, ZSTD(1)),
+    Sum Float64 CODEC(ZSTD(1)),
+    ValueAtQuantiles Nested (
+        Quantile Float64,
+        Value Float64
+    ) CODEC(ZSTD(1)),
+    Flags UInt32 CODEC(ZSTD(1)),
+    INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1
+) ENGINE = MergeTree
+PARTITION BY toDate(TimeUnix)
+ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;

--- a/clickhouse/init/03-create-otel-tables.sql
+++ b/clickhouse/init/03-create-otel-tables.sql
@@ -139,3 +139,44 @@ CREATE TABLE IF NOT EXISTS otel.otel_metrics_sum (
 PARTITION BY toDate(TimeUnix)
 ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+
+CREATE TABLE IF NOT EXISTS otel.otel_metrics_histogram (
+    ResourceAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    ResourceSchemaUrl String CODEC(ZSTD(1)),
+    ScopeName String CODEC(ZSTD(1)),
+    ScopeVersion String CODEC(ZSTD(1)),
+    ScopeAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    ScopeDroppedAttrCount UInt32 CODEC(ZSTD(1)),
+    ScopeSchemaUrl String CODEC(ZSTD(1)),
+    ServiceName LowCardinality(String) CODEC(ZSTD(1)),
+    MetricName String CODEC(ZSTD(1)),
+    MetricDescription String CODEC(ZSTD(1)),
+    MetricUnit String CODEC(ZSTD(1)),
+    Attributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    StartTimeUnix DateTime64(9) CODEC(Delta, ZSTD(1)),
+    TimeUnix DateTime64(9) CODEC(Delta, ZSTD(1)),
+    Count UInt64 CODEC(Delta, ZSTD(1)),
+    Sum Float64 CODEC(ZSTD(1)),
+    BucketCounts Array(UInt64) CODEC(ZSTD(1)),
+    ExplicitBounds Array(Float64) CODEC(ZSTD(1)),
+    Exemplars Nested (
+        FilteredAttributes Map(LowCardinality(String), String),
+        TimeUnix DateTime64(9),
+        Value Float64,
+        SpanId String,
+        TraceId String
+    ) CODEC(ZSTD(1)),
+    Flags UInt32 CODEC(ZSTD(1)),
+    Min Float64 CODEC(ZSTD(1)),
+    Max Float64 CODEC(ZSTD(1)),
+    AggregationTemporality Int32 CODEC(ZSTD(1)),
+    INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1
+) ENGINE = MergeTree
+PARTITION BY toDate(TimeUnix)
+ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;

--- a/clickhouse/init/03-create-otel-tables.sql
+++ b/clickhouse/init/03-create-otel-tables.sql
@@ -180,3 +180,48 @@ CREATE TABLE IF NOT EXISTS otel.otel_metrics_histogram (
 PARTITION BY toDate(TimeUnix)
 ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+
+CREATE TABLE IF NOT EXISTS otel.otel_metrics_exponential_histogram (
+    ResourceAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    ResourceSchemaUrl String CODEC(ZSTD(1)),
+    ScopeName String CODEC(ZSTD(1)),
+    ScopeVersion String CODEC(ZSTD(1)),
+    ScopeAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    ScopeDroppedAttrCount UInt32 CODEC(ZSTD(1)),
+    ScopeSchemaUrl String CODEC(ZSTD(1)),
+    ServiceName LowCardinality(String) CODEC(ZSTD(1)),
+    MetricName String CODEC(ZSTD(1)),
+    MetricDescription String CODEC(ZSTD(1)),
+    MetricUnit String CODEC(ZSTD(1)),
+    Attributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    StartTimeUnix DateTime64(9) CODEC(Delta, ZSTD(1)),
+    TimeUnix DateTime64(9) CODEC(Delta, ZSTD(1)),
+    Count UInt64 CODEC(Delta, ZSTD(1)),
+    Sum Float64 CODEC(ZSTD(1)),
+    Scale Int32 CODEC(ZSTD(1)),
+    ZeroCount UInt64 CODEC(ZSTD(1)),
+    PositiveOffset Int32 CODEC(ZSTD(1)),
+    PositiveBucketCounts Array(UInt64) CODEC(ZSTD(1)),
+    NegativeOffset Int32 CODEC(ZSTD(1)),
+    NegativeBucketCounts Array(UInt64) CODEC(ZSTD(1)),
+    Exemplars Nested (
+        FilteredAttributes Map(LowCardinality(String), String),
+        TimeUnix DateTime64(9),
+        Value Float64,
+        SpanId String,
+        TraceId String
+    ) CODEC(ZSTD(1)),
+    Flags UInt32 CODEC(ZSTD(1)),
+    Min Float64 CODEC(ZSTD(1)),
+    Max Float64 CODEC(ZSTD(1)),
+    AggregationTemporality Int32 CODEC(ZSTD(1)),
+    INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1
+) ENGINE = MergeTree
+PARTITION BY toDate(TimeUnix)
+ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;

--- a/clickhouse/init/10-create-mvs.sql
+++ b/clickhouse/init/10-create-mvs.sql
@@ -137,3 +137,25 @@ SELECT
   *,
   ResourceAttributes['everr.tenant.id'] AS tenant_id
 FROM otel.otel_metrics_sum;
+
+-- Metrics (Histogram): tenant-enriched read table + MV
+CREATE TABLE IF NOT EXISTS app.metrics_histogram
+ENGINE = MergeTree
+PARTITION BY toDate(TimeUnix)
+ORDER BY (tenant_id, ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+TTL toDateTime(TimeUnix) + INTERVAL dictGetOrDefault('app.tenant_retention', 'metrics_days', tenant_id, toUInt32(3650)) DAY
+SETTINGS index_granularity = 8192
+AS
+SELECT
+  *,
+  CAST(ResourceAttributes['everr.tenant.id'] AS String) AS tenant_id
+FROM otel.otel_metrics_histogram
+WHERE 1 = 0;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS app.metrics_histogram_mv
+TO app.metrics_histogram
+AS
+SELECT
+  *,
+  ResourceAttributes['everr.tenant.id'] AS tenant_id
+FROM otel.otel_metrics_histogram;

--- a/clickhouse/init/10-create-mvs.sql
+++ b/clickhouse/init/10-create-mvs.sql
@@ -181,3 +181,25 @@ SELECT
   *,
   ResourceAttributes['everr.tenant.id'] AS tenant_id
 FROM otel.otel_metrics_exponential_histogram;
+
+-- Metrics (Summary): tenant-enriched read table + MV
+CREATE TABLE IF NOT EXISTS app.metrics_summary
+ENGINE = MergeTree
+PARTITION BY toDate(TimeUnix)
+ORDER BY (tenant_id, ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+TTL toDateTime(TimeUnix) + INTERVAL dictGetOrDefault('app.tenant_retention', 'metrics_days', tenant_id, toUInt32(3650)) DAY
+SETTINGS index_granularity = 8192
+AS
+SELECT
+  *,
+  CAST(ResourceAttributes['everr.tenant.id'] AS String) AS tenant_id
+FROM otel.otel_metrics_summary
+WHERE 1 = 0;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS app.metrics_summary_mv
+TO app.metrics_summary
+AS
+SELECT
+  *,
+  ResourceAttributes['everr.tenant.id'] AS tenant_id
+FROM otel.otel_metrics_summary;

--- a/clickhouse/init/10-create-mvs.sql
+++ b/clickhouse/init/10-create-mvs.sql
@@ -159,3 +159,25 @@ SELECT
   *,
   ResourceAttributes['everr.tenant.id'] AS tenant_id
 FROM otel.otel_metrics_histogram;
+
+-- Metrics (Exponential Histogram): tenant-enriched read table + MV
+CREATE TABLE IF NOT EXISTS app.metrics_exponential_histogram
+ENGINE = MergeTree
+PARTITION BY toDate(TimeUnix)
+ORDER BY (tenant_id, ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+TTL toDateTime(TimeUnix) + INTERVAL dictGetOrDefault('app.tenant_retention', 'metrics_days', tenant_id, toUInt32(3650)) DAY
+SETTINGS index_granularity = 8192
+AS
+SELECT
+  *,
+  CAST(ResourceAttributes['everr.tenant.id'] AS String) AS tenant_id
+FROM otel.otel_metrics_exponential_histogram
+WHERE 1 = 0;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS app.metrics_exponential_histogram_mv
+TO app.metrics_exponential_histogram
+AS
+SELECT
+  *,
+  ResourceAttributes['everr.tenant.id'] AS tenant_id
+FROM otel.otel_metrics_exponential_histogram;

--- a/clickhouse/init/15-create-sql-api-role.sql
+++ b/clickhouse/init/15-create-sql-api-role.sql
@@ -56,7 +56,8 @@ CREATE ROLE IF NOT EXISTS sql_api_role SETTINGS PROFILE 'sql_api_profile';
 GRANT SELECT ON app.traces        TO sql_api_role;
 GRANT SELECT ON app.logs          TO sql_api_role;
 GRANT SELECT ON app.metrics_gauge TO sql_api_role;
-GRANT SELECT ON app.metrics_sum   TO sql_api_role;
+GRANT SELECT ON app.metrics_sum       TO sql_api_role;
+GRANT SELECT ON app.metrics_histogram TO sql_api_role;
 
 -- Clean up accidental/manual system grants. SHOW TABLES handles schema
 -- discovery without exposing storage counters from system.tables or the
@@ -101,4 +102,6 @@ CREATE ROW POLICY IF NOT EXISTS sql_api_default_deny_logs
 CREATE ROW POLICY IF NOT EXISTS sql_api_default_deny_metrics_gauge
   ON app.metrics_gauge FOR SELECT USING 0 TO sql_api_role;
 CREATE ROW POLICY IF NOT EXISTS sql_api_default_deny_metrics_sum
-  ON app.metrics_sum   FOR SELECT USING 0 TO sql_api_role;
+  ON app.metrics_sum       FOR SELECT USING 0 TO sql_api_role;
+CREATE ROW POLICY IF NOT EXISTS sql_api_default_deny_metrics_histogram
+  ON app.metrics_histogram FOR SELECT USING 0 TO sql_api_role;

--- a/clickhouse/init/15-create-sql-api-role.sql
+++ b/clickhouse/init/15-create-sql-api-role.sql
@@ -59,6 +59,7 @@ GRANT SELECT ON app.metrics_gauge TO sql_api_role;
 GRANT SELECT ON app.metrics_sum       TO sql_api_role;
 GRANT SELECT ON app.metrics_histogram              TO sql_api_role;
 GRANT SELECT ON app.metrics_exponential_histogram TO sql_api_role;
+GRANT SELECT ON app.metrics_summary              TO sql_api_role;
 
 -- Clean up accidental/manual system grants. SHOW TABLES handles schema
 -- discovery without exposing storage counters from system.tables or the
@@ -108,3 +109,5 @@ CREATE ROW POLICY IF NOT EXISTS sql_api_default_deny_metrics_histogram
   ON app.metrics_histogram              FOR SELECT USING 0 TO sql_api_role;
 CREATE ROW POLICY IF NOT EXISTS sql_api_default_deny_metrics_exponential_histogram
   ON app.metrics_exponential_histogram FOR SELECT USING 0 TO sql_api_role;
+CREATE ROW POLICY IF NOT EXISTS sql_api_default_deny_metrics_summary
+  ON app.metrics_summary               FOR SELECT USING 0 TO sql_api_role;

--- a/clickhouse/init/15-create-sql-api-role.sql
+++ b/clickhouse/init/15-create-sql-api-role.sql
@@ -57,7 +57,8 @@ GRANT SELECT ON app.traces        TO sql_api_role;
 GRANT SELECT ON app.logs          TO sql_api_role;
 GRANT SELECT ON app.metrics_gauge TO sql_api_role;
 GRANT SELECT ON app.metrics_sum       TO sql_api_role;
-GRANT SELECT ON app.metrics_histogram TO sql_api_role;
+GRANT SELECT ON app.metrics_histogram              TO sql_api_role;
+GRANT SELECT ON app.metrics_exponential_histogram TO sql_api_role;
 
 -- Clean up accidental/manual system grants. SHOW TABLES handles schema
 -- discovery without exposing storage counters from system.tables or the
@@ -104,4 +105,6 @@ CREATE ROW POLICY IF NOT EXISTS sql_api_default_deny_metrics_gauge
 CREATE ROW POLICY IF NOT EXISTS sql_api_default_deny_metrics_sum
   ON app.metrics_sum       FOR SELECT USING 0 TO sql_api_role;
 CREATE ROW POLICY IF NOT EXISTS sql_api_default_deny_metrics_histogram
-  ON app.metrics_histogram FOR SELECT USING 0 TO sql_api_role;
+  ON app.metrics_histogram              FOR SELECT USING 0 TO sql_api_role;
+CREATE ROW POLICY IF NOT EXISTS sql_api_default_deny_metrics_exponential_histogram
+  ON app.metrics_exponential_histogram FOR SELECT USING 0 TO sql_api_role;

--- a/clickhouse/init/20-apply-rls.sql
+++ b/clickhouse/init/20-apply-rls.sql
@@ -37,3 +37,10 @@ ON app.metrics_histogram
 FOR SELECT
 USING tenant_id = getSetting('SQL_everr_tenant_id')
 TO app_ro;
+
+DROP ROW POLICY IF EXISTS tenant_filter_metrics_exponential_histogram ON app.metrics_exponential_histogram;
+CREATE ROW POLICY tenant_filter_metrics_exponential_histogram
+ON app.metrics_exponential_histogram
+FOR SELECT
+USING tenant_id = getSetting('SQL_everr_tenant_id')
+TO app_ro;

--- a/clickhouse/init/20-apply-rls.sql
+++ b/clickhouse/init/20-apply-rls.sql
@@ -30,3 +30,10 @@ ON app.metrics_sum
 FOR SELECT
 USING tenant_id = getSetting('SQL_everr_tenant_id')
 TO app_ro;
+
+DROP ROW POLICY IF EXISTS tenant_filter_metrics_histogram ON app.metrics_histogram;
+CREATE ROW POLICY tenant_filter_metrics_histogram
+ON app.metrics_histogram
+FOR SELECT
+USING tenant_id = getSetting('SQL_everr_tenant_id')
+TO app_ro;

--- a/clickhouse/init/20-apply-rls.sql
+++ b/clickhouse/init/20-apply-rls.sql
@@ -44,3 +44,10 @@ ON app.metrics_exponential_histogram
 FOR SELECT
 USING tenant_id = getSetting('SQL_everr_tenant_id')
 TO app_ro;
+
+DROP ROW POLICY IF EXISTS tenant_filter_metrics_summary ON app.metrics_summary;
+CREATE ROW POLICY tenant_filter_metrics_summary
+ON app.metrics_summary
+FOR SELECT
+USING tenant_id = getSetting('SQL_everr_tenant_id')
+TO app_ro;

--- a/packages/app/src/lib/clickhouse.test.ts
+++ b/packages/app/src/lib/clickhouse.test.ts
@@ -111,6 +111,7 @@ describe("provisionSqlApiOrgUser", () => {
       `CREATE ROW POLICY IF NOT EXISTS \`${ORG_USER}_metrics_gauge\` ON app.\`metrics_gauge\` FOR SELECT USING tenant_id = '${ORG}' TO \`${ORG_USER}\``,
       `CREATE ROW POLICY IF NOT EXISTS \`${ORG_USER}_metrics_sum\` ON app.\`metrics_sum\` FOR SELECT USING tenant_id = '${ORG}' TO \`${ORG_USER}\``,
       `CREATE ROW POLICY IF NOT EXISTS \`${ORG_USER}_metrics_histogram\` ON app.\`metrics_histogram\` FOR SELECT USING tenant_id = '${ORG}' TO \`${ORG_USER}\``,
+      `CREATE ROW POLICY IF NOT EXISTS \`${ORG_USER}_metrics_exponential_histogram\` ON app.\`metrics_exponential_histogram\` FOR SELECT USING tenant_id = '${ORG}' TO \`${ORG_USER}\``,
     ]);
   });
 });
@@ -126,6 +127,7 @@ describe("deprovisionSqlApiOrgUser", () => {
       `DROP ROW POLICY IF EXISTS \`${ORG_USER}_metrics_gauge\` ON app.\`metrics_gauge\``,
       `DROP ROW POLICY IF EXISTS \`${ORG_USER}_metrics_sum\` ON app.\`metrics_sum\``,
       `DROP ROW POLICY IF EXISTS \`${ORG_USER}_metrics_histogram\` ON app.\`metrics_histogram\``,
+      `DROP ROW POLICY IF EXISTS \`${ORG_USER}_metrics_exponential_histogram\` ON app.\`metrics_exponential_histogram\``,
       `DROP USER IF EXISTS \`${ORG_USER}\``,
     ]);
   });

--- a/packages/app/src/lib/clickhouse.test.ts
+++ b/packages/app/src/lib/clickhouse.test.ts
@@ -110,6 +110,7 @@ describe("provisionSqlApiOrgUser", () => {
       `CREATE ROW POLICY IF NOT EXISTS \`${ORG_USER}_logs\` ON app.\`logs\` FOR SELECT USING tenant_id = '${ORG}' TO \`${ORG_USER}\``,
       `CREATE ROW POLICY IF NOT EXISTS \`${ORG_USER}_metrics_gauge\` ON app.\`metrics_gauge\` FOR SELECT USING tenant_id = '${ORG}' TO \`${ORG_USER}\``,
       `CREATE ROW POLICY IF NOT EXISTS \`${ORG_USER}_metrics_sum\` ON app.\`metrics_sum\` FOR SELECT USING tenant_id = '${ORG}' TO \`${ORG_USER}\``,
+      `CREATE ROW POLICY IF NOT EXISTS \`${ORG_USER}_metrics_histogram\` ON app.\`metrics_histogram\` FOR SELECT USING tenant_id = '${ORG}' TO \`${ORG_USER}\``,
     ]);
   });
 });
@@ -124,6 +125,7 @@ describe("deprovisionSqlApiOrgUser", () => {
       `DROP ROW POLICY IF EXISTS \`${ORG_USER}_logs\` ON app.\`logs\``,
       `DROP ROW POLICY IF EXISTS \`${ORG_USER}_metrics_gauge\` ON app.\`metrics_gauge\``,
       `DROP ROW POLICY IF EXISTS \`${ORG_USER}_metrics_sum\` ON app.\`metrics_sum\``,
+      `DROP ROW POLICY IF EXISTS \`${ORG_USER}_metrics_histogram\` ON app.\`metrics_histogram\``,
       `DROP USER IF EXISTS \`${ORG_USER}\``,
     ]);
   });

--- a/packages/app/src/lib/clickhouse.test.ts
+++ b/packages/app/src/lib/clickhouse.test.ts
@@ -112,6 +112,7 @@ describe("provisionSqlApiOrgUser", () => {
       `CREATE ROW POLICY IF NOT EXISTS \`${ORG_USER}_metrics_sum\` ON app.\`metrics_sum\` FOR SELECT USING tenant_id = '${ORG}' TO \`${ORG_USER}\``,
       `CREATE ROW POLICY IF NOT EXISTS \`${ORG_USER}_metrics_histogram\` ON app.\`metrics_histogram\` FOR SELECT USING tenant_id = '${ORG}' TO \`${ORG_USER}\``,
       `CREATE ROW POLICY IF NOT EXISTS \`${ORG_USER}_metrics_exponential_histogram\` ON app.\`metrics_exponential_histogram\` FOR SELECT USING tenant_id = '${ORG}' TO \`${ORG_USER}\``,
+      `CREATE ROW POLICY IF NOT EXISTS \`${ORG_USER}_metrics_summary\` ON app.\`metrics_summary\` FOR SELECT USING tenant_id = '${ORG}' TO \`${ORG_USER}\``,
     ]);
   });
 });
@@ -128,6 +129,7 @@ describe("deprovisionSqlApiOrgUser", () => {
       `DROP ROW POLICY IF EXISTS \`${ORG_USER}_metrics_sum\` ON app.\`metrics_sum\``,
       `DROP ROW POLICY IF EXISTS \`${ORG_USER}_metrics_histogram\` ON app.\`metrics_histogram\``,
       `DROP ROW POLICY IF EXISTS \`${ORG_USER}_metrics_exponential_histogram\` ON app.\`metrics_exponential_histogram\``,
+      `DROP ROW POLICY IF EXISTS \`${ORG_USER}_metrics_summary\` ON app.\`metrics_summary\``,
       `DROP USER IF EXISTS \`${ORG_USER}\``,
     ]);
   });

--- a/packages/app/src/lib/clickhouse.ts
+++ b/packages/app/src/lib/clickhouse.ts
@@ -49,6 +49,7 @@ const SQL_API_TENANT_TABLES = [
   "metrics_gauge",
   "metrics_sum",
   "metrics_histogram",
+  "metrics_exponential_histogram",
 ] as const;
 
 function sqlApiOrgUserName(organizationId: string): string {

--- a/packages/app/src/lib/clickhouse.ts
+++ b/packages/app/src/lib/clickhouse.ts
@@ -50,6 +50,7 @@ const SQL_API_TENANT_TABLES = [
   "metrics_sum",
   "metrics_histogram",
   "metrics_exponential_histogram",
+  "metrics_summary",
 ] as const;
 
 function sqlApiOrgUserName(organizationId: string): string {

--- a/packages/app/src/lib/clickhouse.ts
+++ b/packages/app/src/lib/clickhouse.ts
@@ -48,6 +48,7 @@ const SQL_API_TENANT_TABLES = [
   "logs",
   "metrics_gauge",
   "metrics_sum",
+  "metrics_histogram",
 ] as const;
 
 function sqlApiOrgUserName(organizationId: string): string {


### PR DESCRIPTION
## Summary
- Add `otel.otel_metrics_histogram` raw landing table for the ClickHouse OTel exporter
- Add `app.metrics_histogram` tenant-enriched table with materialized view, TTL, and RLS
- Wire up SQL API grants, default-deny row policies, and per-org provisioning

## Context
The collector's ClickHouse exporter was failing with `Table otel.otel_metrics_histogram does not exist`, dropping histogram metric batches on every retry cycle.

## Test plan
- [x] Unit tests updated and passing
- [ ] Restart local ClickHouse to run init scripts, verify table exists
- [ ] Confirm collector stops logging histogram export errors