### PR TITLE
Fix desktop Tauri event cleanup

### DIFF
--- a/packages/desktop-app/src/lib/tauri-events.test.tsx
+++ b/packages/desktop-app/src/lib/tauri-events.test.tsx
@@ -1,0 +1,70 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { safeGetCurrentWindow } from "./tauri";
+import { useTauriEvent } from "./tauri-events";
+
+vi.mock("./tauri", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./tauri")>();
+  return {
+    ...actual,
+    safeGetCurrentWindow: vi.fn(),
+  };
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+
+  return { promise, resolve };
+}
+
+describe("useTauriEvent", () => {
+  const windowMock = {
+    listen: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(safeGetCurrentWindow).mockReturnValue(windowMock as never);
+  });
+
+  it("unlistens when listener setup resolves after unmount", async () => {
+    const setup = deferred<() => void>();
+    const unlisten = vi.fn();
+    windowMock.listen.mockReturnValue(setup.promise);
+
+    const { unmount } = renderHook(() => useTauriEvent("event-name", vi.fn()));
+
+    unmount();
+
+    await act(async () => {
+      setup.resolve(unlisten);
+      await setup.promise;
+    });
+
+    expect(unlisten).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles rejected unlisten promises during cleanup", async () => {
+    const unlisten = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValue(new Error("listener already removed"));
+    windowMock.listen.mockResolvedValue(unlisten);
+
+    const { unmount } = renderHook(() => useTauriEvent("event-name", vi.fn()));
+
+    await act(async () => {
+      await windowMock.listen.mock.results[0]?.value;
+    });
+
+    unmount();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(unlisten).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/desktop-app/src/lib/tauri-events.ts
+++ b/packages/desktop-app/src/lib/tauri-events.ts
@@ -7,6 +7,14 @@ function setIsFullscreen(value: boolean) {
   document.documentElement.dataset.fullscreen = value ? "true" : "false";
 }
 
+function cleanupTauriListener(unlisten: UnlistenFn) {
+  try {
+    void Promise.resolve(unlisten()).catch(() => {});
+  } catch {
+    // Listener cleanup is best-effort; Tauri may have already removed it.
+  }
+}
+
 /**
  * Tracks whether the main window is in native (macOS) fullscreen, where the
  * traffic-light buttons are hidden. Used to collapse the titlebar insets so the
@@ -33,7 +41,7 @@ export function useIsFullscreen() {
     sync();
     void appWindow.onResized(sync).then((cleanup) => {
       if (cancelled) {
-        cleanup();
+        cleanupTauriListener(cleanup);
       } else {
         unlisten = cleanup;
       }
@@ -41,7 +49,9 @@ export function useIsFullscreen() {
 
     return () => {
       cancelled = true;
-      unlisten?.();
+      if (unlisten) {
+        cleanupTauriListener(unlisten);
+      }
     };
   }, []);
 }
@@ -61,17 +71,25 @@ export function useTauriEvent<T = unknown>(
     }
 
     let unlisten: UnlistenFn | undefined;
+    let cancelled = false;
 
     void appWindow
       .listen<T>(eventName, (event) => {
         handleEvent(event.payload);
       })
       .then((cleanup) => {
-        unlisten = cleanup;
+        if (cancelled) {
+          cleanupTauriListener(cleanup);
+        } else {
+          unlisten = cleanup;
+        }
       });
 
     return () => {
-      unlisten?.();
+      cancelled = true;
+      if (unlisten) {
+        cleanupTauriListener(unlisten);
+      }
     };
   }, [eventName, handleEvent]);
 }


### PR DESCRIPTION
## Summary
- Add a shared best-effort cleanup helper for Tauri listener unlisten functions.
- Clean up listeners when async listener setup resolves after React has already unmounted.
- Add regression tests for late listener setup and rejected cleanup promises.

## Root Cause
Production error `3476075679312339010` was an `everr-desktop` browser unhandled rejection from Tauri listener cleanup: `undefined is not an object (evaluating 'listeners[eventId].handlerId')`. The shared `useTauriEvent` hook did not handle the case where `appWindow.listen()` resolves after effect cleanup, and Tauri cleanup can reject if the browser-side listener has already been removed.

## Verification
- `env CI=true pnpm --filter @everr/desktop-app test -- src/lib/tauri-events.test.tsx`
- `env CI=true pnpm exec biome check packages/desktop-app/src/lib/tauri-events.ts packages/desktop-app/src/lib/tauri-events.test.tsx`
