### PR TITLE
Fix traces duration filter

### DIFF
--- a/packages/desktop-app/src/features/logs/local-sql-client.ts
+++ b/packages/desktop-app/src/features/logs/local-sql-client.ts
@@ -1,4 +1,5 @@
 import type { SqlClient } from "@everr/telemetry-explorer/logs";
+import { logs, SeverityNumber } from "@opentelemetry/api-logs";
 import { invokeCommand } from "@/lib/tauri";
 
 /**
@@ -11,6 +12,23 @@ export const localSqlClient: SqlClient = {
     sql: string,
     params: Record<string, unknown>,
   ): Promise<Row[]> => {
-    return invokeCommand<Row[]>("telemetry_sql_query", { sql, params });
+    try {
+      return await invokeCommand<Row[]>("telemetry_sql_query", { sql, params });
+    } catch (error) {
+      const isError = error instanceof Error;
+      logs.getLogger("everr-desktop.local-sql").emit({
+        severityNumber: SeverityNumber.ERROR,
+        severityText: "ERROR",
+        body: "everr.desktop.local_sql.query_error",
+        attributes: {
+          "exception.type": isError ? error.name : "Error",
+          "exception.message": isError ? error.message : String(error),
+          "exception.stacktrace": isError ? (error.stack ?? "") : "",
+          "error.handled": true,
+        },
+        exception: isError ? error : undefined,
+      });
+      throw error;
+    }
   },
 };

--- a/packages/telemetry-explorer/src/traces/data/repository.test.ts
+++ b/packages/telemetry-explorer/src/traces/data/repository.test.ts
@@ -259,8 +259,10 @@ describe("TracesRepository.search", () => {
 
     const [sql, params] = query.mock.calls[0] ?? [];
     expect(sql).toContain("HAVING");
-    expect(sql).toContain("durationNsRaw >= {minDurationNs:UInt64}");
-    expect(sql).not.toContain("durationNsRaw <= {maxDurationNs:UInt64}");
+    expect(sql).toContain("durationNsRaw >= toUInt64({minDurationNs:String})");
+    expect(sql).not.toContain(
+      "durationNsRaw <= toUInt64({maxDurationNs:String})",
+    );
     expect(sql).toContain("countIf(StatusCode = 'Error') > 0");
     expect(params).toMatchObject({ minDurationNs: "1000" });
   });

--- a/packages/telemetry-explorer/src/traces/data/repository.ts
+++ b/packages/telemetry-explorer/src/traces/data/repository.ts
@@ -139,11 +139,15 @@ export class TracesRepository {
     // exposes it as a string. Filter on the raw int to avoid a double
     // toString → toUInt64 round-trip per row.
     if (input.minDurationNs !== undefined) {
-      aggregateHavingParts.push("durationNsRaw >= {minDurationNs:UInt64}");
+      aggregateHavingParts.push(
+        "durationNsRaw >= toUInt64({minDurationNs:String})",
+      );
       params.minDurationNs = input.minDurationNs;
     }
     if (input.maxDurationNs !== undefined) {
-      aggregateHavingParts.push("durationNsRaw <= {maxDurationNs:UInt64}");
+      aggregateHavingParts.push(
+        "durationNsRaw <= toUInt64({maxDurationNs:String})",
+      );
       params.maxDurationNs = input.maxDurationNs;
     }
     // Span-level, matching the rest of the filters: 'error' = trace contains


### PR DESCRIPTION
## Summary

- Fix the desktop traces duration filter by binding duration bounds as string params and casting them to `UInt64` in SQL.
- Emit handled browser error logs for local SQL query failures, including string rejection values.

## Root Cause

The desktop local SQL transport JSON-encodes string params before server-side placeholder substitution. The traces query sent duration bounds as strings while declaring `{minDurationNs:UInt64}`, so the local parameter renderer rejected quoted numeric strings.

## Validation

- `pnpm exec biome check packages/desktop-app/src/features/logs/local-sql-client.ts packages/telemetry-explorer/src/traces/data/repository.ts packages/telemetry-explorer/src/traces/data/repository.test.ts`
- `pnpm --filter @everr/telemetry-explorer test -- src/traces/data/repository.test.ts`
- `pnpm --filter @everr/desktop-app exec tsc --noEmit`
- `pnpm --filter @everr/desktop-app test -- src/features/traces/traces-page.test.tsx`
