### PR TITLE
Use Changesets for desktop releases

### DIFF
--- a/.github/workflows/deploy-desktop-app.yml
+++ b/.github/workflows/deploy-desktop-app.yml
@@ -10,11 +10,47 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".changeset/**"
+      - ".github/workflows/deploy-desktop-app.yml"
+      - "packages/desktop-app/CHANGELOG.md"
+      - "packages/desktop-app/package.json"
+      - "packages/desktop-app/scripts/desktop-release-gate.ts"
+      - "packages/desktop-app/src-tauri/Cargo.toml"
+      - "packages/desktop-app/src-tauri/tauri.conf.json"
 
 jobs:
+  release-gate:
+    name: Check Desktop Changeset Release
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    outputs:
+      should_release: ${{ steps.gate.outputs.should_release }}
+      version: ${{ steps.gate.outputs.version }}
+      artifact_name: ${{ steps.gate.outputs.artifact_name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Evaluate desktop release gate
+        id: gate
+        run: |
+          node packages/desktop-app/scripts/desktop-release-gate.ts \
+            --base "${{ github.event.before }}" \
+            --head "${{ github.sha }}"
+
   build:
     name: Build, Sign, Notarize
+    needs: release-gate
+    if: needs.release-gate.outputs.should_release == 'true'
     runs-on: blacksmith-6vcpu-macos-15
     timeout-minutes: 60
     env:
@@ -191,7 +227,7 @@ jobs:
         id: upload-desktop-release
         uses: actions/upload-artifact@v4
         with:
-          name: everr-desktop-release-${{ github.sha }}
+          name: everr-desktop-release-${{ needs.release-gate.outputs.version }}
           path: target/desktop-release
           if-no-files-found: error
           retention-days: 14
@@ -201,7 +237,7 @@ jobs:
           {
             echo "## Desktop release artifact"
             echo
-            echo "- Artifact name: everr-desktop-release-${GITHUB_SHA}"
+            echo "- Artifact name: ${{ needs.release-gate.outputs.artifact_name }}"
             echo "- Artifact ID: ${{ steps.upload-desktop-release.outputs.artifact-id }}"
             echo "- Artifact digest: ${{ steps.upload-desktop-release.outputs.artifact-digest }}"
             echo
@@ -221,18 +257,11 @@ jobs:
   notify-deploy:
     name: Notify Deploy Repo
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    needs: build
+    needs:
+      - release-gate
+      - build
+    if: needs.release-gate.outputs.should_release == 'true'
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Read desktop app version
-        id: version
-        run: |
-          set -euo pipefail
-          version="$(node -p "require('./packages/desktop-app/package.json').version")"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@v3
@@ -253,6 +282,6 @@ jobs:
               "source_repo": "${{ github.repository }}",
               "run_id": "${{ github.run_id }}",
               "sha": "${{ github.sha }}",
-              "version": "${{ steps.version.outputs.version }}",
-              "artifact_name": "everr-desktop-release-${{ github.sha }}"
+              "version": "${{ needs.release-gate.outputs.version }}",
+              "artifact_name": "${{ needs.release-gate.outputs.artifact_name }}"
             }

--- a/docs/desktop-release-secrets.md
+++ b/docs/desktop-release-secrets.md
@@ -118,12 +118,15 @@ The release workflow requires this secret before building. During the Tauri rele
 
 Workflow: **Deploy Desktop App**
 
-Run it manually from GitHub Actions. CI uses the commit SHA as the release identity and generates the numeric Tauri/macOS updater version from the checked-in development version plus the workflow run number.
+The workflow runs on `main` pushes from the Changesets version PR. It releases
+only when the merged diff deletes a `.changeset` file that targets
+`@everr/desktop-app`, and it uses the checked-in desktop app version as the
+Tauri/macOS updater version.
 
 The uploaded artifact is named:
 
 ```text
-everr-desktop-release-<git-sha>
+everr-desktop-release-<version>
 ```
 
 It contains:
@@ -151,7 +154,7 @@ Using the GitHub CLI:
 ```bash
 gh run download <run-id> \
   --repo everr-labs/everr \
-  --name everr-desktop-release-<git-sha> \
+  --name everr-desktop-release-<version> \
   --dir ./desktop-release
 ```
 
@@ -164,7 +167,7 @@ Using `actions/download-artifact` in the deploy repo:
     github-token: ${{ secrets.EVERR_SOURCE_REPO_TOKEN }}
     repository: everr-labs/everr
     run-id: ${{ inputs.source_run_id }}
-    name: everr-desktop-release-${{ inputs.source_sha }}
+    name: ${{ inputs.artifact_name }}
     path: ./desktop-release
 ```
 

--- a/packages/desktop-app/README.md
+++ b/packages/desktop-app/README.md
@@ -26,10 +26,9 @@ CI uses the same release path through:
 pnpm build:desktop:ci
 ```
 
-CI uses the commit SHA as the human release identity and generates the numeric
-Tauri/macOS updater version from the checked-in development version plus the
-workflow run number. The checked-in version stays as the local development
-fallback.
+CI releases only when the Changesets version PR consumes a changeset for
+`@everr/desktop-app`. The checked-in Changesets version is the Tauri/macOS
+updater version; the commit SHA is kept only as release metadata.
 
 Install the signed release CLI into `~/.local/bin` only when you explicitly opt in:
 

--- a/packages/desktop-app/scripts/build-support.test.ts
+++ b/packages/desktop-app/scripts/build-support.test.ts
@@ -61,7 +61,7 @@ afterEach(async () => {
 });
 
 describe("build-support version helpers", () => {
-  it("derives CI release identity from GitHub Actions env vars", () => {
+  it("uses the checked-in desktop version for GitHub Actions release identity", () => {
     expect(
       resolveDesktopReleaseIdentity({
         env: {
@@ -72,7 +72,7 @@ describe("build-support version helpers", () => {
         fallbackSha: "localsha",
       }),
     ).toEqual({
-      platformVersion: "0.1.1264",
+      platformVersion: "0.1.30",
       releaseSha: "82efe1cf1358e8395b2862c4ee9f93567f10c16e",
       releaseShortSha: "82efe1c",
       source: "github-actions",
@@ -114,8 +114,8 @@ describe("build-support version helpers", () => {
     });
   });
 
-  it("rejects invalid generated platform versions", () => {
-    expect(() =>
+  it("does not use GitHub run number when resolving release identity", () => {
+    expect(
       resolveDesktopReleaseIdentity({
         env: {
           GITHUB_SHA: "82efe1cf1358e8395b2862c4ee9f93567f10c16e",
@@ -124,7 +124,12 @@ describe("build-support version helpers", () => {
         fallbackVersion: "0.1.30",
         fallbackSha: "localsha",
       }),
-    ).toThrow(/GITHUB_RUN_NUMBER/);
+    ).toEqual({
+      platformVersion: "0.1.30",
+      releaseSha: "82efe1cf1358e8395b2862c4ee9f93567f10c16e",
+      releaseShortSha: "82efe1c",
+      source: "github-actions",
+    });
   });
 
   it("writes a Tauri config override with the generated platform version", async () => {

--- a/packages/desktop-app/scripts/build-support.ts
+++ b/packages/desktop-app/scripts/build-support.ts
@@ -15,7 +15,7 @@ import path from "node:path";
 import { pipeline } from "node:stream/promises";
 import { fileURLToPath } from "node:url";
 import { createGzip } from "node:zlib";
-import { parse as parseVersion, valid as validVersion } from "semver";
+import { valid as validVersion } from "semver";
 import { $ } from "zx";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
@@ -342,30 +342,6 @@ function releaseShortSha(releaseSha: string) {
   return releaseSha === "unknown" ? "unknown" : releaseSha.slice(0, 7);
 }
 
-function normalizeGithubRunNumber(value: string) {
-  const trimmed = value.trim();
-  if (!/^[1-9][0-9]*$/.test(trimmed)) {
-    throw new Error(
-      `GITHUB_RUN_NUMBER must be a positive integer to generate a desktop platform version; got "${value}".`,
-    );
-  }
-
-  return trimmed;
-}
-
-function buildGithubActionsPlatformVersion(fallbackVersion: string, githubRunNumber: string) {
-  const parsed = parseVersion(normalizeDesktopVersion(fallbackVersion));
-  if (!parsed) {
-    throw new Error(
-      `Unsupported desktop app version "${fallbackVersion}". Expected a semantic version in the form X.Y.Z.`,
-    );
-  }
-
-  return normalizeDesktopVersion(
-    `${parsed.major}.${parsed.minor}.${parsed.patch + Number(githubRunNumber)}`,
-  );
-}
-
 function normalizeReleaseSha(value: string) {
   const trimmed = value.trim();
   if (!/^[0-9a-f]{7,40}$/i.test(trimmed)) {
@@ -396,19 +372,15 @@ export function resolveDesktopReleaseIdentity({
       platformVersion,
       releaseSha,
       releaseShortSha: envReleaseShortSha || releaseShortSha(releaseSha),
-      source: env.GITHUB_SHA && env.GITHUB_RUN_NUMBER ? "github-actions" : "local",
+      source: env.GITHUB_SHA ? "github-actions" : "local",
     };
   }
 
   const githubSha = env.GITHUB_SHA?.trim();
-  const githubRunNumber = env.GITHUB_RUN_NUMBER?.trim();
 
-  if (githubSha && githubRunNumber) {
+  if (githubSha) {
     const releaseSha = normalizeReleaseSha(githubSha);
-    const platformVersion = buildGithubActionsPlatformVersion(
-      fallbackVersion,
-      normalizeGithubRunNumber(githubRunNumber),
-    );
+    const platformVersion = normalizeDesktopVersion(fallbackVersion);
 
     return {
       platformVersion,

--- a/packages/desktop-app/scripts/desktop-release-gate.test.ts
+++ b/packages/desktop-app/scripts/desktop-release-gate.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluateDesktopReleaseGate,
+  parseCargoPackageVersion,
+  targetsDesktopPackage,
+} from "./desktop-release-gate";
+
+const desktopChangeset = `---
+"@everr/desktop-app": patch
+---
+
+Desktop release notes.
+`;
+
+describe("desktop release gate", () => {
+  it("releases when a deleted changeset targets the desktop app and versions match", () => {
+    expect(
+      evaluateDesktopReleaseGate({
+        deletedChangesets: [
+          {
+            path: ".changeset/desktop-release.md",
+            contents: desktopChangeset,
+          },
+        ],
+        packageVersion: "0.1.32",
+        tauriVersion: "0.1.32",
+        cargoVersion: "0.1.32",
+      }),
+    ).toEqual({
+      shouldRelease: true,
+      version: "0.1.32",
+      artifactName: "everr-desktop-release-0.1.32",
+      reason: "Deleted changeset .changeset/desktop-release.md targets @everr/desktop-app.",
+    });
+  });
+
+  it("skips when deleted changesets do not target the desktop app", () => {
+    expect(
+      evaluateDesktopReleaseGate({
+        deletedChangesets: [
+          {
+            path: ".changeset/action-release.md",
+            contents: `---
+"@everr/action": patch
+---
+
+Action release notes mention @everr/desktop-app in the body only.
+`,
+          },
+        ],
+        packageVersion: "0.1.32",
+        tauriVersion: "0.1.32",
+        cargoVersion: "0.1.32",
+      }),
+    ).toEqual({
+      shouldRelease: false,
+      reason: "No deleted changeset targets @everr/desktop-app.",
+    });
+  });
+
+  it("fails when desktop versions disagree", () => {
+    expect(() =>
+      evaluateDesktopReleaseGate({
+        deletedChangesets: [
+          {
+            path: ".changeset/desktop-release.md",
+            contents: desktopChangeset,
+          },
+        ],
+        packageVersion: "0.1.32",
+        tauriVersion: "0.1.31",
+        cargoVersion: "0.1.32",
+      }),
+    ).toThrow(
+      "Desktop release versions must match: package.json=0.1.32, tauri.conf.json=0.1.31, Cargo.toml=0.1.32.",
+    );
+  });
+
+  it("fails when the desktop package version is not semantic", () => {
+    expect(() =>
+      evaluateDesktopReleaseGate({
+        deletedChangesets: [
+          {
+            path: ".changeset/desktop-release.md",
+            contents: desktopChangeset,
+          },
+        ],
+        packageVersion: "82efe1c",
+        tauriVersion: "82efe1c",
+        cargoVersion: "82efe1c",
+      }),
+    ).toThrow('Unsupported desktop app version "82efe1c". Expected X.Y.Z.');
+  });
+
+  it("detects the desktop package only in changeset frontmatter", () => {
+    expect(targetsDesktopPackage(desktopChangeset)).toBe(true);
+    expect(
+      targetsDesktopPackage(`---
+"@everr/action": patch
+---
+
+Body mentions @everr/desktop-app.
+`),
+    ).toBe(false);
+  });
+
+  it("reads the Cargo package version", () => {
+    expect(
+      parseCargoPackageVersion(`[workspace]
+members = []
+
+[package]
+name = "everr-app"
+version = "0.1.32"
+edition = "2021"
+`),
+    ).toBe("0.1.32");
+  });
+});

--- a/packages/desktop-app/scripts/desktop-release-gate.ts
+++ b/packages/desktop-app/scripts/desktop-release-gate.ts
@@ -1,0 +1,277 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { appendFile, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCallback);
+
+const DESKTOP_PACKAGE_NAME = "@everr/desktop-app";
+const ZERO_SHA = /^0{40}$/;
+
+export type DeletedChangeset = {
+  path: string;
+  contents: string;
+};
+
+export type DesktopReleaseGateInput = {
+  deletedChangesets: DeletedChangeset[];
+  packageVersion: string;
+  tauriVersion: string;
+  cargoVersion: string;
+};
+
+export type DesktopReleaseGateResult =
+  | {
+      shouldRelease: true;
+      version: string;
+      artifactName: string;
+      reason: string;
+    }
+  | {
+      shouldRelease: false;
+      reason: string;
+    };
+
+function normalizeDesktopVersion(version: string) {
+  const trimmed = version.trim();
+  if (
+    !/^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(
+      trimmed,
+    )
+  ) {
+    throw new Error(`Unsupported desktop app version "${version}". Expected X.Y.Z.`);
+  }
+
+  return trimmed;
+}
+
+function changesetFrontmatter(contents: string) {
+  const lines = contents.trimStart().split(/\r?\n/);
+  if (lines[0]?.trim() !== "---") {
+    return "";
+  }
+
+  const end = lines.findIndex((line, index) => index > 0 && line.trim() === "---");
+  if (end === -1) {
+    return "";
+  }
+
+  return lines.slice(1, end).join("\n");
+}
+
+export function targetsDesktopPackage(contents: string) {
+  return /^['"]?@everr\/desktop-app['"]?\s*:/m.test(changesetFrontmatter(contents));
+}
+
+export function parseCargoPackageVersion(contents: string) {
+  const lines = contents.split(/\r?\n/);
+  let inPackageSection = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+      inPackageSection = trimmed === "[package]";
+      continue;
+    }
+
+    if (inPackageSection) {
+      const match = /^\s*version\s*=\s*"([^"]+)"\s*$/.exec(line);
+      if (match) {
+        return match[1];
+      }
+    }
+  }
+
+  throw new Error("Could not find [package].version in Cargo.toml.");
+}
+
+export function evaluateDesktopReleaseGate(
+  input: DesktopReleaseGateInput,
+): DesktopReleaseGateResult {
+  const desktopChangeset = input.deletedChangesets.find((changeset) =>
+    targetsDesktopPackage(changeset.contents),
+  );
+
+  if (!desktopChangeset) {
+    return {
+      shouldRelease: false,
+      reason: `No deleted changeset targets ${DESKTOP_PACKAGE_NAME}.`,
+    };
+  }
+
+  const packageVersion = normalizeDesktopVersion(input.packageVersion);
+  const tauriVersion = normalizeDesktopVersion(input.tauriVersion);
+  const cargoVersion = normalizeDesktopVersion(input.cargoVersion);
+
+  if (packageVersion !== tauriVersion || packageVersion !== cargoVersion) {
+    throw new Error(
+      `Desktop release versions must match: package.json=${packageVersion}, tauri.conf.json=${tauriVersion}, Cargo.toml=${cargoVersion}.`,
+    );
+  }
+
+  return {
+    shouldRelease: true,
+    version: packageVersion,
+    artifactName: `everr-desktop-release-${packageVersion}`,
+    reason: `Deleted changeset ${desktopChangeset.path} targets ${DESKTOP_PACKAGE_NAME}.`,
+  };
+}
+
+function parseArgs(args: string[]) {
+  let base: string | undefined;
+  let head: string | undefined;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--base") {
+      base = args[++index];
+      continue;
+    }
+    if (arg === "--head") {
+      head = args[++index];
+      continue;
+    }
+    throw new Error(`Unsupported argument: ${arg}`);
+  }
+
+  if (!base || !head) {
+    throw new Error("Usage: desktop-release-gate.ts --base <sha> --head <sha>");
+  }
+
+  return { base, head };
+}
+
+async function git(args: string[], cwd: string) {
+  const result = await execFile("git", args, {
+    cwd,
+    maxBuffer: 1024 * 1024,
+  });
+  return result.stdout.trimEnd();
+}
+
+async function listDeletedChangesets({
+  base,
+  head,
+  cwd,
+}: {
+  base: string;
+  head: string;
+  cwd: string;
+}) {
+  if (ZERO_SHA.test(base)) {
+    return [];
+  }
+
+  const stdout = await git(
+    ["diff", "--name-status", "--diff-filter=D", base, head, "--", ".changeset"],
+    cwd,
+  );
+
+  return stdout
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => line.split("\t"))
+    .filter(([status, filename]) => status === "D" && filename?.endsWith(".md"))
+    .map(([, filename]) => filename);
+}
+
+async function readDeletedChangesets({
+  base,
+  paths,
+  cwd,
+}: {
+  base: string;
+  paths: string[];
+  cwd: string;
+}): Promise<DeletedChangeset[]> {
+  return Promise.all(
+    paths.map(async (changesetPath) => ({
+      path: changesetPath,
+      contents: await git(["show", `${base}:${changesetPath}`], cwd),
+    })),
+  );
+}
+
+async function readDesktopVersions(cwd: string) {
+  const packageJsonPath = path.join(cwd, "packages", "desktop-app", "package.json");
+  const tauriConfigPath = path.join(
+    cwd,
+    "packages",
+    "desktop-app",
+    "src-tauri",
+    "tauri.conf.json",
+  );
+  const cargoTomlPath = path.join(
+    cwd,
+    "packages",
+    "desktop-app",
+    "src-tauri",
+    "Cargo.toml",
+  );
+
+  const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as {
+    version?: string;
+  };
+  const tauriConfig = JSON.parse(await readFile(tauriConfigPath, "utf8")) as {
+    version?: string;
+  };
+  const cargoToml = await readFile(cargoTomlPath, "utf8");
+
+  if (!packageJson.version) {
+    throw new Error(`Could not find version in ${packageJsonPath}.`);
+  }
+  if (!tauriConfig.version) {
+    throw new Error(`Could not find version in ${tauriConfigPath}.`);
+  }
+
+  return {
+    packageVersion: packageJson.version,
+    tauriVersion: tauriConfig.version,
+    cargoVersion: parseCargoPackageVersion(cargoToml),
+  };
+}
+
+async function writeOutputs(
+  result: DesktopReleaseGateResult,
+  outputPath = process.env.GITHUB_OUTPUT,
+) {
+  const outputs = [`should_release=${result.shouldRelease ? "true" : "false"}`];
+  if (result.shouldRelease) {
+    outputs.push(`version=${result.version}`);
+    outputs.push(`artifact_name=${result.artifactName}`);
+  }
+
+  if (outputPath) {
+    await appendFile(outputPath, `${outputs.join("\n")}\n`);
+  } else {
+    console.log(outputs.join("\n"));
+  }
+}
+
+export async function runDesktopReleaseGate(
+  args = process.argv.slice(2),
+  cwd = process.cwd(),
+) {
+  const { base, head } = parseArgs(args);
+  const paths = await listDeletedChangesets({ base, head, cwd });
+  const deletedChangesets = await readDeletedChangesets({ base, paths, cwd });
+  const versions = await readDesktopVersions(cwd);
+  const result = evaluateDesktopReleaseGate({
+    deletedChangesets,
+    ...versions,
+  });
+
+  console.log(result.reason);
+  await writeOutputs(result);
+  return result;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    await runDesktopReleaseGate();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/packages/desktop-app/scripts/desktop-release-workflow.test.ts
+++ b/packages/desktop-app/scripts/desktop-release-workflow.test.ts
@@ -12,7 +12,29 @@ describe("desktop release workflow", () => {
 
     expect(workflow).toContain("name: Deploy Desktop App");
     expect(workflow).toContain("event-type: desktop-app-release");
-    expect(workflow).toContain('"artifact_name": "everr-desktop-release-${{ github.sha }}"');
+    expect(workflow).toContain(
+      '"artifact_name": "${{ needs.release-gate.outputs.artifact_name }}"',
+    );
+  });
+
+  it("runs from main pushes and not manual dispatch", async () => {
+    const workflow = await readFile(workflowPath, "utf8");
+
+    expect(workflow).toContain("push:");
+    expect(workflow).toContain("branches: [main]");
+    expect(workflow).toContain("packages/desktop-app/package.json");
+    expect(workflow).not.toContain("workflow_dispatch");
+  });
+
+  it("gates releases on a consumed desktop app changeset", async () => {
+    const workflow = await readFile(workflowPath, "utf8");
+
+    expect(workflow).toContain("release-gate:");
+    expect(workflow).toContain("node packages/desktop-app/scripts/desktop-release-gate.ts");
+    expect(workflow).toContain("if: needs.release-gate.outputs.should_release == 'true'");
+    expect(workflow).toContain(
+      "name: everr-desktop-release-${{ needs.release-gate.outputs.version }}",
+    );
   });
 
   it("assesses the DMG with the primary-signature Gatekeeper context", async () => {


### PR DESCRIPTION
## Summary
- Make the desktop deploy workflow run from Changesets version PR merges instead of manual dispatch.
- Add a release gate that requires a consumed @everr/desktop-app changeset and matching package/Tauri/Cargo versions.
- Use version-based desktop release artifact names and update release docs.

## Test Plan
- pnpm --filter @everr/desktop-app test
- pnpm --filter @everr/desktop-app exec tsc --noEmit
- git diff --check
- node packages/desktop-app/scripts/desktop-release-gate.ts --base 0000000000000000000000000000000000000000 --head f54e330c7e0cc93f56088a4e0afc2b19ca5be606