### PR TITLE
docs(skills): everr-write-dashboards skill with per-visualization rule files

### DIFF
--- a/crates/everr-core/assets/skills/everr-write-dashboards/SKILL.md
+++ b/crates/everr-core/assets/skills/everr-write-dashboards/SKILL.md
@@ -20,7 +20,7 @@ The file format mirrors [Perses](https://perses.dev), so the structure (`kind`/`
 
 1. **Queries are ClickHouse SQL, not PromQL.** The only query plugin is `ClickHouseSQL`. No Prometheus, no `rate()`, no `$__rate_interval`, no `PrometheusTimeSeriesQuery`.
 2. **Time range is two SQL params:** `{from:String}` and `{to:String}`. You must put them in your `WHERE`. There is no auto-injection.
-3. **Visualizations are three kinds with simple specs:** `TimeSeriesChart`, `Table`, `StatChart`. They infer structure from the columns you `SELECT` — there is no `yAxis`, `legend`, `columnSettings`, `format.unit`, etc.
+3. **Visualizations are four kinds with simple specs:** `TimeSeriesChart`, `Table`, `StatChart`, `GeoMap`. They infer structure from the columns you `SELECT` — there is no `yAxis`, `legend`, `columnSettings`, `format.unit`, etc.
 4. **Variable options come from `StaticListVariable` or `ClickHouseSQLVariable` only** — not `PrometheusLabelValuesVariable`. `$name` interpolates to a quoted ClickHouse literal.
 
 ## File layout and the required manifest
@@ -72,7 +72,7 @@ panels:
     spec:
       display: { name: Error rate }      # description optional
       plugin:
-        kind: TimeSeriesChart            # TimeSeriesChart | Table | StatChart
+        kind: TimeSeriesChart            # TimeSeriesChart | Table | StatChart | GeoMap
         spec: { unit: "%", showLegend: true }
       queries:
         - kind: ClickHouseSQL            # outer query kind
@@ -84,7 +84,7 @@ panels:
                   SELECT ...
 ```
 
-The double `ClickHouseSQL` (query `kind` **and** inner `plugin.kind`) is required, not a typo. Multiple queries are allowed: time-series overlays them, table shows a selector, stat renders one tile per series. The panel `plugin.kind` is one of `TimeSeriesChart`, `Table`, `StatChart` — see [Visualization options](#visualization-options) for each kind's `spec`.
+The double `ClickHouseSQL` (query `kind` **and** inner `plugin.kind`) is required, not a typo. Multiple queries are allowed: time-series overlays them, table shows a selector, stat renders one tile per series, geo-map overlays markers (points) or merges regions (choropleth). The panel `plugin.kind` is one of `TimeSeriesChart`, `Table`, `StatChart`, `GeoMap` — see [Visualization options](#visualization-options) for each kind's `spec`.
 
 ### Layout — panels only render if a layout references them
 
@@ -130,6 +130,7 @@ Data shape per visualization (the viz infers everything from your columns):
 | `TimeSeriesChart` | a time column (aliased above) + numeric series columns. A non-numeric **string** column pivots one value column into one line per label (e.g. `GROUP BY ts, ServiceName`) — but **only with exactly one numeric column** (see `rules/timeseries.md`). |
 | `Table` | any columns, rendered as-is in query order (no formatting — do it in SQL). |
 | `StatChart` | one or more numeric columns — **one tile per numeric column** (each reduced by `calculation`). A string column creates no tile. Include a time column for per-tile sparklines. |
+| `GeoMap` | points mode: numeric lat/lon columns (+ optional value/label); choropleth mode: an ISO-3166 alpha-2/alpha-3 country-code column + a numeric value column (see `rules/geomap.md`). No time axis. |
 
 ## Visualization options
 
@@ -140,6 +141,7 @@ Each visualization has its own option set and behaviors. **Load the rule file fo
 | `TimeSeriesChart` | `rules/timeseries.md` | a line chart over time — units, legend, curve, gaps, per-series breakdown |
 | `Table` | `rules/table.md` | a row/column table — sticky header, column formatting (SQL-side) |
 | `StatChart` | `rules/statchart.md` | big single-value tiles — calculations, sparklines, threshold coloring |
+| `GeoMap` | `rules/geomap.md` | a world map — lat/lon markers or country shading, aggregation, color/size scales |
 
 ## Variables
 
@@ -312,7 +314,7 @@ Apply is **declarative and delete-by-default within the declared projects**: new
 | Forgetting the `everr.yaml` manifest, or a `metadata.project` not listed in it | Every apply dir needs `everr.yaml` listing projects; each dashboard's project must be in it. |
 | No `{from:String}`/`{to:String}` in the `WHERE` | Add `WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}` — it is not auto-injected. |
 | Time-series x-axis blank | Alias the time column to `ts`/`time`/`timestamp`/… so it's detected. |
-| Inventing viz options (`yAxis`, `legend`, `columnSettings`, `format.unit`, `calculation: last-number`, axis min/max, stacking) | Only the options in each viz's rule file (`rules/timeseries.md`, `rules/table.md`, `rules/statchart.md`) exist. Format/round in SQL, not via spec. |
+| Inventing viz options (`yAxis`, `legend`, `columnSettings`, `format.unit`, `calculation: last-number`, axis min/max, stacking) | Only the options in each viz's rule file (`rules/timeseries.md`, `rules/table.md`, `rules/statchart.md`, `rules/geomap.md`) exist. Format/round in SQL, not via spec. |
 | `PrometheusLabelValuesVariable` or other variable plugins | Only `StaticListVariable` and `ClickHouseSQLVariable`. |
 | Single `ClickHouseSQL` in the query block | Both the query `kind` and the inner `plugin.kind` are `ClickHouseSQL`. |
 | `Duration` treated as ms/seconds | It's **nanoseconds** — divide by `1e6` (ms) or `1e9` (s). |

--- a/crates/everr-core/assets/skills/everr-write-dashboards/SKILL.md
+++ b/crates/everr-core/assets/skills/everr-write-dashboards/SKILL.md
@@ -1,0 +1,321 @@
+---
+name: everr-write-dashboards
+description: Use when creating, editing, or applying an Everr dashboard as code — Perses-format dashboard YAML/JSON files, panels, ClickHouse queries, dashboard variables, grid layouts, the everr.yaml manifest, or the `everr apply` CLI.
+---
+
+## Startup Access
+
+Writing dashboards is just editing files. Two things need access:
+
+- **`everr apply`** talks to your Everr host. Allow production network `https://app.everr.dev` and filesystem read of `~/Library/Application Support/everr/session.json` (and `session-dev.json`) and their parent directory. Apply uses your `everr cloud login` session, or `EVERR_API_TOKEN` for CI.
+- **Writing correct queries** means knowing your real ClickHouse columns. Discover them with `everr cloud query "DESCRIBE TABLE traces"` (or sample rows), or use the `everr-use-telemetry` skill. **Do not invent metric/label names.**
+
+# Writing Everr Dashboards
+
+Everr dashboards are **as-code**: a Perses-style YAML or JSON file on disk, reconciled into Everr with `everr apply`. The file is the source of truth.
+
+## The model is Perses, but the engine is ClickHouse
+
+The file format mirrors [Perses](https://perses.dev), so the structure (`kind`/`metadata`/`spec`, `panels` map, `layouts` grid, `$ref` pointers) is standard Perses. **But the four things below are Everr-specific — stock Perses/Grafana knowledge gets them wrong:**
+
+1. **Queries are ClickHouse SQL, not PromQL.** The only query plugin is `ClickHouseSQL`. No Prometheus, no `rate()`, no `$__rate_interval`, no `PrometheusTimeSeriesQuery`.
+2. **Time range is two SQL params:** `{from:String}` and `{to:String}`. You must put them in your `WHERE`. There is no auto-injection.
+3. **Visualizations are three kinds with simple specs:** `TimeSeriesChart`, `Table`, `StatChart`. They infer structure from the columns you `SELECT` — there is no `yAxis`, `legend`, `columnSettings`, `format.unit`, etc.
+4. **Variable options come from `StaticListVariable` or `ClickHouseSQLVariable` only** — not `PrometheusLabelValuesVariable`. `$name` interpolates to a quoted ClickHouse literal.
+
+## File layout and the required manifest
+
+`everr apply <dir>` reconciles a directory. The directory **must** contain an `everr.yaml` (or `.yml`) at its root declaring the projects it manages — apply errors without it. There is no implicit `default`.
+
+```
+dashboards/
+  everr.yaml                 # REQUIRED manifest — declares the reconcile scope
+  api-latency.yaml           # root folder
+  platform/
+    db-health.yaml           # folder "platform" (from the directory name)
+```
+
+`dashboards/everr.yaml`:
+
+```yaml
+projects:
+  - default
+  - platform
+```
+
+Every dashboard's `metadata.project` (or `default` when omitted) **must** appear in this list, or apply rejects it. Folders in the UI come from the directory tree — there are no folder objects.
+
+## Dashboard spec quick reference
+
+```yaml
+kind: Dashboard
+metadata:
+  name: <slug>               # required; lowercase letters/digits/hyphens, 1–200 chars, the URL segment
+  project: platform          # optional; defaults to "default"; must be in everr.yaml
+spec:
+  display: { name: ..., description: ... }   # optional
+  duration: 1h               # optional; seeds the time-range picker (e.g. 1h, 24h)
+  refreshInterval: 30s       # optional; seeds auto-refresh
+  variables: [ ... ]         # optional; see Variables
+  panels: { <key>: Panel }   # required; map of panel key -> panel
+  layouts: [ Grid ]          # required; places panels on a 24-column grid
+```
+
+Identity is `project` + `slug` → URL `/dashboards/<project>/<slug>`.
+
+### Panel
+
+```yaml
+panels:
+  error-rate:                            # panel key — referenced by the layout's $ref
+    kind: Panel
+    spec:
+      display: { name: Error rate }      # description optional
+      plugin:
+        kind: TimeSeriesChart            # TimeSeriesChart | Table | StatChart
+        spec: { unit: "%", showLegend: true }
+      queries:
+        - kind: ClickHouseSQL            # outer query kind
+          spec:
+            plugin:
+              kind: ClickHouseSQL        # inner plugin kind — yes, both say ClickHouseSQL
+              spec:
+                query: |
+                  SELECT ...
+```
+
+The double `ClickHouseSQL` (query `kind` **and** inner `plugin.kind`) is required, not a typo. Multiple queries are allowed: time-series overlays them, table shows a selector, stat renders one tile per series. The panel `plugin.kind` is one of `TimeSeriesChart`, `Table`, `StatChart` — see [Visualization options](#visualization-options) for each kind's `spec`.
+
+### Layout — panels only render if a layout references them
+
+```yaml
+layouts:
+  - kind: Grid
+    spec:
+      items:
+        - { x: 0,  y: 0, width: 12, height: 8, content: { $ref: "#/spec/panels/error-rate" } }
+        - { x: 12, y: 0, width: 12, height: 8, content: { $ref: "#/spec/panels/latency" } }
+```
+
+`content.$ref` is always `#/spec/panels/<panel-key>`. Grid is 24 columns wide; `x`/`y` are cells, `width`/`height` are spans.
+
+## Writing the SQL
+
+Every panel query runs against your ClickHouse telemetry tables (`traces`, `logs`, `metrics_*`). Three rules:
+
+- **Scope to the picker.** Always include `WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}`. Omitting it scans all history and stops following the time picker (Table/Stat aggregate everything).
+- **Alias the time column** for time-series x-axis. It's detected by name — alias to one of: `ts`, `time`, `timestamp`, `date`, `datetime`, `created_at`, `period`, `bucket`, `interval`.
+- **`Duration` is nanoseconds.** Divide by `1e6` for ms, `1e9` for seconds. `StatusCode = 'Error'` for failed spans.
+- **Bucket time-series adaptively** (see below) — never hard-code `toStartOfMinute` for a chart that can be viewed over days.
+
+### Bucketing time-series
+
+`toStartOfMinute(Timestamp)` is fine for a 1-hour view but produces ~10k points per series over 7 days — slow and unreadable. Everr supplies a third parameter, **`{step:UInt32}`** — the adaptive bucket width in **seconds**, computed server-side from the selected range (snapped to a clean clock interval, ~500 points). Bucket time-series with it instead of a fixed `toStartOfMinute`:
+
+```sql
+SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} SECOND) AS ts,
+       count() AS spans
+FROM traces
+WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+GROUP BY ts
+ORDER BY ts
+```
+
+`{step}` tracks the time picker automatically: ~10s buckets at 1h, ~30m at 7d, always ~500 points. Use the **same** `INTERVAL {step:UInt32} SECOND` on the metrics tables' `TimeUnix` column. Keep `toStartOfMinute`/`toStartOfHour` only for a chart pinned to a short, fixed range. (Tables and time-less Stat panels don't bucket — they aggregate; a Stat sparkline benefits, though.)
+
+Data shape per visualization (the viz infers everything from your columns):
+
+| Viz | Return |
+| --- | --- |
+| `TimeSeriesChart` | a time column (aliased above) + numeric series columns. A non-numeric **string** column pivots one value column into one line per label (e.g. `GROUP BY ts, ServiceName`) — but **only with exactly one numeric column** (see `rules/timeseries.md`). |
+| `Table` | any columns, rendered as-is in query order (no formatting — do it in SQL). |
+| `StatChart` | one or more numeric columns — **one tile per numeric column** (each reduced by `calculation`). A string column creates no tile. Include a time column for per-tile sparklines. |
+
+## Visualization options
+
+Each visualization has its own option set and behaviors. **Load the rule file for the visualization you're using** before writing its `spec` — each file lists the *complete* set of options, the exact data shape it expects, and its footguns. Anything not listed there does not exist; do not invent options.
+
+| Visualization | Rule | Load when you need |
+| --- | --- | --- |
+| `TimeSeriesChart` | `rules/timeseries.md` | a line chart over time — units, legend, curve, gaps, per-series breakdown |
+| `Table` | `rules/table.md` | a row/column table — sticky header, column formatting (SQL-side) |
+| `StatChart` | `rules/statchart.md` | big single-value tiles — calculations, sparklines, threshold coloring |
+
+## Variables
+
+Define under `spec.variables`; reference in SQL with `$name`. Everr interpolates **server-side** before running the query.
+
+```yaml
+variables:
+  - kind: ListVariable
+    spec:
+      name: service
+      display: { name: Service }
+      allowMultiple: true        # optional
+      allowAllValue: true        # optional; adds "All"
+      sort: alphabetical-asc     # optional
+      plugin:
+        kind: ClickHouseSQLVariable          # or StaticListVariable
+        spec:
+          query: SELECT DISTINCT ServiceName FROM traces ORDER BY ServiceName
+          # values: [a, b]       # for StaticListVariable instead of query
+  - kind: TextVariable
+    spec:
+      name: search
+      value: ""                  # default; constant: true makes it a fixed, hidden value
+```
+
+Interpolation tokens:
+
+| Token | Expands to |
+| --- | --- |
+| `$name` | a ClickHouse literal — `'api'`, or a list `('api','web')` for multi-select (empty → `(NULL)`) |
+| `${name}` | same, with explicit delimiters for embedding (`pre${name}post`) |
+| `${name:raw}` | **unquoted**, comma-joined for lists — only for trusted, non-string fragments |
+
+```sql
+WHERE ServiceName IN $service        -- ('api','web')
+  AND Environment = $env             -- 'prod'
+```
+
+For `allowAllValue`, "All" expands to every loaded option as a quoted list; set `customAllValue` (inserted verbatim, quote it yourself, e.g. `"'%'"`) for a fixed substitution. **Not supported** (accepted but inert): variable chaining, `capturingRegexp`, per-panel overrides, variables in titles.
+
+## Complete worked example
+
+`dashboards/everr.yaml`:
+
+```yaml
+projects:
+  - demo
+```
+
+`dashboards/checkout-api.yaml`:
+
+```yaml
+kind: Dashboard
+metadata:
+  name: checkout-api
+  project: demo
+spec:
+  display:
+    name: Checkout API
+  duration: 1h
+  refreshInterval: 30s
+  variables:
+    - kind: ListVariable
+      spec:
+        name: service
+        display: { name: Service }
+        allowMultiple: true
+        allowAllValue: true
+        sort: alphabetical-asc
+        plugin:
+          kind: ClickHouseSQLVariable
+          spec:
+            query: SELECT DISTINCT ServiceName FROM traces ORDER BY ServiceName
+  panels:
+    p95-latency:
+      kind: Panel
+      spec:
+        display: { name: p95 request latency (ms) }
+        plugin:
+          kind: TimeSeriesChart
+          spec: { unit: ms, showLegend: true }
+        queries:
+          - kind: ClickHouseSQL
+            spec:
+              plugin:
+                kind: ClickHouseSQL
+                spec:
+                  query: |
+                    SELECT toStartOfMinute(Timestamp) AS ts,
+                           quantile(0.95)(Duration) / 1e6 AS p95_ms
+                    FROM traces
+                    WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                      AND ServiceName IN $service
+                    GROUP BY ts
+                    ORDER BY ts
+    error-rate:
+      kind: Panel
+      spec:
+        display: { name: Error rate }
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            unit: "%"
+            thresholds:
+              mode: absolute
+              defaultColor: "#22c55e"
+              steps:
+                - { value: 1, color: "#f59e0b" }
+                - { value: 5, color: "#ef4444" }
+        queries:
+          - kind: ClickHouseSQL
+            spec:
+              plugin:
+                kind: ClickHouseSQL
+                spec:
+                  query: |
+                    SELECT countIf(StatusCode = 'Error') / count() * 100 AS error_pct
+                    FROM traces
+                    WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                      AND ServiceName IN $service
+    slowest-endpoints:
+      kind: Panel
+      spec:
+        display: { name: Top 10 slowest endpoints }
+        plugin:
+          kind: Table
+          spec: { stickyHeader: true }
+        queries:
+          - kind: ClickHouseSQL
+            spec:
+              plugin:
+                kind: ClickHouseSQL
+                spec:
+                  query: |
+                    SELECT SpanName,
+                           round(quantile(0.95)(Duration) / 1e6, 1) AS p95_ms,
+                           count() AS spans
+                    FROM traces
+                    WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                      AND ServiceName IN $service
+                    GROUP BY SpanName
+                    ORDER BY p95_ms DESC
+                    LIMIT 10
+  layouts:
+    - kind: Grid
+      spec:
+        items:
+          - { x: 0,  y: 0, width: 16, height: 8,  content: { $ref: "#/spec/panels/p95-latency" } }
+          - { x: 16, y: 0, width: 8,  height: 8,  content: { $ref: "#/spec/panels/error-rate" } }
+          - { x: 0,  y: 8, width: 24, height: 10, content: { $ref: "#/spec/panels/slowest-endpoints" } }
+```
+
+> The column names above (`ServiceName`, `SpanName`, `Duration`, `StatusCode`) are the standard `traces` columns. If you query attributes (`SpanAttributes['http.route']`, etc.) or other tables, discover the real columns first — see Startup Access.
+
+## Apply workflow
+
+```sh
+everr apply ./dashboards --dry-run     # always preview first; writes nothing
+everr apply ./dashboards               # prints the destination org, then asks to confirm
+```
+
+Apply is **declarative and delete-by-default within the declared projects**: new files are created, changed files updated, removed files **deleted**. Re-applying with no changes prints `Nothing to apply.` In CI, set `EVERR_API_TOKEN` and pass `--yes`.
+
+## Common mistakes
+
+| Mistake | Fix |
+| --- | --- |
+| PromQL / `rate()` / `$__rate_interval` / `PrometheusTimeSeriesQuery` | Queries are **ClickHouse SQL**; the only query plugin is `ClickHouseSQL`. |
+| Forgetting the `everr.yaml` manifest, or a `metadata.project` not listed in it | Every apply dir needs `everr.yaml` listing projects; each dashboard's project must be in it. |
+| No `{from:String}`/`{to:String}` in the `WHERE` | Add `WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}` — it is not auto-injected. |
+| Time-series x-axis blank | Alias the time column to `ts`/`time`/`timestamp`/… so it's detected. |
+| Inventing viz options (`yAxis`, `legend`, `columnSettings`, `format.unit`, `calculation: last-number`, axis min/max, stacking) | Only the options in each viz's rule file (`rules/timeseries.md`, `rules/table.md`, `rules/statchart.md`) exist. Format/round in SQL, not via spec. |
+| `PrometheusLabelValuesVariable` or other variable plugins | Only `StaticListVariable` and `ClickHouseSQLVariable`. |
+| Single `ClickHouseSQL` in the query block | Both the query `kind` and the inner `plugin.kind` are `ClickHouseSQL`. |
+| `Duration` treated as ms/seconds | It's **nanoseconds** — divide by `1e6` (ms) or `1e9` (s). |
+| Panel defined but not on the grid | A panel renders only if a `layouts` item `$ref`s it. |
+| `everr dashboard apply -f file.yaml` | The command is `everr apply <dir>` against a directory, not a single file. |
+| Inventing metric/label/column names | Discover real columns with `everr cloud query "DESCRIBE TABLE traces"` or the `everr-use-telemetry` skill. |

--- a/crates/everr-core/assets/skills/everr-write-dashboards/SKILL.md
+++ b/crates/everr-core/assets/skills/everr-write-dashboards/SKILL.md
@@ -104,7 +104,7 @@ layouts:
 Every panel query runs against your ClickHouse telemetry tables (`traces`, `logs`, `metrics_*`). Three rules:
 
 - **Scope to the picker.** Always include `WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}`. Omitting it scans all history and stops following the time picker (Table/Stat aggregate everything).
-- **Alias the time column** for time-series x-axis. It's detected by name — alias to one of: `ts`, `time`, `timestamp`, `date`, `datetime`, `created_at`, `period`, `bucket`, `interval`.
+- **Alias the time column** for time-series x-axis. It's detected by exact name (case-insensitive) — alias to one of: `ts`, `time`, `timestamp`.
 - **`Duration` is nanoseconds.** Divide by `1e6` for ms, `1e9` for seconds. `StatusCode = 'Error'` for failed spans.
 - **Bucket time-series adaptively** (see below) — never hard-code `toStartOfMinute` for a chart that can be viewed over days.
 

--- a/crates/everr-core/assets/skills/everr-write-dashboards/rules/geomap.md
+++ b/crates/everr-core/assets/skills/everr-write-dashboards/rules/geomap.md
@@ -1,0 +1,59 @@
+# GeoMap
+
+A world map. Two modes: `points` plots latitude/longitude markers sized by a value; `choropleth` shades whole countries by a value keyed on an ISO-3166 country code. Like every other visualization it infers structure from the columns you `SELECT` — the `*Column` options just name which columns to read.
+
+## Options (`plugin.spec`)
+
+| Option | Type | Default | Values | Effect |
+| --- | --- | --- | --- | --- |
+| `mode` | string | `points` | `points`, `choropleth` | Markers at coordinates vs. shaded countries. |
+| `latColumn` | string | `lat` | column name | Latitude column (points mode). Rows outside ±90 are dropped. |
+| `lonColumn` | string | `lon` | column name | Longitude column (points mode). Rows outside ±180 are dropped. |
+| `regionColumn` | string | `region` | column name | ISO-3166 **alpha-2 or alpha-3** country code column (choropleth mode), case-insensitive — `US`, `usa`, `DE`. Anything else (full names, "UK" instead of `GB`) does not resolve. |
+| `aggregation` | string | `sum` | `sum`, `avg`, `min`, `max`, `last` | Choropleth: how rows mapping to the same country combine. `sum` is only correct for additive metrics (request counts); use `avg`/`max` for latencies, percentiles, rates. `last` follows result-set order — only meaningful with an `ORDER BY`. |
+| `valueColumn` | string | `value` | column name | Sizes markers (points) / shades countries (choropleth). |
+| `labelColumn` | string | — | column name | Tooltip title. Falls back to the country name (choropleth) or raw coordinates (points). |
+| `unit` | string | `""` | any string | Suffix on tooltip and legend values (space-separated). |
+| `showLegend` | boolean | `true` | `false` | Points: the value→marker-size mapping plus per-query color swatches when the panel has multiple queries. Choropleth: the color ramp with its bounds. |
+| `colorScheme` | string | `blue` | `blue`, `green`, `orange`, `red` | Marker base color / choropleth ramp color. |
+| `projection` | string | `naturalEarth1` | `naturalEarth1`, `mercator`, `equalEarth` | Map projection. |
+| `scaleType` | string | `linear` | `linear`, `sqrt`, `log` | Value→size/color curve. `sqrt` keeps marker **area** proportional to the value; `log` keeps small values visible when one country dominates. |
+| `minRadius` | number | `3` | > 0 | Points: smallest marker radius, in viewBox units (the map viewBox is 980×500). |
+| `maxRadius` | number | `22` | > 0 | Points: largest marker radius. |
+| `min` | number | auto | any number | Lower bound of the color/size domain. Unset: **0** in choropleth (legend reads 0→max; data min if values go negative), the data minimum in points. |
+| `max` | number | auto | any number | Upper bound of the domain. Unset: the data maximum. |
+
+```yaml
+plugin:
+  kind: GeoMap
+  spec: { mode: choropleth, regionColumn: country, valueColumn: requests, aggregation: sum, colorScheme: blue }
+```
+
+These sixteen are the complete set. There is **no** zoom/pan config, custom geojson, city/state-level regions (countries only), heatmap mode, cluster mode, or per-marker color column. Marker color encodes which *query* a row came from, not a data column.
+
+## Data shape
+
+- **Points:** one row per marker — numeric `latColumn` + `lonColumn`, plus optional `valueColumn` (marker size) and `labelColumn` (tooltip). Rows with missing/invalid coordinates are skipped.
+- **Choropleth:** one row per country — `regionColumn` with an ISO alpha-2/alpha-3 code + numeric `valueColumn`. Rows that repeat a country are combined with `aggregation`; codes that don't resolve are skipped.
+
+Skipped rows in either mode surface as an "N rows not mapped" badge on the panel — if you see it, your coordinates or country codes are wrong, not hidden.
+
+```sql
+-- choropleth: requests per country (alpha-2 codes)
+SELECT SpanAttributes['geo.country_code'] AS region,
+       count() AS value
+FROM traces
+WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+  AND SpanAttributes['geo.country_code'] != ''
+GROUP BY region
+```
+
+The geo attribute names above are illustrative — discover what your telemetry actually carries before writing the query (see Startup Access). There is no GeoIP lookup in Everr; the query must already return codes or coordinates.
+
+## Behaviors to know
+
+- **No time axis.** A GeoMap aggregates the selected range into one picture; still scope the `WHERE` to `{from}`/`{to}` so it follows the picker.
+- **Multiple queries:** points mode overlays them, one marker color per query (legend shows swatches). Choropleth merges all queries' rows into one shading via `aggregation`.
+- **Choropleth shading fades from transparent (domain min) to the full scheme color (domain max)** — with the default 0-floored domain a shaded country never fades out entirely.
+- Big markers render behind small ones, so overlapping small markers stay hoverable.
+- A query returning no mappable rows renders a "No mappable data in this result" empty state.

--- a/crates/everr-core/assets/skills/everr-write-dashboards/rules/statchart.md
+++ b/crates/everr-core/assets/skills/everr-write-dashboards/rules/statchart.md
@@ -1,0 +1,49 @@
+# StatChart
+
+One or more big single-value tiles, each optionally with a sparkline and threshold coloring.
+
+## Options (`plugin.spec`)
+
+| Option | Type | Default | Values | Effect |
+| --- | --- | --- | --- | --- |
+| `calculation` | string | `last` | `last`, `first`, `mean`, `min`, `max`, `sum` | How each tile's column is reduced to one number. An unknown value falls back to `last`. |
+| `unit` | string | `""` | any string | Suffix after the value. No precision control — the value shows up to 2 decimals, locale-grouped. |
+| `sparkline` | boolean | `false` | `true` | Draw a trend line under the value. **Needs a time column and ≥2 points** (see Data shape) or nothing draws. |
+| `thresholds` | object | none | see below | Color the value (and sparkline). Omit for default text color. |
+
+### `thresholds`
+
+| Field | Type | Default | Values | Effect |
+| --- | --- | --- | --- | --- |
+| `mode` | string | `absolute` | `absolute`, `percent` | `absolute` compares the raw value; `percent` compares `value / tileMax × 100`. |
+| `defaultColor` | string | none | CSS color | Color before any step is crossed. Optional. |
+| `steps` | array | `[]` | `{ value: number, color?: string }` | Sorted ascending internally; the **highest step whose `value` ≤ the compare value wins**. A step with no `color` is crossed but leaves the color unchanged. |
+
+```yaml
+plugin:
+  kind: StatChart
+  spec:
+    calculation: last
+    unit: "%"
+    sparkline: true
+    thresholds:
+      mode: absolute
+      defaultColor: "#22c55e"            # green below the first step
+      steps:
+        - { value: 1, color: "#f59e0b" }   # amber once value ≥ 1
+        - { value: 5, color: "#ef4444" }   # red once value ≥ 5
+```
+
+There is **no** `min` / `max`, `decimals` / precision, `title`, `colorMode`, `orientation`, or `graphMode`. `calculation`, `unit`, and `thresholds` apply to **every** tile uniformly.
+
+## Data shape — one tile per numeric column per query
+
+- **Each numeric column → one tile**, reduced by `calculation`. N numeric columns × M queries = N×M tiles. To show p50/p95/p99 side by side, return three numeric columns from one query.
+- A **string** column creates **no** tile and is ignored — there is no per-label split here (unlike TimeSeriesChart). To break a stat out by label, pivot in SQL into separate numeric columns: `countIf(ServiceName = 'api') AS api, countIf(ServiceName = 'web') AS web`.
+- **Sparkline** needs a detected **time column** (same aliases as TimeSeriesChart) and at least two points; `calculation: last` then reads the latest bucket. A time-less query shows the number but no sparkline.
+
+## Behaviors to know
+
+- A **single tile hides its label**; with multiple tiles each shows its column name. Choose column aliases accordingly.
+- **`percent` mode** compares against the tile's own series max, so a single-value (time-less) tile is always 100% — use `percent` with a sparkline series, not a scalar.
+- The resolved threshold color tints **both** the number and the sparkline.

--- a/crates/everr-core/assets/skills/everr-write-dashboards/rules/statchart.md
+++ b/crates/everr-core/assets/skills/everr-write-dashboards/rules/statchart.md
@@ -6,16 +6,21 @@ One or more big single-value tiles, each optionally with a sparkline and thresho
 
 | Option | Type | Default | Values | Effect |
 | --- | --- | --- | --- | --- |
-| `calculation` | string | `last` | `last`, `first`, `mean`, `min`, `max`, `sum` | How each tile's column is reduced to one number. An unknown value falls back to `last`. |
-| `unit` | string | `""` | any string | Suffix after the value. No precision control — the value shows up to 2 decimals, locale-grouped. |
+| `calculation` | string | `last` | `last`, `first`, `mean`, `min`, `max`, `sum`, `count`, `range`, `diff` | How each tile's column is reduced to one number. `count` = number of points, `range` = max − min, `diff` = last − first. An unknown value is rejected by `everr apply`. |
+| `unit` | string | `""` | any string | Suffix after the value. |
+| `decimals` | number | none | `0`–`10` | Fixed fraction digits. Omitted: up to 2, trailing zeros dropped. |
 | `sparkline` | boolean | `false` | `true` | Draw a trend line under the value. **Needs a time column and ≥2 points** (see Data shape) or nothing draws. |
+| `colorMode` | string | `value` | `value`, `background` | `value` tints the number with the threshold color; `background` fills the whole tile. No effect without `thresholds`. |
+| `showLabel` | boolean | `false` | `true` | Show the column-name label even on a single-tile panel (multi-tile always shows it). |
+| `noValue` | string | `–` | any string | Text rendered for a query that produced no value (empty result / no numeric column). |
 | `thresholds` | object | none | see below | Color the value (and sparkline). Omit for default text color. |
 
 ### `thresholds`
 
 | Field | Type | Default | Values | Effect |
 | --- | --- | --- | --- | --- |
-| `mode` | string | `absolute` | `absolute`, `percent` | `absolute` compares the raw value; `percent` compares `value / tileMax × 100`. |
+| `mode` | string | `absolute` | `absolute`, `percent` | `absolute` compares the raw value; `percent` compares `value / max × 100`. |
+| `max` | number | tile's series max | any number | Reference for `percent` mode. Set it (e.g. an SLA ceiling) so percentages don't shift with the time window. Non-positive → no step is crossed. |
 | `defaultColor` | string | none | CSS color | Color before any step is crossed. Optional. |
 | `steps` | array | `[]` | `{ value: number, color?: string }` | Sorted ascending internally; the **highest step whose `value` ≤ the compare value wins**. A step with no `color` is crossed but leaves the color unchanged. |
 
@@ -25,6 +30,7 @@ plugin:
   spec:
     calculation: last
     unit: "%"
+    decimals: 1
     sparkline: true
     thresholds:
       mode: absolute
@@ -34,7 +40,7 @@ plugin:
         - { value: 5, color: "#ef4444" }   # red once value ≥ 5
 ```
 
-There is **no** `min` / `max`, `decimals` / precision, `title`, `colorMode`, `orientation`, or `graphMode`. `calculation`, `unit`, and `thresholds` apply to **every** tile uniformly.
+There is **no** `title`, `orientation`, or `graphMode`. `calculation`, `unit`, and `thresholds` apply to **every** tile uniformly.
 
 ## Data shape — one tile per numeric column per query
 
@@ -44,6 +50,9 @@ There is **no** `min` / `max`, `decimals` / precision, `title`, `colorMode`, `or
 
 ## Behaviors to know
 
-- A **single tile hides its label**; with multiple tiles each shows its column name. Choose column aliases accordingly.
-- **`percent` mode** compares against the tile's own series max, so a single-value (time-less) tile is always 100% — use `percent` with a sparkline series, not a scalar.
-- The resolved threshold color tints **both** the number and the sparkline.
+- A **single tile hides its label** unless `showLabel: true`; with multiple tiles each shows its column name. Choose column aliases accordingly.
+- Values ≥ 1 million **abbreviate** (`1234567` → `1.23M`, then `B`, `T`); smaller values keep thousands grouping.
+- A query that returns no value still renders its tile with the `noValue` text — it does not silently vanish from a multi-query panel.
+- **`percent` mode** without `thresholds.max` compares against the tile's own series max, so a single-value (time-less) tile is always 100% — set `max` or use it with a sparkline series.
+- The resolved threshold color tints **both** the number and the sparkline (`colorMode: background` fills the tile instead).
+- Value text scales down as tiles crowd the panel.

--- a/crates/everr-core/assets/skills/everr-write-dashboards/rules/table.md
+++ b/crates/everr-core/assets/skills/everr-write-dashboards/rules/table.md
@@ -1,0 +1,29 @@
+# Table
+
+Renders query rows as a plain table. Columns and their order come entirely from the `SELECT`; there is no column, formatting, sort, or pagination configuration.
+
+## Options (`plugin.spec`)
+
+| Option | Type | Default | Values | Effect |
+| --- | --- | --- | --- | --- |
+| `stickyHeader` | boolean | `false` | `true` | Keep the header row visible while the body scrolls. Only the literal `true` enables it. |
+
+```yaml
+plugin:
+  kind: Table
+  spec: { stickyHeader: true }
+```
+
+`stickyHeader` is the only option. There is **no** `columns`, `columnSettings`, `unit`, `format`, `sort`, `align`, `pagination`, `pageSize`, or `density`.
+
+## Data shape
+
+Any columns. They render **as-is, in `SELECT` order**, with the column alias as the header. There is no type-aware formatting:
+
+- **Numbers are not formatted** — no thousands separators, rounding, units, or alignment. Format in SQL: `round(quantile(0.95)(Duration) / 1e6, 1) AS p95_ms`. Convey the unit through the alias or panel title; a literal "ms" suffix is not rendered.
+- **`NULL` cells render the literal text `NULL`** (muted). Use `coalesce` / `ifNull` in SQL if you want blanks or a placeholder.
+
+## Behaviors to know
+
+- **Multiple queries** show a `Query A` / `Query B` / … toggle and display one query at a time — they are not merged.
+- **An empty result** shows a "no data" placeholder.

--- a/crates/everr-core/assets/skills/everr-write-dashboards/rules/timeseries.md
+++ b/crates/everr-core/assets/skills/everr-write-dashboards/rules/timeseries.md
@@ -1,0 +1,51 @@
+# TimeSeriesChart
+
+A line chart over time. It infers its structure from the columns you `SELECT` — there is no axis, color, stacking, or area configuration.
+
+## Options (`plugin.spec`)
+
+| Option | Type | Default | Values | Effect |
+| --- | --- | --- | --- | --- |
+| `unit` | string | `""` | any string | Suffix on y-axis ticks and tooltip values. Raw concatenation, **no space** — `unit: ms` renders `123ms`. |
+| `showLegend` | boolean | `false` | `true` | Show the series legend. Only the literal `true` enables it. |
+| `lineWidth` | number | `1.5` | any number | Line stroke width. |
+| `curveType` | string | `monotone` | `monotone`, `linear`, `natural`, `stepBefore`, `stepAfter` | Line interpolation. An unknown value falls back to the renderer default. |
+| `connectNulls` | boolean | `false` | `true` | Bridge gaps instead of breaking the line at them. |
+
+```yaml
+plugin:
+  kind: TimeSeriesChart
+  spec: { unit: ms, showLegend: true, lineWidth: 1.5, curveType: monotone, connectNulls: false }
+```
+
+These five are the complete set. There is **no** `yAxis` / `min` / `max`, `legend` object, `stack` / `stacking`, area / fill, `thresholds`, `decimals`, `pointRadius`, or per-series color. Series colors come from a fixed 6-color palette assigned by order (wrapping after 6) and are not configurable.
+
+## Data shape
+
+Return a **time column** plus one or more **numeric** columns:
+
+- **Time column** — aliased to a detected name (case-insensitive prefix): `ts`, `time`, `timestamp`, `date`, `datetime`, `created_at`, `period`, `bucket`, `interval`. No match → the chart draws nothing. Bucket it adaptively with `toStartOfInterval(col, INTERVAL {step:UInt32} SECOND)`.
+- **Numeric columns** → one line each. Quoted ClickHouse integers (e.g. `"42"`) count as numeric.
+
+### One line per label (string pivot) — mind the precondition
+
+A non-numeric **string** column pivots a value column into one line per distinct value (e.g. one line per service):
+
+```sql
+-- ✅ exactly one numeric column + ServiceName → one line per service
+SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} SECOND) AS ts,
+       ServiceName, count() AS spans
+FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+GROUP BY ts, ServiceName ORDER BY ts
+```
+
+**The pivot fires only when the query returns exactly one numeric column.** With two or more numeric columns the string column is **ignored** and each numeric column becomes one line. So `SELECT ts, ServiceName, p50, p95, p99 ...` does **not** produce per-service lines — it produces three lines (p50/p95/p99) aggregated across services, and `ServiceName` is dropped.
+
+To break **multiple** metrics out per service, use **one query per metric** (each returning that single metric + the string column); the queries overlay on one timeline. The label column can be any non-numeric string expression, including a computed one — e.g. `concat(ServiceName, ' p95') AS series` — which is the idiomatic way to keep the lines distinct across the overlaid per-metric queries. Multiple string columns concatenate into one label joined with ` · `.
+
+## Behaviors to know
+
+- **Multiple queries overlay** on one shared timeline; series colors continue across queries.
+- **Gaps:** a line breaks where two consecutive points are more than ~1.5× the series' median interval apart. `connectNulls: true` bridges them. Irregularly-sampled series look broken unless bucketed evenly.
+- **Edge buckets are partial** (the picker rarely lands on a bucket boundary): the leading bucket is kept but clipped at the left edge, and the trailing bucket reads low. Don't mistake the trailing dip for a real regression.
+- **Drag across the plot to zoom** — a user action that rewrites the time range; nothing to configure.

--- a/crates/everr-core/assets/skills/everr-write-dashboards/rules/timeseries.md
+++ b/crates/everr-core/assets/skills/everr-write-dashboards/rules/timeseries.md
@@ -24,7 +24,7 @@ These five are the complete set. There is **no** `yAxis` / `min` / `max`, `legen
 
 Return a **time column** plus one or more **numeric** columns:
 
-- **Time column** — aliased to a detected name (case-insensitive prefix): `ts`, `time`, `timestamp`, `date`, `datetime`, `created_at`, `period`, `bucket`, `interval`. No match → the chart draws nothing. Bucket it adaptively with `toStartOfInterval(col, INTERVAL {step:UInt32} SECOND)`.
+- **Time column** — aliased to a detected name (case-insensitive **exact** match): `ts`, `time`, or `timestamp`. No match → the chart draws nothing. Bucket it adaptively with `toStartOfInterval(col, INTERVAL {step:UInt32} SECOND)`.
 - **Numeric columns** → one line each. Quoted ClickHouse integers (e.g. `"42"`) count as numeric.
 
 ### One line per label (string pivot) — mind the precondition


### PR DESCRIPTION
## What

Adds the `everr-write-dashboards` skill (as-code dashboard authoring) with a **progressive-disclosure** structure modeled on `everr-setup-telemetry`: a general `SKILL.md` plus per-visualization rule files loaded on demand.

```
everr-write-dashboards/
  SKILL.md            general model + a viz loader table
  rules/timeseries.md TimeSeriesChart — options, pivot precondition, gaps, partial buckets, palette
  rules/table.md      Table — stickyHeader only, NULL literal, format-in-SQL, query selector
  rules/statchart.md  StatChart — calculation/unit/sparkline/thresholds, tiling model, percent semantics
```

## Why per-viz files

The per-viz specs were both incomplete (the renderers support options the skill never documented) and, once completed, substantial enough to justify deferring — inlining all four full option sets would bloat every load. The main skill keeps a general data-shape list + loader table; each viz's complete option set lives in its own file.

## How the options were derived

`plugin.spec` is an opaque `Record` in the Zod schema (not validated), so the visualization renderers are the only source of truth. Each viz's options, defaults, accepted values, and footguns were extracted directly from the renderer components.

## Validation (TDD-for-skills)

- RED: authoring scenarios against the prior single-file skill exposed the TimeSeriesChart pivot precondition gap (agent guessed at ~70% confidence).
- GREEN: re-ran the scenarios against the restructured skill — agents load only the relevant rule file(s), state the pivot precondition as fact, and still refuse to invent non-existent options.
- REFACTOR: closed a residual uncertainty (computed concat() string columns pivot too).

## Note

Documents the adaptive `{step:UInt32}` parameter from #198, so it should merge around/after that PR. The `rules/geomap.md` file documents the GeoMap visualization including the options added on `gio/geo-map-panel`, so it should also merge after that branch.
