### PR TITLE
Surface local telemetry collector status with a restart control

### DIFF
--- a/packages/desktop-app/src-tauri/src/commands.rs
+++ b/packages/desktop-app/src-tauri/src/commands.rs
@@ -17,6 +17,7 @@ use crate::settings::{
     current_app_state, emit_auth_changed, emit_settings_changed, reset_dev_onboarding_inner,
     update_persisted_state, update_settings, wizard_status_response,
 };
+use crate::telemetry::sidecar::{CollectorStatusResponse, Sidecar};
 use crate::{
     current_base_url, AuthStatusResponse, CommandResult, DevResetResponse, IntoCommandResult,
     PendingAuthResponse, RuntimeState, SignInResponse, TestNotificationResponse,
@@ -167,6 +168,20 @@ pub(crate) fn get_build_info() -> CommandResult<BuildInfoResponse> {
         release_sha: env!("EVERR_RELEASE_SHA"),
         release_short_sha: env!("EVERR_RELEASE_SHORT_SHA"),
     })
+}
+
+#[tauri::command]
+pub(crate) fn get_collector_status(
+    sidecar: State<'_, Sidecar>,
+) -> CommandResult<CollectorStatusResponse> {
+    Ok(sidecar.status())
+}
+
+#[tauri::command]
+pub(crate) async fn restart_collector(
+    sidecar: State<'_, Sidecar>,
+) -> CommandResult<CollectorStatusResponse> {
+    Ok(sidecar.restart().await)
 }
 
 #[tauri::command]

--- a/packages/desktop-app/src-tauri/src/lib.rs
+++ b/packages/desktop-app/src-tauri/src/lib.rs
@@ -30,11 +30,11 @@ mod tests;
 
 use commands::{
     copy_notification_auto_fix_prompt, copy_run_auto_fix_prompt, dismiss_active_notification,
-    get_active_notification, get_auth_status, get_build_info, get_notification_emails,
-    get_pending_sign_in, get_runs_list, get_user_profile, get_wizard_status,
-    open_notification_target, open_run_in_browser, open_sign_in_browser, poll_sign_in,
-    reset_dev_onboarding, set_notification_emails, sign_out, start_sign_in,
-    trigger_test_notification,
+    get_active_notification, get_auth_status, get_build_info, get_collector_status,
+    get_notification_emails, get_pending_sign_in, get_runs_list, get_user_profile,
+    get_wizard_status, open_notification_target, open_run_in_browser, open_sign_in_browser,
+    poll_sign_in, reset_dev_onboarding, restart_collector, set_notification_emails, sign_out,
+    start_sign_in, trigger_test_notification,
 };
 use notifications::{dismiss_active_notification_inner, start_notifier_loop};
 use settings::{open_settings_window, wizard_incomplete};
