### PR TITLE
docs: quality pass, overview page, and coverage fixes

### DIFF
--- a/packages/docs/content/docs/ci-insights/cost-analysis.mdx
+++ b/packages/docs/content/docs/ci-insights/cost-analysis.mdx
@@ -13,43 +13,11 @@ dashboard and hand to a coding assistant. The goal is not just to show a bill;
 it is to show which workflows, repositories, and runner choices are worth
 changing.
 
-## How billing minutes work
-
-GitHub Actions billing is based on runner time, not on workflow wall-clock
-time. The important unit is the job.
-
-For each job:
-
-1. GitHub measures how long the job ran on its runner.
-2. Partial minutes are rounded up to the nearest whole minute.
-3. The rounded minutes are charged at the rate for that runner type.
-
-In practice:
-
-```txt
-job billed minutes = ceil(job duration in seconds / 60)
-job estimated cost = job billed minutes * runner rate
-workflow estimated cost = sum(job estimated cost for every job)
-```
-
-That means parallel jobs do not make billing minutes disappear. If a workflow
-has five Linux jobs that each run for two minutes, the workflow may finish in
-about two minutes of wall time, but it used about ten billed runner minutes.
-
-Retries also count again. A job that fails after five minutes and then succeeds
-after ten more minutes used two job attempts, and each attempt is rounded
-separately.
-
-Runner type matters too. Standard Linux, Windows, macOS, larger, GPU, ARM, and
-third-party hosted runners all have different rates. Public repositories,
-included plan minutes, enterprise discounts, budgets, and storage charges can
-change what appears on your final provider invoice, so Everr treats cost as an
-estimate from runner usage rather than as the billing source of truth.
-
-For the current provider details, see GitHub's [Actions billing
-docs](https://docs.github.com/en/billing/concepts/product-billing/github-actions)
-and [Actions runner pricing
-reference](https://docs.github.com/en/billing/reference/actions-runner-pricing).
+Cost is estimated per job from runner time, so parallel jobs, retries, and
+per-minute rounding all change the bill in ways a single run's wall-clock time
+hides. If those numbers ever look surprising, read [How CI Billing
+Works](/docs/ci-insights/how-billing-works) for the full model behind Everr's
+estimates.
 
 ## Working with a coding assistant
 
@@ -105,11 +73,8 @@ moving lint to Linux" or "reduce rounding waste by merging three sub-minute
 jobs."
 
 If you use Everr's bundled skills, install them so assistants know how to fetch
-CI context directly:
-
-```sh
-everr skills install --all --project
-```
+CI context directly. See [Skills](/docs/reference/skills) for installation and
+management.
 
 ## How to find optimization work
 

--- a/packages/docs/content/docs/ci-insights/how-billing-works.mdx
+++ b/packages/docs/content/docs/ci-insights/how-billing-works.mdx
@@ -1,0 +1,69 @@
+---
+title: How CI Billing Works
+description: Understand how GitHub Actions charges runner time and why Everr treats cost as an estimate.
+---
+
+Before you optimize CI cost, it helps to understand how the bill is actually
+produced. CI cost is hard to reason about from a single workflow run: a
+five-minute run can be cheap or expensive depending on how many jobs ran in
+parallel, which runner labels they used, whether the jobs retried, and how much
+rounding the billing system applied.
+
+This page explains the model Everr uses to turn GitHub Actions job data into a
+cost estimate. For the practical workflow of finding and fixing expensive CI,
+see [Cost Analysis](/docs/ci-insights/cost-analysis).
+
+## Billing is per job, not per workflow
+
+GitHub Actions billing is based on runner time, not on workflow wall-clock
+time. The important unit is the job.
+
+For each job:
+
+1. GitHub measures how long the job ran on its runner.
+2. Partial minutes are rounded up to the nearest whole minute.
+3. The rounded minutes are charged at the rate for that runner type.
+
+In practice:
+
+```txt
+job billed minutes = ceil(job duration in seconds / 60)
+job estimated cost = job billed minutes * runner rate
+workflow estimated cost = sum(job estimated cost for every job)
+```
+
+## Why parallel jobs don't save money
+
+Parallel jobs do not make billing minutes disappear. If a workflow has five
+Linux jobs that each run for two minutes, the workflow may finish in about two
+minutes of wall time, but it used about ten billed runner minutes.
+
+This is the most common surprise in CI cost: a workflow that *feels* fast can
+still be expensive because the cost is the sum of every job's rounded runner
+time, regardless of how much of it overlapped.
+
+## Why retries and rounding add up
+
+Retries count again. A job that fails after five minutes and then succeeds
+after ten more minutes used two job attempts, and each attempt is rounded
+separately.
+
+Rounding compounds when many short jobs run. Ten jobs that each take 15 seconds
+of real work still bill ten whole minutes, because each one rounds up to a full
+minute on its own.
+
+## Why Everr's cost is an estimate
+
+Runner type matters too. Standard Linux, Windows, macOS, larger, GPU, ARM, and
+third-party hosted runners all have different rates. Public repositories,
+included plan minutes, enterprise discounts, budgets, and storage charges can
+change what appears on your final provider invoice, so Everr treats cost as an
+estimate from runner usage rather than as the billing source of truth.
+
+Use the estimate to compare workflows and runner choices against each other and
+to spot trends — not to reconcile an invoice to the cent.
+
+For the current provider details, see GitHub's [Actions billing
+docs](https://docs.github.com/en/billing/concepts/product-billing/github-actions)
+and [Actions runner pricing
+reference](https://docs.github.com/en/billing/reference/actions-runner-pricing).

--- a/packages/docs/content/docs/ci-insights/meta.json
+++ b/packages/docs/content/docs/ci-insights/meta.json
@@ -1,5 +1,11 @@
 {
   "title": "CI Insights",
   "defaultOpen": true,
-  "pages": ["setup-new-repo", "resource-monitoring", "debug-ci", "cost-analysis"]
+  "pages": [
+    "setup-new-repo",
+    "resource-monitoring",
+    "debug-ci",
+    "how-billing-works",
+    "cost-analysis"
+  ]
 }

--- a/packages/docs/content/docs/getting-started/first-trace.mdx
+++ b/packages/docs/content/docs/getting-started/first-trace.mdx
@@ -1,0 +1,90 @@
+---
+title: Your First Trace
+description: A guided walkthrough to send telemetry from your app and query your first trace locally.
+---
+
+This tutorial walks you through the shortest path to working observability: you
+will start the local collector, send telemetry from your own app, and query your
+first trace. By the end you will have one row of real telemetry you produced and
+the query that found it.
+
+This is the local feedback loop the rest of Everr builds on. We keep everything
+on your machine so the loop is fast and nothing leaves your laptop.
+
+<Callout>
+  This is a guided lesson with one happy path. Once you finish, the
+  [Setup Telemetry](/docs/getting-started/setup-telemetry) and
+  [Local Debugging](/docs/local-debugging/setup) how-tos cover the variations and
+  options.
+</Callout>
+
+## Before you start
+
+Make sure the CLI is installed and you have finished `everr setup`. If not, see
+[Install](/docs/getting-started/install) first.
+
+## Step 1 — Start the local collector
+
+The local collector receives your telemetry on your machine. Start it in its own
+terminal:
+
+```sh
+everr local start
+```
+
+It runs in the foreground and prints the OTLP HTTP endpoint when it is ready.
+Leave it running. (If you use Everr Desktop, the collector already runs while
+the app is open — you can skip this step and confirm with `everr local status`.)
+
+## Step 2 — Send telemetry from your app
+
+Point your app's OpenTelemetry exporter at the endpoint the collector printed.
+If your app already emits OpenTelemetry, set these in the environment you run it
+from:
+
+```sh
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://127.0.0.1:54318"
+export OTEL_SERVICE_NAME="my-app"
+```
+
+Use the exact endpoint printed by `everr local start` or `everr local status`.
+
+If your app does not emit OpenTelemetry yet, ask your coding assistant to run the
+`everr-setup-telemetry` skill. It inspects your stack, adds the smallest standard
+setup for your runtime, and points it at the local collector for you.
+
+## Step 3 — Exercise your app
+
+Run your app and trigger the path you want to see — load a page, call an
+endpoint, or run the instrumented command. The collector records telemetry as
+your app emits it.
+
+## Step 4 — Query your first trace
+
+Now ask the local store what it received:
+
+```sh
+everr local query "SELECT Timestamp, ServiceName, SpanName FROM otel_traces ORDER BY Timestamp DESC LIMIT 20"
+```
+
+You should see recent rows with your `ServiceName` and the span names your app
+produced. That is your first trace in Everr. You can also open Everr Desktop to
+browse the same traces, logs, and metrics visually.
+
+If no rows appear, confirm the collector is running (`everr local status`) and
+that your app started *after* `OTEL_EXPORTER_OTLP_ENDPOINT` was set, then trigger
+the instrumented path again.
+
+## What you learned
+
+You now have the core loop: emit telemetry, run the workflow, and query what
+happened instead of reconstructing it from terminal scrollback. Everything else
+in Everr — local debugging, CI insights, and production monitoring — reuses this
+same loop.
+
+## Next steps
+
+- [Local Debugging](/docs/local-debugging/setup) — turn this loop into an
+  assistant-led debugging workflow.
+- [Setup Telemetry](/docs/getting-started/setup-telemetry) — the full reference
+  for local and production setup, including per-signal URLs and production keys.

--- a/packages/docs/content/docs/getting-started/install.mdx
+++ b/packages/docs/content/docs/getting-started/install.mdx
@@ -21,13 +21,13 @@ Note: The installer currently supports macOS on Apple Silicon.
 
 If the GitHub App is installed for your repository, Everr should start receiving CI runs from new workflow executions. Trigger or wait for a new run, then check the dashboard or CLI after ingestion catches up.
 
-### Notification Emails
+### Notification emails
 
 During setup, Everr asks which email addresses belong to you. Everr uses those addresses to identify your CI runs and notify you when one of your runs fails or needs attention.
 
 You can update the email list later from the desktop app settings.
 
-### Install Agent Skills
+### Install agent skills
 
 Skills make it easy for agents to interact with Everr.
 

--- a/packages/docs/content/docs/getting-started/meta.json
+++ b/packages/docs/content/docs/getting-started/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Getting Started",
   "defaultOpen": true,
-  "pages": ["install", "setup-telemetry"]
+  "pages": ["install", "first-trace", "setup-telemetry"]
 }

--- a/packages/docs/content/docs/getting-started/setup-telemetry.mdx
+++ b/packages/docs/content/docs/getting-started/setup-telemetry.mdx
@@ -5,7 +5,7 @@ description: Use the Everr setup telemetry skill to configure local and producti
 
 Use the `everr-setup-telemetry` skill to add OpenTelemetry to your app. The skill inspects your stack, adds the smallest standard setup for your runtime, configures local export to Everr, and verifies that fresh telemetry is visible before considering the setup done.
 
-## Local Collector
+## Local collector
 
 For local development, Everr runs an OpenTelemetry collector on your machine.
 
@@ -23,11 +23,11 @@ everr local query "SELECT Timestamp, ServiceName, SpanName FROM otel_traces ORDE
 
 You can also open Everr Desktop and inspect traces, logs, and metrics there.
 
-## Production Telemetry
+## Production telemetry
 
-For production, create an ingest key from the [Ingest Keys page](https://app.everr.dev/ingest-keys) and store it in your secret manager.
+For production, create an ingest key from the [Ingest Keys page](https://app.everr.dev/ingest-keys) and store it in your secret manager. See [Production Monitoring](/docs/production-monitoring/setup) for the full minting and forwarding reference.
 
-### Set Up The Header
+### Set up the header
 
 Production telemetry is authenticated with the ingest key as a bearer token:
 
@@ -37,7 +37,7 @@ Authorization: Bearer <your-ingest-key>
 
 Set the key through your deployment secret manager, for example as `EVERR_INGEST_KEY`, and configure your OTLP/HTTP exporter to send it on every request.
 
-### Forward From A Collector
+### Forward from a collector
 
 If you already run an OpenTelemetry Collector, forward telemetry to Everr with an OTLP HTTP exporter:
 
@@ -50,3 +50,11 @@ exporters:
 ```
 
 The collector can receive telemetry from your services and attach the ingest key server-side before forwarding traces, logs, and metrics to Everr.
+
+## Next steps
+
+With telemetry flowing, continue to:
+
+- [Local Debugging](/docs/local-debugging/setup) — use the local feedback loop to debug your app.
+- [CI Insights](/docs/ci-insights/setup-new-repo) — connect repositories and monitor GitHub Actions.
+- [Production Monitoring](/docs/production-monitoring/setup) — send and inspect production telemetry.

--- a/packages/docs/content/docs/getting-started/setup-telemetry.mdx
+++ b/packages/docs/content/docs/getting-started/setup-telemetry.mdx
@@ -34,5 +34,5 @@ See [Production Monitoring](/docs/production-monitoring/setup) for the ingest en
 With telemetry flowing, continue to:
 
 - [Local Debugging](/docs/local-debugging/setup) — use the local feedback loop to debug your app.
-- [CI Insights](/docs/ci-insights/setup-new-repo) — connect repositories and monitor GitHub Actions.
 - [Production Monitoring](/docs/production-monitoring/setup) — send and inspect production telemetry.
+- [CI Insights](/docs/ci-insights/setup-new-repo) — connect repositories and monitor GitHub Actions.

--- a/packages/docs/content/docs/getting-started/setup-telemetry.mdx
+++ b/packages/docs/content/docs/getting-started/setup-telemetry.mdx
@@ -25,31 +25,9 @@ You can also open Everr Desktop and inspect traces, logs, and metrics there.
 
 ## Production telemetry
 
-For production, create an ingest key from the [Ingest Keys page](https://app.everr.dev/ingest-keys) and store it in your secret manager. See [Production Monitoring](/docs/production-monitoring/setup) for the full minting and forwarding reference.
+For production, mint an ingest key from the [Ingest Keys page](https://app.everr.dev/ingest-keys), store it in your secret manager, and configure your OTLP/HTTP exporter — or your own OpenTelemetry Collector — to send the key as a bearer token on every request.
 
-### Set up the header
-
-Production telemetry is authenticated with the ingest key as a bearer token:
-
-```text
-Authorization: Bearer <your-ingest-key>
-```
-
-Set the key through your deployment secret manager, for example as `EVERR_INGEST_KEY`, and configure your OTLP/HTTP exporter to send it on every request.
-
-### Forward from a collector
-
-If you already run an OpenTelemetry Collector, forward telemetry to Everr with an OTLP HTTP exporter:
-
-```yaml
-exporters:
-  otlphttp/everr:
-    endpoint: https://ingest.everr.dev
-    headers:
-      Authorization: "Bearer ${env:EVERR_INGEST_KEY}"
-```
-
-The collector can receive telemetry from your services and attach the ingest key server-side before forwarding traces, logs, and metrics to Everr.
+See [Production Monitoring](/docs/production-monitoring/setup) for the ingest endpoint, header format, collector forwarding example, and troubleshooting.
 
 ## Next steps
 

--- a/packages/docs/content/docs/local-debugging/debug-traces.mdx
+++ b/packages/docs/content/docs/local-debugging/debug-traces.mdx
@@ -92,16 +92,12 @@ created inside the wrapped work are linked under the debug span.
 
 ## Run the assistant loop
 
-A useful assistant loop is:
-
-1. Pick the question the trace should answer.
-2. Add the smallest debug span, event, or log that records the needed value.
-3. Run the app after the instrumentation change.
-4. Ask the agent to manually exercise the broken workflow, or do it yourself if
-   automation is not possible.
-5. Ask the assistant to inspect the newest local trace data for the debug spans
-   it added.
-6. Make the next change only after the trace explains the current behavior.
+This is the [evidence loop](/docs/overview) with debug traces as the signal:
+pick the question the trace should answer, add the smallest debug span or event
+for it, run the app, then exercise the broken workflow — ask the agent to drive
+it, or do it yourself when automation is not possible. Have the assistant
+inspect the newest traces for the debug span names it added, and make the next
+change only after the trace explains the current behavior.
 
 For example, after you reproduce the bug:
 

--- a/packages/docs/content/docs/local-debugging/setup.mdx
+++ b/packages/docs/content/docs/local-debugging/setup.mdx
@@ -79,7 +79,7 @@ Install the Everr skills from [Skills](/docs/reference/skills) so your
 assistant knows when to use local telemetry and how to query it during an
 investigation.
 
-When you ask for help with a local bug, ask for an evidence loop:
+When you ask for help with a local bug, ask for an [evidence loop](/docs/overview):
 
 ```text
 Use Everr local telemetry for this investigation. Check collector status,
@@ -87,9 +87,8 @@ query recent traces or logs before changing code, and add targeted debug
 telemetry if the current data does not explain the behavior.
 ```
 
-That gives the assistant a concrete workflow: inspect existing telemetry first,
-instrument only the missing facts, reproduce the issue, then compare observed
-state to expected state.
+That points the assistant at existing telemetry first and at instrumenting only
+the facts that are still missing, instead of guessing from source code.
 
 ## Troubleshooting
 

--- a/packages/docs/content/docs/local-debugging/test-production-telemetry.mdx
+++ b/packages/docs/content/docs/local-debugging/test-production-telemetry.mdx
@@ -48,13 +48,10 @@ boundary. If a log says an operation failed but not which branch failed, add the
 safe attribute that distinguishes the branches. If every row is technically
 correct but hard to query, improve names and resource attributes.
 
-Keep the loop small:
-
-1. State the production question the telemetry should answer.
-2. Add the smallest span, log, metric, or attribute for that question.
-3. Run the feature locally with the local collector enabled.
-4. Ask the assistant to inspect the newest local telemetry.
-5. Keep, rename, or extend the signal based on what the data proves.
+This is the [evidence loop](/docs/overview) applied to instrumentation design:
+state the production question, add the smallest signal that answers it, run the
+feature locally, inspect the newest telemetry, then keep, rename, or extend the
+signal based on what the data proves.
 
 This keeps production telemetry practical. You add signals because they helped
 you understand a real local run, not because an abstract observability checklist

--- a/packages/docs/content/docs/meta.json
+++ b/packages/docs/content/docs/meta.json
@@ -2,6 +2,7 @@
   "pages": [
     "getting-started",
     "ci-insights",
+    "test-analytics",
     "local-debugging",
     "production-monitoring",
     "reference"

--- a/packages/docs/content/docs/meta.json
+++ b/packages/docs/content/docs/meta.json
@@ -1,5 +1,6 @@
 {
   "pages": [
+    "overview",
     "getting-started",
     "local-debugging",
     "production-monitoring",

--- a/packages/docs/content/docs/meta.json
+++ b/packages/docs/content/docs/meta.json
@@ -1,10 +1,10 @@
 {
   "pages": [
     "getting-started",
-    "ci-insights",
-    "test-analytics",
     "local-debugging",
     "production-monitoring",
+    "ci-insights",
+    "test-analytics",
     "reference"
   ]
 }

--- a/packages/docs/content/docs/overview.mdx
+++ b/packages/docs/content/docs/overview.mdx
@@ -1,0 +1,55 @@
+---
+title: How Everr Works
+description: The mental model behind Everr — one OpenTelemetry pipeline across local development, CI, and production.
+---
+
+Everr is built on a single idea: the signals that explain your software should be available wherever your code runs — on your laptop, in CI, and in production — and they should be as easy for a coding assistant to read as they are for you.
+
+Instead of separate tools for local debugging, CI inspection, and production monitoring, Everr collects everything as standard [OpenTelemetry](https://opentelemetry.io) and makes it queryable through one CLI and one workspace.
+
+## One pipeline, everywhere your code runs
+
+The same telemetry model follows your code through its whole lifecycle. Each place your code runs feeds the same queryable store.
+
+### Local development
+
+A collector runs on your machine — either through the CLI (`everr local start`) or while [Everr Desktop](/docs/getting-started/install) is open. Your app, tests, and wrapped commands export to it, and the data stays local. This is the fast feedback loop you use while writing and debugging code.
+
+See [Local Debugging](/docs/local-debugging/setup).
+
+### Production
+
+Your services send OpenTelemetry to the Everr cloud over OTLP, authenticated with an [ingest key](/docs/production-monitoring/setup). Everything lands in a shared, per-organization workspace you can inspect during and after an incident.
+
+See [Production Monitoring](/docs/production-monitoring/setup).
+
+### CI
+
+The Everr GitHub App ingests your GitHub Actions runs — workflows, jobs, steps, and logs — so a failing run is structured data rather than pasted screenshots. An optional [action](/docs/ci-insights/resource-monitoring) adds per-job resource metrics, and verbose test output is parsed into per-test spans.
+
+See [CI Insights](/docs/ci-insights/setup-new-repo) and [Test Analytics](/docs/test-analytics).
+
+## The signals are all OpenTelemetry
+
+Traces, logs, and metrics are standard OpenTelemetry. CI runs and test results are represented as the same kinds of signals, so one set of tools works everywhere — you don't learn a different model for CI than you use for production.
+
+## Built for coding assistants
+
+Everr assumes a coding assistant is a primary user. [Bundled skills](/docs/reference/skills) teach assistants when to reach for telemetry and how to query it, and your assistant works from the repository so it can connect runtime signal back to the code that produced it.
+
+The recurring pattern across every Everr workflow is the **evidence loop**:
+
+1. State the question the telemetry should answer.
+2. Add the smallest signal that answers it (or use what's already there).
+3. Run the workflow — exercise the app, trigger the CI run, reproduce the bug.
+4. Inspect what was actually recorded.
+5. Compare it to what you expected, then make the next change.
+
+Local debugging, production monitoring, and CI investigation are all variations on this loop. The rest of the docs show what it looks like in each context.
+
+## Where to go next
+
+- [Getting Started](/docs/getting-started/install) — install Everr and send your [first trace](/docs/getting-started/first-trace).
+- [Local Debugging](/docs/local-debugging/setup) — the local feedback loop.
+- [Production Monitoring](/docs/production-monitoring/setup) — send and inspect production telemetry.
+- [CI Insights](/docs/ci-insights/setup-new-repo) — connect repositories and monitor GitHub Actions.

--- a/packages/docs/content/docs/production-monitoring/check-with-assistant.mdx
+++ b/packages/docs/content/docs/production-monitoring/check-with-assistant.mdx
@@ -50,7 +50,8 @@ Then it can query the right cloud tables instead of scanning blindly.
 
 ## Investigation loop
 
-A good production investigation usually follows this loop:
+A production investigation is the [evidence loop](/docs/overview) specialized
+for cloud data:
 
 1. State the question the telemetry should answer.
 2. Check that production data is fresh.

--- a/packages/docs/content/docs/production-monitoring/setup.mdx
+++ b/packages/docs/content/docs/production-monitoring/setup.mdx
@@ -20,9 +20,9 @@ In the Everr dashboard, open the user menu (top-left) and click **Ingest Keys**,
 
 ## Endpoints
 
-| Protocol  | URL                         |
-| --------- | --------------------------- |
-| OTLP HTTP | `https://ingest.everr.dev/` |
+| Protocol  | URL                        |
+| --------- | -------------------------- |
+| OTLP HTTP | `https://ingest.everr.dev` |
 
 Send the key as a bearer token in the `Authorization` header:
 

--- a/packages/docs/content/docs/reference/cli.mdx
+++ b/packages/docs/content/docs/reference/cli.mdx
@@ -3,10 +3,12 @@ title: CLI
 description: Reference for all Everr CLI commands.
 ---
 
-## Authentication
+## Cloud
 
 - `everr cloud login` — authenticate with your Everr account
 - `everr cloud logout` — sign out
+- `everr cloud query "<SQL>"` — run a read-only SQL query against your cloud telemetry and CI data
+  - `--format <json|ndjson|table>` output format (default: `table` in a terminal, `ndjson` otherwise)
 
 ## Setup
 
@@ -38,6 +40,7 @@ description: Reference for all Everr CLI commands.
   - `--conclusion <success|failure|cancellation>` filter by outcome
   - `--workflow-name <name>` filter by workflow
   - `--run-id <id>` fetch a specific run
+  - `--from <expr>` / `--to <expr>` restrict to a time range (accepts [date math](/docs/reference/datemath), e.g. `now-7d`)
 
 - `everr ci show <trace_id>` — show jobs and steps for a run
   - `--failed` show only failed jobs and their failed steps
@@ -47,14 +50,18 @@ description: Reference for all Everr CLI commands.
   - `--step-number <n>` / `--log-failed` select a step (exactly one required)
   - `--tail <n>` how many lines from the bottom
   - `--limit <n>` / `--offset <n>` raw paging
+  - `--egrep <pattern>` keep only lines matching a re2 regex (exits non-zero if none match)
+  - `--color` preserve ANSI color codes (stripped by default)
 
 Collection-style commands accept `--limit <n>` and `--offset <n>` for pagination.
 
 ## Local Telemetry
 
 - `everr local start` — start the local OpenTelemetry collector
+  - `--quiet` suppress the collector URL output after startup
 - `everr local status` — check whether the local OpenTelemetry collector is running and print local OTLP/SQL URLs
 - `everr local query "<SQL>"` — query local telemetry with read-only SQL
+  - `--format <json|ndjson|table>` output format (default: `table` in a terminal, `ndjson` otherwise)
 - `everr wrap -- <command>` — run a command normally and mirror stdout/stderr into local telemetry
   - Requires a running collector; if unavailable, the command is not run
   - Preserves the wrapped command's non-zero exit code


### PR DESCRIPTION
Review and improvement pass over `packages/docs/content/docs`, guided by the Diátaxis framework. Content-only — no homepage changes, kept the assistant-first scope.

## Navigation & structure
- **Surface the orphaned Test Analytics section** — it was written but missing from the root `meta.json`, so it was unreachable from the sidebar.
- **Reorder the top-level nav** to lead with the local telemetry feedback loop: Overview → Getting Started → Local Debugging → Production Monitoring → CI Insights → Test Analytics → Reference.
- **Close the Getting Started dead-end** with a Next steps block.

## New pages
- **How Everr Works** (`overview.mdx`, first in nav) — a conceptual page explaining the unified OpenTelemetry pipeline across local, production, and CI, and naming the **evidence loop** once.
- **Your First Trace** (`getting-started/first-trace.mdx`) — a linear, local-first tutorial that ends in one verifiable outcome, filling the missing learning-oriented quadrant.
- **How CI Billing Works** (`ci-insights/how-billing-works.mdx`) — extracts the billing model out of the Cost Analysis how-to into a dedicated explanation page (Diátaxis: explanation vs. how-to).

## Clarity & de-duplication
- Collapse the near-duplicate numbered "loops" in the local-debugging, test-production-telemetry, debug-traces, and check-with-assistant pages into references to the canonical evidence loop, keeping each page's context-specific steps.
- Trim the duplicated production ingest mechanics out of `getting-started/setup-telemetry` down to a summary that links to the canonical Production Monitoring page.
- Replace the redundant skills-install command block in Cost Analysis with a link to the Skills reference.

## Correctness fixes
- **CLI reference**: document the previously-undocumented `everr cloud query` plus the missing `ci runs --from/--to`, `ci logs --egrep/--color`, `local start --quiet`, and `--format` flags (verified against the CLI source).
- Normalize Getting Started headings to sentence case to match the rest of the docs.
- Fix the OTLP endpoint trailing-slash mismatch in the Production Monitoring endpoints table.

## Verification
- All MDX compiles (`fumadocs-mdx`).
- No broken internal `/docs/` links (checked across the full doc set).
- Docs vitest suite passes.