### PR TITLE
Report browser render crashes to telemetry

### DIFF
--- a/packages/app/src/lib/serverFn.test.ts
+++ b/packages/app/src/lib/serverFn.test.ts
@@ -10,6 +10,10 @@ const mocked = vi.hoisted(() => ({
     options: { type: string };
     __handler: FunctionMiddlewareHandler;
   } | null,
+  allDefinitions: [] as Array<{
+    options: { type: string };
+    __handler: FunctionMiddlewareHandler;
+  }>,
   createServerFnMiddleware: vi.fn(),
   createServerFnResult: {},
   getRequest: vi.fn(),
@@ -27,6 +31,8 @@ function getHandler(): FunctionMiddlewareHandler {
 beforeEach(() => {
   vi.resetModules();
   mocked.handler = null;
+  mocked.middlewareDefinition = null;
+  mocked.allDefinitions = [];
   mocked.createServerFnMiddleware.mockReset();
   mocked.createServerFnMiddleware.mockReturnValue(mocked.createServerFnResult);
   mocked.getRequest.mockReset();
@@ -56,6 +62,7 @@ async function loadModule() {
         };
         mocked.handler = composed;
         mocked.middlewareDefinition = definition;
+        mocked.allDefinitions.push(definition);
         return definition;
       },
     };
@@ -85,9 +92,12 @@ describe("createAuthenticatedServerFn", () => {
   it("wires the auth middleware into createServerFn", async () => {
     const { createAuthenticatedServerFn } = await loadModule();
 
+    // allDefinitions order: [errorTelemetryMiddleware, authMiddleware, requireOrgMiddleware]
+    const [errorTelemetryDef, , requireOrgDef] = mocked.allDefinitions;
     expect(createAuthenticatedServerFn).toBe(mocked.createServerFnResult);
     expect(mocked.createServerFnMiddleware).toHaveBeenCalledWith([
-      mocked.middlewareDefinition,
+      requireOrgDef,
+      errorTelemetryDef,
     ]);
   });
 });

--- a/packages/app/src/lib/serverFn.ts
+++ b/packages/app/src/lib/serverFn.ts
@@ -1,6 +1,34 @@
+import { logs, SeverityNumber } from "@opentelemetry/api-logs";
 import { createMiddleware, createServerFn } from "@tanstack/react-start";
 import { auth } from "@/lib/auth.server";
+import { getExceptionAttributes } from "@/telemetry/shared";
 import { createClickhouseQuery } from "./clickhouse";
+
+// Server function handler errors are caught by the framework and returned as a
+// failed RPC, so they never hit process-level uncaughtException/unhandledRejection
+// instrumentation. Wrap the handler to emit an exception log before rethrowing,
+// so backend failures land in telemetry (and the Errors UI).
+const errorTelemetryMiddleware = createMiddleware().server(async ({ next }) => {
+  try {
+    return await next();
+  } catch (error) {
+    const attributes = getExceptionAttributes(error);
+    logs.getLogger("everr-web-server-fn-errors").emit({
+      severityNumber: SeverityNumber.ERROR,
+      severityText: "ERROR",
+      body:
+        typeof attributes["exception.message"] === "string"
+          ? attributes["exception.message"]
+          : "Server function error",
+      attributes: {
+        ...attributes,
+        "error.source": "server-fn",
+        "exception.escaped": true,
+      },
+    });
+    throw error;
+  }
+});
 
 const authMiddleware = createMiddleware().server(async ({ request, next }) => {
   const session = await auth.api.getSession({
@@ -44,6 +72,7 @@ export const requireOrgMiddleware = createMiddleware()
 
 export const createAuthenticatedServerFn = createServerFn().middleware([
   requireOrgMiddleware,
+  errorTelemetryMiddleware,
 ]);
 
 /**
@@ -52,5 +81,5 @@ export const createAuthenticatedServerFn = createServerFn().middleware([
  * active organization yet, such as the onboarding flow.
  */
 export const createPartiallyAuthenticatedServerFn = createServerFn().middleware(
-  [authMiddleware],
+  [authMiddleware, errorTelemetryMiddleware],
 );

--- a/packages/app/src/lib/serverFn.ts
+++ b/packages/app/src/lib/serverFn.ts
@@ -1,3 +1,4 @@
+import { SpanStatusCode, trace } from "@opentelemetry/api";
 import { logs, SeverityNumber } from "@opentelemetry/api-logs";
 import { createMiddleware, createServerFn } from "@tanstack/react-start";
 import { auth } from "@/lib/auth.server";
@@ -6,20 +7,30 @@ import { createClickhouseQuery } from "./clickhouse";
 
 // Server function handler errors are caught by the framework and returned as a
 // failed RPC, so they never hit process-level uncaughtException/unhandledRejection
-// instrumentation. Wrap the handler to emit an exception log before rethrowing,
-// so backend failures land in telemetry (and the Errors UI).
+// instrumentation. Wrap the handler to record the failure on the active span
+// (so the trace shows StatusCode=Error) and emit an exception log — which the
+// OTel SDK stamps with the active TraceId/SpanId — before rethrowing, so
+// backend failures land in telemetry and the Errors UI, linked to their trace.
 const errorTelemetryMiddleware = createMiddleware().server(async ({ next }) => {
   try {
     return await next();
   } catch (error) {
     const attributes = getExceptionAttributes(error);
+    const message =
+      typeof attributes["exception.message"] === "string"
+        ? attributes["exception.message"]
+        : "Server function error";
+
+    const span = trace.getActiveSpan();
+    if (span) {
+      span.recordException(error as Error);
+      span.setStatus({ code: SpanStatusCode.ERROR, message });
+    }
+
     logs.getLogger("everr-web-server-fn-errors").emit({
       severityNumber: SeverityNumber.ERROR,
       severityText: "ERROR",
-      body:
-        typeof attributes["exception.message"] === "string"
-          ? attributes["exception.message"]
-          : "Server function error",
+      body: message,
       attributes: {
         ...attributes,
         "error.source": "server-fn",

--- a/packages/app/src/router.tsx
+++ b/packages/app/src/router.tsx
@@ -1,26 +1,11 @@
 import { QueryClient } from "@tanstack/react-query";
-import {
-  createRouter,
-  ErrorComponent,
-  type ErrorComponentProps,
-} from "@tanstack/react-router";
+import { createRouter } from "@tanstack/react-router";
 import { Loader2 } from "lucide-react";
-import { useEffect } from "react";
 import { routeTree } from "./routeTree.gen";
 import type { EverrErrorReporterWindow } from "./telemetry/browser";
 
 if (typeof window !== "undefined" && import.meta.env.DEV) {
   void import("./telemetry/browser");
-}
-
-function RootErrorComponent({ error }: ErrorComponentProps) {
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    (window as EverrErrorReporterWindow).__everrReportError?.(error, {
-      "error.source": "react.error-boundary",
-    });
-  }, [error]);
-  return <ErrorComponent error={error} />;
 }
 
 export interface RouterContext {
@@ -44,7 +29,11 @@ export const getRouter = () => {
     context: { queryClient },
     // TODO: maybe preload?
     // defaultPreload: "intent",
-    defaultErrorComponent: RootErrorComponent,
+    defaultOnCatch: (error) => {
+      (window as EverrErrorReporterWindow).__everrReportError?.(error, {
+        "error.source": "react.error-boundary",
+      });
+    },
     scrollRestoration: true,
     // defaultPreloadStaleTime: 0,
     defaultPendingComponent: () => (

--- a/packages/app/src/router.tsx
+++ b/packages/app/src/router.tsx
@@ -1,10 +1,26 @@
 import { QueryClient } from "@tanstack/react-query";
-import { createRouter } from "@tanstack/react-router";
+import {
+  createRouter,
+  ErrorComponent,
+  type ErrorComponentProps,
+} from "@tanstack/react-router";
 import { Loader2 } from "lucide-react";
+import { useEffect } from "react";
 import { routeTree } from "./routeTree.gen";
+import type { EverrErrorReporterWindow } from "./telemetry/browser";
 
 if (typeof window !== "undefined" && import.meta.env.DEV) {
   void import("./telemetry/browser");
+}
+
+function RootErrorComponent({ error }: ErrorComponentProps) {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    (window as EverrErrorReporterWindow).__everrReportError?.(error, {
+      "error.source": "react.error-boundary",
+    });
+  }, [error]);
+  return <ErrorComponent error={error} />;
 }
 
 export interface RouterContext {
@@ -28,6 +44,7 @@ export const getRouter = () => {
     context: { queryClient },
     // TODO: maybe preload?
     // defaultPreload: "intent",
+    defaultErrorComponent: RootErrorComponent,
     scrollRestoration: true,
     // defaultPreloadStaleTime: 0,
     defaultPendingComponent: () => (

--- a/packages/app/src/telemetry/browser.ts
+++ b/packages/app/src/telemetry/browser.ts
@@ -1,4 +1,8 @@
-import { logs, SeverityNumber } from "@opentelemetry/api-logs";
+import {
+  type LogAttributes,
+  logs,
+  SeverityNumber,
+} from "@opentelemetry/api-logs";
 import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-proto";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
 import { registerInstrumentations } from "@opentelemetry/instrumentation";
@@ -21,6 +25,15 @@ type BrowserTelemetryConfig = {
   enabled: boolean;
   endpoint: string;
   serviceName: string;
+};
+
+export type EverrErrorReporter = (
+  error: unknown,
+  extra?: LogAttributes,
+) => void;
+
+export type EverrErrorReporterWindow = Window & {
+  __everrReportError?: EverrErrorReporter;
 };
 
 declare const __EVERR_BROWSER_OTEL__: BrowserTelemetryConfig;
@@ -53,6 +66,28 @@ if (config.enabled && typeof window !== "undefined") {
     errorLogger.emit(logRecord);
     void loggerProvider.forceFlush().catch(() => {});
   }
+
+  // React render crashes are caught by router/error-boundary and never reach
+  // the window "error" event, so expose a reporter the error boundary calls.
+  const reportError = (error: unknown, extra?: LogAttributes) => {
+    const attributes = getExceptionAttributes(error);
+    emitErrorLog({
+      severityNumber: SeverityNumber.ERROR,
+      severityText: "ERROR",
+      body:
+        typeof attributes["exception.message"] === "string"
+          ? attributes["exception.message"]
+          : "Browser error",
+      attributes: {
+        ...attributes,
+        "exception.escaped": true,
+        "url.full": window.location.href,
+        "url.path": window.location.pathname,
+        ...extra,
+      },
+    });
+  };
+  (window as EverrErrorReporterWindow).__everrReportError = reportError;
 
   const provider = new WebTracerProvider({
     resource,

--- a/packages/app/src/telemetry/browser.ts
+++ b/packages/app/src/telemetry/browser.ts
@@ -1,3 +1,4 @@
+import { SpanStatusCode, trace } from "@opentelemetry/api";
 import {
   type LogAttributes,
   logs,
@@ -71,13 +72,21 @@ if (config.enabled && typeof window !== "undefined") {
   // the window "error" event, so expose a reporter the error boundary calls.
   const reportError = (error: unknown, extra?: LogAttributes) => {
     const attributes = getExceptionAttributes(error);
+    const message =
+      typeof attributes["exception.message"] === "string"
+        ? attributes["exception.message"]
+        : "Browser error";
+
+    const span = trace.getActiveSpan();
+    if (span) {
+      span.recordException(error as Error);
+      span.setStatus({ code: SpanStatusCode.ERROR, message });
+    }
+
     emitErrorLog({
       severityNumber: SeverityNumber.ERROR,
       severityText: "ERROR",
-      body:
-        typeof attributes["exception.message"] === "string"
-          ? attributes["exception.message"]
-          : "Browser error",
+      body: message,
       attributes: {
         ...attributes,
         "exception.escaped": true,


### PR DESCRIPTION
## What

React **render** crashes (e.g. a route component throwing) are caught by the router/error-boundary and never fire the `window.error` event, so the browser OTel instrumentation never exported them as exception logs — they were invisible in the Errors UI and local `otel_logs`.

## Changes

- `telemetry/browser.ts`: expose an `__everrReportError(error, extra)` reporter (dev-only, gated on the existing browser-OTel config) that emits an OTel log with `getExceptionAttributes` (`exception.type`/`message`/`stacktrace`).
- `router.tsx`: add a `defaultErrorComponent` that reports the caught error with `error.source = "react.error-boundary"`, then renders the default error UI.

Render crashes now flush to the collector with `exception.*` attributes, so they pass the error-fingerprint filter and appear in the Errors interface.

## Notes

- No-op in production (browser OTel is dev-only); the router imports the reporter type only, so no OpenTelemetry code is pulled into the prod bundle.