@@ -242,7 +242,12 @@ pub fn run() {
 
             let sidecar =
                 tauri::async_runtime::block_on(telemetry::sidecar::Sidecar::start(app.handle()));
+            let collector_state = sidecar.state();
             app.manage(sidecar);
+            telemetry::sidecar::start_collector_state_event_loop(
+                app.handle().clone(),
+                collector_state,
+            );
 
             build_tray(app.handle())?;
             if wizard_incomplete(&runtime)? {
@@ -270,6 +275,8 @@ pub fn run() {
             get_notification_emails,
             set_notification_emails,
             get_build_info,
+            get_collector_status,
+            restart_collector,
             get_user_profile,
             get_runs_list,
             open_run_in_browser,

--- a/packages/desktop-app/src-tauri/src/telemetry/sidecar.rs
+++ b/packages/desktop-app/src-tauri/src/telemetry/sidecar.rs
@@ -5,25 +5,54 @@ use std::time::{Duration, Instant};
 use nix::errno::Errno;
 use nix::sys::signal::{killpg, Signal};
 use nix::unistd::Pid;
-use tauri::AppHandle;
+use serde::Serialize;
+use tauri::{AppHandle, Emitter};
 use tokio::process::{Child, Command};
-use tokio::sync::watch;
+use tokio::sync::{mpsc, oneshot, watch};
+use tokio::task::{JoinError, JoinHandle};
 use tokio::time::{sleep, timeout};
 
 use crate::telemetry::ports::{HEALTHCHECK_PORT, OTLP_HTTP_PORT};
 
 pub const COLLECTOR_START_ARGS: [&str; 3] = ["local", "start", "--quiet"];
+pub const COLLECTOR_CHANGED_EVENT: &str = "everr://collector-changed";
 
 #[derive(Debug, Clone)]
 pub enum TelemetryState {
     Starting,
-    Ready { otlp_endpoint: String },
-    Disabled { reason: String },
+    Ready {
+        otlp_endpoint: String,
+    },
+    /// Intentionally stopped (app shutdown).
+    Stopped,
+    /// Failed to start or exited unexpectedly.
+    Disabled {
+        reason: String,
+    },
 }
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CollectorStatusResponse {
+    pub status: &'static str,
+    pub reason: Option<String>,
+    pub otlp_endpoint: String,
+    pub sql_endpoint: String,
+    pub health_endpoint: String,
+    pub telemetry_dir: Option<String>,
+}
+
+/// Commands sent to the supervisor task that owns the collector process.
+enum SupervisorCommand {
+    Restart(oneshot::Sender<CollectorStatusResponse>),
+    Shutdown(oneshot::Sender<()>),
+}
+
+/// Handle to the collector supervisor. All process state lives in the
+/// supervisor task; this struct only carries channels to talk to it, so there
+/// is no shared mutable process state to guard.
 pub struct Sidecar {
-    child: std::sync::Arc<std::sync::Mutex<Option<Child>>>,
-    state_tx: watch::Sender<TelemetryState>,
+    cmd_tx: mpsc::Sender<SupervisorCommand>,
     state_rx: watch::Receiver<TelemetryState>,
 }
 
@@ -32,93 +61,267 @@ impl Sidecar {
         self.state_rx.clone()
     }
 
-    /// Starts the collector from inside Tauri's `setup()` callback.
-    pub async fn start(app: &AppHandle) -> Self {
-        kill_orphaned_collector();
-
-        let cli_path = match crate::cli::bundled_cli_path(app) {
-            Ok(path) => path,
-            Err(err) => {
-                return Self::disabled(format!("bundled CLI: {err}"));
-            }
-        };
-
-        let (tx, rx) = watch::channel(TelemetryState::Starting);
-        let child = match spawn_cli_collector(&cli_path).await {
-            Ok(child) => child,
-            Err(err) => {
-                return Self::disabled(format!("CLI collector spawn: {err}"));
-            }
-        };
-        let child = std::sync::Arc::new(std::sync::Mutex::new(Some(child)));
-
-        tokio::spawn(monitor_child(child.clone(), tx.clone()));
-        tokio::spawn(monitor_readiness(tx.clone(), tx.subscribe()));
-
-        Self {
-            child,
-            state_tx: tx,
-            state_rx: rx,
-        }
+    pub fn status(&self) -> CollectorStatusResponse {
+        status_response(&self.state_rx.borrow())
     }
 
-    fn disabled(reason: String) -> Self {
-        let (tx, rx) = watch::channel(TelemetryState::Disabled {
-            reason: reason.clone(),
-        });
-        Self {
-            child: std::sync::Arc::new(std::sync::Mutex::new(None)),
-            state_tx: tx,
-            state_rx: rx,
+    /// Starts the collector from inside Tauri's `setup()` callback.
+    pub async fn start(app: &AppHandle) -> Self {
+        let (state_tx, state_rx) = watch::channel(TelemetryState::Starting);
+        let (cmd_tx, cmd_rx) = mpsc::channel(8);
+
+        // Spawn the first generation up front so an immediate failure surfaces
+        // as `Disabled` before we hand the supervisor over.
+        kill_orphaned_collector();
+        let child = match spawn_collector(app).await {
+            Ok(child) => Some(child),
+            Err(reason) => {
+                let _ = state_tx.send(TelemetryState::Disabled { reason });
+                None
+            }
+        };
+
+        let supervisor = Supervisor {
+            app: app.clone(),
+            state_tx,
+            child,
+            readiness: None,
+        };
+        // `tauri::async_runtime::spawn` works regardless of the current runtime
+        // context (`start` runs inside Tauri's synchronous `setup`).
+        tauri::async_runtime::spawn(supervisor.run(cmd_rx));
+
+        Self { cmd_tx, state_rx }
+    }
+
+    pub async fn restart(&self) -> CollectorStatusResponse {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        if self
+            .cmd_tx
+            .send(SupervisorCommand::Restart(reply_tx))
+            .await
+            .is_err()
+        {
+            return self.status();
         }
+        reply_rx.await.unwrap_or_else(|_| self.status())
     }
 
     pub async fn shutdown(&self) {
-        let Some(mut child) = self.child.lock().unwrap().take() else {
-            return;
-        };
-        let Some(pid) = child.id() else {
-            let _ = child.kill().await;
-            return;
-        };
+        let (reply_tx, reply_rx) = oneshot::channel();
+        if self
+            .cmd_tx
+            .send(SupervisorCommand::Shutdown(reply_tx))
+            .await
+            .is_ok()
+        {
+            let _ = reply_rx.await;
+        }
+    }
+}
 
-        let process_group = Pid::from_raw(pid as i32);
-        match killpg(process_group, Signal::SIGTERM) {
-            Ok(()) => {}
-            Err(Errno::ESRCH) => {
-                let _ = self.state_tx.send(TelemetryState::Disabled {
-                    reason: "shutdown".into(),
-                });
-                return;
+/// Owns the collector `Child` and its readiness probe, and is the single writer
+/// of `TelemetryState`. Because everything lives in one task, restarts and
+/// shutdowns are serialized for free and no stale generation can race the
+/// current one.
+struct Supervisor {
+    app: AppHandle,
+    state_tx: watch::Sender<TelemetryState>,
+    child: Option<Child>,
+    readiness: Option<JoinHandle<String>>,
+}
+
+impl Supervisor {
+    async fn run(mut self, mut cmd_rx: mpsc::Receiver<SupervisorCommand>) {
+        if self.child.is_some() {
+            self.readiness = Some(tokio::spawn(probe_ready()));
+        }
+
+        loop {
+            tokio::select! {
+                // The collector exited on its own.
+                res = wait_child(&mut self.child), if self.child.is_some() => {
+                    self.abort_readiness();
+                    self.child = None;
+                    let _ = self.state_tx.send(TelemetryState::Disabled {
+                        reason: exit_reason(res),
+                    });
+                }
+                // The readiness probe for the current generation passed.
+                res = wait_handle(&mut self.readiness), if self.readiness.is_some() => {
+                    self.readiness = None;
+                    if let Ok(otlp_endpoint) = res {
+                        let _ = self.state_tx.send(TelemetryState::Ready { otlp_endpoint });
+                    }
+                }
+                cmd = cmd_rx.recv() => match cmd {
+                    Some(SupervisorCommand::Restart(reply)) => self.handle_restart(reply).await,
+                    Some(SupervisorCommand::Shutdown(reply)) => {
+                        self.teardown().await;
+                        let _ = self.state_tx.send(TelemetryState::Stopped);
+                        let _ = reply.send(());
+                        return;
+                    }
+                    None => {
+                        self.teardown().await;
+                        return;
+                    }
+                },
             }
-            Err(err) => {
-                eprintln!("[collector] SIGTERM failed: {err}; hard-killing process group");
-                hard_kill_process_group(process_group, &mut child).await;
-                let _ = self.state_tx.send(TelemetryState::Disabled {
-                    reason: "shutdown".into(),
-                });
-                return;
+        }
+    }
+
+    async fn handle_restart(&mut self, reply: oneshot::Sender<CollectorStatusResponse>) {
+        self.teardown().await;
+        kill_orphaned_collector();
+
+        match spawn_collector(&self.app).await {
+            Ok(child) => {
+                self.child = Some(child);
+                self.readiness = Some(tokio::spawn(probe_ready()));
+                let _ = self.state_tx.send(TelemetryState::Starting);
+            }
+            Err(reason) => {
+                let _ = self.state_tx.send(TelemetryState::Disabled { reason });
             }
         }
 
-        let deadline = Duration::from_secs(3);
-        match timeout(deadline, child.wait()).await {
-            Ok(Ok(_)) => { /* clean exit */ }
-            Ok(Err(err)) => {
-                eprintln!("[collector] wait after SIGTERM failed: {err}");
-            }
-            Err(_) => {
-                eprintln!(
-                    "[collector] did not exit within 3s of SIGTERM; hard-killing process group"
-                );
-                hard_kill_process_group(process_group, &mut child).await;
-            }
-        }
-
-        let _ = self.state_tx.send(TelemetryState::Disabled {
-            reason: "shutdown".into(),
+        // Reply once the new generation settles. The waiter only observes the
+        // state channel — the main loop keeps driving the transitions — so it
+        // can't deadlock against this task.
+        let state_rx = self.state_tx.subscribe();
+        tokio::spawn(async move {
+            let status = wait_until_settled(state_rx, Duration::from_secs(12)).await;
+            let _ = reply.send(status);
         });
     }
+
+    /// Stops the current collector and cancels its readiness probe, leaving the
+    /// supervisor with no live generation.
+    async fn teardown(&mut self) {
+        self.abort_readiness();
+        stop_child(&mut self.child).await;
+    }
+
+    fn abort_readiness(&mut self) {
+        if let Some(handle) = self.readiness.take() {
+            handle.abort();
+        }
+    }
+}
+
+/// Awaits the child's exit, or pends forever when there is no child.
+async fn wait_child(child: &mut Option<Child>) -> std::io::Result<std::process::ExitStatus> {
+    match child {
+        Some(child) => child.wait().await,
+        None => std::future::pending().await,
+    }
+}
+
+/// Awaits the readiness probe handle, or pends forever when there is none.
+async fn wait_handle(handle: &mut Option<JoinHandle<String>>) -> Result<String, JoinError> {
+    match handle {
+        Some(handle) => handle.await,
+        None => std::future::pending().await,
+    }
+}
+
+fn exit_reason(res: std::io::Result<std::process::ExitStatus>) -> String {
+    match res {
+        Ok(status) => format!("collector CLI terminated: {status}"),
+        Err(err) => format!("collector CLI wait failed: {err}"),
+    }
+}
+
+/// Polls the collector healthcheck until it passes, returning the OTLP endpoint.
+async fn probe_ready() -> String {
+    let endpoint = format!("http://127.0.0.1:{HEALTHCHECK_PORT}/");
+    loop {
+        if everr_core::collector::wait_healthcheck(&endpoint, Duration::from_secs(3)).await {
+            return format!("http://127.0.0.1:{OTLP_HTTP_PORT}");
+        }
+        eprintln!("[collector] healthcheck not ready after 3s; continuing background wait");
+        sleep(Duration::from_secs(1)).await;
+    }
+}
+
+async fn spawn_collector(app: &AppHandle) -> Result<Child, String> {
+    let cli_path =
+        crate::cli::bundled_cli_path(app).map_err(|err| format!("bundled CLI: {err}"))?;
+    spawn_cli_collector(&cli_path)
+        .await
+        .map_err(|err| format!("CLI collector spawn: {err}"))
+}
+
+/// Terminates the collector process group (SIGTERM, then SIGKILL on timeout)
+/// and clears the slot.
+async fn stop_child(slot: &mut Option<Child>) {
+    let Some(mut child) = slot.take() else {
+        return;
+    };
+    let Some(pid) = child.id() else {
+        let _ = child.kill().await;
+        return;
+    };
+
+    let process_group = Pid::from_raw(pid as i32);
+    match killpg(process_group, Signal::SIGTERM) {
+        Ok(()) => {}
+        Err(Errno::ESRCH) => return,
+        Err(err) => {
+            eprintln!("[collector] SIGTERM failed: {err}; hard-killing process group");
+            hard_kill_process_group(process_group, &mut child).await;
+            return;
+        }
+    }
+
+    match timeout(Duration::from_secs(3), child.wait()).await {
+        Ok(Ok(_)) => { /* clean exit */ }
+        Ok(Err(err)) => eprintln!("[collector] wait after SIGTERM failed: {err}"),
+        Err(_) => {
+            eprintln!("[collector] did not exit within 3s of SIGTERM; hard-killing process group");
+            hard_kill_process_group(process_group, &mut child).await;
+        }
+    }
+}
+
+fn status_response(state: &TelemetryState) -> CollectorStatusResponse {
+    let otlp_endpoint = match state {
+        TelemetryState::Ready { otlp_endpoint } => otlp_endpoint.clone(),
+        _ => everr_core::build::otlp_http_origin(),
+    };
+    let (status, reason) = match state {
+        TelemetryState::Starting => ("starting", None),
+        TelemetryState::Ready { .. } => ("running", None),
+        TelemetryState::Stopped => ("stopped", None),
+        TelemetryState::Disabled { reason } => ("failed", Some(reason.clone())),
+    };
+
+    CollectorStatusResponse {
+        status,
+        reason,
+        otlp_endpoint,
+        sql_endpoint: everr_core::build::sql_http_origin(),
+        health_endpoint: everr_core::build::healthcheck_origin(),
+        telemetry_dir: everr_core::build::telemetry_dir()
+            .ok()
+            .map(|path| path.display().to_string()),
+    }
+}
+
+pub fn start_collector_state_event_loop(
+    app: AppHandle,
+    mut state_rx: watch::Receiver<TelemetryState>,
+) {
+    // Called from Tauri's synchronous `setup()` (outside a Tokio runtime
+    // context), so use the Tauri runtime spawner rather than `tokio::spawn`.
+    tauri::async_runtime::spawn(async move {
+        let _ = app.emit(COLLECTOR_CHANGED_EVENT, status_response(&state_rx.borrow()));
+        while state_rx.changed().await.is_ok() {
+            let status = status_response(&state_rx.borrow_and_update());
+            let _ = app.emit(COLLECTOR_CHANGED_EVENT, status);
+        }
+    });
 }
 
 async fn hard_kill_process_group(process_group: Pid, child: &mut Child) {
@@ -142,92 +345,51 @@ fn kill_orphaned_collector() {
     everr_core::collector::kill_processes_on_port(HEALTHCHECK_PORT, "orphaned collector process");
 }
 
+/// Waits until the collector leaves the `Starting` state (or the deadline
+/// elapses), returning the resulting status snapshot.
+async fn wait_until_settled(
+    mut state_rx: watch::Receiver<TelemetryState>,
+    deadline: Duration,
+) -> CollectorStatusResponse {
+    let start = Instant::now();
+    loop {
+        if !matches!(&*state_rx.borrow(), TelemetryState::Starting) {
+            return status_response(&state_rx.borrow());
+        }
+        let Some(remaining) = deadline.checked_sub(start.elapsed()) else {
+            return status_response(&state_rx.borrow());
+        };
+        if timeout(remaining, state_rx.changed()).await.is_err() {
+            return status_response(&state_rx.borrow());
+        }
+        if state_rx.has_changed().is_err() {
+            return status_response(&state_rx.borrow());
+        }
+    }
+}
+
 pub async fn wait_for_disabled_state(
     mut state_rx: watch::Receiver<TelemetryState>,
     deadline: Duration,
 ) -> bool {
-    if matches!(&*state_rx.borrow(), TelemetryState::Disabled { .. }) {
+    let is_disabled = |state: &TelemetryState| matches!(state, TelemetryState::Disabled { .. });
+    if is_disabled(&state_rx.borrow()) {
         return true;
     }
 
     let start = Instant::now();
     loop {
         let Some(remaining) = deadline.checked_sub(start.elapsed()) else {
-            return matches!(&*state_rx.borrow(), TelemetryState::Disabled { .. });
+            return is_disabled(&state_rx.borrow());
         };
-
         match timeout(remaining, state_rx.changed()).await {
             Ok(Ok(())) => {
-                if matches!(
-                    &*state_rx.borrow_and_update(),
-                    TelemetryState::Disabled { .. }
-                ) {
+                if is_disabled(&state_rx.borrow_and_update()) {
                     return true;
                 }
             }
-            Ok(Err(_)) => return matches!(&*state_rx.borrow(), TelemetryState::Disabled { .. }),
-            Err(_) => return matches!(&*state_rx.borrow(), TelemetryState::Disabled { .. }),
+            Ok(Err(_)) | Err(_) => return is_disabled(&state_rx.borrow()),
         }
-    }
-}
-
-async fn monitor_child(
-    child: std::sync::Arc<std::sync::Mutex<Option<Child>>>,
-    state_tx: watch::Sender<TelemetryState>,
-) {
-    loop {
-        let status = {
-            let mut guard = child.lock().unwrap();
-            let Some(child) = guard.as_mut() else {
-                break;
-            };
-            match child.try_wait() {
-                Ok(Some(status)) => {
-                    guard.take();
-                    Some(Ok(status))
-                }
-                Ok(None) => None,
-                Err(err) => Some(Err(err)),
-            }
-        };
-
-        match status {
-            Some(Ok(status)) => {
-                let _ = state_tx.send(TelemetryState::Disabled {
-                    reason: format!("collector CLI terminated: {status}"),
-                });
-                break;
-            }
-            Some(Err(err)) => {
-                let _ = state_tx.send(TelemetryState::Disabled {
-                    reason: format!("collector CLI wait failed: {err}"),
-                });
-                break;
-            }
-            None => sleep(Duration::from_millis(250)).await,
-        }
-    }
-}
-
-async fn monitor_readiness(
-    state_tx: watch::Sender<TelemetryState>,
-    state_rx: watch::Receiver<TelemetryState>,
-) {
-    let endpoint = format!("http://127.0.0.1:{HEALTHCHECK_PORT}/");
-    loop {
-        if everr_core::collector::wait_healthcheck(&endpoint, Duration::from_secs(3)).await {
-            let _ = state_tx.send(TelemetryState::Ready {
-                otlp_endpoint: format!("http://127.0.0.1:{OTLP_HTTP_PORT}"),
-            });
-            break;
-        }
-
-        if matches!(*state_rx.borrow(), TelemetryState::Disabled { .. }) {
-            break;
-        }
-
-        eprintln!("[collector] healthcheck not ready after 3s; continuing background wait");
-        sleep(Duration::from_secs(1)).await;
     }
 }
 
@@ -242,15 +404,8 @@ pub async fn spawn_cli_collector_detached(
             .env("EVERR_SKIP_ORPHANED_COLLECTOR_KILL", "1");
     })
     .await?;
-    let child = std::sync::Arc::new(std::sync::Mutex::new(Some(child)));
-    let (tx, rx) = watch::channel(TelemetryState::Starting);
-    tokio::spawn(monitor_child(child.clone(), tx.clone()));
     Ok(DetachedSidecar {
-        inner: Sidecar {
-            child,
-            state_tx: tx,
-            state_rx: rx,
-        },
+        child: tokio::sync::Mutex::new(Some(child)),
     })
 }
 
@@ -289,30 +444,28 @@ async fn spawn_cli_collector_with(
     Ok(child)
 }
 
+/// A standalone collector process used by tests. Owns its `Child` directly and
+/// drives readiness on demand via [`DetachedSidecar::wait_ready`].
 pub struct DetachedSidecar {
-    inner: Sidecar,
+    child: tokio::sync::Mutex<Option<Child>>,
 }
 
 impl DetachedSidecar {
     pub async fn wait_ready(&self) -> TelemetryState {
         let endpoint = format!("http://127.0.0.1:{HEALTHCHECK_PORT}/");
         if everr_core::collector::wait_healthcheck(&endpoint, Duration::from_secs(10)).await {
-            let otlp = format!("http://127.0.0.1:{OTLP_HTTP_PORT}");
-            let state = TelemetryState::Ready {
-                otlp_endpoint: otlp,
-            };
-            let _ = self.inner.state_tx.send(state.clone());
-            state
+            TelemetryState::Ready {
+                otlp_endpoint: format!("http://127.0.0.1:{OTLP_HTTP_PORT}"),
+            }
         } else {
-            let state = TelemetryState::Disabled {
+            TelemetryState::Disabled {
                 reason: "healthcheck timeout".into(),
-            };
-            let _ = self.inner.state_tx.send(state.clone());
-            state
+            }
         }
     }
 
     pub async fn shutdown(&self) {
-        self.inner.shutdown().await;
+        let mut guard = self.child.lock().await;
+        stop_child(&mut guard).await;
     }
 }

--- a/packages/desktop-app/src/App.test.tsx
+++ b/packages/desktop-app/src/App.test.tsx
@@ -45,6 +45,15 @@ type TestNotificationResponse = {
   status: "shown" | "queued";
 };
 
+type CollectorStatus = {
+  status: "starting" | "running" | "failed" | "stopped";
+  reason?: string;
+  otlpEndpoint: string;
+  sqlEndpoint: string;
+  healthEndpoint: string;
+  telemetryDir?: string;
+};
+
 type RunListItem = {
   traceId: string;
   runId: string;
@@ -70,6 +79,8 @@ type MainCommand =
   | "reset_dev_onboarding"
   | "trigger_test_notification"
   | "get_build_info"
+  | "get_collector_status"
+  | "restart_collector"
   | "get_runs_list"
   | "open_run_in_browser"
   | "copy_run_auto_fix_prompt";
@@ -80,6 +91,7 @@ type RenderMainOptions = {
   testNotification?: TestNotificationResponse;
   pendingSignIn?: PendingSignIn | null;
   runs?: RunListItem[];
+  collectorStatus?: CollectorStatus;
   commandOverrides?: Partial<Record<MainCommand, (args: unknown) => unknown>>;
 };
 
@@ -149,6 +161,18 @@ function renderMainApp(options: RenderMainOptions = {}) {
     () => options.testNotification ?? { status: "shown" },
   );
   let runs = options.runs ?? [];
+  const runningCollectorStatus = {
+    status: "running",
+    otlpEndpoint: "http://127.0.0.1:54318",
+    sqlEndpoint: "http://127.0.0.1:54320",
+    healthEndpoint: "http://127.0.0.1:54319",
+    telemetryDir: "/tmp/everr/telemetry-dev",
+  } satisfies CollectorStatus;
+  let collectorStatus = options.collectorStatus ?? runningCollectorStatus;
+  const restartCollectorSpy = vi.fn(() => {
+    collectorStatus = runningCollectorStatus;
+    return collectorStatus;
+  });
 
   mockWindows("main");
   mockIPC(
@@ -209,6 +233,10 @@ function renderMainApp(options: RenderMainOptions = {}) {
             release_sha: "unknown",
             release_short_sha: "unknown",
           };
+        case "get_collector_status":
+          return collectorStatus;
+        case "restart_collector":
+          return restartCollectorSpy();
         case "get_runs_list":
           return runs;
         case "open_run_in_browser":
@@ -228,6 +256,7 @@ function renderMainApp(options: RenderMainOptions = {}) {
     openSignInBrowserSpy,
     resetDevOnboardingSpy,
     triggerTestNotificationSpy,
+    restartCollectorSpy,
     setRuns(next: RunListItem[]) {
       runs = next;
     },
@@ -626,6 +655,105 @@ describe("runs list", () => {
     expect(screen.getByText("release/v2")).toBeInTheDocument();
     expect(screen.getByText("failure")).toBeInTheDocument();
     expect(screen.getByText("success")).toBeInTheDocument();
+  });
+});
+
+describe("local telemetry collector", () => {
+  it("shows an inline restart action when logs are unavailable", async () => {
+    const { restartCollectorSpy } = renderMainApp({
+      collectorStatus: {
+        status: "failed",
+        reason: "collector exited",
+        otlpEndpoint: "http://127.0.0.1:54318",
+        sqlEndpoint: "http://127.0.0.1:54320",
+        healthEndpoint: "http://127.0.0.1:54319",
+        telemetryDir: "/tmp/everr/telemetry-dev",
+      },
+    });
+
+    await act(async () => {
+      await router.navigate({ to: "/logs" });
+    });
+
+    expect(
+      await screen.findByText("Local telemetry unavailable"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("collector exited")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Restart collector" }));
+
+    await waitFor(() => {
+      expect(restartCollectorSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("shows local telemetry diagnostics in settings", async () => {
+    renderMainApp({
+      collectorStatus: {
+        status: "running",
+        otlpEndpoint: "http://127.0.0.1:54318",
+        sqlEndpoint: "http://127.0.0.1:54320",
+        healthEndpoint: "http://127.0.0.1:54319",
+        telemetryDir: "/tmp/everr/telemetry-dev",
+      },
+    });
+
+    await act(async () => {
+      await router.navigate({ to: "/settings" });
+    });
+
+    expect(await screen.findByText("Local telemetry")).toBeInTheDocument();
+    expect(await screen.findByText("running")).toBeInTheDocument();
+    expect(screen.getByText("http://127.0.0.1:54318")).toBeInTheDocument();
+    expect(screen.getByText("http://127.0.0.1:54320")).toBeInTheDocument();
+  });
+
+  it("shows a starting gate while the collector is starting", async () => {
+    renderMainApp({
+      collectorStatus: {
+        status: "starting",
+        otlpEndpoint: "http://127.0.0.1:54318",
+        sqlEndpoint: "http://127.0.0.1:54320",
+        healthEndpoint: "http://127.0.0.1:54319",
+        telemetryDir: "/tmp/everr/telemetry-dev",
+      },
+    });
+
+    await act(async () => {
+      await router.navigate({ to: "/logs" });
+    });
+
+    expect(
+      await screen.findByText("Starting local telemetry"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("The local collector is starting."),
+    ).toBeInTheDocument();
+  });
+
+  it("restarts the collector from the settings page", async () => {
+    const { restartCollectorSpy } = renderMainApp({
+      collectorStatus: {
+        status: "failed",
+        reason: "collector exited",
+        otlpEndpoint: "http://127.0.0.1:54318",
+        sqlEndpoint: "http://127.0.0.1:54320",
+        healthEndpoint: "http://127.0.0.1:54319",
+        telemetryDir: "/tmp/everr/telemetry-dev",
+      },
+    });
+
+    await act(async () => {
+      await router.navigate({ to: "/settings" });
+    });
+
+    expect(await screen.findByText("Local telemetry")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Restart collector" }));
+
+    await waitFor(() => {
+      expect(restartCollectorSpy).toHaveBeenCalledTimes(1);
+    });
   });
 });
 

--- a/packages/desktop-app/src/features/desktop-shell/settings-page.tsx
+++ b/packages/desktop-app/src/features/desktop-shell/settings-page.tsx
@@ -1,6 +1,12 @@
+import { Button } from "@everr/ui/components/button";
 import { useQuery } from "@tanstack/react-query";
+import { RotateCw } from "lucide-react";
 import { invokeCommand } from "@/lib/tauri";
 import { AuthSettingsSection } from "../auth/auth";
+import {
+  useCollectorStatusQuery,
+  useRestartCollectorMutation,
+} from "../local-telemetry/collector-status";
 import { NotificationEmailsSection } from "../notifications/notification-emails-section";
 import { SettingsSection } from "./ui";
 
@@ -34,6 +40,61 @@ function BuildInfoSection() {
   );
 }
 
+function LocalTelemetrySection() {
+  const statusQuery = useCollectorStatusQuery();
+  const restartMutation = useRestartCollectorMutation();
+  const status = statusQuery.data;
+
+  return (
+    <SettingsSection
+      title="Local telemetry"
+      description="Collector status and local endpoints used by Logs, Errors, and Traces."
+      action={
+        <Button
+          type="button"
+          variant="outline"
+          disabled={restartMutation.isPending}
+          onClick={() => restartMutation.mutate()}
+        >
+          <RotateCw data-icon="inline-start" />
+          {restartMutation.isPending ? "Restarting" : "Restart collector"}
+        </Button>
+      }
+    >
+      <dl className="grid max-w-[680px] grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+        <dt className="text-[var(--settings-text-muted)]">Status</dt>
+        <dd className="m-0 font-mono text-[var(--settings-text)]">
+          {status?.status ?? (statusQuery.isPending ? "loading" : "unknown")}
+        </dd>
+        {status?.reason ? (
+          <>
+            <dt className="text-[var(--settings-text-muted)]">Reason</dt>
+            <dd className="m-0 min-w-0 truncate font-mono text-[var(--settings-text)]">
+              {status.reason}
+            </dd>
+          </>
+        ) : null}
+        <dt className="text-[var(--settings-text-muted)]">OTLP</dt>
+        <dd className="m-0 min-w-0 truncate font-mono text-[var(--settings-text)]">
+          {status?.otlpEndpoint ?? "unknown"}
+        </dd>
+        <dt className="text-[var(--settings-text-muted)]">SQL</dt>
+        <dd className="m-0 min-w-0 truncate font-mono text-[var(--settings-text)]">
+          {status?.sqlEndpoint ?? "unknown"}
+        </dd>
+        <dt className="text-[var(--settings-text-muted)]">Health</dt>
+        <dd className="m-0 min-w-0 truncate font-mono text-[var(--settings-text)]">
+          {status?.healthEndpoint ?? "unknown"}
+        </dd>
+        <dt className="text-[var(--settings-text-muted)]">Data</dt>
+        <dd className="m-0 min-w-0 truncate font-mono text-[var(--settings-text)]">
+          {status?.telemetryDir ?? "unknown"}
+        </dd>
+      </dl>
+    </SettingsSection>
+  );
+}
+
 export function SettingsPage() {
   return (
     <div className="flex h-full flex-col overflow-hidden">
@@ -53,6 +114,7 @@ export function SettingsPage() {
             <AuthSettingsSection />
           </div>
           <NotificationEmailsSection />
+          <LocalTelemetrySection />
           <BuildInfoSection />
         </div>
       </div>

--- a/packages/desktop-app/src/features/errors/errors-page.tsx
+++ b/packages/desktop-app/src/features/errors/errors-page.tsx
@@ -29,6 +29,7 @@ import {
   useSearch,
 } from "@tanstack/react-router";
 import { type ReactNode, useEffect, useMemo, useRef } from "react";
+import { LocalTelemetryGate } from "../local-telemetry/collector-status";
 import { localSqlClient } from "../logs/local-sql-client";
 
 export { ErrorIssueSearchSchema };
@@ -62,29 +63,31 @@ export function ErrorsPage() {
         })
       }
     >
-      <ErrorIssues
-        repo={localErrorsRepo}
-        timeRange={timeRange}
-        refresh={refresh ?? ""}
-        search={{ q, service, fingerprint, sort, attributes }}
-        onSearchChange={(patch) =>
-          navigate({
-            to: "/errors",
-            search: (prev) => ({ ...prev, ...patch }),
-            replace: true,
-          })
-        }
-        renderIssueLink={({ fingerprint: issueFingerprint, children }) => (
-          <Link
-            to="/errors/$fingerprint"
-            params={{ fingerprint: issueFingerprint }}
-            search={(prev) => ({ ...prev, occurrence: "" })}
-            className="block text-foreground no-underline"
-          >
-            {children}
-          </Link>
-        )}
-      />
+      <LocalTelemetryGate>
+        <ErrorIssues
+          repo={localErrorsRepo}
+          timeRange={timeRange}
+          refresh={refresh ?? ""}
+          search={{ q, service, fingerprint, sort, attributes }}
+          onSearchChange={(patch) =>
+            navigate({
+              to: "/errors",
+              search: (prev) => ({ ...prev, ...patch }),
+              replace: true,
+            })
+          }
+          renderIssueLink={({ fingerprint: issueFingerprint, children }) => (
+            <Link
+              to="/errors/$fingerprint"
+              params={{ fingerprint: issueFingerprint }}
+              search={(prev) => ({ ...prev, occurrence: "" })}
+              className="block text-foreground no-underline"
+            >
+              {children}
+            </Link>
+          )}
+        />
+      </LocalTelemetryGate>
     </ErrorsPageShell>
   );
 }
@@ -119,51 +122,53 @@ export function ErrorDetailPage() {
         })
       }
     >
-      <ErrorDetail
-        repo={localErrorsRepo}
-        fingerprint={fingerprint}
-        timeRange={timeRange}
-        refresh={refresh ?? ""}
-        service={service}
-        occurrence={search.occurrence}
-        renderBackLink={(children) => (
-          <Link
-            to="/errors"
-            search={(prev) => ({ ...prev, occurrence: "" })}
-            className={buttonVariants({
-              variant: "outline",
-              size: "sm",
-              className: "shrink-0",
-            })}
-          >
-            {children}
-          </Link>
-        )}
-        renderOccurrenceLink={({
-          occurrence: linkedOccurrence,
-          children,
-          isSelected,
-        }) => (
-          <Link
-            to="/errors/$fingerprint"
-            params={{ fingerprint }}
-            search={(prev) => ({
-              ...prev,
-              occurrence: getErrorOccurrenceKey(linkedOccurrence),
-            })}
-            aria-current={isSelected ? "page" : undefined}
-            className={buttonVariants({
-              variant: isSelected ? "secondary" : "outline",
-              size: "sm",
-            })}
-          >
-            {children}
-          </Link>
-        )}
-        renderTracePanel={({ occurrence }) => (
-          <DesktopErrorTracePanel occurrence={occurrence} />
-        )}
-      />
+      <LocalTelemetryGate>
+        <ErrorDetail
+          repo={localErrorsRepo}
+          fingerprint={fingerprint}
+          timeRange={timeRange}
+          refresh={refresh ?? ""}
+          service={service}
+          occurrence={search.occurrence}
+          renderBackLink={(children) => (
+            <Link
+              to="/errors"
+              search={(prev) => ({ ...prev, occurrence: "" })}
+              className={buttonVariants({
+                variant: "outline",
+                size: "sm",
+                className: "shrink-0",
+              })}
+            >
+              {children}
+            </Link>
+          )}
+          renderOccurrenceLink={({
+            occurrence: linkedOccurrence,
+            children,
+            isSelected,
+          }) => (
+            <Link
+              to="/errors/$fingerprint"
+              params={{ fingerprint }}
+              search={(prev) => ({
+                ...prev,
+                occurrence: getErrorOccurrenceKey(linkedOccurrence),
+              })}
+              aria-current={isSelected ? "page" : undefined}
+              className={buttonVariants({
+                variant: isSelected ? "secondary" : "outline",
+                size: "sm",
+              })}
+            >
+              {children}
+            </Link>
+          )}
+          renderTracePanel={({ occurrence }) => (
+            <DesktopErrorTracePanel occurrence={occurrence} />
+          )}
+        />
+      </LocalTelemetryGate>
     </ErrorsPageShell>
   );
 }

--- a/packages/desktop-app/src/features/local-telemetry/collector-status.tsx
+++ b/packages/desktop-app/src/features/local-telemetry/collector-status.tsx
@@ -1,0 +1,114 @@
+import { Button } from "@everr/ui/components/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from "@everr/ui/components/empty";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { RotateCw } from "lucide-react";
+import type { ReactNode } from "react";
+import { COLLECTOR_CHANGED_EVENT, invokeCommand } from "@/lib/tauri";
+import { useInvalidateOnTauriEvent } from "@/lib/tauri-events";
+
+type CollectorStatus = "starting" | "running" | "failed" | "stopped";
+
+type CollectorStatusResponse = {
+  status: CollectorStatus;
+  reason?: string;
+  otlpEndpoint: string;
+  sqlEndpoint: string;
+  healthEndpoint: string;
+  telemetryDir?: string;
+};
+
+const collectorStatusQueryKey = ["desktop-app", "collector-status"] as const;
+
+export function useCollectorStatusQuery() {
+  useInvalidateOnTauriEvent(COLLECTOR_CHANGED_EVENT, (queryClient) => {
+    void queryClient.invalidateQueries({ queryKey: collectorStatusQueryKey });
+  });
+
+  return useQuery({
+    queryKey: collectorStatusQueryKey,
+    queryFn: () =>
+      invokeCommand<CollectorStatusResponse>("get_collector_status"),
+  });
+}
+
+export function useRestartCollectorMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () =>
+      invokeCommand<CollectorStatusResponse>("restart_collector"),
+    onSuccess: (status) => {
+      queryClient.setQueryData(collectorStatusQueryKey, status);
+      if (status.status === "running") {
+        void queryClient.invalidateQueries();
+      }
+    },
+  });
+}
+
+export function LocalTelemetryGate({ children }: { children: ReactNode }) {
+  const statusQuery = useCollectorStatusQuery();
+  const restartMutation = useRestartCollectorMutation();
+  const status = statusQuery.data;
+
+  if (status?.status === "running") {
+    return children;
+  }
+
+  if (status?.status === "starting" || statusQuery.isPending) {
+    return (
+      <LocalTelemetryState
+        title="Starting local telemetry"
+        description="The local collector is starting."
+      />
+    );
+  }
+
+  return (
+    <LocalTelemetryState
+      title="Local telemetry unavailable"
+      description={
+        status?.reason ||
+        (statusQuery.error as Error | undefined)?.message ||
+        "The local collector is not running."
+      }
+      action={
+        <Button
+          type="button"
+          variant="outline"
+          disabled={restartMutation.isPending}
+          onClick={() => restartMutation.mutate()}
+        >
+          <RotateCw data-icon="inline-start" />
+          {restartMutation.isPending ? "Restarting" : "Restart collector"}
+        </Button>
+      }
+    />
+  );
+}
+
+function LocalTelemetryState({
+  title,
+  description,
+  action,
+}: {
+  title: string;
+  description: string;
+  action?: ReactNode;
+}) {
+  return (
+    <Empty className="min-h-96 border-0">
+      <EmptyHeader>
+        <EmptyTitle>{title}</EmptyTitle>
+        <EmptyDescription>{description}</EmptyDescription>
+      </EmptyHeader>
+      {action ? <EmptyContent>{action}</EmptyContent> : null}
+    </Empty>
+  );
+}

--- a/packages/desktop-app/src/features/logs/logs-page.tsx
+++ b/packages/desktop-app/src/features/logs/logs-page.tsx
@@ -17,6 +17,7 @@ import { useIsFetching, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useEffect, useMemo, useRef } from "react";
 import { z } from "zod";
+import { LocalTelemetryGate } from "../local-telemetry/collector-status";
 import { localSqlClient } from "./local-sql-client";
 
 export const LogsSearchSchema = z.object({
@@ -107,29 +108,31 @@ export function LogsPage() {
         </div>
       </header>
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        <LogsExplorer
-          repo={repo}
-          timeRange={timeRange}
-          search={explorerSearch}
-          onSearchChange={(next) =>
-            navigate({
-              to: "/logs",
-              search: (prev) => ({ ...prev, ...next }),
-              replace: true,
-            })
-          }
-          onTimeRangeSelect={(from, to) =>
-            navigate({
-              to: "/logs",
-              search: (prev) => ({
-                ...prev,
-                from: from.toISOString(),
-                to: to.toISOString(),
-              }),
-              replace: true,
-            })
-          }
-        />
+        <LocalTelemetryGate>
+          <LogsExplorer
+            repo={repo}
+            timeRange={timeRange}
+            search={explorerSearch}
+            onSearchChange={(next) =>
+              navigate({
+                to: "/logs",
+                search: (prev) => ({ ...prev, ...next }),
+                replace: true,
+              })
+            }
+            onTimeRangeSelect={(from, to) =>
+              navigate({
+                to: "/logs",
+                search: (prev) => ({
+                  ...prev,
+                  from: from.toISOString(),
+                  to: to.toISOString(),
+                }),
+                replace: true,
+              })
+            }
+          />
+        </LocalTelemetryGate>
       </div>
     </div>
   );

--- a/packages/desktop-app/src/features/traces/traces-page.tsx
+++ b/packages/desktop-app/src/features/traces/traces-page.tsx
@@ -26,6 +26,7 @@ import {
   useSearch,
 } from "@tanstack/react-router";
 import { type ReactNode, useEffect, useMemo, useRef } from "react";
+import { LocalTelemetryGate } from "../local-telemetry/collector-status";
 import { localSqlClient } from "../logs/local-sql-client";
 
 export { TraceDetailParamsSchema, TraceSearchParamsSchema };
@@ -58,38 +59,40 @@ export function TracesPage() {
         })
       }
     >
-      <TracesSearch
-        repo={localTracesRepo}
-        timeRange={timeRange}
-        refresh={refresh}
-        search={{
-          namespace: search.namespace,
-          service: search.service,
-          name: search.name,
-          minMs: search.minMs,
-          maxMs: search.maxMs,
-          status: search.status,
-          attributes: search.attributes,
-          limit: search.limit,
-        }}
-        onSearchChange={(patch) =>
-          navigate({
-            to: "/traces",
-            search: (prev) => ({ ...prev, ...patch }),
-            replace: true,
-          })
-        }
-        renderTraceLink={({ traceId, start, end, className, children }) => (
-          <Link
-            to="/traces/$traceId"
-            params={{ traceId }}
-            search={(prev) => ({ ...prev, start, end })}
-            className={className}
-          >
-            {children}
-          </Link>
-        )}
-      />
+      <LocalTelemetryGate>
+        <TracesSearch
+          repo={localTracesRepo}
+          timeRange={timeRange}
+          refresh={refresh}
+          search={{
+            namespace: search.namespace,
+            service: search.service,
+            name: search.name,
+            minMs: search.minMs,
+            maxMs: search.maxMs,
+            status: search.status,
+            attributes: search.attributes,
+            limit: search.limit,
+          }}
+          onSearchChange={(patch) =>
+            navigate({
+              to: "/traces",
+              search: (prev) => ({ ...prev, ...patch }),
+              replace: true,
+            })
+          }
+          renderTraceLink={({ traceId, start, end, className, children }) => (
+            <Link
+              to="/traces/$traceId"
+              params={{ traceId }}
+              search={(prev) => ({ ...prev, start, end })}
+              className={className}
+            >
+              {children}
+            </Link>
+          )}
+        />
+      </LocalTelemetryGate>
     </TracePageShell>
   );
 }
@@ -126,25 +129,27 @@ export function TraceDetailPage() {
         })
       }
     >
-      <TraceDetail
-        repo={localTracesRepo}
-        traceId={traceId}
-        search={search}
-        onBack={() =>
-          navigate({
-            to: "/traces",
-            search: toTraceListSearch(search),
-          })
-        }
-        onSpanChange={(spanId) =>
-          navigate({
-            to: "/traces/$traceId",
-            params: { traceId },
-            search: (prev) => ({ ...prev, span: spanId }),
-            replace: true,
-          })
-        }
-      />
+      <LocalTelemetryGate>
+        <TraceDetail
+          repo={localTracesRepo}
+          traceId={traceId}
+          search={search}
+          onBack={() =>
+            navigate({
+              to: "/traces",
+              search: toTraceListSearch(search),
+            })
+          }
+          onSpanChange={(spanId) =>
+            navigate({
+              to: "/traces/$traceId",
+              params: { traceId },
+              search: (prev) => ({ ...prev, span: spanId }),
+              replace: true,
+            })
+          }
+        />
+      </LocalTelemetryGate>
     </TracePageShell>
   );
 }

--- a/packages/desktop-app/src/features/traces/traces-page.tsx
+++ b/packages/desktop-app/src/features/traces/traces-page.tsx
@@ -72,7 +72,6 @@ export function TracesPage() {
             maxMs: search.maxMs,
             status: search.status,
             attributes: search.attributes,
-            limit: search.limit,
           }}
           onSearchChange={(patch) =>
             navigate({

--- a/packages/desktop-app/src/lib/tauri.ts
+++ b/packages/desktop-app/src/lib/tauri.ts
@@ -4,6 +4,7 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 export const AUTH_CHANGED_EVENT = "everr://auth-changed";
 export const SETTINGS_CHANGED_EVENT = "everr://settings-changed";
 export const NOTIFICATION_CHANGED_EVENT = "everr://notification-changed";
+export const COLLECTOR_CHANGED_EVENT = "everr://collector-changed";
 export const NOTIFICATION_HOVER_EVENT = "everr://notification-hover";
 export const NOTIFICATION_EXIT_EVENT = "everr://notification-exit";
 export const NOTIFIER_CHECKED_EVENT = "everr://notifier-checked";


### PR DESCRIPTION
## What

Exposes the desktop collector's lifecycle to the UI so the **Logs**, **Errors**, and **Traces** pages react to collector state instead of silently querying a dead collector, and reworks the sidecar internals so that lifecycle is robust.

### UI / IPC
- New Tauri commands `get_collector_status` and `restart_collector`, plus a `everr://collector-changed` event, backed by a `CollectorStatusResponse` (`status`, `reason`, OTLP/SQL/health endpoints, telemetry dir).
- `LocalTelemetryGate` wraps the telemetry pages: shows a *starting* state while the collector boots and an *unavailable* state with an inline **Restart collector** action when it's down; renders the page only once the collector is `running`.
- A **Local telemetry** section in Settings showing the live endpoints and a restart button.

### Sidecar rewrite
Reworked the collector sidecar as a **single supervisor task** that owns the child process and is the sole writer of `TelemetryState`. One `tokio::select!` loop handles child exit, readiness, and `Restart`/`Shutdown` commands. This replaces:
- `Arc<Mutex<Option<Child>>>` → a plain owned `Option<Child>` (readiness/exit detection via `child.wait().await`, no busy-poll, no lock dance)
- the monitor-handle `Vec` + manual abort → a single per-generation readiness handle the task owns
- the `lifecycle_lock` mutex → gone; one task serializes restart/shutdown for free, and no stale generation can race the current one
- the `reason == "shutdown"` sentinel string → an explicit `TelemetryState::Stopped` variant

## Testing
- `cargo check` + `clippy` clean; `cargo fmt --check` clean
- `cargo test --test telemetry_sidecar` — 3/3 pass (CLI-gated case self-skips)
- Frontend `tsc --noEmit` clean; new `App.test.tsx` cases for the gate, settings diagnostics, starting state, and restart — 4/4 pass