### PR TITLE
Handle null log bodies

### DIFF
--- a/packages/app/src/data/runs/server.ts
+++ b/packages/app/src/data/runs/server.ts
@@ -19,10 +19,10 @@ const TEST_RESULT_TO_CONCLUSION: Record<string, string> = {
   skip: "skip",
 };
 
-function mapLogRow(row: { timestamp: string; body: string }): LogEntry {
+function mapLogRow(row: { timestamp: string; body: string | null }): LogEntry {
   return {
     timestamp: normalizeTimestampToUtc(row.timestamp),
-    body: row.body,
+    body: row.body ?? "",
   };
 }
 
@@ -118,7 +118,7 @@ async function getRawStepLogs(
 
   const result = await clickhouse.query<{
     timestamp: string;
-    body: string;
+    body: string | null;
   }>(sql, {
     traceId: params.traceId,
     stepNumber: params.stepNumber,

--- a/packages/app/src/lib/log-parser.test.ts
+++ b/packages/app/src/lib/log-parser.test.ts
@@ -96,6 +96,19 @@ describe("parseLogs", () => {
     expect(groups).toHaveLength(0);
   });
 
+  it("treats null bodies as empty log lines", () => {
+    const { lines, groups } = parseLogs([
+      {
+        timestamp: "2025-01-01T00:00:00Z",
+        body: null as unknown as string,
+      },
+    ]);
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0].body).toBe("");
+    expect(groups).toHaveLength(0);
+  });
+
   it("parses groups", () => {
     const { lines, groups } = parseLogs([
       { timestamp: "2025-01-01T00:00:00Z", body: "##[group]Setup" },

--- a/packages/app/src/lib/log-parser.ts
+++ b/packages/app/src/lib/log-parser.ts
@@ -74,7 +74,8 @@ export function parseLogs(logs: LogEntry[]): {
 
   for (let i = 0; i < logs.length; i++) {
     const log = logs[i];
-    const marker = parseGitHubMarker(log.body);
+    const body = log.body ?? "";
+    const marker = parseGitHubMarker(body);
 
     if (marker?.type === "group") {
       const id = `group-${groupId++}`;
@@ -91,20 +92,20 @@ export function parseLogs(logs: LogEntry[]): {
       }
       lines.push({
         timestamp: log.timestamp,
-        body: log.body,
+        body,
         isGroupEnd: true,
       });
     } else if (marker) {
       // error, warning, notice, debug markers
       lines.push({
         timestamp: log.timestamp,
-        body: log.body,
+        body,
         markerType: marker.type,
       });
     } else {
       lines.push({
         timestamp: log.timestamp,
-        body: log.body,
+        body,
       });
     }
   }

--- a/packages/telemetry-explorer/src/logs/sql/explorer.test.ts
+++ b/packages/telemetry-explorer/src/logs/sql/explorer.test.ts
@@ -68,4 +68,17 @@ describe("mapExplorerRow", () => {
     expect(row.timestamp).toMatch(/^2026-03-09T12:00:00/);
     expect(row.identity.bodyHash).toBe("h");
   });
+
+  it("normalizes null bodies to empty strings", () => {
+    const row = mapExplorerRow({
+      timestampRaw: "2026-03-09 12:00:00",
+      level: "info",
+      body: null,
+      traceId: "t",
+      spanId: "s",
+      serviceName: "svc",
+      bodyHash: "h",
+    });
+    expect(row.body).toBe("");
+  });
 });

--- a/packages/telemetry-explorer/src/logs/sql/explorer.ts
+++ b/packages/telemetry-explorer/src/logs/sql/explorer.ts
@@ -8,7 +8,7 @@ import { buildWhereClause } from "./where";
 export interface ExplorerRowRaw {
   timestampRaw: string;
   level: LogLevel;
-  body: string;
+  body: string | null;
   traceId: string;
   spanId: string;
   serviceName: string;
@@ -78,6 +78,6 @@ export function mapExplorerRow(row: ExplorerRowRaw): LogExplorerRow {
     identity,
     timestamp: normalizeTimestampToUtc(row.timestampRaw),
     level: row.level,
-    body: row.body,
+    body: row.body ?? "",
   };
 }


### PR DESCRIPTION
## Summary
- Normalize nullable log bodies to empty strings before rendering explorer rows.
- Normalize nullable run-step log bodies before GitHub marker parsing.
- Add regression coverage for null log bodies in both paths.

## Root Cause
ClickHouse can return `NULL` for `Body`, but the UI-facing types treated log bodies as non-null strings. Downstream rendering and marker parsing passed those values into string-only code paths, which could break when a log body was null.

## Validation
- `pnpm --filter @everr/telemetry-explorer exec vitest run src/logs`
- `pnpm --filter @everr/app exec vitest run src/lib/log-parser.test.ts src/components/run-detail/log-viewer.test.tsx`
- `pnpm --filter @everr/telemetry-explorer typecheck`
- `pnpm --filter @everr/app typecheck`