### PR TITLE
Fix sql_api_role GRANT failing on ClickHouse 26

### DIFF
--- a/clickhouse/Dockerfile
+++ b/clickhouse/Dockerfile
@@ -1,2 +1,2 @@
-FROM clickhouse/clickhouse-server:26.1
+FROM clickhouse/clickhouse-server:26.2
 COPY init/ /docker-entrypoint-initdb.d/

--- a/clickhouse/init/15-create-sql-api-role.sql
+++ b/clickhouse/init/15-create-sql-api-role.sql
@@ -75,10 +75,8 @@ GRANT sql_api_role TO web_app_admin WITH ADMIN OPTION;
 -- Keep sql_api_role out of web_app_admin's default roles. Otherwise CH would
 -- auto-activate it on every connection and apply sql_api_profile (readonly=1,
 -- allow_ddl=0, etc.) to web_app_admin's sessions, which would break the
--- CREATE USER / GRANT / CREATE ROW POLICY work it has to do. ADMIN OPTION
--- doesn't require the role to be active, so per-org GRANT sql_api_role still
--- works. web_app_admin's own table access is covered by direct grants in
--- 00-setup.sh and above on app.tenant_retention_source.
+-- CREATE USER / GRANT / CREATE ROW POLICY work it has to do. The app code
+-- uses SET ROLE to activate it only for the GRANT statement.
 ALTER USER web_app_admin DEFAULT ROLE NONE;
 
 -- Quota: per-tenant limits. Keyed by client_key so each org gets its own

--- a/packages/app/src/lib/clickhouse.test.ts
+++ b/packages/app/src/lib/clickhouse.test.ts
@@ -104,6 +104,7 @@ describe("provisionSqlApiOrgUser", () => {
     const calls = mockCommand.mock.calls.map(([args]) => args.query);
     expect(calls).toEqual([
       `CREATE USER IF NOT EXISTS \`${ORG_USER}\` IDENTIFIED WITH sha256_password BY '${ORG_PASSWORD}' SETTINGS PROFILE 'sql_api_profile'`,
+      "SET ROLE sql_api_role",
       `GRANT sql_api_role TO \`${ORG_USER}\``,
       `ALTER USER \`${ORG_USER}\` DEFAULT ROLE sql_api_role`,
       `CREATE ROW POLICY IF NOT EXISTS \`${ORG_USER}_traces\` ON app.\`traces\` FOR SELECT USING tenant_id = '${ORG}' TO \`${ORG_USER}\``,
@@ -114,6 +115,13 @@ describe("provisionSqlApiOrgUser", () => {
       `CREATE ROW POLICY IF NOT EXISTS \`${ORG_USER}_metrics_exponential_histogram\` ON app.\`metrics_exponential_histogram\` FOR SELECT USING tenant_id = '${ORG}' TO \`${ORG_USER}\``,
       `CREATE ROW POLICY IF NOT EXISTS \`${ORG_USER}_metrics_summary\` ON app.\`metrics_summary\` FOR SELECT USING tenant_id = '${ORG}' TO \`${ORG_USER}\``,
     ]);
+
+    const setRoleCall = mockCommand.mock.calls[1][0];
+    const grantCall = mockCommand.mock.calls[2][0];
+    expect(setRoleCall.clickhouse_settings.session_id).toBeDefined();
+    expect(grantCall.clickhouse_settings.session_id).toBe(
+      setRoleCall.clickhouse_settings.session_id,
+    );
   });
 });
 

--- a/packages/app/src/lib/clickhouse.ts
+++ b/packages/app/src/lib/clickhouse.ts
@@ -1,4 +1,4 @@
-import { createHmac } from "node:crypto";
+import { createHmac, randomUUID } from "node:crypto";
 import { env } from "@/env";
 import { createClient } from "@/lib/clickhouse-client";
 
@@ -148,8 +148,17 @@ export async function provisionSqlApiOrgUser(
   await clickhouseAdmin.command({
     query: `CREATE USER IF NOT EXISTS \`${username}\` IDENTIFIED WITH sha256_password BY '${password}' SETTINGS PROFILE 'sql_api_profile'`,
   });
+  // CH 26 requires sql_api_role to be active for WITH ADMIN OPTION to work,
+  // but DEFAULT ROLE NONE keeps it off to avoid the readonly profile. Activate
+  // it in an ephemeral session scoped to just these two statements.
+  const sessionId = randomUUID();
+  await clickhouseAdmin.command({
+    query: "SET ROLE sql_api_role",
+    clickhouse_settings: { session_id: sessionId },
+  });
   await clickhouseAdmin.command({
     query: `GRANT sql_api_role TO \`${username}\``,
+    clickhouse_settings: { session_id: sessionId },
   });
   // DEFAULT ROLE has to come after the GRANT — CH validates the role is
   // already granted to the user before it can be the default.


### PR DESCRIPTION
## Summary

ClickHouse 26 changed the behavior of `WITH ADMIN OPTION`: the role must now be **active in the session** for the option to take effect. Our `web_app_admin` user has `DEFAULT ROLE NONE` to avoid activating `sql_api_profile` (which sets `readonly=1`, `allow_ddl=0`), so `GRANT sql_api_role TO <per-org-user>` fails with `ACCESS_DENIED` during org provisioning.

## Root cause

- `15-create-sql-api-role.sql` grants `sql_api_role TO web_app_admin WITH ADMIN OPTION` and then sets `ALTER USER web_app_admin DEFAULT ROLE NONE`
- The `DEFAULT ROLE NONE` is necessary — without it, every `web_app_admin` connection gets `sql_api_profile` applied, which blocks `CREATE USER`, `ALTER USER`, and `CREATE ROW POLICY`
- On ClickHouse < 26, `ADMIN OPTION` worked even when the role wasn't active. On CH 26, it doesn't

## Fix

Use `SET ROLE sql_api_role` in an ephemeral session (random UUID) scoped to just the `GRANT` statement in `provisionSqlApiOrgUser()`. This activates the `ADMIN OPTION` for that one statement without applying the readonly profile to the rest of the provisioning flow (`CREATE USER`, `ALTER USER`, `CREATE ROW POLICY`).

Verified that `GRANT` is classified as an access management statement, not a data query, so `readonly=1` from the activated profile does not block it.

### Why not broader alternatives?

- **`GRANT ROLE ADMIN ON *.*`**: would let `web_app_admin` grant *any* role, not just `sql_api_role` — unnecessary privilege escalation surface
- **Multi-statement query** (`SET ROLE ...; GRANT ...`): ClickHouse HTTP interface rejects multi-statements by default

### Security

- The session ID is a `randomUUID()` generated server-side, never exposed to any client
- Privilege scope unchanged: `WITH ADMIN OPTION` is still scoped to `sql_api_role` only
- Backwards compatible: `SET ROLE` is a no-op on older CH versions where the role is already active

## Changes

- `packages/app/src/lib/clickhouse.ts`: wrap the GRANT in a `SET ROLE` session
- `clickhouse/init/15-create-sql-api-role.sql`: update comment to reflect the new behavior