### PR TITLE
Fix absolute timestamp parsing in error routes

### DIFF
--- a/packages/app/src/routes/_authenticated/_dashboard/errors.test.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/errors.test.tsx
@@ -12,7 +12,7 @@ import { describe, expect, it } from "vitest";
 import { Route as ErrorsFileRoute } from "./errors";
 
 describe("/errors route", () => {
-  it("renders the detail child route for an error fingerprint", async () => {
+  function renderErrorsRoute(initialEntry: string) {
     const rootRoute = createRootRoute({
       component: Outlet,
     });
@@ -29,6 +29,7 @@ describe("/errors route", () => {
     const errorsRoute = createRoute({
       getParentRoute: () => dashboardRoute,
       path: "errors",
+      validateSearch: ErrorsFileRoute.options.validateSearch,
       component: ErrorsFileRoute.options.component,
     });
     const errorDetailRoute = createRoute({
@@ -45,7 +46,7 @@ describe("/errors route", () => {
     ]);
     const router = createRouter({
       routeTree,
-      history: createMemoryHistory({ initialEntries: ["/errors/fp-1"] }),
+      history: createMemoryHistory({ initialEntries: [initialEntry] }),
     });
 
     const queryClient = new QueryClient({
@@ -56,6 +57,20 @@ describe("/errors route", () => {
       <QueryClientProvider client={queryClient}>
         <RouterProvider router={router} />
       </QueryClientProvider>,
+    );
+  }
+
+  it("renders the detail child route for an error fingerprint", async () => {
+    renderErrorsRoute("/errors/fp-1");
+
+    expect(
+      await screen.findByText("Error detail child route"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the detail child route with absolute time search params", async () => {
+    renderErrorsRoute(
+      "/errors/fp-1?from=2026-06-04%2018%3A45%3A10.869&to=2026-06-04%2018%3A55%3A10.869",
     );
 
     expect(

--- a/packages/datemath/src/parse.test.ts
+++ b/packages/datemath/src/parse.test.ts
@@ -18,6 +18,13 @@ describe("parse", () => {
     });
   });
 
+  it("parses absolute anchor with a space between date and time", () => {
+    expect(parse("2024-01-15 10:30:00.123")).toEqual({
+      anchor: "2024-01-15 10:30:00.123",
+      ops: [],
+    });
+  });
+
   it("parses now with subtract", () => {
     expect(parse("now-7d")).toEqual({
       anchor: "now",
@@ -73,7 +80,7 @@ describe("parse", () => {
     }
   });
 
-  it("strips whitespace", () => {
+  it("ignores whitespace around operators", () => {
     expect(parse("now - 7d")).toEqual(parse("now-7d"));
   });
 

--- a/packages/datemath/src/parse.ts
+++ b/packages/datemath/src/parse.ts
@@ -21,7 +21,7 @@ const VALID_UNITS = new Set<string>(["s", "m", "h", "d", "w", "M", "y"]);
  * ```
  */
 export function parse(expression: string): DateMathExpression {
-  const input = expression.replace(/\s/g, "");
+  const input = normalizeExpression(expression);
 
   if (input.length === 0) {
     throw new DateMathError("Empty expression", expression);
@@ -59,6 +59,23 @@ export function parse(expression: string): DateMathExpression {
   const ops = parseMathOps(mathPart, expression);
 
   return { anchor, ops };
+}
+
+function normalizeExpression(expression: string): string {
+  const trimmed = expression.trim();
+  const separatorIndex = trimmed.indexOf("||");
+
+  if (separatorIndex !== -1) {
+    const anchor = trimmed.slice(0, separatorIndex).trim();
+    const mathPart = trimmed.slice(separatorIndex + 2).replace(/\s/g, "");
+    return `${anchor}||${mathPart}`;
+  }
+
+  if (trimmed.startsWith("now")) {
+    return trimmed.replace(/\s/g, "");
+  }
+
+  return trimmed;
 }
 
 function parseMathOps(math: string, expression: string): DateMathOp[] {


### PR DESCRIPTION
## Summary
- Preserve whitespace inside absolute date anchors in the date-math parser.
- Keep whitespace normalization for relative expressions like `now - 7d`.
- Add route coverage for `/errors/:fingerprint` with absolute `from`/`to` search params.

## Why
The parser previously removed all whitespace before validating expressions. That turned timestamps like `2026-06-04 18:45:10.869` into invalid anchors and could make `/errors/:fingerprint` fail during search-param validation.

## Checks
- `pnpm --filter @everr/datemath test -- src/parse.test.ts`
- `pnpm --filter @everr/app test:ci -- src/routes/_authenticated/_dashboard/errors.test.tsx`
- `pnpm exec biome check packages/datemath/src/parse.ts packages/datemath/src/parse.test.ts packages/app/src/routes/_authenticated/_dashboard/errors.test.tsx`
