### PR TITLE
Implement account deletion

### DIFF
--- a/packages/app/src/data/account-settings.test.ts
+++ b/packages/app/src/data/account-settings.test.ts
@@ -1,0 +1,85 @@
+import { getRequestHeaders } from "@tanstack/react-start/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { auth } from "@/lib/auth.server";
+import { deleteCurrentUserAccount } from "./account-settings";
+
+vi.mock("@tanstack/react-start/server", () => ({
+  getRequestHeaders: vi.fn(() => new Headers({ cookie: "session=test" })),
+}));
+
+type OrgMember = {
+  userId: string;
+  role: string;
+};
+
+function activeOrg(members: OrgMember[]) {
+  return {
+    id: "test_org",
+    name: "Test Org",
+    members,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("deleteCurrentUserAccount", () => {
+  it("deletes the current user without deleting the active organization by default", async () => {
+    await deleteCurrentUserAccount({ data: { confirmation: "DELETE" } });
+
+    expect(auth.api.getFullOrganization).not.toHaveBeenCalled();
+    expect(auth.api.deleteOrganization).not.toHaveBeenCalled();
+    expect(auth.api.deleteUser).toHaveBeenCalledWith({
+      headers: expect.any(Headers),
+      body: {},
+    });
+  });
+
+  it("deletes the active organization first when an org admin chooses that option", async () => {
+    vi.mocked(auth.api.getFullOrganization).mockResolvedValueOnce(
+      activeOrg([{ userId: "test_user", role: "admin" }]) as never,
+    );
+
+    await deleteCurrentUserAccount({
+      data: { confirmation: "DELETE", deleteOrganization: true },
+    });
+
+    expect(auth.api.getFullOrganization).toHaveBeenCalledWith({
+      headers: expect.any(Headers),
+      query: { organizationId: "test_org" },
+    });
+    expect(auth.api.deleteOrganization).toHaveBeenCalledWith({
+      headers: expect.any(Headers),
+      body: { organizationId: "test_org" },
+    });
+    expect(auth.api.deleteUser).toHaveBeenCalledWith({
+      headers: expect.any(Headers),
+      body: {},
+    });
+    expect(
+      vi.mocked(auth.api.deleteOrganization).mock.invocationCallOrder[0],
+    ).toBeLessThan(vi.mocked(auth.api.deleteUser).mock.invocationCallOrder[0]);
+  });
+
+  it("rejects organization deletion when the current user is not an org admin", async () => {
+    vi.mocked(auth.api.getFullOrganization).mockResolvedValueOnce(
+      activeOrg([{ userId: "test_user", role: "member" }]) as never,
+    );
+
+    await expect(
+      deleteCurrentUserAccount({
+        data: { confirmation: "DELETE", deleteOrganization: true },
+      }),
+    ).rejects.toThrow("Only organization admins can delete the organization");
+
+    expect(auth.api.deleteOrganization).not.toHaveBeenCalled();
+    expect(auth.api.deleteUser).not.toHaveBeenCalled();
+  });
+
+  it("uses the current request headers for Better Auth operations", async () => {
+    await deleteCurrentUserAccount({ data: { confirmation: "DELETE" } });
+
+    expect(getRequestHeaders).toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/data/account-settings.test.ts
+++ b/packages/app/src/data/account-settings.test.ts
@@ -36,9 +36,9 @@ describe("deleteCurrentUserAccount", () => {
     });
   });
 
-  it("deletes the active organization first when an org admin chooses that option", async () => {
+  it("deletes the active organization first when an org owner chooses that option", async () => {
     vi.mocked(auth.api.getFullOrganization).mockResolvedValueOnce(
-      activeOrg([{ userId: "test_user", role: "admin" }]) as never,
+      activeOrg([{ userId: "test_user", role: "owner" }]) as never,
     );
 
     await deleteCurrentUserAccount({
@@ -62,16 +62,16 @@ describe("deleteCurrentUserAccount", () => {
     ).toBeLessThan(vi.mocked(auth.api.deleteUser).mock.invocationCallOrder[0]);
   });
 
-  it("rejects organization deletion when the current user is not an org admin", async () => {
+  it("rejects organization deletion when the current user is not an org owner", async () => {
     vi.mocked(auth.api.getFullOrganization).mockResolvedValueOnce(
-      activeOrg([{ userId: "test_user", role: "member" }]) as never,
+      activeOrg([{ userId: "test_user", role: "admin" }]) as never,
     );
 
     await expect(
       deleteCurrentUserAccount({
         data: { confirmation: "DELETE", deleteOrganization: true },
       }),
-    ).rejects.toThrow("Only organization admins can delete the organization");
+    ).rejects.toThrow("Only organization owners can delete the organization");
 
     expect(auth.api.deleteOrganization).not.toHaveBeenCalled();
     expect(auth.api.deleteUser).not.toHaveBeenCalled();

--- a/packages/app/src/data/account-settings.ts
+++ b/packages/app/src/data/account-settings.ts
@@ -8,12 +8,12 @@ const DeleteCurrentUserAccountInputSchema = z.object({
   deleteOrganization: z.boolean().optional(),
 });
 
-function isOrgAdminRole(role: string | null | undefined) {
+function isOrgOwnerRole(role: string | null | undefined) {
   return (
     role
       ?.split(",")
       .map((part) => part.trim())
-      .some((part) => part === "admin" || part === "owner") ?? false
+      .some((part) => part === "owner") ?? false
   );
 }
 
@@ -33,9 +33,9 @@ export const deleteCurrentUserAccount = createAuthenticatedServerFn({
         (member) => member.userId === session.user.id,
       );
 
-      if (!isOrgAdminRole(currentMember?.role)) {
+      if (!isOrgOwnerRole(currentMember?.role)) {
         throw new Error(
-          "Only organization admins can delete the organization while deleting their account.",
+          "Only organization owners can delete the organization while deleting their account.",
         );
       }
 

--- a/packages/app/src/data/account-settings.ts
+++ b/packages/app/src/data/account-settings.ts
@@ -1,14 +1,52 @@
+import { getRequestHeaders } from "@tanstack/react-start/server";
 import { z } from "zod";
+import { auth } from "@/lib/auth.server";
 import { createAuthenticatedServerFn } from "@/lib/serverFn";
 
 const DeleteCurrentUserAccountInputSchema = z.object({
   confirmation: z.literal("DELETE"),
+  deleteOrganization: z.boolean().optional(),
 });
+
+function isOrgAdminRole(role: string | null | undefined) {
+  return (
+    role
+      ?.split(",")
+      .map((part) => part.trim())
+      .some((part) => part === "admin" || part === "owner") ?? false
+  );
+}
 
 export const deleteCurrentUserAccount = createAuthenticatedServerFn({
   method: "POST",
 })
   .inputValidator(DeleteCurrentUserAccountInputSchema)
-  .handler(() => {
-    throw new Error("Not implemented");
+  .handler(async ({ data, context: { session } }) => {
+    const headers = getRequestHeaders();
+
+    if (data.deleteOrganization) {
+      const org = await auth.api.getFullOrganization({
+        headers,
+        query: { organizationId: session.session.activeOrganizationId },
+      });
+      const currentMember = org?.members.find(
+        (member) => member.userId === session.user.id,
+      );
+
+      if (!isOrgAdminRole(currentMember?.role)) {
+        throw new Error(
+          "Only organization admins can delete the organization while deleting their account.",
+        );
+      }
+
+      await auth.api.deleteOrganization({
+        headers,
+        body: { organizationId: session.session.activeOrganizationId },
+      });
+    }
+
+    await auth.api.deleteUser({
+      headers,
+      body: {},
+    });
   });

--- a/packages/app/src/lib/auth.server.ts
+++ b/packages/app/src/lib/auth.server.ts
@@ -41,6 +41,7 @@ import {
   sendPasswordResetEmail,
   sendVerificationEmail,
 } from "@/lib/email.server";
+import { deletePostgresOrganizationData } from "@/lib/organization-data-cleanup.server";
 import { ensurePolarCustomerForOrg, polarClient } from "@/lib/polar.server";
 import { resolveRetention } from "@/lib/retention";
 import { exceptionAttributes, serverLogger } from "@/telemetry/logger";
@@ -361,6 +362,16 @@ export const auth = betterAuth({
           }
         },
         afterDeleteOrganization: async ({ organization }) => {
+          try {
+            await deletePostgresOrganizationData(organization.id);
+          } catch (error) {
+            serverLogger.error("organization.postgres_data_cleanup.failed", {
+              ...exceptionAttributes(error),
+              "organization.id": organization.id,
+            });
+            throw error;
+          }
+
           try {
             await deprovisionSqlApiOrgUser(organization.id);
           } catch (error) {

--- a/packages/app/src/lib/auth.server.ts
+++ b/packages/app/src/lib/auth.server.ts
@@ -129,7 +129,6 @@ const orgRoles = {
   }),
   admin: orgAc.newRole({
     ...adminAc.statements,
-    organization: ["update", "delete"],
     apiKey: ["create", "read", "update", "delete"],
   }),
   member: orgAc.newRole({

--- a/packages/app/src/lib/auth.server.ts
+++ b/packages/app/src/lib/auth.server.ts
@@ -128,6 +128,7 @@ const orgRoles = {
   }),
   admin: orgAc.newRole({
     ...adminAc.statements,
+    organization: ["update", "delete"],
     apiKey: ["create", "read", "update", "delete"],
   }),
   member: orgAc.newRole({
@@ -152,6 +153,11 @@ export const auth = betterAuth({
     provider: "pg",
   }),
   ...(googleSocialProviders ? { socialProviders: googleSocialProviders } : {}),
+  user: {
+    deleteUser: {
+      enabled: true,
+    },
+  },
   emailAndPassword: {
     enabled: true,
     sendResetPassword: async ({ user, url }) => {

--- a/packages/app/src/lib/organization-data-cleanup.server.test.ts
+++ b/packages/app/src/lib/organization-data-cleanup.server.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockAnd, mockDelete, mockEq, mockTransaction, whereCalls } = vi.hoisted(
+  () => ({
+    mockAnd: vi.fn((...conditions: unknown[]) => ({ type: "and", conditions })),
+    mockDelete: vi.fn(),
+    mockEq: vi.fn((column: unknown, value: unknown) => ({
+      type: "eq",
+      column,
+      value,
+    })),
+    mockTransaction: vi.fn(),
+    whereCalls: [] as Array<{ table: unknown; condition: unknown }>,
+  }),
+);
+
+vi.mock("@/db/client", () => ({
+  db: {
+    transaction: mockTransaction,
+  },
+}));
+
+vi.mock("drizzle-orm", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("drizzle-orm")>();
+  return {
+    ...actual,
+    and: mockAnd,
+    eq: mockEq,
+  };
+});
+
+import {
+  apikey,
+  githubInstallationOrganizations,
+  workflowJobs,
+  workflowRuns,
+} from "@/db/schema";
+import { deletePostgresOrganizationData } from "./organization-data-cleanup.server";
+
+const ORG = "org42";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  whereCalls.length = 0;
+  mockTransaction.mockImplementation(async (callback) =>
+    callback({
+      delete: mockDelete,
+    }),
+  );
+  mockDelete.mockImplementation((table) => ({
+    where: async (condition: unknown) => {
+      whereCalls.push({ table, condition });
+    },
+  }));
+});
+
+describe("deletePostgresOrganizationData", () => {
+  it("deletes non-cascading organization data in a transaction", async () => {
+    await deletePostgresOrganizationData(ORG);
+
+    expect(mockTransaction).toHaveBeenCalledTimes(1);
+    expect(whereCalls.map((call) => call.table)).toEqual([
+      workflowJobs,
+      workflowRuns,
+      githubInstallationOrganizations,
+      apikey,
+    ]);
+    expect(mockEq).toHaveBeenCalledWith(workflowJobs.organizationId, ORG);
+    expect(mockEq).toHaveBeenCalledWith(workflowRuns.organizationId, ORG);
+    expect(mockEq).toHaveBeenCalledWith(
+      githubInstallationOrganizations.organizationId,
+      ORG,
+    );
+    expect(mockEq).toHaveBeenCalledWith(apikey.configId, "ingest");
+    expect(mockEq).toHaveBeenCalledWith(apikey.referenceId, ORG);
+    expect(mockAnd).toHaveBeenCalledWith(
+      { type: "eq", column: apikey.configId, value: "ingest" },
+      { type: "eq", column: apikey.referenceId, value: ORG },
+    );
+  });
+});

--- a/packages/app/src/lib/organization-data-cleanup.server.ts
+++ b/packages/app/src/lib/organization-data-cleanup.server.ts
@@ -1,0 +1,38 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db/client";
+import {
+  apikey,
+  githubInstallationOrganizations,
+  workflowJobs,
+  workflowRuns,
+} from "@/db/schema";
+
+export async function deletePostgresOrganizationData(
+  organizationId: string,
+): Promise<void> {
+  if (!organizationId) {
+    throw new Error("Missing organization id");
+  }
+
+  await db.transaction(async (tx) => {
+    await tx
+      .delete(workflowJobs)
+      .where(eq(workflowJobs.organizationId, organizationId));
+    await tx
+      .delete(workflowRuns)
+      .where(eq(workflowRuns.organizationId, organizationId));
+    await tx
+      .delete(githubInstallationOrganizations)
+      .where(
+        eq(githubInstallationOrganizations.organizationId, organizationId),
+      );
+    await tx
+      .delete(apikey)
+      .where(
+        and(
+          eq(apikey.configId, "ingest"),
+          eq(apikey.referenceId, organizationId),
+        ),
+      );
+  });
+}

--- a/packages/app/src/routes/_authenticated/_dashboard/-account.test.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/-account.test.tsx
@@ -137,7 +137,10 @@ describe("/account route", () => {
       data: {
         id: "test_org",
         name: "Acme",
-        members: [{ userId: "test_user", role: "owner" }],
+        members: [
+          { userId: "test_user", role: "owner" },
+          { userId: "other_owner", role: "owner" },
+        ],
       },
     });
     const Component = Route.options.component as React.ComponentType;
@@ -150,7 +153,7 @@ describe("/account route", () => {
     ).toBeInTheDocument();
   });
 
-  it("requires deleting the organization when the user is its only owner", async () => {
+  it("shows a forced organization deletion notice when the user is its only owner", async () => {
     const user = userEvent.setup();
     mocks.useActiveOrganization.mockReturnValue({
       data: {
@@ -167,9 +170,14 @@ describe("/account route", () => {
 
     await user.click(screen.getByRole("button", { name: "Delete account" }));
 
-    const checkbox = screen.getByLabelText("Delete Acme organization too");
-    expect(checkbox).toBeChecked();
-    expect(checkbox).toBeDisabled();
+    expect(
+      screen.getByText(
+        "This action is also going to delete the Acme organization.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Delete Acme organization too"),
+    ).not.toBeInTheDocument();
   });
 
   it("hides the organization deletion option from organization admins", async () => {

--- a/packages/app/src/routes/_authenticated/_dashboard/-account.test.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/-account.test.tsx
@@ -150,6 +150,28 @@ describe("/account route", () => {
     ).toBeInTheDocument();
   });
 
+  it("requires deleting the organization when the user is its only owner", async () => {
+    const user = userEvent.setup();
+    mocks.useActiveOrganization.mockReturnValue({
+      data: {
+        id: "test_org",
+        name: "Acme",
+        members: [
+          { userId: "test_user", role: "owner" },
+          { userId: "member_user", role: "member" },
+        ],
+      },
+    });
+    const Component = Route.options.component as React.ComponentType;
+    render(<Component />);
+
+    await user.click(screen.getByRole("button", { name: "Delete account" }));
+
+    const checkbox = screen.getByLabelText("Delete Acme organization too");
+    expect(checkbox).toBeChecked();
+    expect(checkbox).toBeDisabled();
+  });
+
   it("hides the organization deletion option from organization admins", async () => {
     const user = userEvent.setup();
     mocks.useActiveOrganization.mockReturnValue({
@@ -175,7 +197,10 @@ describe("/account route", () => {
       data: {
         id: "test_org",
         name: "Acme",
-        members: [{ userId: "test_user", role: "owner" }],
+        members: [
+          { userId: "test_user", role: "owner" },
+          { userId: "other_owner", role: "owner" },
+        ],
       },
     });
     const Component = Route.options.component as React.ComponentType;
@@ -184,6 +209,31 @@ describe("/account route", () => {
     await user.click(screen.getByRole("button", { name: "Delete account" }));
     await user.type(screen.getByLabelText("Confirmation"), "DELETE");
     await user.click(screen.getByLabelText("Delete Acme organization too"));
+    await user.click(
+      screen.getByRole("button", { name: "Delete permanently" }),
+    );
+
+    await waitFor(() => {
+      expect(mocks.deleteCurrentUserAccount).toHaveBeenCalledWith({
+        data: { confirmation: "DELETE", deleteOrganization: true },
+      });
+    });
+  });
+
+  it("passes organization deletion without an extra checkbox click for the only owner", async () => {
+    const user = userEvent.setup();
+    mocks.useActiveOrganization.mockReturnValue({
+      data: {
+        id: "test_org",
+        name: "Acme",
+        members: [{ userId: "test_user", role: "owner" }],
+      },
+    });
+    const Component = Route.options.component as React.ComponentType;
+    render(<Component />);
+
+    await user.click(screen.getByRole("button", { name: "Delete account" }));
+    await user.type(screen.getByLabelText("Confirmation"), "DELETE");
     await user.click(
       screen.getByRole("button", { name: "Delete permanently" }),
     );

--- a/packages/app/src/routes/_authenticated/_dashboard/-account.test.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/-account.test.tsx
@@ -78,13 +78,13 @@ describe("/account route", () => {
     expect(screen.getByText("Connect GitHub")).toBeInTheDocument();
   });
 
-  it("shows the organization deletion option to active organization admins", async () => {
+  it("shows the organization deletion option to active organization owners", async () => {
     const user = userEvent.setup();
     mocks.useActiveOrganization.mockReturnValue({
       data: {
         id: "test_org",
         name: "Acme",
-        members: [{ userId: "test_user", role: "admin" }],
+        members: [{ userId: "test_user", role: "owner" }],
       },
     });
     const Component = Route.options.component as React.ComponentType;
@@ -97,8 +97,15 @@ describe("/account route", () => {
     ).toBeInTheDocument();
   });
 
-  it("hides the organization deletion option from non-admin members", async () => {
+  it("hides the organization deletion option from organization admins", async () => {
     const user = userEvent.setup();
+    mocks.useActiveOrganization.mockReturnValue({
+      data: {
+        id: "test_org",
+        name: "Test Org",
+        members: [{ userId: "test_user", role: "admin" }],
+      },
+    });
     const Component = Route.options.component as React.ComponentType;
     render(<Component />);
 

--- a/packages/app/src/routes/_authenticated/_dashboard/-account.test.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/-account.test.tsx
@@ -1,6 +1,14 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  deleteCurrentUserAccount: vi.fn().mockResolvedValue(undefined),
+  navigate: vi.fn(),
+  useActiveOrganization: vi.fn(),
+  useSession: vi.fn(),
+}));
 
 vi.mock("@tanstack/react-router", async (importOriginal) => {
   const actual =
@@ -20,11 +28,37 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
         {props.children}
       </a>
     ),
-    useNavigate: () => vi.fn(),
+    useNavigate: () => mocks.navigate,
   };
 });
 
+vi.mock("@/data/account-settings", () => ({
+  deleteCurrentUserAccount: mocks.deleteCurrentUserAccount,
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: {
+    useActiveOrganization: mocks.useActiveOrganization,
+    useSession: mocks.useSession,
+  },
+}));
+
 import { Route } from "./account";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.deleteCurrentUserAccount.mockResolvedValue(undefined);
+  mocks.useSession.mockReturnValue({
+    data: { user: { id: "test_user", email: "test@example.com" } },
+  });
+  mocks.useActiveOrganization.mockReturnValue({
+    data: {
+      id: "test_org",
+      name: "Test Org",
+      members: [{ userId: "test_user", role: "member" }],
+    },
+  });
+});
 
 describe("/account route", () => {
   it("renders account settings page with heading and danger zone", () => {
@@ -42,5 +76,62 @@ describe("/account route", () => {
 
     expect(screen.getByText("GitHub Connection")).toBeInTheDocument();
     expect(screen.getByText("Connect GitHub")).toBeInTheDocument();
+  });
+
+  it("shows the organization deletion option to active organization admins", async () => {
+    const user = userEvent.setup();
+    mocks.useActiveOrganization.mockReturnValue({
+      data: {
+        id: "test_org",
+        name: "Acme",
+        members: [{ userId: "test_user", role: "admin" }],
+      },
+    });
+    const Component = Route.options.component as React.ComponentType;
+    render(<Component />);
+
+    await user.click(screen.getByRole("button", { name: "Delete account" }));
+
+    expect(
+      screen.getByLabelText("Delete Acme organization too"),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the organization deletion option from non-admin members", async () => {
+    const user = userEvent.setup();
+    const Component = Route.options.component as React.ComponentType;
+    render(<Component />);
+
+    await user.click(screen.getByRole("button", { name: "Delete account" }));
+
+    expect(
+      screen.queryByLabelText("Delete Test Org organization too"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("passes the organization deletion choice when confirmed", async () => {
+    const user = userEvent.setup();
+    mocks.useActiveOrganization.mockReturnValue({
+      data: {
+        id: "test_org",
+        name: "Acme",
+        members: [{ userId: "test_user", role: "owner" }],
+      },
+    });
+    const Component = Route.options.component as React.ComponentType;
+    render(<Component />);
+
+    await user.click(screen.getByRole("button", { name: "Delete account" }));
+    await user.type(screen.getByLabelText("Confirmation"), "DELETE");
+    await user.click(screen.getByLabelText("Delete Acme organization too"));
+    await user.click(
+      screen.getByRole("button", { name: "Delete permanently" }),
+    );
+
+    await waitFor(() => {
+      expect(mocks.deleteCurrentUserAccount).toHaveBeenCalledWith({
+        data: { confirmation: "DELETE", deleteOrganization: true },
+      });
+    });
   });
 });

--- a/packages/app/src/routes/_authenticated/_dashboard/account.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/account.tsx
@@ -55,10 +55,15 @@ function AccountSettingsPage() {
     (account) => account.providerId === "google",
   );
   const isDeleteConfirmationValid = deleteConfirmation === "DELETE";
-  const currentMemberRole = activeOrganization?.members?.find(
+  const activeOrganizationMembers = activeOrganization?.members ?? [];
+  const currentMemberRole = activeOrganizationMembers.find(
     (member) => member.userId === session?.user?.id,
   )?.role;
   const canDeleteActiveOrganization = isOrgOwnerRole(currentMemberRole);
+  const isOnlyActiveOrganizationOwner =
+    canDeleteActiveOrganization &&
+    activeOrganizationMembers.filter((member) => isOrgOwnerRole(member.role))
+      .length === 1;
   const activeOrganizationName =
     activeOrganization?.name ?? "current organization";
   const googleButtonLabel = isLoadingLinkedAccounts
@@ -150,7 +155,8 @@ function AccountSettingsPage() {
 
     try {
       const shouldDeleteOrganization =
-        canDeleteActiveOrganization && deleteOrganization;
+        canDeleteActiveOrganization &&
+        (deleteOrganization || isOnlyActiveOrganizationOwner);
       await deleteCurrentUserAccount({
         data: shouldDeleteOrganization
           ? { confirmation: "DELETE", deleteOrganization: true }
@@ -296,7 +302,10 @@ function AccountSettingsPage() {
                       type="checkbox"
                       aria-label={`Delete ${activeOrganizationName} organization too`}
                       className="mt-0.5 size-3.5 accent-current"
-                      checked={deleteOrganization}
+                      checked={
+                        deleteOrganization || isOnlyActiveOrganizationOwner
+                      }
+                      disabled={isOnlyActiveOrganizationOwner}
                       onChange={(event) =>
                         setDeleteOrganization(event.target.checked)
                       }
@@ -306,8 +315,9 @@ function AccountSettingsPage() {
                         Delete {activeOrganizationName} organization too
                       </span>
                       <span className="text-muted-foreground">
-                        Leave this unchecked to remove only your account and
-                        keep the organization.
+                        {isOnlyActiveOrganizationOwner
+                          ? "You're the only owner, so deleting your account will also delete the organization."
+                          : "Leave this unchecked to remove only your account and keep the organization."}
                       </span>
                     </span>
                   </label>

--- a/packages/app/src/routes/_authenticated/_dashboard/account.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/account.tsx
@@ -21,6 +21,7 @@ import { Input } from "@everr/ui/components/input";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import { deleteCurrentUserAccount } from "@/data/account-settings";
+import { authClient } from "@/lib/auth-client";
 
 export const Route = createFileRoute("/_authenticated/_dashboard/account")({
   staticData: { breadcrumb: "Account Settings", hideTimeRangePicker: true },
@@ -32,11 +33,20 @@ export const Route = createFileRoute("/_authenticated/_dashboard/account")({
 
 function AccountSettingsPage() {
   const navigate = useNavigate();
+  const { data: session } = authClient.useSession();
+  const { data: activeOrganization } = authClient.useActiveOrganization();
   const [deleteConfirmation, setDeleteConfirmation] = useState("");
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [deleteOrganization, setDeleteOrganization] = useState(false);
   const [isDeletingAccount, setIsDeletingAccount] = useState(false);
 
   const isDeleteConfirmationValid = deleteConfirmation === "DELETE";
+  const currentMemberRole = activeOrganization?.members?.find(
+    (member) => member.userId === session?.user?.id,
+  )?.role;
+  const canDeleteActiveOrganization = isOrgAdminRole(currentMemberRole);
+  const activeOrganizationName =
+    activeOrganization?.name ?? "current organization";
 
   async function handleDeleteAccount() {
     if (isDeletingAccount || !isDeleteConfirmationValid) {
@@ -47,8 +57,12 @@ function AccountSettingsPage() {
     setIsDeletingAccount(true);
 
     try {
+      const shouldDeleteOrganization =
+        canDeleteActiveOrganization && deleteOrganization;
       await deleteCurrentUserAccount({
-        data: { confirmation: "DELETE" },
+        data: shouldDeleteOrganization
+          ? { confirmation: "DELETE", deleteOrganization: true }
+          : { confirmation: "DELETE" },
       });
       await navigate({ to: "/" });
     } catch (error) {
@@ -128,6 +142,32 @@ function AccountSettingsPage() {
                     setDeleteConfirmation(event.target.value)
                   }
                 />
+                {canDeleteActiveOrganization ? (
+                  <label
+                    htmlFor="delete-organization"
+                    className="flex items-start gap-2 rounded-md border border-destructive/20 bg-destructive/5 p-2 text-xs"
+                  >
+                    <input
+                      id="delete-organization"
+                      type="checkbox"
+                      aria-label={`Delete ${activeOrganizationName} organization too`}
+                      className="mt-0.5 size-3.5 accent-current"
+                      checked={deleteOrganization}
+                      onChange={(event) =>
+                        setDeleteOrganization(event.target.checked)
+                      }
+                    />
+                    <span className="flex flex-col gap-1">
+                      <span className="font-medium">
+                        Delete {activeOrganizationName} organization too
+                      </span>
+                      <span className="text-muted-foreground">
+                        Leave this unchecked to remove only your account and
+                        keep the organization.
+                      </span>
+                    </span>
+                  </label>
+                ) : null}
                 {deleteError ? (
                   <p className="text-xs text-destructive" role="alert">
                     {deleteError}
@@ -151,5 +191,14 @@ function AccountSettingsPage() {
         </CardHeader>
       </Card>
     </div>
+  );
+}
+
+function isOrgAdminRole(role: string | null | undefined) {
+  return (
+    role
+      ?.split(",")
+      .map((part) => part.trim())
+      .some((part) => part === "admin" || part === "owner") ?? false
   );
 }

--- a/packages/app/src/routes/_authenticated/_dashboard/account.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/account.tsx
@@ -292,7 +292,13 @@ function AccountSettingsPage() {
                     setDeleteConfirmation(event.target.value)
                   }
                 />
-                {canDeleteActiveOrganization ? (
+                {canDeleteActiveOrganization &&
+                isOnlyActiveOrganizationOwner ? (
+                  <p className="rounded-md border border-destructive/20 bg-destructive/5 p-2 text-xs font-medium">
+                    This action is also going to delete the{" "}
+                    {activeOrganizationName} organization.
+                  </p>
+                ) : canDeleteActiveOrganization ? (
                   <label
                     htmlFor="delete-organization"
                     className="flex items-start gap-2 rounded-md border border-destructive/20 bg-destructive/5 p-2 text-xs"
@@ -302,10 +308,7 @@ function AccountSettingsPage() {
                       type="checkbox"
                       aria-label={`Delete ${activeOrganizationName} organization too`}
                       className="mt-0.5 size-3.5 accent-current"
-                      checked={
-                        deleteOrganization || isOnlyActiveOrganizationOwner
-                      }
-                      disabled={isOnlyActiveOrganizationOwner}
+                      checked={deleteOrganization}
                       onChange={(event) =>
                         setDeleteOrganization(event.target.checked)
                       }
@@ -315,9 +318,8 @@ function AccountSettingsPage() {
                         Delete {activeOrganizationName} organization too
                       </span>
                       <span className="text-muted-foreground">
-                        {isOnlyActiveOrganizationOwner
-                          ? "You're the only owner, so deleting your account will also delete the organization."
-                          : "Leave this unchecked to remove only your account and keep the organization."}
+                        Leave this unchecked to remove only your account and
+                        keep the organization.
                       </span>
                     </span>
                   </label>

--- a/packages/app/src/routes/_authenticated/_dashboard/account.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/account.tsx
@@ -44,7 +44,7 @@ function AccountSettingsPage() {
   const currentMemberRole = activeOrganization?.members?.find(
     (member) => member.userId === session?.user?.id,
   )?.role;
-  const canDeleteActiveOrganization = isOrgAdminRole(currentMemberRole);
+  const canDeleteActiveOrganization = isOrgOwnerRole(currentMemberRole);
   const activeOrganizationName =
     activeOrganization?.name ?? "current organization";
 
@@ -194,11 +194,11 @@ function AccountSettingsPage() {
   );
 }
 
-function isOrgAdminRole(role: string | null | undefined) {
+function isOrgOwnerRole(role: string | null | undefined) {
   return (
     role
       ?.split(",")
       .map((part) => part.trim())
-      .some((part) => part === "admin" || part === "owner") ?? false
+      .some((part) => part === "owner") ?? false
   );
 }

--- a/packages/app/src/test-setup.ts
+++ b/packages/app/src/test-setup.ts
@@ -97,6 +97,12 @@ vi.mock("@/lib/serverFn", async () => {
                 activeOrganizationId: "test_org",
                 id: "test_session",
               },
+              user: {
+                id: "test_user",
+                email: "test@example.com",
+                name: "Test User",
+                image: null,
+              },
             },
             clickhouse: {
               query: <T>(sql: string, params?: Record<string, unknown>) =>
@@ -128,6 +134,8 @@ vi.mock("@/lib/auth.server", () => ({
       }),
       getFullOrganization: vi.fn(),
       createOrganization: vi.fn(),
+      deleteOrganization: vi.fn(),
+      deleteUser: vi.fn(),
       updateOrganization: vi.fn(),
       setActiveOrganization: vi.fn(),
       listOrganizations: vi.fn(),


### PR DESCRIPTION
Implements account deletion:
- Every account can delete themselves
- An owner account will delete their org if they are the last owner, otherwise they will have the option via checkbox
- deleting an org deletes automatically all the related data on Postgres
- Retention will take care of deleting data on CH