### PR TITLE
feat: simplify the local tunnel setup for GH web hooks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,17 +2,17 @@
 
 ## Development
 
-### Set up `devtunnels`
+### Set up GitHub webhook forwarding
 
-> [!NOTE]
-> The following steps are for setting up `devtunnels` for the first time. If you have already set up the devtunnel, you can skip to the last step and directly start the tunnel via `devtunnel host`.
-> You may need to repeat the steps if the tunnel is not used for more than 30 days.
+The web app starts a [`smee`](https://smee.io/) client during Vite dev when `SMEE_CHANNEL` is set.
 
-1. Install and setup [`devtunnels`](https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started?tabs=macos#install).
-2. Login via `devtunnel user login`
-3. Create a tunnel via `devtunnel create -a -d 'Everr app'`
-4. Configure the tunnel `devtunnel port create -p 5173`
-5. Start the tunnel `devtunnel host`
+1. Create or open a smee channel at `https://smee.io/new`.
+2. Copy the channel id from the generated URL. For example, the channel id for `https://smee.io/abc123` is `abc123`.
+3. Set the channel id in `packages/app/.env`:
+   ```bash
+   SMEE_CHANNEL="abc123"
+   ```
+4. Start the web app with `pnpm dev:web`. The dev server forwards events from `https://smee.io/<SMEE_CHANNEL>` to `http://localhost:5173/webhook/github`.
 
 ### Start ClickHouse
 
@@ -31,7 +31,7 @@ pnpm build
 
 1. On GitHub, go to [Settings -> Developer settings -> GitHub Apps](https://github.com/settings/apps) and click **New GitHub App**.
 2. Choose an app name and set a homepage URL.
-3. Under **Webhook**, enable **Active** and set the webhook URL to your tunnel URL with the receiver path, for example: `https://<your-tunnel>/webhook/github`.
+3. Under **Webhook**, enable **Active** and set the webhook URL to your smee channel URL, for example: `https://smee.io/<SMEE_CHANNEL>`.
 4. Set a webhook secret and store it in both `packages/app/.env` as `GITHUB_APP_WEBHOOK_SECRET` and in `collector/config.yml` as `receivers.githubactions.secret`.
 5. Under **Repository permissions**, set **Actions** to **Read-only**.
 6. Under **Subscribe to events**, select **Workflow job** and **Workflow run**.

--- a/packages/app/.env.example
+++ b/packages/app/.env.example
@@ -39,6 +39,8 @@ GITHUB_APP_ID="123456"
 GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
 
 # GitHub webhook worker
+# Optional: forward GitHub webhooks from https://smee.io/<channel> to local dev.
+SMEE_CHANNEL=
 INGRESS_COLLECTOR_URL="http://localhost:8080/webhook/github"
 INGRESS_SOURCE="github"
 INGRESS_WORKER_COUNT="2"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -83,6 +83,7 @@
     "drizzle-kit": "^0.31.10",
     "jsdom": "^29.1.1",
     "nitro": "catalog:",
+    "smee-client": "^5.0.0",
     "typescript": "catalog:",
     "vite": "catalog:"
   }

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -4,6 +4,7 @@ import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import viteReact from "@vitejs/plugin-react";
 import { nitro } from "nitro/vite";
 import { defineConfig, loadEnv } from "vite";
+import { smeeWebhookPlugin } from "./vite.smee";
 
 const config = defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
@@ -59,6 +60,9 @@ const config = defineConfig(({ mode }) => {
       ],
     },
     plugins: [
+      smeeWebhookPlugin({
+        channel: env.SMEE_CHANNEL,
+      }),
       devtools(),
       tailwindcss(),
       tanstackStart({

--- a/packages/app/vite.smee.ts
+++ b/packages/app/vite.smee.ts
@@ -1,0 +1,83 @@
+import SmeeClient from "smee-client";
+import type { AddressInfo } from "node:net";
+import type { Plugin, ViteDevServer } from "vite";
+
+type Logger = Pick<ViteDevServer["config"]["logger"], "error" | "info">;
+
+type SmeeClientOptions = {
+  logger: Logger;
+  source: string;
+  target: string;
+};
+
+type SmeeClientLike = {
+  start: () => Promise<unknown>;
+  stop: () => Promise<void>;
+};
+
+type SmeeWebhookPluginOptions = {
+  channel?: string;
+  createClient?: (options: SmeeClientOptions) => SmeeClientLike;
+};
+
+function addressPort(server: ViteDevServer): number | null {
+  const address = server.httpServer?.address();
+
+  if (!address || typeof address === "string") return null;
+
+  return (address as AddressInfo).port;
+}
+
+function createSmeeClient(options: SmeeClientOptions): SmeeClientLike {
+  return new SmeeClient(options);
+}
+
+export function smeeWebhookPlugin({
+  channel,
+  createClient = createSmeeClient,
+}: SmeeWebhookPluginOptions): Plugin {
+  let client: SmeeClientLike | null = null;
+
+  return {
+    name: "everr:smee-webhook",
+    apply: "serve",
+    configureServer(server) {
+      const normalizedChannel = channel?.trim();
+      if (!normalizedChannel) return;
+
+      const start = () => {
+        if (client) return;
+
+        const port = addressPort(server) ?? server.config.server.port ?? 5173;
+        client = createClient({
+          logger: server.config.logger,
+          source: `https://smee.io/${normalizedChannel}`,
+          target: `http://localhost:${port}/webhook/github`,
+        });
+
+        void client.start().catch((error) => {
+          server.config.logger.error(
+            `[smee] ${error instanceof Error ? error.message : String(error)}`,
+          );
+        });
+      };
+
+      if (server.httpServer?.listening) {
+        start();
+      } else {
+        server.httpServer?.once("listening", start);
+      }
+
+      server.httpServer?.once("close", () => {
+        const stoppingClient = client;
+        client = null;
+
+        void stoppingClient?.stop().catch((error) => {
+          server.config.logger.error(
+            `[smee] ${error instanceof Error ? error.message : String(error)}`,
+          );
+        });
+      });
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,6 +307,9 @@ importers:
       nitro:
         specifier: 'catalog:'
         version: 3.0.260429-beta(@azure/storage-blob@12.31.0)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.17)(pg@8.20.0))(jiti@2.7.0)(lru-cache@11.3.5)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
+      smee-client:
+        specifier: ^5.0.0
+        version: 5.0.0
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -4863,6 +4866,14 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@4.1.0:
+    resolution: {integrity: sha512-2GuF51iuHX6A9xdTccMTsNb7VO0lHZihApxhvQzJB5A03DvHDd2FQepodbMaztPBmBcE/ox7o2gqaxGhYB9LhQ==}
+    engines: {node: '>=20.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -6437,6 +6448,11 @@ packages:
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+
+  smee-client@5.0.0:
+    resolution: {integrity: sha512-OYL8xPr1Tc0iqGohTGqHO/qEvUrPktK0a2Qcb0Uuj+j4KLnH5bsOhOlmpnmdh4zgzL3OwTfodcmkg5fVgiMUHw==}
+    engines: {node: ^20.18 || >= 22}
+    hasBin: true
 
   snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
@@ -11359,6 +11375,12 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.1.0: {}
+
+  eventsource@4.1.0:
+    dependencies:
+      eventsource-parser: 3.1.0
+
   expect-type@1.3.0: {}
 
   exsolve@1.0.8: {}
@@ -13268,6 +13290,11 @@ snapshots:
       totalist: 3.0.1
 
   slash@3.0.0: {}
+
+  smee-client@5.0.0:
+    dependencies:
+      eventsource: 4.1.0
+      undici: 7.25.0
 
   snake-case@3.0.4:
     dependencies:


### PR DESCRIPTION
This PR implements an integrated solution for setting up a public tunnel to ingest GH webhooks.

Using smee.io, the solution suggested by GH docs for this purpose (see [here](https://docs.github.com/en/webhooks/using-webhooks/handling-webhook-deliveries))