### PR TITLE
Limit related trace items

### DIFF
--- a/packages/telemetry-explorer/src/errors/ui/error-pages.test.tsx
+++ b/packages/telemetry-explorer/src/errors/ui/error-pages.test.tsx
@@ -155,6 +155,32 @@ describe("ErrorTracePanel", () => {
     );
   });
 
+  it("limits related trace items and marks overflow", () => {
+    const spans: RelatedSpan[] = Array.from({ length: 11 }, (_, index) => ({
+      spanId: `span-${index + 1}`,
+      parentSpanId: "",
+      name: `Span ${index + 1}`,
+      durationMs: index + 1,
+    }));
+    render(
+      <ErrorTracePanel
+        occurrence={occurrence}
+        spans={spans}
+        isPending={false}
+        isError={false}
+        onRetry={vi.fn()}
+        renderTraceLink={({ traceId, children }) => (
+          <a href={`/traces/${traceId}`}>{children}</a>
+        )}
+      />,
+    );
+
+    expect(screen.getAllByRole("listitem")).toHaveLength(10);
+    expect(screen.getByText("Span 10")).toBeInTheDocument();
+    expect(screen.queryByText("Span 11")).not.toBeInTheDocument();
+    expect(screen.getByText("...")).toBeInTheDocument();
+  });
+
   it("renders nothing without a trace id", () => {
     const { container } = render(
       <ErrorTracePanel

--- a/packages/telemetry-explorer/src/errors/ui/error-trace-panel.tsx
+++ b/packages/telemetry-explorer/src/errors/ui/error-trace-panel.tsx
@@ -8,6 +8,8 @@ import type { ReactNode } from "react";
 import type { ErrorOccurrence, RelatedSpan } from "../data/types";
 import { getErrorTraceWindow } from "./trace-window";
 
+const RELATED_TRACE_ITEM_LIMIT = 10;
+
 export type RenderTraceLink = (input: {
   traceId: string;
   spanId: string;
@@ -43,6 +45,8 @@ export function ErrorTracePanel({
   if (occurrence.traceId.trim().length === 0) return null;
 
   const window = getErrorTraceWindow(occurrence.timestamp);
+  const visibleSpans = spans.slice(0, RELATED_TRACE_ITEM_LIMIT);
+  const hasMoreSpans = spans.length > RELATED_TRACE_ITEM_LIMIT;
 
   return (
     <section className="min-w-0 rounded-md border bg-background">
@@ -99,54 +103,61 @@ export function ErrorTracePanel({
             No spans were found for this trace.
           </p>
         ) : (
-          <ol className="divide-y">
-            {spans.map((span) => {
-              const isErrorSpan = span.spanId === errorSpanId;
-              return (
-                <li
-                  key={span.spanId}
-                  className={cn(
-                    "grid min-w-0 gap-2 px-3 py-2 md:grid-cols-[minmax(0,1fr)_auto]",
-                    isErrorSpan &&
-                      "border-l-2 border-l-destructive bg-destructive/10 pl-2.5",
-                  )}
-                >
-                  <div className="min-w-0">
-                    <div className="flex min-w-0 items-center gap-2">
-                      <span className="truncate text-sm font-medium">
-                        {span.name || "Unnamed span"}
-                      </span>
-                      <Badge
-                        variant={isErrorSpan ? "destructive" : "secondary"}
-                      >
-                        {spanStatusLabel(span, isErrorSpan)}
-                      </Badge>
-                    </div>
-                    <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-                      <span className="font-mono" title={span.spanId}>
-                        {span.spanId}
-                      </span>
-                      {span.parentSpanId ? (
-                        <span className="font-mono" title={span.parentSpanId}>
-                          parent {span.parentSpanId}
+          <>
+            <ol className="divide-y">
+              {visibleSpans.map((span) => {
+                const isErrorSpan = span.spanId === errorSpanId;
+                return (
+                  <li
+                    key={span.spanId}
+                    className={cn(
+                      "grid min-w-0 gap-2 px-3 py-2 md:grid-cols-[minmax(0,1fr)_auto]",
+                      isErrorSpan &&
+                        "border-l-2 border-l-destructive bg-destructive/10 pl-2.5",
+                    )}
+                  >
+                    <div className="min-w-0">
+                      <div className="flex min-w-0 items-center gap-2">
+                        <span className="truncate text-sm font-medium">
+                          {span.name || "Unnamed span"}
                         </span>
-                      ) : (
-                        <span>root span</span>
-                      )}
+                        <Badge
+                          variant={isErrorSpan ? "destructive" : "secondary"}
+                        >
+                          {spanStatusLabel(span, isErrorSpan)}
+                        </Badge>
+                      </div>
+                      <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                        <span className="font-mono" title={span.spanId}>
+                          {span.spanId}
+                        </span>
+                        {span.parentSpanId ? (
+                          <span className="font-mono" title={span.parentSpanId}>
+                            parent {span.parentSpanId}
+                          </span>
+                        ) : (
+                          <span>root span</span>
+                        )}
+                      </div>
                     </div>
-                  </div>
-                  <div className="flex items-center gap-2 text-xs text-muted-foreground md:justify-end">
-                    {span.jobName ? (
-                      <Badge variant="outline">{span.jobName}</Badge>
-                    ) : null}
-                    <span className="font-mono">
-                      {formatDuration(span.durationMs, "ms")}
-                    </span>
-                  </div>
-                </li>
-              );
-            })}
-          </ol>
+                    <div className="flex items-center gap-2 text-xs text-muted-foreground md:justify-end">
+                      {span.jobName ? (
+                        <Badge variant="outline">{span.jobName}</Badge>
+                      ) : null}
+                      <span className="font-mono">
+                        {formatDuration(span.durationMs, "ms")}
+                      </span>
+                    </div>
+                  </li>
+                );
+              })}
+            </ol>
+            {hasMoreSpans ? (
+              <div className="border-t px-3 py-2 text-sm text-muted-foreground">
+                ...
+              </div>
+            ) : null}
+          </>
         )}
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Limit the related trace panel to 10 rendered span items.
- Show `...` when additional related spans exist.
- Add a regression test for the overflow case.

## Checks
- `pnpm biome check packages/telemetry-explorer/src/errors/ui/error-trace-panel.tsx packages/telemetry-explorer/src/errors/ui/error-pages.test.tsx`
- `pnpm --filter @everr/telemetry-explorer test src/errors/ui/error-pages.test.tsx`
- `pnpm --filter @everr/telemetry-explorer typecheck`