### PR TITLE
docs: humanize prose, remove AI writing tells

### DIFF
--- a/packages/docs/content/docs/ci-insights/cost-analysis.mdx
+++ b/packages/docs/content/docs/ci-insights/cost-analysis.mdx
@@ -9,9 +9,9 @@ parallel, which runner labels they used, whether the jobs retried, and how
 much rounding the billing system applied.
 
 Everr turns GitHub Actions job data into a cost view you can inspect in the
-dashboard and hand to a coding assistant. The goal is not just to show a bill;
-it is to show which workflows, repositories, and runner choices are worth
-changing.
+dashboard and hand to a coding assistant. It shows which workflows,
+repositories, and runner choices are worth changing, not just what you spent
+last month.
 
 Cost is estimated per job from runner time, so parallel jobs, retries, and
 per-minute rounding all change the bill in ways a single run's wall-clock time

--- a/packages/docs/content/docs/ci-insights/how-billing-works.mdx
+++ b/packages/docs/content/docs/ci-insights/how-billing-works.mdx
@@ -61,7 +61,7 @@ change what appears on your final provider invoice, so Everr treats cost as an
 estimate from runner usage rather than as the billing source of truth.
 
 Use the estimate to compare workflows and runner choices against each other and
-to spot trends — not to reconcile an invoice to the cent.
+to spot trends, not to reconcile an invoice to the cent.
 
 For the current provider details, see GitHub's [Actions billing
 docs](https://docs.github.com/en/billing/concepts/product-billing/github-actions)

--- a/packages/docs/content/docs/ci-insights/resource-monitoring.mdx
+++ b/packages/docs/content/docs/ci-insights/resource-monitoring.mdx
@@ -36,7 +36,7 @@ jobs:
       # ...the rest of your job
 ```
 
-That's it — the action samples while your job runs and uploads the
+That's it. The action samples while your job runs and uploads the
 artifact in its post-step.
 
 ## How it works

--- a/packages/docs/content/docs/getting-started/first-trace.mdx
+++ b/packages/docs/content/docs/getting-started/first-trace.mdx
@@ -23,7 +23,7 @@ on your machine so the loop is fast and nothing leaves your laptop.
 Make sure the CLI is installed and you have finished `everr setup`. If not, see
 [Install](/docs/getting-started/install) first.
 
-## Step 1 — Start the local collector
+## Start the local collector
 
 The local collector receives your telemetry on your machine. Start it in its own
 terminal:
@@ -34,9 +34,9 @@ everr local start
 
 It runs in the foreground and prints the OTLP HTTP endpoint when it is ready.
 Leave it running. (If you use Everr Desktop, the collector already runs while
-the app is open — you can skip this step and confirm with `everr local status`.)
+the app is open, so you can skip this step and confirm with `everr local status`.)
 
-## Step 2 — Send telemetry from your app
+## Send telemetry from your app
 
 Point your app's OpenTelemetry exporter at the endpoint the collector printed.
 If your app already emits OpenTelemetry, set these in the environment you run it
@@ -53,13 +53,13 @@ If your app does not emit OpenTelemetry yet, ask your coding assistant to run th
 `everr-setup-telemetry` skill. It inspects your stack, adds the smallest standard
 setup for your runtime, and points it at the local collector for you.
 
-## Step 3 — Exercise your app
+## Exercise your app
 
-Run your app and trigger the path you want to see — load a page, call an
+Run your app and trigger the path you want to see: load a page, call an
 endpoint, or run the instrumented command. The collector records telemetry as
 your app emits it.
 
-## Step 4 — Query your first trace
+## Query your first trace
 
 Now ask the local store what it received:
 
@@ -79,7 +79,7 @@ the instrumented path again.
 
 You now have the core loop: emit telemetry, run the workflow, and query what
 happened instead of reconstructing it from terminal scrollback. Everything else
-in Everr — local debugging, CI insights, and production monitoring — reuses this
+in Everr (local debugging, CI insights, and production monitoring) reuses this
 same loop.
 
 ## Next steps

--- a/packages/docs/content/docs/getting-started/setup-telemetry.mdx
+++ b/packages/docs/content/docs/getting-started/setup-telemetry.mdx
@@ -25,7 +25,7 @@ You can also open Everr Desktop and inspect traces, logs, and metrics there.
 
 ## Production telemetry
 
-For production, mint an ingest key from the [Ingest Keys page](https://app.everr.dev/ingest-keys), store it in your secret manager, and configure your OTLP/HTTP exporter — or your own OpenTelemetry Collector — to send the key as a bearer token on every request.
+For production, mint an ingest key from the [Ingest Keys page](https://app.everr.dev/ingest-keys), store it in your secret manager, and configure your OTLP/HTTP exporter (or your own OpenTelemetry Collector) to send the key as a bearer token on every request.
 
 See [Production Monitoring](/docs/production-monitoring/setup) for the ingest endpoint, header format, collector forwarding example, and troubleshooting.
 

--- a/packages/docs/content/docs/local-debugging/debug-traces.mdx
+++ b/packages/docs/content/docs/local-debugging/debug-traces.mdx
@@ -94,7 +94,7 @@ created inside the wrapped work are linked under the debug span.
 
 This is the [evidence loop](/docs/overview) with debug traces as the signal:
 pick the question the trace should answer, add the smallest debug span or event
-for it, run the app, then exercise the broken workflow — ask the agent to drive
+for it, run the app, then exercise the broken workflow. Ask the agent to drive
 it, or do it yourself when automation is not possible. Have the assistant
 inspect the newest traces for the debug span names it added, and make the next
 change only after the trace explains the current behavior.

--- a/packages/docs/content/docs/overview.mdx
+++ b/packages/docs/content/docs/overview.mdx
@@ -1,9 +1,9 @@
 ---
 title: How Everr Works
-description: The mental model behind Everr — one OpenTelemetry pipeline across local development, CI, and production.
+description: The mental model behind Everr, and how one OpenTelemetry pipeline spans local development, CI, and production.
 ---
 
-Everr is built on a single idea: the signals that explain your software should be available wherever your code runs — on your laptop, in CI, and in production — and they should be as easy for a coding assistant to read as they are for you.
+Everr is built on a single idea: the signals that explain your software should be available wherever your code runs, whether that's your laptop, CI, or production. And they should be as easy for a coding assistant to read as they are for you.
 
 Instead of separate tools for local debugging, CI inspection, and production monitoring, Everr collects everything as standard [OpenTelemetry](https://opentelemetry.io) and makes it queryable through one CLI and one workspace.
 
@@ -13,7 +13,7 @@ The same telemetry model follows your code through its whole lifecycle. Each pla
 
 ### Local development
 
-A collector runs on your machine — either through the CLI (`everr local start`) or while [Everr Desktop](/docs/getting-started/install) is open. Your app, tests, and wrapped commands export to it, and the data stays local. This is the fast feedback loop you use while writing and debugging code.
+A collector runs on your machine, either through the CLI (`everr local start`) or while [Everr Desktop](/docs/getting-started/install) is open. Your app, tests, and wrapped commands export to it, and the data stays local. This is the fast feedback loop you use while writing and debugging code.
 
 See [Local Debugging](/docs/local-debugging/setup).
 
@@ -25,13 +25,13 @@ See [Production Monitoring](/docs/production-monitoring/setup).
 
 ### CI
 
-The Everr GitHub App ingests your GitHub Actions runs — workflows, jobs, steps, and logs — so a failing run is structured data rather than pasted screenshots. An optional [action](/docs/ci-insights/resource-monitoring) adds per-job resource metrics, and verbose test output is parsed into per-test spans.
+The Everr GitHub App ingests your GitHub Actions runs (workflows, jobs, steps, and logs), so a failing run is structured data rather than pasted screenshots. An optional [action](/docs/ci-insights/resource-monitoring) adds per-job resource metrics, and verbose test output is parsed into per-test spans.
 
 See [CI Insights](/docs/ci-insights/setup-new-repo) and [Test Analytics](/docs/test-analytics).
 
 ## The signals are all OpenTelemetry
 
-Traces, logs, and metrics are standard OpenTelemetry. CI runs and test results are represented as the same kinds of signals, so one set of tools works everywhere — you don't learn a different model for CI than you use for production.
+Traces, logs, and metrics are standard OpenTelemetry. CI runs and test results are represented as the same kinds of signals, so one set of tools works everywhere. You don't learn a different model for CI than you use for production.
 
 ## Built for coding assistants
 
@@ -41,7 +41,7 @@ The recurring pattern across every Everr workflow is the **evidence loop**:
 
 1. State the question the telemetry should answer.
 2. Add the smallest signal that answers it (or use what's already there).
-3. Run the workflow — exercise the app, trigger the CI run, reproduce the bug.
+3. Run the workflow: exercise the app, trigger the CI run, reproduce the bug.
 4. Inspect what was actually recorded.
 5. Compare it to what you expected, then make the next change.
 

--- a/packages/docs/content/docs/production-monitoring/setup.mdx
+++ b/packages/docs/content/docs/production-monitoring/setup.mdx
@@ -15,7 +15,7 @@ Everr accepts standard OpenTelemetry (OTLP) traces, metrics, and logs from any S
 In the Everr dashboard, open the user menu (top-left) and click **Ingest Keys**, then **New key**.
 
 - Keys are organization-scoped: any data sent with the key is attributed to the organization it belongs to.
-- The full key is shown **once**, at creation time. Copy it into your secret manager — you can't retrieve it later.
+- The full key is shown only once, at creation time. Copy it into your secret manager; you can't retrieve it later.
 - Admins can revoke a key at any time. Revocation is effective within about 30 seconds (the collector's positive cache TTL).
 
 ## Endpoints

--- a/packages/docs/content/docs/reference/cli.mdx
+++ b/packages/docs/content/docs/reference/cli.mdx
@@ -22,7 +22,7 @@ description: Reference for all Everr CLI commands.
 - `everr skills update [SKILL]... [--project|--global] [--agent ...] [--dry-run]` — update installed bundled skills
 - `everr skills uninstall [SKILL]... [--all] [--project|--global] [--agent ...] [--yes] [--dry-run]` — uninstall bundled skills
 
-## CI/CD Status
+## CI/CD status
 
 - `everr ci status` — show the current commit's pipeline state (`state`, `active`, `completed`)
   - `--commit <sha>` target a specific commit
@@ -55,7 +55,7 @@ description: Reference for all Everr CLI commands.
 
 Collection-style commands accept `--limit <n>` and `--offset <n>` for pagination.
 
-## Local Telemetry
+## Local telemetry
 
 - `everr local start` — start the local OpenTelemetry collector
   - `--quiet` suppress the collector URL output after startup

--- a/packages/docs/content/docs/reference/retention.mdx
+++ b/packages/docs/content/docs/reference/retention.mdx
@@ -13,7 +13,7 @@ Everr stores your telemetry for a fixed window based on your plan. Once data fal
 | Logs | 30 days | 90 days |
 | Metrics | 30 days | 13 months |
 
-Each signal type is governed by its own retention window. On the Pro plan, metrics stick around for 13 months — long enough to compare current behavior against the same week or month last year — while traces and logs roll off at 90 days, where the per-event volume is much higher and the long-tail value is lower.
+Each signal type is governed by its own retention window. On the Pro plan, metrics stick around for 13 months, long enough to compare current behavior against the same week or month last year. Traces and logs roll off at 90 days, where the per-event volume is much higher and the long-tail value is lower.
 
 ## When retention changes take effect
 
@@ -21,14 +21,14 @@ When you change plans, the new retention windows start applying within a few min
 
 Retention applies to **all** of your data, not just data ingested after the change:
 
-- **Upgrading.** Your existing data is held for the longer window. Anything that already aged out under the previous plan is gone — we don't restore previously-deleted data when you upgrade.
+- **Upgrading.** Your existing data is held for the longer window. Anything that already aged out under the previous plan is gone. We don't restore previously-deleted data when you upgrade.
 - **Downgrading.** Existing data outside the shorter window will be removed in the minutes after the change. If keeping older data matters, export it before downgrading.
 
 We chose retroactive retention (rather than grandfathering data ingested under the old plan) because it keeps the rules predictable: at any given moment, your retention is exactly what your current plan says it is. We may revisit this with a grace period for downgrades as the product matures.
 
 ## How we handle failures
 
-Retention is enforced by background processes. If those processes can't determine the correct window for a tenant — for example, during a transient outage of an internal service — they intentionally fall back to keeping data **longer**, never shorter. Once the issue clears, the system catches up on the next pass.
+Retention is enforced by background processes. If those processes can't determine the correct window for a tenant (for example, during a transient outage of an internal service), they intentionally fall back to keeping data **longer**, never shorter. Once the issue clears, the system catches up on the next pass.
 
 In short: an internal failure may briefly delay deletion of data that should have been removed, but it will not cause data to be deleted earlier than your plan allows.
 

--- a/packages/docs/content/docs/test-analytics/go-tests.mdx
+++ b/packages/docs/content/docs/test-analytics/go-tests.mdx
@@ -20,7 +20,7 @@ go test -v ./...
   run: go test -v ./...
 ```
 
-That's it — Everr automatically detects and parses Go test output from workflow logs.
+That's it. Everr automatically detects and parses Go test output from workflow logs.
 
 ## What gets parsed
 

--- a/packages/docs/content/docs/test-analytics/index.mdx
+++ b/packages/docs/content/docs/test-analytics/index.mdx
@@ -3,7 +3,7 @@ title: Test Analytics
 description: Track test results, flaky tests, and duration trends from your CI pipelines.
 ---
 
-Everr can parse verbose test output from your CI workflow logs and generate OpenTelemetry trace spans for each test. This enables test result tracking, flaky test detection, failure analysis, and duration trends — all from data you're already producing.
+Everr can parse verbose test output from your CI workflow logs and generate OpenTelemetry trace spans for each test. This enables test result tracking, flaky test detection, failure analysis, and duration trends, all from data you're already producing.
 
 ## How it works
 


### PR DESCRIPTION
Follow-up to #166. A pass over `packages/docs/content/docs` to make the prose read like a person wrote it, using the humanizer pattern checks.

## What changed
- **Rhetorical em dashes → ordinary punctuation.** Replaced mid-sentence dashes in prose with commas, periods, parentheses, and colons. Kept the standard `term — definition` dashes in the reference lists and the "Next steps" link lists, since those are glossary style, not a writing tell.
- **Fixed a negative parallelism** in Cost Analysis ("not just a bill; it is to show…" → a plain declarative sentence).
- **Dropped the `Step N` scaffolding** in the First Trace tutorial; the ordering is implicit, and the headings read less mechanically without it.
- **Trimmed a boldface crutch** in Production Monitoring setup.
- **Sentence-cased** two remaining Title Case headings in the CLI reference for consistency with the rest of the docs.

I deliberately left domain terms and conventions the detector flags as false positives: "ingest key" (the product noun), "cost optimization" (the page's subject), bold UI labels like **Ingest Keys**, and the numbered reference tables.

## Verification
- MDX compiles (`fumadocs-mdx`).
- No broken internal `/docs/` links.
- Humanizer scores dropped on the prose pages (e.g. the Overview page 31 → 2).