### PR TITLE
Traces list UI fixes

### DIFF
--- a/packages/app/src/routes/_authenticated/_dashboard/traces.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/traces.tsx
@@ -7,14 +7,21 @@ import {
   createFileRoute,
   Link,
   Outlet,
+  stripSearchParams,
   useMatch,
 } from "@tanstack/react-router";
 import { remoteTracesRepo } from "@/data/traces/remote-repo";
+
+// Keep the URL clean: the schema fills in defaults (empty arrays, "all",
+// limit, …) during validation, so without this every navigation would
+// serialize them back into the query string.
+const defaultSearch = TraceSearchParamsSchema.parse({});
 
 export const Route = createFileRoute("/_authenticated/_dashboard/traces")({
   staticData: { breadcrumb: "Traces", fullBleed: true },
   head: () => ({ meta: [{ title: "Everr - Traces" }] }),
   validateSearch: TraceSearchParamsSchema,
+  search: { middlewares: [stripSearchParams(defaultSearch)] },
   component: TracesRoute,
 });
 

--- a/packages/app/src/routes/_authenticated/_dashboard/traces.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/traces.tsx
@@ -12,9 +12,9 @@ import {
 } from "@tanstack/react-router";
 import { remoteTracesRepo } from "@/data/traces/remote-repo";
 
