### PR TITLE
feat(apply): respect .gitignore and skip hidden files in the dashboard walk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,6 +703,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,6 +1239,7 @@ dependencies = [
  "eventsource-stream",
  "fs2",
  "futures-util",
+ "ignore",
  "include_dir",
  "mockito",
  "nix",
@@ -1231,7 +1251,6 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "tokio",
- "walkdir",
 ]
 
 [[package]]
@@ -1756,6 +1775,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "gobject-sys"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2181,6 +2213,22 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]

--- a/crates/everr-core/Cargo.toml
+++ b/crates/everr-core/Cargo.toml
@@ -15,7 +15,7 @@ futures-util = "0.3"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 serde_yaml = "0.9"
-walkdir = "2.5"
+ignore = "0.4"
 notify = "8"
 tokio = { version = "1.44.2", features = ["io-util", "macros", "time", "sync"] }
 

--- a/crates/everr-core/src/apply.rs
+++ b/crates/everr-core/src/apply.rs
@@ -1,9 +1,9 @@
 use std::path::Path;
 
 use anyhow::{Context, Result};
+use ignore::WalkBuilder;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use walkdir::WalkDir;
 
 /// A resource document discovered on disk: its repo-relative POSIX path and
 /// parsed JSON contents.
@@ -40,16 +40,32 @@ fn parse_document(path: &Path, contents: &str) -> Result<Value> {
 
 /// Recursively load every `.yaml`/`.yml`/`.json` resource under `dir`,
 /// returning each with its POSIX path relative to `dir`. Errors name the file.
+///
+/// The walk honors `.gitignore`/`.ignore` files within the tree and skips
+/// hidden entries (including `.git`), so generated, vendored, or scratch
+/// YAML/JSON under the apply dir isn't mistaken for desired state. Because the
+/// returned set IS the desired state and apply prunes anything missing, the
+/// ignore scope is deliberately narrow and local: `require_git(false)` so a
+/// `.gitignore` is respected even outside a repo, but `git_global(false)` so a
+/// destructive reconcile never depends on the machine's global excludes.
 pub fn load_resource_documents(dir: &Path) -> Result<Vec<ResourceDocument>> {
     let mut out = Vec::new();
     // Propagate walk errors instead of dropping them: apply treats this set as
     // the complete desired state and prunes anything missing, so a silently
     // truncated walk (unreadable dir, traversal error) would delete dashboards.
-    for entry in WalkDir::new(dir) {
+    let walker = WalkBuilder::new(dir)
+        .require_git(false)
+        .git_global(false)
+        .build();
+    for entry in walker {
         let entry = entry
             .with_context(|| format!("failed to read directory tree under {}", dir.display()))?;
         let path = entry.path();
-        if !entry.file_type().is_file() || is_manifest_file(path) || !is_dashboard_file(path) {
+        // The walker yields directories too; only regular files are resources.
+        if !entry.file_type().is_some_and(|ft| ft.is_file())
+            || is_manifest_file(path)
+            || !is_dashboard_file(path)
+        {
             continue;
         }
         let rel = path
@@ -163,6 +179,38 @@ mod tests {
         fs::write(dir.path().join("README.md"), "# not a dashboard").unwrap();
         let docs = load_resource_documents(dir.path()).unwrap();
         assert!(docs.is_empty());
+    }
+
+    const DASH: &str =
+        "kind: Dashboard\nmetadata:\n  name: d\nspec:\n  panels: {}\n  layouts: []\n";
+
+    #[test]
+    fn respects_gitignore() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join(".gitignore"), "generated/\nscratch.yaml\n").unwrap();
+        fs::write(dir.path().join("cpu.yaml"), DASH).unwrap();
+        fs::write(dir.path().join("scratch.yaml"), DASH).unwrap();
+        fs::create_dir_all(dir.path().join("generated")).unwrap();
+        fs::write(dir.path().join("generated/old.yaml"), DASH).unwrap();
+
+        let docs = load_resource_documents(dir.path()).unwrap();
+
+        let paths: Vec<&str> = docs.iter().map(|d| d.path.as_str()).collect();
+        assert_eq!(paths, vec!["cpu.yaml"], "gitignored files must be excluded");
+    }
+
+    #[test]
+    fn skips_hidden_files_and_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("cpu.yaml"), DASH).unwrap();
+        fs::write(dir.path().join(".hidden.yaml"), DASH).unwrap();
+        fs::create_dir_all(dir.path().join(".git")).unwrap();
+        fs::write(dir.path().join(".git/config.yaml"), DASH).unwrap();
+
+        let docs = load_resource_documents(dir.path()).unwrap();
+
+        let paths: Vec<&str> = docs.iter().map(|d| d.path.as_str()).collect();
+        assert_eq!(paths, vec!["cpu.yaml"], "hidden files/dirs must be skipped");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Makes the `everr apply` file walk **gitignore- and hidden-file-aware**. Previously the walker (`load_resource_documents`) used `walkdir`, a bare recursive traversal with no VCS awareness: any `.yaml`/`.yml`/`.json` under the apply directory was loaded as a resource document — including generated, vendored, or scratch files, and even files under hidden dirs like `.git`. Because the walk's output **is** the desired state and apply prunes anything missing, a stray file was at best applied unintentionally and at worst aborted the whole apply on a parse error.

This switches to the `ignore` crate's `WalkBuilder` (the walker ripgrep uses), so the walk:
- honors `.gitignore` / `.ignore` files found within the applied tree, and
- skips hidden entries (including `.git`) by default.

## Design note — scoped for a destructive reconcile

Apply prunes whatever the walk doesn't return, so the ignore scope is deliberately **narrow and local** rather than full `git`-equivalent semantics:

- `require_git(false)` — a `.gitignore` in the apply directory is respected even when the directory isn't inside a git repo.
- `git_global(false)` — a destructive reconcile never depends on the machine's global excludes (`core.excludesfile`); a stray global `*.yaml` rule can't silently delete dashboards.

Walk errors are still propagated (not swallowed), preserving the existing guarantee that a truncated walk can't quietly prune dashboards.

## Changes

- `crates/everr-core/src/apply.rs` — `load_resource_documents` now builds an `ignore::WalkBuilder`; the manifest exclusion and `.yaml`/`.yml`/`.json` filter are unchanged.
- `crates/everr-core/Cargo.toml` — drop the direct `walkdir` dependency, add `ignore` (`walkdir` remains transitively, used by `ignore`).

## Test plan

- [x] `respects_gitignore` — a `.gitignore` excluding a directory and a file keeps both out of the loaded set
- [x] `skips_hidden_files_and_dirs` — a `.hidden.yaml` and a `.git/` directory are skipped
- [x] Existing walk tests still pass (relative POSIX paths, non-dashboard skip, invalid-YAML error names the file, manifest excluded)
- [x] `cargo test -p everr-core --lib` (73 passed), CLI builds

Targets `gio/perses-dashboard-route` (PR #147).
