### PR TITLE
Update skills, simplify install flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,3 +36,5 @@ When adding or modifying CLI commands, follow the rules in [`docs/cli-guidelines
 ## Everr CLI
 
 Use `everr-dev` (not `everr`) when running CLI commands in this workspace if available.
+Do not mention `everr-dev` in skills.
+Fall-back to everr when everr-dev fails.

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/SKILL.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/SKILL.md
@@ -13,13 +13,13 @@ Prefer real OpenTelemetry for runtime services. Use `everr wrap` only for bounde
 
 1. Run `everr local status`.
 2. If the collector is stopped, run `everr local start` or ask the user to open Everr Desktop.
-3. Use the `otlp:` URL from `everr local status` in exporters.
+3. Use the `otlp:` URL from `everr local status` in exporters. Do not guess or mention a default localhost port unless status returned it.
 4. Inspect the app before adding packages: framework, runtime, existing OTel setup, startup path, logger, and test runner.
 5. Add the smallest standard OTel setup for the stack: `service.name`, traces, logs, metrics when supported, useful resource attributes, automatic error capture, and an OTLP/HTTP exporter.
 6. Configure endpoint selection for both environments: local development exports to the `otlp:` URL from `everr local status`; production exports to `https://ingest.everr.dev/` with an ingest key from the secret manager.
 7. Gate local-only exporters so local collector URLs do not ship in production bundles, and gate hosted ingest so it only runs when a production ingest key is present.
-8. Trigger the instrumented path and verify fresh local rows with `everr local query`, filtered by the expected `ServiceName` and a recent time window. Use a unique run, request, or test id when available.
-9. Do not claim setup works until Everr shows new telemetry.
+8. Trigger the instrumented path and verify fresh local rows with `everr local query`, filtered by the expected `ServiceName`, a recent time window, and a unique run, request, or test id when practical.
+9. Do not claim setup works until query results prove the new telemetry came from the path just exercised.
 
 ## Command Choice
 
@@ -31,6 +31,8 @@ Prefer real OpenTelemetry for runtime services. Use `everr wrap` only for bounde
 | Verify telemetry arrived | `everr local query "<SQL>"` |
 | Capture build/lint output | `everr wrap -- <command>` |
 
+In plans and example commands, keep the endpoint as `<otlp-url-from-status>` until you have actual status output.
+
 `everr local query` accepts ClickHouse-style SQL against the local telemetry store.
 
 ## Runtime Instrumentation
@@ -39,10 +41,12 @@ OpenTelemetry clients can export directly to the local collector. No wrapper is 
 
 When OpenTelemetry is missing:
 - Add the SDK, OTLP/HTTP exporter, and a clear `service.name`.
+- For JavaScript or TypeScript apps, check [OpenTelemetry JS contrib packages](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages) for integrations that match the frameworks and libraries in use before writing custom instrumentation.
 - Load instrumentation before importing HTTP, database, queue, or framework modules.
 - Add spans around entry points and I/O boundaries when auto-instrumentation is not enough.
 - Capture errors as structured telemetry, not only terminal output.
 - Redact secrets, tokens, emails, and request bodies before export.
+- Prefer instrumenting the app's existing structured logger or adding targeted OTel logs at important boundaries. Do not monkey-patch `console.*` or mirror all console output into telemetry unless it is temporary, development-gated, redacted, and bounded to the specific path being verified.
 
 Do not make high-volume runtime traces or debug logs print to stdout/stderr just so they can be inspected. Export them to Everr and query them.
 
@@ -84,6 +88,16 @@ Use `everr wrap -- <command>` only when the command is not OpenTelemetry-instrum
 
 For Playwright or other E2E tests, capture both the app under test and the test runner's view of browser failures. Add a run id such as `e2e.run_id=<uuid>` to resource attributes, emit page errors, console errors, and request failures as OTel logs, then query by that run id.
 
+## Common Mistakes
+
+| Mistake | Fix |
+| --- | --- |
+| Using `everr status` | Use `everr local status`. The `local` subcommand is required. |
+| Naming a likely collector URL such as a default localhost port before reading status | Use `<otlp-url-from-status>` in plans and examples until `everr local status` returns the actual endpoint. |
+| Adding a run, request, or test marker but querying only by service and time | Filter the query by the marker too, or do not claim the marker proved freshness. |
+| Mirroring every `console.*` call into logs | Prefer targeted OTel logs or the app's structured logger; any bridge must be temporary, gated, redacted, and bounded. |
+| Verifying by UI visibility or absence of exporter errors | Run `everr local query` and show rows from the exercised path. |
+
 ## Production Export
 
 When setting up production telemetry, wire the app to Everr's hosted OTLP HTTP ingest endpoint and require an organization ingest key from the user's secret manager.
@@ -110,7 +124,7 @@ Implementation expectations:
 
 ## Verification Queries
 
-Do not treat unfiltered recent rows as proof. Before triggering the app, identify the expected `service.name` and, when practical, add a temporary run, request, or test id as a safe resource or span/log attribute. Verification should prove the telemetry came from the path you just exercised.
+Do not treat UI visibility, lack of exporter errors, or unfiltered recent rows as proof. Before triggering the app, identify the expected `service.name` and, when practical, add a temporary run, request, or test id as a safe resource, span, or log attribute. If you add a marker, the verification query must filter on it. Verification should prove the telemetry came from the path you just exercised.
 
 Fresh trace check:
 
@@ -134,14 +148,30 @@ ORDER BY Timestamp DESC
 LIMIT 20
 ```
 
-Run-id check, when the instrumented path emits one:
+Run-id checks, when the instrumented path emits one:
 
 ```sql
-SELECT Timestamp, ServiceName, Body
+SELECT Timestamp, ServiceName, SpanName, TraceId
+FROM otel_traces
+WHERE Timestamp > now() - INTERVAL 10 MINUTE
+  AND ServiceName = '<service-name>'
+  AND (
+    ResourceAttributes['everr.run_id'] = '<run-id>'
+    OR SpanAttributes['everr.run_id'] = '<run-id>'
+  )
+ORDER BY Timestamp DESC
+LIMIT 20
+```
+
+```sql
+SELECT Timestamp, ServiceName, Body, TraceId
 FROM otel_logs
 WHERE Timestamp > now() - INTERVAL 10 MINUTE
   AND ServiceName = '<service-name>'
-  AND ResourceAttributes['e2e.run_id'] = '<run-id>'
+  AND (
+    ResourceAttributes['everr.run_id'] = '<run-id>'
+    OR LogAttributes['everr.run_id'] = '<run-id>'
+  )
 ORDER BY Timestamp DESC
 LIMIT 20
 ```

--- a/crates/everr-core/assets/skills/everr-use-telemetry/SKILL.md
+++ b/crates/everr-core/assets/skills/everr-use-telemetry/SKILL.md
@@ -89,7 +89,8 @@ Full trace:
 ```sql
 SELECT Timestamp, ServiceName, SpanName, Duration, StatusCode, StatusMessage
 FROM otel_traces
-WHERE TraceId = '<trace-id>'
+WHERE Timestamp > now() - INTERVAL 1 HOUR
+  AND TraceId = '<trace-id>'
 ORDER BY Timestamp ASC
 LIMIT 200
 ```
@@ -144,14 +145,14 @@ LIMIT 20
 
 For "production users are seeing errors":
 1. Query cloud logs for recent errors.
-2. Pick a representative `TraceId` and query cloud traces for the full request.
+2. Pick a representative `TraceId` and query cloud traces for the full request using the same recent window.
 3. Compare errors by service, route, version, or deploy-related attributes if available.
 4. Explain whether the data points to one service, one path, one release, or a broad outage.
 
 For "my local request is slow":
 1. Run `everr local status`.
 2. Query recent slow spans from `otel_traces`.
-3. Pick the slowest `TraceId` and query the full trace in timestamp order.
+3. Pick the slowest `TraceId` and query the full trace in timestamp order using the same recent window.
 4. If spans are missing around the slow boundary, use `everr-setup-telemetry` to add the next targeted signal.
 
 For "debug this failing local test":

--- a/crates/everr-core/assets/skills/everr-working-with-ci/SKILL.md
+++ b/crates/everr-core/assets/skills/everr-working-with-ci/SKILL.md
@@ -5,66 +5,48 @@ description: Use when a task mentions CI, GitHub Actions, workflow runs, checks,
 
 # Working With CI Using Everr
 
-Use Everr from the repository root whenever CI state, workflow logs, test results, or pipeline timing can answer the question. Everr has structured CI data, so start from the actual run data before guessing from memory or asking for pasted logs.
+Use Everr from the repository root for CI state, workflow logs, test results, and pipeline timing. Start with Everr's structured GitHub Actions data before `gh`, the GitHub UI, memory, or pasted logs.
 
-If an Everr command fails, investigate why: wrong repo context, missing auth, missing import, no matching run, or CLI bug. Do not silently fall back to another source unless Everr cannot answer the task.
+If Everr fails, capture the exact command and error, then investigate wrong repo context, missing auth, missing import, no matching run, stale data, or CLI bugs. Use `gh` only after Everr cannot answer, or as a cross-check.
 
-## Default Workflow
+## Workflow
 
 1. Identify the target: current branch/commit, PR branch, run id, workflow, job, or time range.
-2. Check the run list or status before reading logs.
-3. Drill down from run -> failed job/step -> logs.
-4. For flaky, slow, or repeated failures, query cloud telemetry across runs instead of treating one log as the whole story.
-5. Explain the signal you found, then make or recommend the smallest fix.
-6. After changes, watch the relevant run with `everr ci watch --fail-fast` or `everr ci watch --run-id <id> --fail-fast`.
+2. Check status or runs before logs: current commit with `everr ci status`, known commit with `everr ci status --commit <sha>`, known run with `everr ci status --run-id <id>`, or branch with `everr ci runs --current-branch`.
+3. Drill down: run -> `everr ci show <trace_id> --failed` -> `everr ci logs <trace_id> --job-name <job> --log-failed`.
+4. For flaky, slow, or repeated failures, compare history with `everr ci runs` and `everr cloud query`; one run or log is not proof.
+5. If Everr errors, diagnose that failure before using `gh`.
+6. Explain the signal, make or recommend the smallest fix, then watch: `everr ci watch --fail-fast` or `everr ci watch --run-id <id> --fail-fast`.
 
-## Command Choice
+## Commands
 
 | Need | Command |
 | --- | --- |
 | Current commit pipeline state | `everr ci status` |
-| Wait for current commit | `everr ci watch --fail-fast` |
-| Wait for one known run | `everr ci watch --run-id <id> --fail-fast` |
+| Known commit pipeline state | `everr ci status --commit <sha>` |
 | Recent or filtered runs | `everr ci runs` |
 | Jobs and steps for one run | `everr ci show <trace_id>` |
 | Only failed jobs and steps | `everr ci show <trace_id> --failed` |
-| Logs for a known step | `everr ci logs <trace_id> --job-name <job> --step-number <n>` |
-| Logs for the first failed step in a job | `everr ci logs <trace_id> --job-name <job> --log-failed` |
+| Logs for a step | `everr ci logs <trace_id> --job-name <job> --step-number <n>` |
+| First failed step logs | `everr ci logs <trace_id> --job-name <job> --log-failed` |
 | Historical CI/test analysis | `everr cloud query "<SQL>"` |
 
-Useful filters:
-- `everr ci status --commit <sha>` or `--run-id <id>` targets something specific.
-- `everr ci runs --current-branch`, `--branch <name>`, `--conclusion <success|failure|cancellation>`, `--workflow-name <name>`, or `--run-id <id>` narrows run lists.
-- `everr ci logs --job-id <id>` is safer than `--job-name` when a job id is available.
-- `everr ci logs --egrep <pattern>` filters logs with a re2 regex; exit code 1 means no matching lines.
-- `everr ci logs --tail <n>`, `--limit <n>`, and `--offset <n>` page large logs.
+Useful flags: `--branch`, `--current-branch`, `--conclusion`, `--workflow-name`, and `--run-id` narrow runs; `--job-id` is safer than `--job-name`; `--egrep` filters logs; `--tail`, `--limit`, and `--offset` page large logs.
 
-## Smart CI Analysis
+## Historical Queries
 
-Use `everr cloud query "<SQL>"` when the useful answer needs history, comparison, or aggregation. Start with:
-- `traces`: workflow runs, jobs, steps, and test spans
-- `logs`: step logs
-- `metrics_gauge` and `metrics_sum`: resource metrics when needed
+Use `everr cloud query "<SQL>"` when the answer needs history, comparison, or aggregation: flaky tests, slow jobs, retries, failure rates, or "real regression?" questions. Start with `traces` for runs/jobs/steps/test spans, `logs` for step logs, and metrics tables for resource signals.
 
-Common fields:
-- `SpanAttributes['everr.github.workflow_job_step.number']`
-- `ResourceAttributes['everr.github.workflow_job.run_attempt']`
-- `SpanAttributes['everr.test.name']`
-- `SpanAttributes['everr.test.result']`
-- `SpanAttributes['everr.test.duration_seconds']`
-- `SpanAttributes['everr.test.package']`
-- `SpanAttributes['everr.test.parent_test']`
+Always include a time filter, scoped repo/branch/run/workflow/job/test filters when known, and a `LIMIT` under 1000. Do not add tenant filters or `PREWHERE`.
 
-Query rules:
-- Always include a time filter and a `LIMIT` under 1000.
-- Add repo, branch, run id, workflow, job, or test filters when known.
-- Do not add tenant filters; Everr already enforces tenant isolation.
-- Do not use `PREWHERE` unless the user explicitly asks.
+## Common Mistakes
+
+- Starting with `gh pr checks` because it feels faster: run Everr first.
+- Running `everr ci status <sha>`: use `everr ci status --commit <sha>`.
+- Treating one failed log as proof: compare runs, attempts, tests, jobs, and failure signatures.
+- Ignoring an Everr CLI error: diagnose repo context, auth, import state, or CLI behavior.
+- Asking for pasted logs: fetch them with `everr ci logs` unless access is unavailable.
 
 ## Example: CI Is Failing On This Branch
 
-1. Run `everr ci runs --current-branch`.
-2. If a run failed, copy its `trace_id` and run `everr ci show <trace_id> --failed`.
-3. For the failing job, run `everr ci logs <trace_id> --job-name <job> --log-failed`.
-4. If the failure may be flaky, use `everr cloud query "<SQL>"` to compare recent test outcomes by test name, package, branch, and run id.
-5. Summarize what failed, whether history supports flakiness or a real regression, and what evidence supports that conclusion.
+Run `everr ci runs --current-branch`, copy the failed `trace_id`, then run `everr ci show <trace_id> --failed` and `everr ci logs <trace_id> --job-name <job> --log-failed`. If flakiness is possible, query history before deciding whether it is a real regression.

--- a/crates/everr-core/assets/skills/everr-working-with-ci/SKILL.md
+++ b/crates/everr-core/assets/skills/everr-working-with-ci/SKILL.md
@@ -37,7 +37,70 @@ Useful flags: `--branch`, `--current-branch`, `--conclusion`, `--workflow-name`,
 
 Use `everr cloud query "<SQL>"` when the answer needs history, comparison, or aggregation: flaky tests, slow jobs, retries, failure rates, or "real regression?" questions. Start with `traces` for runs/jobs/steps/test spans, `logs` for step logs, and metrics tables for resource signals.
 
-Always include a time filter, scoped repo/branch/run/workflow/job/test filters when known, and a `LIMIT` under 1000. Do not add tenant filters or `PREWHERE`.
+Always include a time filter, scoped repo/branch/run/workflow/job/test filters when known, and a `LIMIT` under 1000. For CI trace queries, include `ServiceName = 'github-actions'`. Do not add tenant filters or `PREWHERE`.
+
+## Querying The Everr DB
+
+Run read-only ClickHouse SQL with `everr cloud query "<SQL>"`. Use `SHOW TABLES`, `DESCRIBE TABLE traces`, or `DESCRIBE TABLE logs` when unsure about columns. Cloud CI data usually starts in `traces`; step log lines are in `logs`; metrics are in `metrics_gauge` and `metrics_sum`.
+
+Common CI attributes:
+- `ResourceAttributes['vcs.repository.name']`: `owner/repo`
+- `ResourceAttributes['vcs.ref.head.name']`: branch
+- `ResourceAttributes['vcs.ref.head.revision']`: commit SHA
+- `ResourceAttributes['cicd.pipeline.name']`: workflow
+- `ResourceAttributes['cicd.pipeline.run.id']`: workflow run id
+- `ResourceAttributes['cicd.pipeline.task.name']`: job
+- `ResourceAttributes['cicd.pipeline.task.run.result']`: job/run result
+- `SpanAttributes['everr.github.workflow_job_step.number']`: step number
+- `ScopeAttributes['cicd.pipeline.task.name']`: job context for logs
+- `LogAttributes['everr.github.workflow_job_step.number']`: log step number
+- `SpanAttributes['everr.test.name']`, `everr.test.result`, `everr.test.duration_seconds`: parsed tests
+
+Recent run history:
+
+```sql
+SELECT
+  max(Timestamp) AS last_seen,
+  TraceId,
+  anyLast(ResourceAttributes['cicd.pipeline.run.id']) AS run_id,
+  anyLast(ResourceAttributes['cicd.pipeline.name']) AS workflow,
+  anyLast(ResourceAttributes['vcs.ref.head.name']) AS branch,
+  anyLast(ResourceAttributes['vcs.ref.head.revision']) AS sha,
+  anyLast(ResourceAttributes['cicd.pipeline.task.run.result']) AS result
+FROM traces
+WHERE Timestamp > now() - INTERVAL 7 DAY
+  AND ServiceName = 'github-actions'
+  AND ResourceAttributes['vcs.repository.name'] = '<owner/repo>'
+  AND ResourceAttributes['cicd.pipeline.run.id'] != ''
+  AND SpanAttributes['everr.github.workflow_job_step.number'] = ''
+  AND SpanAttributes['everr.test.name'] = ''
+GROUP BY TraceId
+ORDER BY last_seen DESC
+LIMIT 20
+```
+
+Repeated failure log lines:
+
+```sql
+SELECT
+  anyLast(ResourceAttributes['cicd.pipeline.name']) AS workflow,
+  anyLast(ScopeAttributes['cicd.pipeline.task.name']) AS job,
+  anyLast(LogAttributes['everr.github.workflow_job_step.number']) AS step,
+  uniqExact(TraceId) AS runs,
+  count() AS lines,
+  max(Timestamp) AS last_seen,
+  anyLast(Body) AS sample
+FROM logs
+WHERE Timestamp > now() - INTERVAL 14 DAY
+  AND ResourceAttributes['vcs.repository.name'] = '<owner/repo>'
+  AND (
+    positionCaseInsensitive(Body, 'error') > 0
+    OR positionCaseInsensitive(Body, 'failed') > 0
+  )
+GROUP BY cityHash64(Body)
+ORDER BY runs DESC, lines DESC, last_seen DESC
+LIMIT 50
+```
 
 ## Common Mistakes
 

--- a/crates/everr-core/assets/skills/everr-working-with-ci/SKILL.md
+++ b/crates/everr-core/assets/skills/everr-working-with-ci/SKILL.md
@@ -43,18 +43,19 @@ Always include a time filter, scoped repo/branch/run/workflow/job/test filters w
 
 Run read-only ClickHouse SQL with `everr cloud query "<SQL>"`. Use `SHOW TABLES`, `DESCRIBE TABLE traces`, or `DESCRIBE TABLE logs` when unsure about columns. Cloud CI data usually starts in `traces`; step log lines are in `logs`; metrics are in `metrics_gauge` and `metrics_sum`.
 
-Common CI attributes:
-- `ResourceAttributes['vcs.repository.name']`: `owner/repo`
-- `ResourceAttributes['vcs.ref.head.name']`: branch
-- `ResourceAttributes['vcs.ref.head.revision']`: commit SHA
-- `ResourceAttributes['cicd.pipeline.name']`: workflow
-- `ResourceAttributes['cicd.pipeline.run.id']`: workflow run id
-- `ResourceAttributes['cicd.pipeline.task.name']`: job
-- `ResourceAttributes['cicd.pipeline.task.run.result']`: job/run result
-- `SpanAttributes['everr.github.workflow_job_step.number']`: step number
-- `ScopeAttributes['cicd.pipeline.task.name']`: job context for logs
-- `LogAttributes['everr.github.workflow_job_step.number']`: log step number
-- `SpanAttributes['everr.test.name']`, `everr.test.result`, `everr.test.duration_seconds`: parsed tests
+Everr CI follows OpenTelemetry semantic conventions where they exist. The conventions used in CI data include:
+- `service.name` as `ServiceName` (`github-actions`)
+- `vcs.repository.name`
+- `vcs.ref.head.name`
+- `vcs.ref.head.revision`
+- `cicd.pipeline.name`
+- `cicd.pipeline.result`
+- `cicd.pipeline.run.id`
+- `cicd.pipeline.task.name`
+- `cicd.pipeline.task.run.id`
+- `cicd.pipeline.task.run.result`
+- `cicd.pipeline.task.run.url.full`
+- `cicd.worker.name`
 
 Recent run history:
 

--- a/crates/everr-core/assets/skills/everr-working-with-ci/SKILL.md
+++ b/crates/everr-core/assets/skills/everr-working-with-ci/SKILL.md
@@ -93,10 +93,7 @@ SELECT
 FROM logs
 WHERE Timestamp > now() - INTERVAL 14 DAY
   AND ResourceAttributes['vcs.repository.name'] = '<owner/repo>'
-  AND (
-    positionCaseInsensitive(Body, 'error') > 0
-    OR positionCaseInsensitive(Body, 'failed') > 0
-  )
+  AND startsWith(Body, '##[error]')
 GROUP BY cityHash64(Body)
 ORDER BY runs DESC, lines DESC, last_seen DESC
 LIMIT 50

--- a/crates/everr-core/build.rs
+++ b/crates/everr-core/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-changed=assets/skills");
+}

--- a/crates/everr-core/src/skills.rs
+++ b/crates/everr-core/src/skills.rs
@@ -361,6 +361,18 @@ pub fn installed_update_skill_names(options: &SkillOperationOptions) -> Result<V
     Ok(names.into_iter().collect())
 }
 
+pub fn has_installed_bundled_skill(options: &SkillOperationOptions) -> Result<bool> {
+    for skill in bundled_skills()? {
+        if skill_path_exists(options, &skill.name) {
+            return Ok(true);
+        }
+    }
+
+    Ok(LEGACY_SKILL_RENAMES
+        .iter()
+        .any(|(legacy_name, _)| skill_path_exists(options, legacy_name)))
+}
+
 pub fn normalize_update_skill_names(skill_names: &[String]) -> Result<Vec<String>> {
     let available: BTreeSet<String> = bundled_skills()?.into_iter().map(|s| s.name).collect();
     let mut names = BTreeSet::new();

--- a/crates/everr-core/tests/skills.rs
+++ b/crates/everr-core/tests/skills.rs
@@ -1,8 +1,8 @@
 use std::fs;
 
 use everr_core::skills::{
-    SkillOperationOptions, SkillPathAction, SkillProvider, SkillScope, install_bundled_skills,
-    uninstall_bundled_skills, update_bundled_skills,
+    SkillOperationOptions, SkillPathAction, SkillProvider, SkillScope, bundled_skills,
+    install_bundled_skills, uninstall_bundled_skills, update_bundled_skills,
 };
 use tempfile::tempdir;
 
@@ -20,6 +20,62 @@ fn assert_symlink_to(path: &std::path::Path, target: &std::path::Path) {
         resolved.canonicalize().expect("canonicalize link target"),
         target.canonicalize().expect("canonicalize target")
     );
+}
+
+#[test]
+fn bundles_using_everr_skill_for_conversation_start() {
+    let skills = bundled_skills().expect("list bundled skills");
+    let using_everr = skills
+        .iter()
+        .find(|skill| skill.name == "using-everr")
+        .expect("using-everr skill should be bundled");
+
+    assert!(
+        using_everr
+            .description
+            .contains("starting any conversation")
+    );
+}
+
+#[test]
+fn installs_using_everr_skill_with_must_use_triggers() {
+    let repo = tempdir().expect("repo tempdir");
+    let home = tempdir().expect("home tempdir");
+    let options = SkillOperationOptions {
+        scope: SkillScope::Project,
+        cwd: repo.path().to_path_buf(),
+        home_dir: home.path().to_path_buf(),
+        providers: vec![SkillProvider::Codex],
+        skill_names: vec!["using-everr".to_string()],
+        all: false,
+        force: false,
+        dry_run: false,
+    };
+
+    install_bundled_skills(&options).expect("install using-everr skill");
+
+    let content = fs::read_to_string(repo.path().join(".agents/skills/using-everr/SKILL.md"))
+        .expect("read installed skill");
+    assert!(content.contains("## Must-Use Skill Triggers"));
+    assert!(content.contains("`everr-working-with-ci`"));
+    assert!(content.contains("`everr-use-telemetry`"));
+    assert!(content.contains("`everr-setup-telemetry`"));
+}
+
+#[test]
+fn everr_use_telemetry_bounds_full_trace_queries_by_time() {
+    let content = fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("assets/skills/everr-use-telemetry/SKILL.md"),
+    )
+    .expect("read everr-use-telemetry skill");
+
+    assert!(
+        content.contains(
+            "WHERE Timestamp > now() - INTERVAL 1 HOUR\n  AND TraceId = '<trace-id>'"
+        )
+    );
+    assert!(content.contains("using the same recent window"));
 }
 
 #[test]

--- a/packages/desktop-app/src-cli/src/cli.rs
+++ b/packages/desktop-app/src-cli/src/cli.rs
@@ -143,8 +143,6 @@ pub struct SkillsListArgs {
 
 #[derive(Args, Debug, Default)]
 pub struct SkillsInstallArgs {
-    /// Skill names to install. Omit in an interactive terminal to choose from a prompt.
-    pub skills: Vec<String>,
     /// Install all bundled skills
     #[arg(long)]
     pub all: bool,
@@ -752,7 +750,7 @@ mod tests {
             "everr",
             "skills",
             "install",
-            "everr-working-with-ci",
+            "--all",
             "--project",
             "--agent",
             "claude-code",
@@ -760,24 +758,16 @@ mod tests {
         .expect("skills install command");
 
         assert!(matches!(cli.command, Commands::Skills(_)));
-        let err = Cli::try_parse_from([
-            "everr",
-            "skills",
-            "install",
-            "everr-working-with-ci",
-            "--json",
-        ])
-        .expect_err("skills install should not accept --json");
+        let err = Cli::try_parse_from(["everr", "skills", "install", "everr-working-with-ci"])
+            .expect_err("skills install should not accept named skills");
+        assert!(err.to_string().contains("everr-working-with-ci"));
+
+        let err = Cli::try_parse_from(["everr", "skills", "install", "--json"])
+            .expect_err("skills install should not accept --json");
         assert!(err.to_string().contains("--json"));
 
-        let err = Cli::try_parse_from([
-            "everr",
-            "skills",
-            "install",
-            "everr-working-with-ci",
-            "--copy",
-        ])
-        .expect_err("skills install should not accept --copy");
+        let err = Cli::try_parse_from(["everr", "skills", "install", "--copy"])
+            .expect_err("skills install should not accept --copy");
         assert!(err.to_string().contains("--copy"));
     }
 

--- a/packages/desktop-app/src-cli/src/onboarding.rs
+++ b/packages/desktop-app/src-cli/src/onboarding.rs
@@ -6,7 +6,7 @@ use std::process::Command as ProcessCommand;
 use anyhow::{Context, Result, bail};
 use everr_core::api::{ApiClient, MeResponse, OrgResponse};
 use everr_core::build;
-use everr_core::skills::{self as core_skills, SkillProvider, SkillScope};
+use everr_core::skills::{self as core_skills, SkillOperationOptions, SkillProvider, SkillScope};
 use everr_core::state::Session;
 
 use crate::auth;
@@ -297,6 +297,12 @@ fn step_install_skills() -> Result<bool> {
     let home_dir = dirs::home_dir().context("failed to resolve home directory")?;
     let provider_statuses = core_skills::provider_statuses(&home_dir);
 
+    if has_global_bundled_skills_installed(&home_dir)? {
+        cli_skills::install_all_for_setup(SkillScope::Global, Vec::new(), true)?;
+        cliclack::log::success("Everr skills installed")?;
+        return Ok(true);
+    }
+
     if interactive {
         cliclack::note(
             "Everr skills",
@@ -374,6 +380,20 @@ fn step_install_skills() -> Result<bool> {
     cliclack::log::success("Everr skills installed")?;
 
     Ok(true)
+}
+
+fn has_global_bundled_skills_installed(home_dir: &Path) -> Result<bool> {
+    let options = SkillOperationOptions {
+        scope: SkillScope::Global,
+        cwd: std::env::current_dir().context("could not determine current directory")?,
+        home_dir: home_dir.to_path_buf(),
+        providers: Vec::new(),
+        skill_names: Vec::new(),
+        all: false,
+        force: false,
+        dry_run: false,
+    };
+    core_skills::has_installed_bundled_skill(&options)
 }
 
 fn print_next_steps() -> Result<()> {

--- a/packages/desktop-app/src-cli/src/skills.rs
+++ b/packages/desktop-app/src-cli/src/skills.rs
@@ -54,21 +54,21 @@ fn run_list(args: SkillsListArgs) -> Result<()> {
 }
 
 fn run_install(args: SkillsInstallArgs) -> Result<()> {
-    if args.all && !args.skills.is_empty() {
-        bail!("skill names cannot be provided when --all is set");
-    }
-
     let interactive = is_interactive_terminal();
-    if !args.all && args.skills.is_empty() && !interactive {
-        bail!("provide at least one skill name or use --all");
+    if !args.all {
+        if !interactive {
+            bail!("use --all to install bundled Everr skills");
+        }
+        let install: bool = cliclack::confirm("Install all bundled Everr skills?")
+            .initial_value(true)
+            .interact()?;
+        if !install {
+            cliclack::log::remark("Skipping Everr skills.")?;
+            return Ok(());
+        }
     }
 
     let home_dir = resolve_home_dir()?;
-    let skill_names = if !args.all && args.skills.is_empty() {
-        prompt_skills_to_install()?
-    } else {
-        args.skills
-    };
     let scope = if args.scope.project || args.scope.global {
         resolve_scope(&args.scope)
     } else if interactive {
@@ -89,8 +89,8 @@ fn run_install(args: SkillsInstallArgs) -> Result<()> {
         scope,
         home_dir,
         providers,
-        skill_names,
-        args.all,
+        Vec::new(),
+        true,
         args.force,
         args.dry_run,
     )?;
@@ -295,24 +295,6 @@ fn resolve_home_dir() -> Result<PathBuf> {
 
 fn is_interactive_terminal() -> bool {
     std::io::stdin().is_terminal() && std::io::stdout().is_terminal()
-}
-
-fn prompt_skills_to_install() -> Result<Vec<String>> {
-    let skills = bundled_skills()?;
-    let mut prompt = cliclack::multiselect("Select skills to install").required(true);
-    for skill in &skills {
-        prompt = prompt.item(
-            skill.name.clone(),
-            skill.name.clone(),
-            skill.description.clone(),
-        );
-    }
-    let defaults: Vec<String> = skills.iter().map(|skill| skill.name.clone()).collect();
-    let selected: Vec<String> = prompt.initial_values(defaults).interact()?;
-    if selected.is_empty() {
-        bail!("no skills selected");
-    }
-    Ok(selected)
 }
 
 fn prompt_scope() -> Result<SkillScope> {

--- a/packages/desktop-app/src-cli/tests/skills_commands.rs
+++ b/packages/desktop-app/src-cli/tests/skills_commands.rs
@@ -46,7 +46,7 @@ fn old_ai_instruction_commands_are_removed() {
 }
 
 #[test]
-fn skills_install_project_creates_canonical_skill_and_provider_symlink() {
+fn skills_install_all_project_creates_canonical_skills_and_provider_symlink() {
     let env = CliTestEnv::new();
     let repo = env.home_dir.join("repo");
     fs::create_dir_all(&repo).expect("create repo");
@@ -56,14 +56,17 @@ fn skills_install_project_creates_canonical_skill_and_provider_symlink() {
         .args([
             "skills",
             "install",
-            "everr-working-with-ci",
+            "--all",
             "--project",
             "--agent",
             "claude-code",
         ])
         .assert()
         .success()
-        .stdout(contains("Installed 1 skill: everr-working-with-ci"));
+        .stdout(contains("Installed"))
+        .stdout(contains("everr-working-with-ci"))
+        .stdout(contains("everr-setup-telemetry"))
+        .stdout(contains("everr-use-telemetry"));
 
     assert!(
         repo.join(".agents/skills/everr-working-with-ci/SKILL.md")
@@ -81,7 +84,18 @@ fn skills_install_without_selection_requires_interactive_terminal() {
         .args(["skills", "install"])
         .assert()
         .failure()
-        .stderr(contains("provide at least one skill name or use --all"));
+        .stderr(contains("use --all"));
+}
+
+#[test]
+fn skills_install_rejects_named_skills() {
+    let env = CliTestEnv::new();
+
+    env.command()
+        .args(["skills", "install", "everr-use-telemetry", "--global"])
+        .assert()
+        .failure()
+        .stderr(contains("unexpected argument"));
 }
 
 #[test]
@@ -89,17 +103,11 @@ fn skills_install_global_creates_provider_symlink() {
     let env = CliTestEnv::new();
 
     env.command()
-        .args([
-            "skills",
-            "install",
-            "everr-use-telemetry",
-            "--global",
-            "--agent",
-            "codex",
-        ])
+        .args(["skills", "install", "--all", "--global", "--agent", "codex"])
         .assert()
         .success()
-        .stdout(contains("Installed 1 skill: everr-use-telemetry"));
+        .stdout(contains("Installed"))
+        .stdout(contains("everr-use-telemetry"));
 
     assert!(
         env.home_dir
@@ -118,21 +126,10 @@ fn skills_update_without_scope_checks_global_skills() {
     let repo = env.home_dir.join("repo");
     fs::create_dir_all(&repo).expect("create repo");
 
-    env.command()
-        .args([
-            "skills",
-            "install",
-            "everr-use-telemetry",
-            "--global",
-            "--agent",
-            "codex",
-        ])
-        .assert()
-        .success();
-
     let skill_doc = env
         .home_dir
         .join(".agents/skills/everr-use-telemetry/SKILL.md");
+    fs::create_dir_all(skill_doc.parent().expect("skill parent")).expect("create skill parent");
     fs::write(&skill_doc, "local edits").expect("edit global skill");
 
     env.command()
@@ -200,6 +197,48 @@ fn setup_installs_project_skills_when_noninteractive_and_authenticated() {
     );
     #[cfg(unix)]
     assert_symlink(&repo.join(".claude/skills/everr-working-with-ci"));
+}
+
+#[test]
+fn setup_syncs_all_global_skills_when_any_global_skill_exists() {
+    let env = CliTestEnv::new();
+    let repo = env.home_dir.join("repo");
+    fs::create_dir_all(&repo).expect("create repo");
+    env.write_session("http://127.0.0.1:0", "token-123");
+
+    let existing_skill = env
+        .home_dir
+        .join(".agents/skills/everr-use-telemetry/SKILL.md");
+    fs::create_dir_all(existing_skill.parent().expect("skill parent"))
+        .expect("create skill parent");
+    fs::write(&existing_skill, "local edits").expect("write edited skill");
+
+    env.command_with_api_base_url("http://127.0.0.1:0")
+        .current_dir(&repo)
+        .arg("setup")
+        .write_stdin("\n")
+        .assert()
+        .success()
+        .stderr(contains("Already logged in"));
+
+    let content = fs::read_to_string(&existing_skill).expect("read synced skill");
+    assert!(content.contains("name: everr-use-telemetry"));
+    assert!(!content.contains("local edits"));
+    assert!(
+        env.home_dir
+            .join(".agents/skills/everr-working-with-ci/SKILL.md")
+            .is_file()
+    );
+    assert!(
+        env.home_dir
+            .join(".agents/skills/everr-setup-telemetry/SKILL.md")
+            .is_file()
+    );
+    assert!(
+        !repo
+            .join(".agents/skills/everr-working-with-ci/SKILL.md")
+            .exists()
+    );
 }
 
 #[test]

--- a/packages/docs/content/docs/ci-insights/cost-analysis.mdx
+++ b/packages/docs/content/docs/ci-insights/cost-analysis.mdx
@@ -108,7 +108,7 @@ If you use Everr's bundled skills, install them so assistants know how to fetch
 CI context directly:
 
 ```sh
-everr skills install everr-working-with-ci --project
+everr skills install --all --project
 ```
 
 ## How to find optimization work

--- a/packages/docs/content/docs/reference/cli.mdx
+++ b/packages/docs/content/docs/reference/cli.mdx
@@ -16,7 +16,7 @@ description: Reference for all Everr CLI commands.
 ## Skills
 
 - `everr skills list [--project|--global] [--agent <codex|claude-code|cursor|all>]` — list bundled Everr skills
-- `everr skills install [SKILL]... [--all] [--project|--global] [--agent ...] [--force] [--dry-run]` — install bundled skills; omitting `SKILL` in a terminal opens an interactive installer
+- `everr skills install [--all] [--project|--global] [--agent ...] [--force] [--dry-run]` — install all bundled skills; omitting `--all` in a terminal asks for confirmation
 - `everr skills update [SKILL]... [--project|--global] [--agent ...] [--dry-run]` — update installed bundled skills
 - `everr skills uninstall [SKILL]... [--all] [--project|--global] [--agent ...] [--yes] [--dry-run]` — uninstall bundled skills
 

--- a/packages/docs/content/docs/reference/skills.mdx
+++ b/packages/docs/content/docs/reference/skills.mdx
@@ -7,6 +7,7 @@ description: Install bundled Everr skills for supported coding assistants.
 
 Everr ships bundled skills for coding assistants that need CI and telemetry context.
 
+- `using-everr` explains what Everr is and when the Everr skills must be used.
 - `everr-working-with-ci` explains how to inspect CI runs, jobs, steps, logs, and historical test data.
 - `everr-setup-telemetry` explains how to make apps, services, tests, and commands emit telemetry.
 - `everr-use-telemetry` explains how to query cloud and local telemetry during investigations.
@@ -14,14 +15,10 @@ Everr ships bundled skills for coding assistants that need CI and telemetry cont
 ## Install
 
 ```shell
-everr skills install everr-working-with-ci everr-setup-telemetry everr-use-telemetry --project
-```
-
-To install every bundled Everr skill instead:
-
-```shell
 everr skills install --all --project
 ```
+
+The installer manages bundled Everr skills as a set.
 
 Use `--global` when you want the skills available outside the current repository.
 


### PR DESCRIPTION
## Summary

- Treat bundled Everr skills as an all-or-nothing install set in the CLI and docs.
- Sync existing global bundled skills during setup instead of prompting again.
- Tighten bundled skill guidance for CI, telemetry setup, and telemetry queries.
- Add a build script so changes under `assets/skills` trigger rebuilds.

## Validation

- `cargo test -p everr-core skills` passed.
- `cargo test -p everr-cli --test skills_commands` passed.
- `cargo test -p everr-core` fails in `bundles_using_everr_skill_for_conversation_start` and `installs_using_everr_skill_with_must_use_triggers` because `using-everr` is expected by the tests but is not present under `crates/everr-core/assets/skills` in this checkout.