### PR TITLE
Serve docs as Markdown with llms.txt

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -17,6 +17,9 @@
   "entry": [
     // CI scripts invoked directly by GitHub Actions workflows.
     ".github/actions/everr-action/scripts/build-readme.mjs",
+    // Nitro scans these folders as file-based server entry points for docs.
+    "packages/docs/middleware/**/*.{ts,tsx}",
+    "packages/docs/routes/**/*.{ts,tsx}",
     // Static entry points reached via Vite resolve.alias in
     // packages/app/vite.config.ts (use-sync-external-store/shim).
     "packages/app/src/ssr-shims/**"

--- a/packages/docs/middleware/docs-markdown.ts
+++ b/packages/docs/middleware/docs-markdown.ts
@@ -1,0 +1,16 @@
+import { defineEventHandler, getRequestURL } from "nitro/h3";
+import { docsMarkdownResponse } from "../src/lib/llms";
+import { source } from "../src/lib/source";
+
+export default defineEventHandler((event) => {
+  const pathname = getRequestURL(event).pathname;
+
+  if (
+    pathname !== "/docs.md" &&
+    !(pathname.startsWith("/docs/") && pathname.endsWith(".md"))
+  ) {
+    return;
+  }
+
+  return docsMarkdownResponse(source, pathname);
+});

--- a/packages/docs/routes/__docs-markdown.get.dev.ts
+++ b/packages/docs/routes/__docs-markdown.get.dev.ts
@@ -1,0 +1,13 @@
+import { getRequestURL } from "nitro/h3";
+import { docsMarkdownResponse } from "../src/lib/llms";
+import { source } from "../src/lib/source";
+
+export default function handler(event: Parameters<typeof getRequestURL>[0]) {
+  const pathname = getRequestURL(event).searchParams.get("pathname");
+
+  if (!pathname) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  return docsMarkdownResponse(source, pathname);
+}

--- a/packages/docs/routes/llms.txt.get.ts
+++ b/packages/docs/routes/llms.txt.get.ts
@@ -1,0 +1,7 @@
+import { llms } from "fumadocs-core/source";
+import { source } from "../src/lib/source";
+import { markdownDocsLinks, textResponse } from "../src/lib/llms";
+
+export default function handler() {
+  return textResponse(markdownDocsLinks(llms(source).index()));
+}

--- a/packages/docs/source.config.ts
+++ b/packages/docs/source.config.ts
@@ -4,6 +4,11 @@ import { z } from 'zod';
 /** @expected-unused — read by fumadocs build pipeline, not by TS imports. */
 export const docs = defineDocs({
   dir: 'content/docs',
+  docs: {
+    postprocess: {
+      includeProcessedMarkdown: true,
+    },
+  },
 });
 
 /** @expected-unused — read by fumadocs build pipeline, not by TS imports. */

--- a/packages/docs/src/lib/llms.test.ts
+++ b/packages/docs/src/lib/llms.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import {
+  docsMarkdownPathToSlugs,
+  docsMarkdownResponse,
+  getLLMText,
+  markdownDocsLinks,
+  markdownResponse,
+} from "./llms";
+
+describe("docs LLM helpers", () => {
+  it("renders a docs page as Markdown with a canonical title and URL", async () => {
+    const text = await getLLMText({
+      url: "/docs/getting-started/install",
+      data: {
+        title: "Install",
+        getText: async (type) => {
+          expect(type).toBe("processed");
+          return "Run the installer from a terminal.";
+        },
+      },
+    });
+
+    expect(text).toBe(
+      "# Install (/docs/getting-started/install)\n\nRun the installer from a terminal.",
+    );
+  });
+
+  it("maps docs Markdown paths to Fumadocs slugs", () => {
+    expect(docsMarkdownPathToSlugs("/docs/getting-started/install.md")).toEqual(
+      ["getting-started", "install"],
+    );
+    expect(docsMarkdownPathToSlugs("/docs/index.md")).toEqual([]);
+    expect(docsMarkdownPathToSlugs("/docs.md")).toEqual([]);
+  });
+
+  it("rejects non-docs Markdown paths and path traversal segments", () => {
+    expect(docsMarkdownPathToSlugs("/devlog/example.md")).toBeNull();
+    expect(docsMarkdownPathToSlugs("/docs/getting-started/install")).toBeNull();
+    expect(docsMarkdownPathToSlugs("/docs/../secret.md")).toBeNull();
+  });
+
+  it("serves Markdown responses with a text/markdown content type", async () => {
+    const response = markdownResponse("# Install");
+
+    expect(response.headers.get("content-type")).toBe(
+      "text/markdown; charset=utf-8",
+    );
+    expect(await response.text()).toBe("# Install");
+  });
+
+  it("serves a matching docs page as Markdown", async () => {
+    const response = await docsMarkdownResponse(
+      {
+        getPage(slugs) {
+          expect(slugs).toEqual(["reference", "cli"]);
+          return {
+            url: "/docs/reference/cli",
+            data: {
+              title: "CLI",
+              getText: async () => "Use `everr --help`.",
+            },
+          };
+        },
+      },
+      "/docs/reference/cli.md",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "text/markdown; charset=utf-8",
+    );
+    expect(await response.text()).toBe(
+      "# CLI (/docs/reference/cli)\n\nUse `everr --help`.",
+    );
+  });
+
+  it("returns 404 when no Markdown docs page matches", async () => {
+    const response = await docsMarkdownResponse(
+      {
+        getPage() {
+          return undefined;
+        },
+      },
+      "/docs/missing.md",
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("rewrites docs links in llms.txt to Markdown endpoints", () => {
+    expect(
+      markdownDocsLinks(
+        [
+          "- [Docs](/docs): Home",
+          "- [Install](/docs/getting-started/install): Install Everr.",
+          "- [Devlog](/devlog): Updates",
+        ].join("\n"),
+      ),
+    ).toBe(
+      [
+        "- [Docs](/docs.md): Home",
+        "- [Install](/docs/getting-started/install.md): Install Everr.",
+        "- [Devlog](/devlog): Updates",
+      ].join("\n"),
+    );
+  });
+});

--- a/packages/docs/src/lib/llms.ts
+++ b/packages/docs/src/lib/llms.ts
@@ -1,0 +1,101 @@
+const MARKDOWN_CONTENT_TYPE = "text/markdown; charset=utf-8";
+const TEXT_CONTENT_TYPE = "text/plain; charset=utf-8";
+
+type DocsPage = {
+  url: string;
+  data: {
+    title: string;
+    getText: (type: "processed") => Promise<string>;
+  };
+};
+
+type DocsSource = {
+  getPage: (slugs: string[]) => DocsPage | undefined;
+};
+
+export async function getLLMText(page: DocsPage) {
+  const processed = await page.data.getText("processed");
+  return `# ${page.data.title} (${page.url})\n\n${processed}`;
+}
+
+export function markdownResponse(markdown: string) {
+  return new Response(markdown, {
+    headers: {
+      "content-type": MARKDOWN_CONTENT_TYPE,
+    },
+  });
+}
+
+export function textResponse(text: string) {
+  return new Response(text, {
+    headers: {
+      "content-type": TEXT_CONTENT_TYPE,
+    },
+  });
+}
+
+export function markdownDocsLinks(text: string) {
+  return text.replace(
+    /\]\((\/docs(?:\/[^)\s?#]*)?)([?#][^)]*)?\)/g,
+    (_match, url: string, suffix: string | undefined) =>
+      `](${docsUrlToMarkdownPath(url)}${suffix ?? ""})`,
+  );
+}
+
+function docsUrlToMarkdownPath(url: string) {
+  if (url === "/docs") return "/docs.md";
+  if (url === "/docs.md") return url;
+  if (url.startsWith("/docs/") && !url.endsWith(".md")) {
+    return `${url}.md`;
+  }
+  return url;
+}
+
+export function docsMarkdownPathToSlugs(pathname: string) {
+  if (pathname === "/docs.md") return [];
+  if (!pathname.startsWith("/docs/") || !pathname.endsWith(".md")) {
+    return null;
+  }
+
+  const slugPath = pathname.slice("/docs/".length, -".md".length);
+  if (slugPath === "index") return [];
+  if (slugPath.length === 0) return null;
+
+  const encodedSegments = slugPath.split("/");
+  if (encodedSegments.some((segment) => segment.length === 0)) return null;
+
+  try {
+    return encodedSegments.map((segment) => {
+      const decoded = decodeURIComponent(segment);
+      if (
+        decoded.length === 0 ||
+        decoded === "." ||
+        decoded === ".." ||
+        decoded.includes("/")
+      ) {
+        throw new Error("Invalid docs Markdown path segment");
+      }
+
+      return decoded;
+    });
+  } catch {
+    return null;
+  }
+}
+
+export async function docsMarkdownResponse(
+  source: DocsSource,
+  pathname: string,
+) {
+  const slugs = docsMarkdownPathToSlugs(pathname);
+  if (!slugs) return notFoundResponse();
+
+  const page = source.getPage(slugs);
+  if (!page) return notFoundResponse();
+
+  return markdownResponse(await getLLMText(page));
+}
+
+function notFoundResponse() {
+  return new Response("Not found", { status: 404 });
+}

--- a/packages/docs/vite.config.ts
+++ b/packages/docs/vite.config.ts
@@ -4,7 +4,7 @@ import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import react from "@vitejs/plugin-react";
 import mdx from "fumadocs-mdx/vite";
 import { nitro } from "nitro/vite";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import svgr from "vite-plugin-svgr";
 
 export default defineConfig({
@@ -22,14 +22,39 @@ export default defineConfig({
   },
   plugins: [
     devtools(),
+    docsMarkdownDevRequests(),
     mdx(await import("./source.config")),
     tailwindcss(),
     tanstackStart(),
     react(),
     nitro({
       preset: "node-server",
+      scanDirs: ["."],
       traceDeps: ["@takumi-rs/image-response", "@takumi-rs/core"],
     }),
     svgr(),
   ],
 });
+
+function docsMarkdownDevRequests(): Plugin {
+  return {
+    name: "everr-docs-markdown-dev-requests",
+    apply: "serve",
+    configureServer(server) {
+      server.middlewares.use((req, _res, next) => {
+        if (!req.url) return next();
+
+        const pathname = new URL(req.url, "http://localhost").pathname;
+        if (
+          pathname === "/docs.md" ||
+          (pathname.startsWith("/docs/") && pathname.endsWith(".md"))
+        ) {
+          req.url = `/__docs-markdown?pathname=${encodeURIComponent(pathname)}`;
+          req.headers.accept = `text/html,${req.headers.accept ?? "*/*"}`;
+        }
+
+        next();
+      });
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Serve `/llms.txt` for the docs site and point its docs links at Markdown endpoints.
- Add Markdown responses for docs pages such as `/docs/getting-started/install.md`, plus `/docs.md` for the docs root.
- Preserve the normal HTML docs routes and add a dev-server rewrite so the same Markdown URLs work on `localhost:3000`.
- Mark Nitro docs routes and middleware as fallow entry points.

## Validation

- `pnpm exec fallow dead-code --fail-on-issues --quiet`
- `pnpm --filter @everr/docs exec vitest src/lib/llms.test.ts --run`
- `pnpm --filter @everr/docs types:check`
- `pnpm --filter @everr/docs build`
- Local smoke checks on `http://localhost:3000` for `/llms.txt`, `/docs.md`, `/docs/getting-started/install.md`, and `/docs/getting-started/install`.
