### PR TITLE
Test larger ARM runners for CPU-bound CI jobs

### DIFF
--- a/.github/workflows/build-and-test-collector.yml
+++ b/.github/workflows/build-and-test-collector.yml
@@ -66,7 +66,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     needs: install-tools
     steps:
       - name: Checkout
@@ -125,7 +125,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     needs: install-tools
     steps:
       - name: Checkout

--- a/.github/workflows/build-everr-cli.yml
+++ b/.github/workflows/build-everr-cli.yml
@@ -33,7 +33,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## What changed

This switches the CPU-bound benchmark jobs from `blacksmith-2vcpu-ubuntu-2404-arm` to `blacksmith-4vcpu-ubuntu-2404-arm`:

- `Everr CLI CI / Build`
- `Build & Test Collector / Lint`
- `Build & Test Collector / Build`

The collector `Test` job is already on a 4-vCPU runner, so it is unchanged.

## Why

Recent CI resource telemetry showed these jobs spending meaningful time near full CPU utilization while memory and disk stayed well below pressure. This PR keeps the jobs on ARM and only changes runner size, so the check results can compare 2-vCPU ARM against 4-vCPU ARM.

## Validation

- `git diff --check origin/main...HEAD`
- parsed the edited workflow YAML files with Ruby YAML
- pre-commit hook ran and had no matching source files to inspect

## Follow-up measurement

After this PR checks finish, compare this run against recent baseline runs for:

- exact job duration
- rounded job-minutes
- resource utilization
- runner price multiplier

Keep the runner change only if reduced runtime offsets the larger runner cost.