-// Keep the URL clean: the schema fills in defaults (empty arrays, "all",
-// limit, …) during validation, so without this every navigation would
-// serialize them back into the query string.
+// Keep the URL clean: the schema fills in defaults (empty arrays, "all", …)
+// during validation, so without this every navigation would serialize them
+// back into the query string.
 const defaultSearch = TraceSearchParamsSchema.parse({});
 
 export const Route = createFileRoute("/_authenticated/_dashboard/traces")({
@@ -51,7 +51,6 @@ function TracesSearchPage() {
         maxMs: search.maxMs,
         status: search.status,
         attributes: search.attributes,
-        limit: search.limit,
       }}
       onSearchChange={(patch) =>
         navigate({

--- a/packages/desktop-app/src/features/traces/traces-page.tsx
+++ b/packages/desktop-app/src/features/traces/traces-page.tsx
@@ -70,7 +70,6 @@ export function TracesPage() {
           maxMs: search.maxMs,
           status: search.status,
           attributes: search.attributes,
-          limit: search.limit,
         }}
         onSearchChange={(patch) =>
           navigate({

--- a/packages/telemetry-explorer/src/traces/data/schemas.test.ts
+++ b/packages/telemetry-explorer/src/traces/data/schemas.test.ts
@@ -13,7 +13,6 @@ describe("TraceDetailParamsSchema", () => {
       minMs: 10,
       maxMs: 500,
       status: "error",
-      limit: 100,
       start: "2026-05-21T10:12:00.000Z",
       end: "2026-05-21T10:12:02.000Z",
       span: "span-1",
@@ -26,7 +25,6 @@ describe("TraceDetailParamsSchema", () => {
       minMs: 10,
       maxMs: 500,
       status: "error",
-      limit: 100,
       start: "2026-05-21T10:12:00.000Z",
       end: "2026-05-21T10:12:02.000Z",
       span: "span-1",
@@ -46,7 +44,6 @@ describe("toTraceListSearch", () => {
       minMs: 10,
       maxMs: 500,
       status: "error",
-      limit: 100,
       start: "2026-05-21T10:12:00.000Z",
       end: "2026-05-21T10:12:02.000Z",
       span: "span-1",
@@ -63,7 +60,6 @@ describe("toTraceListSearch", () => {
       maxMs: 500,
       status: "error",
       attributes: [],
-      limit: 100,
     });
   });
 });

--- a/packages/telemetry-explorer/src/traces/data/schemas.ts
+++ b/packages/telemetry-explorer/src/traces/data/schemas.ts
@@ -25,7 +25,6 @@ export const TraceSearchParamsSchema = TimeRangeSearchSchema.extend({
   maxMs: z.number().int().nonnegative().optional(),
   status: SpanStatusFilterSchema.default("all"),
   attributes: attributesField(["resource", "span"]),
-  limit: z.number().int().positive().max(500).default(50),
 });
 export type TraceSearchParams = z.infer<typeof TraceSearchParamsSchema>;
 

--- a/packages/telemetry-explorer/src/traces/ui/trace-results-list.test.tsx
+++ b/packages/telemetry-explorer/src/traces/ui/trace-results-list.test.tsx
@@ -9,15 +9,25 @@ vi.mock("react-virtuoso", () => ({
     data,
     itemContent,
     components,
+    endReached,
   }: {
     data: T[];
     itemContent: (index: number, item: T) => React.ReactNode;
     components?: { Footer?: () => React.ReactNode };
+    endReached?: () => void;
   }) => (
     <div data-testid="virtuoso-mock">
       {data.map((item, i) => (
         <div key={i}>{itemContent(i, item)}</div>
       ))}
+      {/* Lets tests simulate scrolling to the bottom of the virtual list. */}
+      <button
+        type="button"
+        data-testid="virtuoso-end-reached"
+        onClick={() => endReached?.()}
+      >
+        end
+      </button>
       {components?.Footer ? <components.Footer /> : null}
     </div>
   ),
@@ -160,7 +170,33 @@ describe("TraceResultsList", () => {
     expect(onClearFilters).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps rows visible while loading more pages", () => {
+  it("fetches the next page when the list reaches the end", async () => {
+    const user = userEvent.setup();
+    const onLoadMore = vi.fn();
+    const rows = [row({ traceId: "a", rootName: "GET /a" })];
+
+    render(
+      <TraceResultsList
+        rows={rows}
+        isPending={false}
+        isError={false}
+        error={null}
+        refetch={() => {}}
+        hasMore={true}
+        isLoadingMore={false}
+        renderTraceLink={renderTraceLink}
+        onLoadMore={onLoadMore}
+        onClearFilters={() => {}}
+      />,
+    );
+
+    await user.click(screen.getByTestId("virtuoso-end-reached"));
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fetch again while a page is already loading", async () => {
+    const user = userEvent.setup();
+    const onLoadMore = vi.fn();
     const rows = [row({ traceId: "a", rootName: "GET /a" })];
 
     render(
@@ -173,14 +209,43 @@ describe("TraceResultsList", () => {
         hasMore={true}
         isLoadingMore={true}
         renderTraceLink={renderTraceLink}
-        onLoadMore={() => {}}
+        onLoadMore={onLoadMore}
         onClearFilters={() => {}}
       />,
     );
 
     expect(screen.getByText("GET /a")).toBeInTheDocument();
-    expect(screen.queryByText("Failed to load traces")).not.toBeInTheDocument();
-    expect(screen.queryByText("No traces")).not.toBeInTheDocument();
     expect(screen.getByText(/loading more traces/i)).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("virtuoso-end-reached"));
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch past the last page", async () => {
+    const user = userEvent.setup();
+    const onLoadMore = vi.fn();
+    const rows = [row({ traceId: "a", rootName: "GET /a" })];
+
+    render(
+      <TraceResultsList
+        rows={rows}
+        isPending={false}
+        isError={false}
+        error={null}
+        refetch={() => {}}
+        hasMore={false}
+        isLoadingMore={false}
+        renderTraceLink={renderTraceLink}
+        onLoadMore={onLoadMore}
+        onClearFilters={() => {}}
+      />,
+    );
+
+    expect(
+      screen.getByText(/showing all 1 matching traces/i),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("virtuoso-end-reached"));
+    expect(onLoadMore).not.toHaveBeenCalled();
   });
 });

--- a/packages/telemetry-explorer/src/traces/ui/trace-results-list.test.tsx
+++ b/packages/telemetry-explorer/src/traces/ui/trace-results-list.test.tsx
@@ -8,14 +8,17 @@ vi.mock("react-virtuoso", () => ({
   Virtuoso: <T,>({
     data,
     itemContent,
+    components,
   }: {
     data: T[];
     itemContent: (index: number, item: T) => React.ReactNode;
+    components?: { Footer?: () => React.ReactNode };
   }) => (
     <div data-testid="virtuoso-mock">
       {data.map((item, i) => (
         <div key={i}>{itemContent(i, item)}</div>
       ))}
+      {components?.Footer ? <components.Footer /> : null}
     </div>
   ),
 }));
@@ -157,9 +160,7 @@ describe("TraceResultsList", () => {
     expect(onClearFilters).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps rows visible and shows load-more fetching only on the button", async () => {
-    const user = userEvent.setup();
-    const onLoadMore = vi.fn();
+  it("keeps rows visible while loading more pages", () => {
     const rows = [row({ traceId: "a", rootName: "GET /a" })];
 
     render(
@@ -172,7 +173,7 @@ describe("TraceResultsList", () => {
         hasMore={true}
         isLoadingMore={true}
         renderTraceLink={renderTraceLink}
-        onLoadMore={onLoadMore}
+        onLoadMore={() => {}}
         onClearFilters={() => {}}
       />,
     );
@@ -180,10 +181,6 @@ describe("TraceResultsList", () => {
     expect(screen.getByText("GET /a")).toBeInTheDocument();
     expect(screen.queryByText("Failed to load traces")).not.toBeInTheDocument();
     expect(screen.queryByText("No traces")).not.toBeInTheDocument();
-
-    const button = screen.getByRole("button", { name: /loading more/i });
-    expect(button).toBeDisabled();
-    await user.click(button);
-    expect(onLoadMore).not.toHaveBeenCalled();
+    expect(screen.getByText(/loading more traces/i)).toBeInTheDocument();
   });
 });

--- a/packages/telemetry-explorer/src/traces/ui/trace-results-list.tsx
+++ b/packages/telemetry-explorer/src/traces/ui/trace-results-list.tsx
@@ -7,8 +7,19 @@ import {
 } from "@everr/ui/components/empty";
 import { RetryError } from "@everr/ui/components/retry-error";
 import { Skeleton } from "@everr/ui/components/skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@everr/ui/components/tooltip";
 import { formatDuration } from "@everr/ui/lib/formatting";
-import { type ReactNode, useMemo } from "react";
+import {
+  formatRelativeTime,
+  formatTimestampTimeOfDay,
+  parseTimestampAsUTC,
+} from "@everr/ui/lib/timestamp";
+import { Check, Copy, TriangleAlert } from "lucide-react";
+import { type ReactNode, useCallback, useMemo, useState } from "react";
 import { Virtuoso } from "react-virtuoso";
 import type { TraceSummary } from "../data/types";
 import { addNsToCHDateTime } from "../data/window";
@@ -17,6 +28,7 @@ import { DurationBar } from "./duration-bar";
 import { serviceColor } from "./shared/service-color";
 
 const SKELETON_DELAY_MS = 1000;
+const VIRTUOSO_OVERSCAN = 600;
 
 type Props = {
   rows: TraceSummary[];
@@ -60,6 +72,34 @@ export function TraceResultsList({
     return max;
   }, [rows]);
 
+  const endReached = useCallback(() => {
+    if (hasMore && !isLoadingMore) onLoadMore();
+  }, [hasMore, isLoadingMore, onLoadMore]);
+
+  const itemContent = useCallback(
+    (_index: number, row: TraceSummary) => (
+      <TraceRow
+        row={row}
+        maxDuration={maxDuration}
+        renderTraceLink={renderTraceLink}
+      />
+    ),
+    [maxDuration, renderTraceLink],
+  );
+
+  const components = useMemo(
+    () => ({
+      Footer: () => (
+        <ResultsFooter
+          count={rows.length}
+          hasMore={hasMore}
+          isLoadingMore={isLoadingMore}
+        />
+      ),
+    }),
+    [rows.length, hasMore, isLoadingMore],
+  );
+
   const showSkeleton = useDelayedFlag(isPending, SKELETON_DELAY_MS);
   if (isPending) return showSkeleton ? <ResultsSkeleton /> : null;
   if (isError) {
@@ -77,30 +117,28 @@ export function TraceResultsList({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
+      <ResultsHeader />
       <Virtuoso
-        className="flex-1"
+        className="min-h-0 flex-1"
         data={rows}
-        itemContent={(_, row) => (
-          <TraceRow
-            row={row}
-            maxDuration={maxDuration}
-            renderTraceLink={renderTraceLink}
-          />
-        )}
+        increaseViewportBy={VIRTUOSO_OVERSCAN}
+        endReached={endReached}
+        computeItemKey={(_, row) => row.traceId}
+        itemContent={itemContent}
+        components={components}
       />
-      {hasMore && (
-        <div className="flex justify-center border-t py-2">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="text-muted-foreground text-xs"
-            onClick={onLoadMore}
-            disabled={isLoadingMore}
-          >
-            {isLoadingMore ? "Loading more..." : "Load more"}
-          </Button>
-        </div>
-      )}
+    </div>
+  );
+}
+
+function ResultsHeader() {
+  return (
+    <div className="text-muted-foreground bg-background flex items-center gap-3 border-b px-3 py-1.5 text-xs font-medium">
+      <span className="size-2 shrink-0" />
+      <span className="min-w-0 flex-1">Trace</span>
+      <span className="w-32 text-right">Duration</span>
+      <span className="hidden w-14 text-right md:inline">Spans</span>
+      <span className="hidden w-20 text-right lg:inline">Started</span>
     </div>
   );
 }
@@ -116,7 +154,8 @@ function TraceRow({
 }) {
   const end = addNsToCHDateTime(row.startTs, BigInt(row.durationNs));
   const className =
-    "hover:bg-muted/50 flex items-center gap-3 border-b px-3 py-2";
+    "hover:bg-muted/50 flex items-center gap-3 border-b px-3 py-1.5 text-sm leading-tight";
+  const started = parseTimestampAsUTC(row.startTs);
   return renderTraceLink({
     traceId: row.traceId,
     start: row.startTs,
@@ -125,44 +164,160 @@ function TraceRow({
     children: (
       <>
         <span
-          className="h-2 w-2 shrink-0 rounded-full"
+          className="size-2 shrink-0 rounded-full"
           style={{
             backgroundColor: serviceColor(row.rootNamespace, row.rootService),
           }}
         />
         <div className="min-w-0 flex-1">
-          <div className="truncate font-medium">{row.rootName}</div>
-          <div className="text-muted-foreground truncate text-xs">
+          <div className="flex items-center gap-1.5 leading-tight">
+            {row.errorCount > 0 && (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <span
+                      role="img"
+                      aria-label={`${row.errorCount} ${
+                        row.errorCount === 1 ? "error" : "errors"
+                      }`}
+                      className="text-destructive flex shrink-0 items-center"
+                    />
+                  }
+                >
+                  <TriangleAlert className="size-3.5" />
+                </TooltipTrigger>
+                <TooltipContent>
+                  {row.errorCount} {row.errorCount === 1 ? "error" : "errors"}
+                </TooltipContent>
+              </Tooltip>
+            )}
+            <span className="truncate font-medium">{row.rootName}</span>
+            <TraceIdBadge traceId={row.traceId} />
+          </div>
+          <div className="text-muted-foreground truncate text-xs leading-tight">
             {row.rootService}
           </div>
         </div>
-        <DurationBar
-          durationNs={BigInt(row.durationNs)}
-          maxDurationNs={maxDuration}
-        />
-        <div className="w-20 text-right text-sm tabular-nums">
-          {formatDuration(Number(row.durationNs), "ns")}
-        </div>
-        <div className="text-muted-foreground w-16 text-right text-xs">
-          {row.spanCount} spans
-        </div>
-        {row.errorCount > 0 ? (
-          <span className="text-destructive w-16 text-right text-xs">
-            {row.errorCount} err
+        <div className="flex w-32 shrink-0 flex-col items-end gap-1">
+          <span className="tabular-nums">
+            {formatDuration(Number(row.durationNs), "ns")}
           </span>
-        ) : (
-          <span className="w-16" />
-        )}
+          <DurationBar
+            durationNs={BigInt(row.durationNs)}
+            maxDurationNs={maxDuration}
+          />
+        </div>
+        <span className="text-muted-foreground hidden w-14 text-right text-xs tabular-nums md:inline">
+          {row.spanCount} {row.spanCount === 1 ? "span" : "spans"}
+        </span>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <span className="text-muted-foreground hidden w-20 text-right text-xs tabular-nums lg:inline" />
+            }
+          >
+            {formatTimestampTimeOfDay(row.startTs)}
+          </TooltipTrigger>
+          <TooltipContent side="left">
+            {started ? (
+              <span className="flex flex-col gap-0.5">
+                <span className="tabular-nums">{started.toLocaleString()}</span>
+                <span className="text-background/70">
+                  {formatRelativeTime(row.startTs)}
+                </span>
+              </span>
+            ) : (
+              row.startTs
+            )}
+          </TooltipContent>
+        </Tooltip>
       </>
     ),
   });
 }
 
+function TraceIdBadge({ traceId }: { traceId: string }) {
+  const [copied, setCopied] = useState(false);
+  const short = traceId.slice(0, 8);
+
+  // The whole row is wrapped in a link, so stop the click from navigating or
+  // bubbling to the router before copying the full id to the clipboard.
+  const copy = (event: {
+    preventDefault: () => void;
+    stopPropagation: () => void;
+  }) => {
+    event.preventDefault();
+    event.stopPropagation();
+    void navigator.clipboard?.writeText(traceId).then(() => setCopied(true));
+  };
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          // biome-ignore lint/a11y/useSemanticElements: A button would nest inside the row's anchor.
+          <span
+            role="button"
+            tabIndex={0}
+            aria-label="Copy trace ID"
+            className="text-muted-foreground hover:text-foreground group inline-flex shrink-0 cursor-pointer items-center gap-1 font-mono text-xs font-normal"
+            onClick={copy}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" || event.key === " ") copy(event);
+            }}
+            onMouseLeave={() => setCopied(false)}
+          />
+        }
+      >
+        {short}
+        {copied ? (
+          <Check className="size-3" />
+        ) : (
+          <Copy className="size-3 opacity-0 transition-opacity group-hover:opacity-70" />
+        )}
+      </TooltipTrigger>
+      <TooltipContent>
+        {copied ? "Copied!" : <span className="font-mono">{traceId}</span>}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function ResultsFooter({
+  count,
+  hasMore,
+  isLoadingMore,
+}: {
+  count: number;
+  hasMore: boolean;
+  isLoadingMore: boolean;
+}) {
+  return (
+    <div className="text-muted-foreground flex h-10 items-center justify-center px-3 text-xs">
+      {isLoadingMore ? (
+        <span className="flex items-center gap-2">
+          <Skeleton className="size-2 rounded-full" />
+          Loading more traces
+        </span>
+      ) : hasMore ? (
+        <span>Showing {count.toLocaleString()} traces</span>
+      ) : (
+        <span>Showing all {count.toLocaleString()} matching traces</span>
+      )}
+    </div>
+  );
+}
+
 function ResultsSkeleton() {
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-2">
-      {Array.from({ length: 8 }).map((_, i) => (
-        <Skeleton key={i} className="h-10 w-full" />
+    <div className="flex min-h-0 flex-1 flex-col">
+      {Array.from({ length: 12 }).map((_, i) => (
+        <div key={i} className="flex items-center gap-3 border-b px-3 py-1.5">
+          <Skeleton className="size-2 shrink-0 rounded-full" />
+          <Skeleton className="h-4 min-w-0 flex-1" />
+          <Skeleton className="h-4 w-16" />
+          <Skeleton className="hidden h-3 w-14 lg:block" />
+        </div>
       ))}
     </div>
   );

--- a/packages/telemetry-explorer/src/traces/ui/trace-results-list.tsx
+++ b/packages/telemetry-explorer/src/traces/ui/trace-results-list.tsx
@@ -153,99 +153,99 @@ function TraceRow({
   renderTraceLink: (props: TraceLinkRenderProps) => React.ReactNode;
 }) {
   const end = addNsToCHDateTime(row.startTs, BigInt(row.durationNs));
-  const className =
-    "hover:bg-muted/50 flex items-center gap-3 border-b px-3 py-1.5 text-sm leading-tight";
   const started = parseTimestampAsUTC(row.startTs);
-  return renderTraceLink({
-    traceId: row.traceId,
-    start: row.startTs,
-    end,
-    className,
-    children: (
-      <>
-        <span
-          className="size-2 shrink-0 rounded-full"
-          style={{
-            backgroundColor: serviceColor(row.rootNamespace, row.rootService),
-          }}
-        />
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-1.5 leading-tight">
-            {row.errorCount > 0 && (
-              <Tooltip>
-                <TooltipTrigger
-                  render={
-                    <span
-                      role="img"
-                      aria-label={`${row.errorCount} ${
-                        row.errorCount === 1 ? "error" : "errors"
-                      }`}
-                      className="text-destructive flex shrink-0 items-center"
-                    />
-                  }
-                >
-                  <TriangleAlert className="size-3.5" />
-                </TooltipTrigger>
-                <TooltipContent>
-                  {row.errorCount} {row.errorCount === 1 ? "error" : "errors"}
-                </TooltipContent>
-              </Tooltip>
-            )}
-            <span className="truncate font-medium">{row.rootName}</span>
-            <TraceIdBadge traceId={row.traceId} />
-          </div>
-          <div className="text-muted-foreground truncate text-xs leading-tight">
-            {row.rootService}
-          </div>
+  // The link wraps only the name but its `after` pseudo-element stretches over
+  // the whole row, so the entire row navigates while the copy control and
+  // tooltips stay as siblings (lifted above the overlay with z-10) instead of
+  // nested interactive elements inside the anchor.
+  return (
+    <div className="hover:bg-muted/50 relative flex items-center gap-3 border-b px-3 py-1.5 text-sm leading-tight">
+      <span
+        className="size-2 shrink-0 rounded-full"
+        style={{
+          backgroundColor: serviceColor(row.rootNamespace, row.rootService),
+        }}
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1.5 leading-tight">
+          {row.errorCount > 0 && (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <span
+                    role="img"
+                    aria-label={`${row.errorCount} ${
+                      row.errorCount === 1 ? "error" : "errors"
+                    }`}
+                    className="text-destructive relative z-10 flex shrink-0 items-center"
+                  />
+                }
+              >
+                <TriangleAlert className="size-3.5" />
+              </TooltipTrigger>
+              <TooltipContent>
+                {row.errorCount} {row.errorCount === 1 ? "error" : "errors"}
+              </TooltipContent>
+            </Tooltip>
+          )}
+          {renderTraceLink({
+            traceId: row.traceId,
+            start: row.startTs,
+            end,
+            className:
+              "min-w-0 truncate font-medium after:absolute after:inset-0 after:content-['']",
+            children: row.rootName,
+          })}
+          <TraceIdBadge traceId={row.traceId} />
         </div>
-        <div className="flex w-32 shrink-0 flex-col items-end gap-1">
-          <span className="tabular-nums">
-            {formatDuration(Number(row.durationNs), "ns")}
-          </span>
-          <DurationBar
-            durationNs={BigInt(row.durationNs)}
-            maxDurationNs={maxDuration}
-          />
+        <div className="text-muted-foreground truncate text-xs leading-tight">
+          {row.rootService}
         </div>
-        <span className="text-muted-foreground hidden w-14 text-right text-xs tabular-nums md:inline">
-          {row.spanCount} {row.spanCount === 1 ? "span" : "spans"}
+      </div>
+      <div className="flex w-32 shrink-0 flex-col items-end gap-1">
+        <span className="tabular-nums">
+          {formatDuration(Number(row.durationNs), "ns")}
         </span>
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <span className="text-muted-foreground hidden w-20 text-right text-xs tabular-nums lg:inline" />
-            }
-          >
-            {formatTimestampTimeOfDay(row.startTs)}
-          </TooltipTrigger>
-          <TooltipContent side="left">
-            {started ? (
-              <span className="flex flex-col gap-0.5">
-                <span className="tabular-nums">{started.toLocaleString()}</span>
-                <span className="text-background/70">
-                  {formatRelativeTime(row.startTs)}
-                </span>
+        <DurationBar
+          durationNs={BigInt(row.durationNs)}
+          maxDurationNs={maxDuration}
+        />
+      </div>
+      <span className="text-muted-foreground hidden w-14 text-right text-xs tabular-nums md:inline">
+        {row.spanCount} {row.spanCount === 1 ? "span" : "spans"}
+      </span>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <span className="text-muted-foreground relative z-10 hidden w-20 text-right text-xs tabular-nums lg:inline" />
+          }
+        >
+          {formatTimestampTimeOfDay(row.startTs)}
+        </TooltipTrigger>
+        <TooltipContent side="left">
+          {started ? (
+            <span className="flex flex-col gap-0.5">
+              <span className="tabular-nums">{started.toLocaleString()}</span>
+              <span className="text-background/70">
+                {formatRelativeTime(row.startTs)}
               </span>
-            ) : (
-              row.startTs
-            )}
-          </TooltipContent>
-        </Tooltip>
-      </>
-    ),
-  });
+            </span>
+          ) : (
+            row.startTs
+          )}
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  );
 }
 
 function TraceIdBadge({ traceId }: { traceId: string }) {
   const [copied, setCopied] = useState(false);
   const short = traceId.slice(0, 8);
 
-  // The whole row is wrapped in a link, so stop the click from navigating or
-  // bubbling to the router before copying the full id to the clipboard.
-  const copy = (event: {
-    preventDefault: () => void;
-    stopPropagation: () => void;
-  }) => {
+  // The badge sits above the row's stretched link overlay, but still guard the
+  // click so copying never navigates or bubbles to the router.
+  const copy = (event: React.MouseEvent) => {
     event.preventDefault();
     event.stopPropagation();
     void navigator.clipboard?.writeText(traceId).then(() => setCopied(true));
@@ -255,16 +255,11 @@ function TraceIdBadge({ traceId }: { traceId: string }) {
     <Tooltip>
       <TooltipTrigger
         render={
-          // biome-ignore lint/a11y/useSemanticElements: A button would nest inside the row's anchor.
-          <span
-            role="button"
-            tabIndex={0}
+          <button
+            type="button"
             aria-label="Copy trace ID"
-            className="text-muted-foreground hover:text-foreground group inline-flex shrink-0 cursor-pointer items-center gap-1 font-mono text-xs font-normal"
+            className="text-muted-foreground hover:text-foreground group relative z-10 inline-flex shrink-0 cursor-pointer items-center gap-1 font-mono text-xs font-normal"
             onClick={copy}
-            onKeyDown={(event) => {
-              if (event.key === "Enter" || event.key === " ") copy(event);
-            }}
             onMouseLeave={() => setCopied(false)}
           />
         }

--- a/packages/telemetry-explorer/src/traces/ui/traces-search-page.tsx
+++ b/packages/telemetry-explorer/src/traces/ui/traces-search-page.tsx
@@ -19,6 +19,10 @@ import {
 
 export type { TraceLinkRenderProps };
 
+// How many traces each infinite-query page fetches. Not user-tunable, so it
+// lives here rather than in the URL search params.
+const TRACES_PAGE_SIZE = 50;
+
 export type TraceSearchValue = {
   namespace: string[];
   service: string[];
@@ -27,7 +31,6 @@ export type TraceSearchValue = {
   maxMs: number | undefined;
   status: SpanStatusFilter;
   attributes: AttributeFilter[];
-  limit: number;
 };
 
 export type TracesSearchProps = {
@@ -71,7 +74,7 @@ export function TracesSearch({
       maxMs: search.maxMs,
       status: search.status,
       attributes: search.attributes,
-      limit: search.limit,
+      limit: TRACES_PAGE_SIZE,
     }),
     placeholderData: keepPreviousData,
   });
@@ -97,7 +100,7 @@ export function TracesSearch({
         identities={identitiesQuery.data ?? []}
         onChange={onSearchChange}
       />
-      <main className="flex min-h-0 min-w-0 flex-col p-4">
+      <main className="flex min-h-0 min-w-0 flex-col">
         <TraceResultsList
           rows={rows}
           isPending={isPending}
@@ -117,7 +120,6 @@ export function TracesSearch({
               maxMs: undefined,
               status: "all",
               attributes: [],
-              limit: 50,
             })
           }
         />


### PR DESCRIPTION
General UI fixes for the traces list.

## Changes

- **Clean URLs** — add a `stripSearchParams` middleware so default/empty search params (`namespace`, `service`, `name`, `status`, `attributes`) are no longer serialized into the URL on every navigation.
- **Compact rows** — denser two-line rows with a start timestamp (UI tooltip showing full local + relative time).
- **Infinite scroll** — replace the "Load more" button with Virtuoso's `endReached` plus a footer status line.
- **Sticky header + flush content** — pinned column header and removed the outer padding around the list.
- **Inline error indicator** — error icon next to the operation name (with the count in a tooltip), replacing the dedicated errors column.
- **Trace id** — shown next to the name as a muted, click-to-copy badge (full id in a tooltip).
- **Stacked duration** — duration value and bar combined into a single column.
- **`limit` demoted** — moved the per-page size from a URL search param to an internal `TRACES_PAGE_SIZE` constant, since it was never user-tunable.

## Testing

- `tsc --noEmit` clean across `app`, `telemetry-explorer`, and `desktop-app`.
- `vitest` green for the traces schema, options, and results-list suites.