### PR TITLE
feat(dashboards): validate visualization options with per-plugin zod schemas

### DIFF
--- a/.agents/skills/add-dashboard-visualization/SKILL.md
+++ b/.agents/skills/add-dashboard-visualization/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-dashboard-visualization
-description: Use when adding a new visualization type (chart, table, stat, gauge, etc.) to the dashboard panel system. Guides creating the read-only renderer component and registering it.
+description: Use when adding a new visualization type (chart, table, stat, gauge, etc.) to the dashboard panel system. Guides creating the spec schema, the read-only renderer component, and registering both.
 user-invocable: true
 ---
 
@@ -8,30 +8,34 @@ user-invocable: true
 
 Follow these steps to add a new visualization type to the dashboard panel system.
 
-Dashboards are **read-only**: they are defined as code (Perses YAML/JSON in a source repo) and reconciled into Everr with `everr apply`. There is no in-app editor or chart-type picker. A visualization is therefore a **pure renderer** — it takes a panel's `plugin` config plus the query results and draws them. Selecting a visualization for a panel happens in the dashboard file (`plugin.kind`), not in the UI.
+Dashboards are **read-only**: they are defined as code (Perses YAML/JSON in a source repo) and reconciled into Everr with `everr apply`. There is no in-app editor or chart-type picker. A visualization is therefore a **pure renderer** — it takes its parsed spec options plus the query results and draws them. Selecting a visualization for a panel happens in the dashboard file (`plugin.kind`), not in the UI.
 
 ## Architecture
 
-Visualizations live in `packages/app/src/components/dashboards/visualizations/`. Each type gets its own subdirectory:
+Visualizations live in `packages/app/src/components/dashboards/visualizations/`. Each type gets its own subdirectory with a renderer and a zod spec schema:
 
 ```
 visualizations/
-├── index.tsx                          # Registry — maps plugin.kind to components
+├── index.tsx                          # Registry — maps plugin.kind to { schema, component, inset }
+├── parse-spec.ts                      # Lenient spec parsing (invalid options → defaults + warnings)
 ├── table/
+│   ├── spec.ts                        # Zod schema for the plugin's options
 │   └── table-visualization.tsx        # Renders the visualization
 └── <your-new-type>/
+    ├── spec.ts
     └── <type>-visualization.tsx
 ```
 
+The schema is used twice: `everr apply` validates dashboard files against it (strict, via `data/dashboards/plugin-specs.ts`), and at render time the raw spec is parsed leniently — invalid options fall back to their defaults and surface as a warning icon in the panel header.
+
 ## Key interfaces
 
-The visualization component receives the panel's `plugin` config and the
-results of running the panel's queries:
+The visualization component receives its **parsed spec** (the output of its schema — defaulted and typed, never the raw plugin config) and the results of running the panel's queries:
 
 ```ts
 // From visualizations/index.tsx
-interface VisualizationProps {
-  plugin: PanelPlugin;        // { kind: string; spec: Record<string, PluginSpecValue> }
+interface VisualizationProps<TSpec = unknown> {
+  spec: TSpec;                // parsed output of the visualization's spec schema
   data?: QueryResultRow[][];  // one frame (row[]) per panel query; undefined while loading
   timeRange?: ResolvedTimeRange;                 // { from: Date; to: Date }
   onTimeRangeChange?: (range: ResolvedTimeRange) => void; // e.g. drag-to-zoom
@@ -39,8 +43,8 @@ interface VisualizationProps {
 ```
 
 `data` is an array of query frames — one entry per query on the panel, each a
-list of rows. Display options come from `plugin.spec`. Loading, error, and empty
-states are handled by the panel shell and by the renderer's own `!data` branch.
+list of rows. Loading, error, and empty states are handled by the panel shell
+and by the renderer's own `!data` branch.
 
 ## Steps
 
@@ -52,20 +56,44 @@ packages/app/src/components/dashboards/visualizations/<kind>/
 
 Use the lowercase kebab-case of the `kind` value (e.g., `TimeSeriesChart` → `time-series-chart/`).
 
-### 2. Create the visualization component
+### 2. Define the spec schema
 
-File: `<kind>-visualization.tsx`
+File: `<kind>/spec.ts` — pure zod, **no React imports** (it is loaded from server code).
+
+```ts
+import * as z from "zod";
+
+export const <kind>Spec = z.looseObject({
+  showLegend: z.boolean().default(false),
+  unit: z.string().default(""),
+});
+
+export type <Kind>Spec = z.infer<typeof <kind>Spec>;
+```
+
+Two contracts to respect:
+
+- **`looseObject`, never `object`/`strictObject`** — unknown option keys must flow through verbatim (validation is never stricter than Perses on shape).
+- **`{}` must parse** — every known field needs `.default(...)` or `.optional()`. The lenient render path relies on this to fall back to defaults when an option is invalid.
+
+### 3. Create the visualization component
+
+File: `<kind>/<kind>-visualization.tsx`
 
 ```tsx
 import type { VisualizationProps } from "../index";
+import type { <Kind>Spec } from "./spec";
 
-export function <Kind>Visualization({ plugin, data }: VisualizationProps) {
-  // Read display options from plugin.spec (e.g. plugin.spec.showLegend)
+export function <Kind>Visualization({
+  spec,
+  data,
+}: VisualizationProps<<Kind>Spec>) {
+  // Options are already validated and defaulted — read them directly
+  // (e.g. spec.showLegend), no typeof narrowing or casts.
   // Render `data` (one frame per panel query); render an empty state when !data
 }
 ```
 
-- Read display options from `plugin.spec` (e.g., `plugin.spec.showLegend`)
 - Render the query results passed in `data`; handle the `!data` / empty cases
 - Available chart library: **Recharts** (Bar, Line, Area, ComposedChart, ScatterChart, etc.)
 - Available chart wrapper: `ChartContainer` from `@everr/ui/components/chart`
@@ -74,15 +102,11 @@ export function <Kind>Visualization({ plugin, data }: VisualizationProps) {
 **Scrolling and overflow are visualization concerns.** `PanelShell` provides `min-h-0 flex-1` on its content area but no `overflow`. Each visualization must manage its own scroll container. For example, the table visualization wraps itself in a flex column with a scrollable inner div:
 
 ```tsx
-export function MyVisualization({ plugin }: VisualizationProps) {
-  return (
-    <div className="flex h-full flex-col">
-      <div className="min-h-0 flex-1 overflow-auto overscroll-none">
-        {/* visualization content */}
-      </div>
-    </div>
-  );
-}
+<div className="flex h-full flex-col">
+  <div className="min-h-0 flex-1 overflow-auto overscroll-none">
+    {/* visualization content */}
+  </div>
+</div>
 ```
 
 For `flush-content` visualizations that need a top border separating the header from content, place `border-t border-border` on the outer wrapper — outside the scroll container so it stays fixed:
@@ -95,31 +119,46 @@ For `flush-content` visualizations that need a top border separating the header 
 </div>
 ```
 
-### 3. Register the visualization
+### 4. Register the visualization
 
-In `packages/app/src/components/dashboards/visualizations/index.tsx`:
+In `packages/app/src/components/dashboards/visualizations/index.tsx`, import the component and its schema, then add a `defineVisualization` entry to the `registry` object — it type-checks that the component's props match the schema's output:
 
-1. Import the component:
-   ```tsx
-   import { <Kind>Visualization } from "./<kind>/<kind>-visualization";
-   ```
+```tsx
+import { <kind>Spec } from "./<kind>/spec";
+import { <Kind>Visualization } from "./<kind>/<kind>-visualization";
 
-2. Add an entry to the `registry` object:
-   ```tsx
-   const registry: Record<string, VisualizationEntry> = {
-     // ... existing entries
-     <Kind>: {
-       component: <Kind>Visualization,
-       inset: "default",               // or "flush-content" for edge-to-edge content like tables
-     },
-   };
-   ```
+const registry: Record<string, VisualizationEntry> = {
+  // ... existing entries
+  <Kind>: defineVisualization({
+    schema: <kind>Spec,
+    component: <Kind>Visualization,
+    inset: "default",               // or "flush-content" for edge-to-edge content like tables
+  }),
+};
+```
 
 The `inset` option controls padding inside the panel card:
 - `"default"` — standard padding (use for charts, stats)
 - `"flush-content"` — no horizontal padding or bottom padding (use for tables, maps)
 
-### 4. Use it in a dashboard
+### 5. Register the schema for apply-time validation
+
+In `packages/app/src/data/dashboards/plugin-specs.ts`, add the schema under the plugin kind:
+
+```ts
+export const panelPluginSpecs: Record<string, z.ZodType> = {
+  // ... existing entries
+  <Kind>: <kind>Spec,
+};
+```
+
+Without this, `everr apply` accepts any spec for the new kind instead of rejecting invalid option values with the file and option path. There is a test asserting every registered schema parses `{}` (`visualizations/parse-spec.test.ts`).
+
+### 6. Document the options
+
+Add the new kind and its option table to `packages/docs/content/docs/dashboards/visualizations.mdx`, and update the `everr-write-dashboards` skill in `crates/everr-core/assets/skills/` so dashboard-authoring agents know the options exist.
+
+### 7. Use it in a dashboard
 
 There is no UI picker — a panel selects this visualization by setting
 `plugin.kind` in a dashboard file. Add a panel to a Perses dashboard
@@ -133,8 +172,8 @@ spec:
       spec:
         display: { name: Panel Title, description: Optional description }
         plugin:
-          kind: <Kind>            # matches the registry key from step 3
-          spec: { showLegend: true }   # whatever your renderer reads from plugin.spec
+          kind: <Kind>            # matches the registry key from step 4
+          spec: { showLegend: true }   # validated against the spec schema from step 2
         queries:
           - kind: ClickHouseSQL
             spec:
@@ -144,15 +183,17 @@ spec:
 Reference the panel from a layout item in the same dashboard, then reconcile it:
 
 ```bash
-everr apply ./dashboards --source=<source> --dry-run   # preview the diff
-everr apply ./dashboards --source=<source>             # write it
+everr apply ./dashboards --dry-run   # preview the diff
+everr apply ./dashboards             # write it
 ```
 
-Open `/dashboards/<source>/<slug>` to see it render with live query results.
+The dashboard's project comes from `metadata.project` (default `"default"`).
+Open `/dashboards/<project>/<slug>` to see it render with live query results.
 
 ## Reference: Table visualization
 
 The Table visualization is a complete example:
 
-- **Visualization:** `visualizations/table/table-visualization.tsx` — uses `DataTable` from `@everr/ui`, renders the `data` frames, reads `plugin.spec.stickyHeader`
+- **Spec schema:** `visualizations/table/spec.ts` — `stickyHeader` boolean, defaulted
+- **Visualization:** `visualizations/table/table-visualization.tsx` — uses `DataTable` from `@everr/ui`, renders the `data` frames, reads `spec.stickyHeader`
 - **Registry:** `inset: "flush-content"` so the table sits edge-to-edge in the panel

--- a/packages/app/src/components/dashboards/dashboard-panel.tsx
+++ b/packages/app/src/components/dashboards/dashboard-panel.tsx
@@ -1,15 +1,53 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@everr/ui/components/tooltip";
 import { resolveTimeRange } from "@everr/ui/lib/time-range";
 import { useNavigate } from "@tanstack/react-router";
-import { useCallback } from "react";
+import { TriangleAlert } from "lucide-react";
+import { useCallback, useMemo } from "react";
 import type { Panel } from "@/data/dashboards/schema";
 import { useTimeRange } from "@/hooks/use-time-range";
 import { PanelShell } from "../panel-shell";
 import { usePanelQueries } from "./use-panel-queries";
-import { getVisualizationInset, PanelVisualization } from "./visualizations";
+import {
+  getVisualizationInset,
+  getVisualizationSpecWarnings,
+  PanelVisualization,
+} from "./visualizations";
 
 interface DashboardPanelProps {
   panel: Panel;
   panelKey: string;
+}
+
+function SpecWarningsIndicator({ warnings }: { warnings: string[] }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <button
+            type="button"
+            className="text-amber-500 hover:text-amber-400"
+            aria-label="Invalid panel options"
+          />
+        }
+      >
+        <TriangleAlert className="size-4" />
+      </TooltipTrigger>
+      <TooltipContent className="max-w-72">
+        <p className="mb-1 font-medium">
+          Invalid panel options ignored (defaults used):
+        </p>
+        <ul className="list-disc space-y-0.5 pl-4">
+          {warnings.map((w) => (
+            <li key={w}>{w}</li>
+          ))}
+        </ul>
+      </TooltipContent>
+    </Tooltip>
+  );
 }
 
 export function DashboardPanel({ panel, panelKey }: DashboardPanelProps) {
@@ -22,6 +60,11 @@ export function DashboardPanel({ panel, panelKey }: DashboardPanelProps) {
 
   const { data, status, errorMessage } = usePanelQueries(panel, { from, to });
   const { fromDate, toDate } = resolveTimeRange(timeRange);
+
+  const specWarnings = useMemo(
+    () => getVisualizationSpecWarnings(plugin),
+    [plugin],
+  );
 
   const handleTimeRangeChange = useCallback(
     (range: { from: Date; to: Date }) => {
@@ -47,6 +90,11 @@ export function DashboardPanel({ panel, panelKey }: DashboardPanelProps) {
         errorMessage={errorMessage}
         className="h-full"
         inset={getVisualizationInset(plugin.kind)}
+        action={
+          specWarnings.length > 0 ? (
+            <SpecWarningsIndicator warnings={specWarnings} />
+          ) : undefined
+        }
       >
         <PanelVisualization
           plugin={plugin}

--- a/packages/app/src/components/dashboards/visualizations/index.tsx
+++ b/packages/app/src/components/dashboards/visualizations/index.tsx
@@ -1,7 +1,12 @@
-import type { ComponentType } from "react";
+import { type ComponentType, useMemo } from "react";
+import type * as z from "zod";
 import type { PanelPlugin } from "@/data/dashboards/schema";
+import { parseSpecLenient } from "./parse-spec";
+import { statChartSpec } from "./stat-chart/spec";
 import { StatChartVisualization } from "./stat-chart/stat-chart-visualization";
+import { tableSpec } from "./table/spec";
 import { TableVisualization } from "./table/table-visualization";
+import { timeSeriesChartSpec } from "./time-series-chart/spec";
 import { TimeSeriesChartVisualization } from "./time-series-chart/time-series-chart-visualization";
 
 export type QueryResultRow = Record<string, string | number | boolean | null>;
@@ -11,29 +16,46 @@ export interface ResolvedTimeRange {
   to: Date;
 }
 
-export interface VisualizationProps {
-  plugin: PanelPlugin;
+export interface VisualizationProps<TSpec = unknown> {
+  spec: TSpec;
   data?: QueryResultRow[][];
   timeRange?: ResolvedTimeRange;
   onTimeRangeChange?: (range: ResolvedTimeRange) => void;
 }
 
 interface VisualizationEntry {
+  schema: z.ZodType;
   component: ComponentType<VisualizationProps>;
   inset?: "default" | "flush-content";
 }
 
+/**
+ * Ties a visualization's component to its spec schema: the component receives
+ * the schema's parsed output, never the raw plugin spec. The registry erases
+ * the spec type; this definition site is where the pairing is checked.
+ */
+function defineVisualization<S extends z.ZodType>(entry: {
+  schema: S;
+  component: ComponentType<VisualizationProps<z.output<S>>>;
+  inset?: "default" | "flush-content";
+}): VisualizationEntry {
+  return entry as VisualizationEntry;
+}
+
 const registry: Record<string, VisualizationEntry> = {
-  StatChart: {
+  StatChart: defineVisualization({
+    schema: statChartSpec,
     component: StatChartVisualization,
-  },
-  Table: {
+  }),
+  Table: defineVisualization({
+    schema: tableSpec,
     component: TableVisualization,
     inset: "flush-content",
-  },
-  TimeSeriesChart: {
+  }),
+  TimeSeriesChart: defineVisualization({
+    schema: timeSeriesChartSpec,
     component: TimeSeriesChartVisualization,
-  },
+  }),
 };
 
 export function getVisualizationInset(
@@ -42,15 +64,38 @@ export function getVisualizationInset(
   return registry[kind]?.inset ?? "default";
 }
 
+/**
+ * Warnings for plugin spec options that fail the visualization's schema and
+ * will be ignored at render time (defaults apply instead). Empty for valid
+ * specs and unknown kinds.
+ */
+export function getVisualizationSpecWarnings(plugin: PanelPlugin): string[] {
+  const entry = registry[plugin.kind];
+  if (!entry) return [];
+  return parseSpecLenient(entry.schema, plugin.spec).warnings;
+}
+
+export interface PanelVisualizationProps {
+  plugin: PanelPlugin;
+  data?: QueryResultRow[][];
+  timeRange?: ResolvedTimeRange;
+  onTimeRangeChange?: (range: ResolvedTimeRange) => void;
+}
+
 export function PanelVisualization({
   plugin,
   data,
   timeRange,
   onTimeRangeChange,
-}: VisualizationProps) {
+}: PanelVisualizationProps) {
   const entry = registry[plugin.kind];
 
-  if (!entry) {
+  const parsed = useMemo(
+    () => (entry ? parseSpecLenient(entry.schema, plugin.spec) : null),
+    [entry, plugin.spec],
+  );
+
+  if (!entry || !parsed) {
     return (
       <div className="flex h-full items-center justify-center p-4 text-center text-muted-foreground">
         <p className="text-sm">
@@ -64,7 +109,7 @@ export function PanelVisualization({
   const Component = entry.component;
   return (
     <Component
-      plugin={plugin}
+      spec={parsed.spec}
       data={data}
       timeRange={timeRange}
       onTimeRangeChange={onTimeRangeChange}

--- a/packages/app/src/components/dashboards/visualizations/parse-spec.test.ts
+++ b/packages/app/src/components/dashboards/visualizations/parse-spec.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { panelPluginSpecs } from "@/data/dashboards/plugin-specs";
+import { parseSpecLenient } from "./parse-spec";
+import { statChartSpec } from "./stat-chart/spec";
+import { timeSeriesChartSpec } from "./time-series-chart/spec";
+
+describe("parseSpecLenient", () => {
+  it("returns the parsed spec with no warnings for valid input", () => {
+    const { spec, warnings } = parseSpecLenient(timeSeriesChartSpec, {
+      unit: "ms",
+      lineWidth: 2,
+    });
+    expect(warnings).toEqual([]);
+    expect(spec.unit).toBe("ms");
+    expect(spec.lineWidth).toBe(2);
+    expect(spec.curveType).toBe("monotone");
+  });
+
+  it("drops an invalid option to its default and warns with the path", () => {
+    const { spec, warnings } = parseSpecLenient(timeSeriesChartSpec, {
+      lineWidth: "3",
+      unit: "ms",
+    });
+    expect(spec.lineWidth).toBe(1.5);
+    expect(spec.unit).toBe("ms");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/^lineWidth: /);
+  });
+
+  it("warns once per invalid option and keeps the valid ones", () => {
+    const { spec, warnings } = parseSpecLenient(timeSeriesChartSpec, {
+      lineWidth: -1,
+      curveType: "wiggly",
+      showLegend: true,
+    });
+    expect(spec.lineWidth).toBe(1.5);
+    expect(spec.curveType).toBe("monotone");
+    expect(spec.showLegend).toBe(true);
+    expect(warnings).toHaveLength(2);
+  });
+
+  it("drops a structurally invalid nested option entirely", () => {
+    const { spec, warnings } = parseSpecLenient(statChartSpec, {
+      thresholds: { steps: [{ value: "high" }] },
+      unit: "%",
+    });
+    expect(spec.thresholds).toBeUndefined();
+    expect(spec.unit).toBe("%");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/^thresholds\.steps\.0\.value: /);
+  });
+
+  it("falls back to all defaults for a non-object spec", () => {
+    const { spec, warnings } = parseSpecLenient(timeSeriesChartSpec, "nope");
+    expect(spec.lineWidth).toBe(1.5);
+    expect(warnings.length).toBeGreaterThan(0);
+  });
+
+  it("preserves unknown keys (never stricter than Perses)", () => {
+    const { spec, warnings } = parseSpecLenient(timeSeriesChartSpec, {
+      somethingNew: true,
+    });
+    expect(warnings).toEqual([]);
+    expect((spec as Record<string, unknown>).somethingNew).toBe(true);
+  });
+});
+
+describe("panel plugin spec contracts", () => {
+  it("every registered spec schema parses {} (lenient fallback never throws)", () => {
+    for (const [kind, schema] of Object.entries(panelPluginSpecs)) {
+      expect(schema.safeParse({}).success, `${kind} must parse {}`).toBe(true);
+    }
+  });
+});

--- a/packages/app/src/components/dashboards/visualizations/parse-spec.ts
+++ b/packages/app/src/components/dashboards/visualizations/parse-spec.ts
@@ -1,0 +1,44 @@
+import type * as z from "zod";
+
+export interface ParsedSpec<T> {
+  spec: T;
+  /** Human-readable "path: problem" entries for options that were ignored. */
+  warnings: string[];
+}
+
+function formatIssue(issue: z.core.$ZodIssue): string {
+  const path = issue.path.map(String).join(".");
+  return path ? `${path}: ${issue.message}` : issue.message;
+}
+
+/**
+ * Parse a plugin spec without ever failing: invalid options are dropped (their
+ * schema defaults apply instead) and reported as warnings so the UI can
+ * surface them. The strict counterpart runs at apply time; this lenient path
+ * exists so a stored dashboard that predates validation still renders.
+ *
+ * Requires a schema where `{}` parses (all known fields defaulted/optional).
+ */
+export function parseSpecLenient<S extends z.ZodType>(
+  schema: S,
+  raw: unknown,
+): ParsedSpec<z.output<S>> {
+  const strict = schema.safeParse(raw);
+  if (strict.success) return { spec: strict.data, warnings: [] };
+
+  const warnings = strict.error.issues.map(formatIssue);
+  const cleaned: Record<string, unknown> =
+    typeof raw === "object" && raw !== null && !Array.isArray(raw)
+      ? { ...(raw as Record<string, unknown>) }
+      : {};
+  for (const issue of strict.error.issues) {
+    const head = issue.path[0];
+    if (typeof head === "string") delete cleaned[head];
+  }
+
+  const lenient = schema.safeParse(cleaned);
+  // Stripping every offending top-level key leaves only valid fields, so this
+  // parse can only fail if the schema breaks the `{}`-parses contract.
+  if (lenient.success) return { spec: lenient.data, warnings };
+  return { spec: schema.parse({}), warnings };
+}

--- a/packages/app/src/components/dashboards/visualizations/stat-chart/spec.ts
+++ b/packages/app/src/components/dashboards/visualizations/stat-chart/spec.ts
@@ -1,0 +1,30 @@
+import * as z from "zod";
+
+const thresholdStep = z.looseObject({
+  value: z.number(),
+  color: z.string().optional(),
+});
+
+const thresholdsSpec = z.looseObject({
+  mode: z.enum(["absolute", "percent"]).optional(),
+  defaultColor: z.string().optional(),
+  steps: z.array(thresholdStep).optional(),
+});
+
+/**
+ * StatChart plugin options. Loose so unknown keys flow through verbatim
+ * (validation must never be stricter than Perses on shape); every known field
+ * is defaulted so `{}` always parses — the lenient render path relies on it.
+ */
+export const statChartSpec = z.looseObject({
+  calculation: z
+    .enum(["last", "first", "mean", "min", "max", "sum"])
+    .default("last"),
+  unit: z.string().default(""),
+  sparkline: z.boolean().default(false),
+  thresholds: thresholdsSpec.optional(),
+});
+
+export type StatChartSpec = z.infer<typeof statChartSpec>;
+export type CalculationType = StatChartSpec["calculation"];
+export type ThresholdsSpec = z.infer<typeof thresholdsSpec>;

--- a/packages/app/src/components/dashboards/visualizations/stat-chart/stat-calculations.ts
+++ b/packages/app/src/components/dashboards/visualizations/stat-chart/stat-calculations.ts
@@ -1,17 +1,6 @@
-export type CalculationType = "last" | "first" | "mean" | "min" | "max" | "sum";
+import type { CalculationType, ThresholdsSpec } from "./spec";
 
-const CALCULATIONS: ReadonlyArray<{ value: CalculationType }> = [
-  { value: "last" },
-  { value: "first" },
-  { value: "mean" },
-  { value: "min" },
-  { value: "max" },
-  { value: "sum" },
-] as const;
-
-export function isCalculationType(value: unknown): value is CalculationType {
-  return CALCULATIONS.some((c) => c.value === value);
-}
+export type { CalculationType, ThresholdsSpec } from "./spec";
 
 export function calculate(
   values: number[],
@@ -32,17 +21,6 @@ export function calculate(
     case "sum":
       return values.reduce((a, b) => a + b, 0);
   }
-}
-
-export interface ThresholdStep {
-  value: number;
-  color?: string;
-}
-
-export interface ThresholdsSpec {
-  mode?: "absolute" | "percent";
-  defaultColor?: string;
-  steps?: ThresholdStep[];
 }
 
 export function resolveThresholdColor(

--- a/packages/app/src/components/dashboards/visualizations/stat-chart/stat-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/stat-chart/stat-chart-visualization.tsx
@@ -3,26 +3,17 @@ import { Hash } from "lucide-react";
 import { useMemo } from "react";
 import { Area, AreaChart } from "recharts";
 import type { VisualizationProps } from "../index";
-import {
-  formatStatValue,
-  isCalculationType,
-  resolveThresholdColor,
-  type ThresholdsSpec,
-} from "./stat-calculations";
+import type { StatChartSpec } from "./spec";
+import { formatStatValue, resolveThresholdColor } from "./stat-calculations";
 import { computeStatTiles } from "./stat-series";
 
 const SPARKLINE_COLOR = "hsl(217, 91%, 60%)";
 
-export function StatChartVisualization({ plugin, data }: VisualizationProps) {
-  const spec = plugin.spec;
-  const calculation = isCalculationType(spec.calculation)
-    ? spec.calculation
-    : "last";
-  const unit = typeof spec.unit === "string" ? spec.unit : "";
-  const showSparkline = spec.sparkline === true;
-  const thresholds = (spec.thresholds ?? undefined) as
-    | ThresholdsSpec
-    | undefined;
+export function StatChartVisualization({
+  spec,
+  data,
+}: VisualizationProps<StatChartSpec>) {
+  const { calculation, unit, sparkline: showSparkline, thresholds } = spec;
 
   const tiles = useMemo(
     () => (data ? computeStatTiles(data, calculation) : []),

--- a/packages/app/src/components/dashboards/visualizations/table/spec.ts
+++ b/packages/app/src/components/dashboards/visualizations/table/spec.ts
@@ -1,0 +1,12 @@
+import * as z from "zod";
+
+/**
+ * Table plugin options. Loose so unknown keys flow through verbatim
+ * (validation must never be stricter than Perses on shape); every known field
+ * is defaulted so `{}` always parses — the lenient render path relies on it.
+ */
+export const tableSpec = z.looseObject({
+  stickyHeader: z.boolean().default(false),
+});
+
+export type TableSpec = z.infer<typeof tableSpec>;

--- a/packages/app/src/components/dashboards/visualizations/table/table-visualization.test.tsx
+++ b/packages/app/src/components/dashboards/visualizations/table/table-visualization.test.tsx
@@ -1,27 +1,26 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import { tableSpec } from "./spec";
 import { TableVisualization } from "./table-visualization";
 
-const plugin = { kind: "Table", spec: {} };
+const spec = tableSpec.parse({});
 
 describe("TableVisualization", () => {
   it("shows no selector for a single query", () => {
-    render(<TableVisualization plugin={plugin} data={[[{ a: 1 }]]} />);
+    render(<TableVisualization spec={spec} data={[[{ a: 1 }]]} />);
     expect(screen.queryByText("Query B")).toBeNull();
     expect(screen.getByText("1")).toBeInTheDocument();
   });
 
   it("shows a selector with one entry per query", () => {
-    render(
-      <TableVisualization plugin={plugin} data={[[{ a: 1 }], [{ a: 2 }]]} />,
-    );
+    render(<TableVisualization spec={spec} data={[[{ a: 1 }], [{ a: 2 }]]} />);
     expect(screen.getByText("Query A")).toBeInTheDocument();
     expect(screen.getByText("Query B")).toBeInTheDocument();
   });
 
   it("shows the borderless empty state for a single query with no rows", () => {
     const { container } = render(
-      <TableVisualization plugin={plugin} data={[[]]} />,
+      <TableVisualization spec={spec} data={[[]]} />,
     );
     expect(screen.getByText(/no data/i)).toBeInTheDocument();
     // No bordered container (the empty state has no border-t).
@@ -29,7 +28,7 @@ describe("TableVisualization", () => {
   });
 
   it("keeps the selector and shows 'No rows' when a query frame is empty", () => {
-    render(<TableVisualization plugin={plugin} data={[[{ a: 1 }], []]} />);
+    render(<TableVisualization spec={spec} data={[[{ a: 1 }], []]} />);
     expect(screen.getByText("Query A")).toBeInTheDocument();
     expect(screen.getByText("Query B")).toBeInTheDocument();
   });

--- a/packages/app/src/components/dashboards/visualizations/table/table-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/table/table-visualization.tsx
@@ -6,6 +6,7 @@ import {
 import { TableIcon } from "lucide-react";
 import { useState } from "react";
 import type { QueryResultRow, VisualizationProps } from "../index";
+import type { TableSpec } from "./spec";
 
 const QUERY_LABELS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
@@ -23,7 +24,10 @@ function buildColumns(rows: QueryResultRow[]): Column<QueryResultRow>[] {
   }));
 }
 
-export function TableVisualization({ plugin, data }: VisualizationProps) {
+export function TableVisualization({
+  spec,
+  data,
+}: VisualizationProps<TableSpec>) {
   const sets = data ?? [];
   const [selected, setSelected] = useState(0);
 
@@ -77,7 +81,7 @@ export function TableVisualization({ plugin, data }: VisualizationProps) {
             data={rows}
             columns={columns}
             rowKey={(_, i) => String(i)}
-            stickyHeader={plugin.spec.stickyHeader === true}
+            stickyHeader={spec.stickyHeader}
             bordered
           />
         )}

--- a/packages/app/src/components/dashboards/visualizations/time-series-chart/spec.ts
+++ b/packages/app/src/components/dashboards/visualizations/time-series-chart/spec.ts
@@ -1,0 +1,18 @@
+import * as z from "zod";
+
+/**
+ * TimeSeriesChart plugin options. Loose so unknown keys flow through verbatim
+ * (validation must never be stricter than Perses on shape); every known field
+ * is defaulted so `{}` always parses — the lenient render path relies on it.
+ */
+export const timeSeriesChartSpec = z.looseObject({
+  unit: z.string().default(""),
+  showLegend: z.boolean().default(false),
+  lineWidth: z.number().positive().default(1.5),
+  curveType: z
+    .enum(["monotone", "linear", "natural", "stepBefore", "stepAfter"])
+    .default("monotone"),
+  connectNulls: z.boolean().default(false),
+});
+
+export type TimeSeriesChartSpec = z.infer<typeof timeSeriesChartSpec>;

--- a/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-chart-visualization.tsx
@@ -23,9 +23,8 @@ import {
   YAxis,
 } from "recharts";
 import type { VisualizationProps } from "../index";
+import type { TimeSeriesChartSpec } from "./spec";
 import { buildChartModel, TS_KEY } from "./time-series-data";
-
-type CurveType = "monotone" | "linear" | "natural" | "stepBefore" | "stepAfter";
 
 function createTickFormatter(domain?: [number, number]) {
   const span = domain ? domain[1] - domain[0] : 0;
@@ -101,20 +100,12 @@ function pxToTimestamp(
 }
 
 export function TimeSeriesChartVisualization({
-  plugin,
+  spec,
   data,
   timeRange,
   onTimeRangeChange,
-}: VisualizationProps) {
-  const showLegend = plugin.spec.showLegend === true;
-  const connectNulls = plugin.spec.connectNulls === true;
-  const lineWidth =
-    typeof plugin.spec.lineWidth === "number" ? plugin.spec.lineWidth : 1.5;
-  const unit = typeof plugin.spec.unit === "string" ? plugin.spec.unit : "";
-  const curveType: CurveType =
-    typeof plugin.spec.curveType === "string"
-      ? (plugin.spec.curveType as CurveType)
-      : "monotone";
+}: VisualizationProps<TimeSeriesChartSpec>) {
+  const { showLegend, connectNulls, lineWidth, unit, curveType } = spec;
 
   const containerRef = useRef<HTMLDivElement>(null);
   const plotRectRef = useRef<DOMRect | null>(null);

--- a/packages/app/src/data/dashboards/desired.test.ts
+++ b/packages/app/src/data/dashboards/desired.test.ts
@@ -57,6 +57,33 @@ describe("buildDesiredSet", () => {
     );
   });
 
+  it("rejects an invalid plugin option, naming the file and the option path", () => {
+    const input = [
+      {
+        path: "team/cpu.yaml",
+        document: {
+          kind: "Dashboard",
+          metadata: { name: "cpu" },
+          spec: {
+            panels: {
+              cpu: {
+                kind: "Panel",
+                spec: {
+                  plugin: { kind: "TimeSeriesChart", spec: { lineWidth: "3" } },
+                },
+              },
+            },
+            layouts: [],
+          },
+        },
+      },
+    ];
+    expect(() => buildDesiredSet(input)).toThrow(ApplyValidationError);
+    expect(() => buildDesiredSet(input)).toThrow(
+      /team\/cpu\.yaml: invalid dashboard spec at panels\.cpu\.spec\.plugin\.spec\.lineWidth/,
+    );
+  });
+
   it("allows the same slug in different projects, rejects a duplicate within one project", () => {
     const a = {
       kind: "Dashboard",

--- a/packages/app/src/data/dashboards/desired.ts
+++ b/packages/app/src/data/dashboards/desired.ts
@@ -3,7 +3,7 @@ import type { DesiredDashboard } from "./reconcile";
 import {
   dashboardProjectSchema,
   dashboardSlugSchema,
-  dashboardSpecSchema,
+  dashboardSpecSchemaStrict,
 } from "./schema";
 
 export interface InputDocument {
@@ -78,10 +78,15 @@ export function buildDesiredSet(inputs: InputDocument[]): DesiredDashboard[] {
     }
 
     const rawSpec = (document as { spec?: unknown }).spec;
-    const specResult = dashboardSpecSchema.safeParse(rawSpec);
+    const specResult = dashboardSpecSchemaStrict.safeParse(rawSpec);
     if (!specResult.success) {
+      const issue = specResult.error.issues[0];
+      const where =
+        issue && issue.path.length > 0
+          ? ` at ${issue.path.map(String).join(".")}`
+          : "";
       throw new ApplyValidationError(
-        `${path}: invalid dashboard spec: ${specResult.error.issues[0]?.message}`,
+        `${path}: invalid dashboard spec${where}: ${issue?.message}`,
       );
     }
 

--- a/packages/app/src/data/dashboards/plugin-specs.ts
+++ b/packages/app/src/data/dashboards/plugin-specs.ts
@@ -1,0 +1,17 @@
+import type * as z from "zod";
+import { statChartSpec } from "@/components/dashboards/visualizations/stat-chart/spec";
+import { tableSpec } from "@/components/dashboards/visualizations/table/spec";
+import { timeSeriesChartSpec } from "@/components/dashboards/visualizations/time-series-chart/spec";
+
+/**
+ * Spec schema per known panel plugin kind. The spec modules are pure zod
+ * (no React imports) so this stays safe to load from server code.
+ *
+ * Kinds not listed here are accepted as-is: the dashboard renders an
+ * "Unknown visualization" placeholder for them instead of failing validation.
+ */
+export const panelPluginSpecs: Record<string, z.ZodType> = {
+  StatChart: statChartSpec,
+  Table: tableSpec,
+  TimeSeriesChart: timeSeriesChartSpec,
+};

--- a/packages/app/src/data/dashboards/schema.test.ts
+++ b/packages/app/src/data/dashboards/schema.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { dashboardSlugSchema, dashboardSpecSchema } from "./schema";
+import {
+  dashboardSlugSchema,
+  dashboardSpecSchema,
+  dashboardSpecSchemaStrict,
+} from "./schema";
 
 const panel = {
   kind: "Panel" as const,
@@ -72,6 +76,73 @@ describe("dashboardSpecSchema datasources", () => {
         ch: { plugin: { kind: "ClickHouseDatasource", spec: {} } },
       },
     });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("dashboardSpecSchemaStrict plugin specs", () => {
+  const specWithPlugin = (kind: string, pluginSpec: unknown) => ({
+    panels: {
+      cpu: {
+        kind: "Panel" as const,
+        spec: { plugin: { kind, spec: pluginSpec } },
+      },
+    },
+    layouts: [
+      {
+        kind: "Grid" as const,
+        spec: { items: [gridItem("#/spec/panels/cpu")] },
+      },
+    ],
+  });
+
+  it("accepts valid options for a known kind", () => {
+    const result = dashboardSpecSchemaStrict.safeParse(
+      specWithPlugin("TimeSeriesChart", { unit: "ms", lineWidth: 2 }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an invalid option value with the full panel path", () => {
+    const result = dashboardSpecSchemaStrict.safeParse(
+      specWithPlugin("TimeSeriesChart", { lineWidth: "3" }),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual([
+      "panels",
+      "cpu",
+      "spec",
+      "plugin",
+      "spec",
+      "lineWidth",
+    ]);
+  });
+
+  it("rejects an out-of-enum option", () => {
+    const result = dashboardSpecSchemaStrict.safeParse(
+      specWithPlugin("StatChart", { calculation: "median" }),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts unknown option keys on a known kind (never stricter than Perses)", () => {
+    const result = dashboardSpecSchemaStrict.safeParse(
+      specWithPlugin("Table", { stickyHeader: true, futureOption: 1 }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts unknown plugin kinds with arbitrary specs", () => {
+    const result = dashboardSpecSchemaStrict.safeParse(
+      specWithPlugin("GaugeChart", { whatever: { nested: true } }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("the base schema stays lenient for the read path", () => {
+    const result = dashboardSpecSchema.safeParse(
+      specWithPlugin("TimeSeriesChart", { lineWidth: "3" }),
+    );
     expect(result.success).toBe(true);
   });
 });

--- a/packages/app/src/data/dashboards/schema.ts
+++ b/packages/app/src/data/dashboards/schema.ts
@@ -1,4 +1,5 @@
 import * as z from "zod";
+import { panelPluginSpecs } from "./plugin-specs";
 
 /** Recursive JSON-serializable value type for Perses plugin specs. */
 export type PluginSpecValue =
@@ -172,6 +173,42 @@ export const dashboardSpecSchema = z
       });
     });
   });
+
+/**
+ * Strict variant for the write path (`everr apply`): additionally validates
+ * each panel's plugin spec against its visualization schema, so a typo'd
+ * option fails the apply with a precise path instead of silently falling back
+ * to a default at render time. Unknown plugin kinds still pass — they render
+ * a placeholder, never break validation.
+ *
+ * The read path (`server.ts`) keeps the base schema on purpose: a stored
+ * dashboard that predates validation must still load; the renderer parses
+ * specs leniently and surfaces ignored options as panel warnings.
+ */
+export const dashboardSpecSchemaStrict = dashboardSpecSchema.superRefine(
+  (spec, ctx) => {
+    for (const [key, p] of Object.entries(spec.panels)) {
+      const pluginSchema = panelPluginSpecs[p.spec.plugin.kind];
+      if (!pluginSchema) continue;
+      const result = pluginSchema.safeParse(p.spec.plugin.spec);
+      if (result.success) continue;
+      for (const issue of result.error.issues) {
+        ctx.addIssue({
+          code: "custom",
+          message: issue.message,
+          path: [
+            "panels",
+            key,
+            "spec",
+            "plugin",
+            "spec",
+            ...issue.path.map(String),
+          ],
+        });
+      }
+    }
+  },
+);
 
 export type DashboardDisplay = z.infer<typeof dashboardDisplay>;
 export type PanelPlugin = z.infer<typeof panelPlugin>;

--- a/packages/docs/content/docs/dashboards/visualizations.mdx
+++ b/packages/docs/content/docs/dashboards/visualizations.mdx
@@ -7,6 +7,8 @@ A panel's `plugin.kind` selects its visualization and `plugin.spec` configures i
 
 All three infer their structure from the columns your query returns — see [Panels and visualizations](/docs/dashboards/panels-and-visualizations#shaping-data-for-each-visualization) for the data shapes.
 
+Options are validated: `everr apply` rejects a dashboard whose option values don't match the tables below, naming the file and the offending option. Unknown option keys are accepted and preserved. If an already-stored dashboard contains an invalid value, the panel still renders with the default and shows a warning icon in its header listing the ignored options.
+
 ## TimeSeriesChart
 
 Line chart over time. The query's time column (detected by name: `ts`, `time`, `timestamp`, `date`, `datetime`, `created_at`, `period`, `bucket`, `interval`) is the x-axis; numeric columns become series, and a string column pivots a value column into one line per label. Supports drag-to-zoom (writes the new range to the URL).


### PR DESCRIPTION
## What

Each visualization plugin now defines its own zod spec schema, replacing the fully opaque `spec: z.record(...)` with typed, defaulted, self-documenting option schemas.

Stacked on #198 (change the base to `main` after it merges).

## Why

Visualization options were untyped: renderers narrowed raw values field by field (`typeof spec.lineWidth === "number" ? ... : 1.5`) with unchecked casts (`as CurveType`, `as ThresholdsSpec`), defaults were buried in component code, and a typo'd option was silently ignored with no feedback anywhere.

## How

- **Per-plugin schemas** — `time-series-chart/spec.ts`, `table/spec.ts`, `stat-chart/spec.ts`: pure zod `looseObject`s (no React imports), every option defaulted and enum-constrained. Unknown keys flow through verbatim, so validation is never stricter than Perses on shape. `stat-calculations.ts` now derives `CalculationType`/`ThresholdsSpec` from the schemas.
- **Strict write path** — `dashboardSpecSchemaStrict` validates each panel's plugin spec against the registry in `data/dashboards/plugin-specs.ts`. `everr apply` now rejects invalid option values naming the file and full path: `team/cpu.yaml: invalid dashboard spec at panels.cpu.spec.plugin.spec.lineWidth: ...`. Unknown plugin kinds still pass (they render the existing placeholder).
- **Lenient read path with surfaced fallbacks** — stored dashboards always load: `parseSpecLenient` parses strictly first, and on failure drops the offending options (defaults apply) and reports each as a warning. The panel header shows an amber indicator with a tooltip listing exactly which options were ignored.
- **Typed renderers** — components receive the parsed spec (`VisualizationProps<TimeSeriesChartSpec>` etc.); `defineVisualization` ties each schema to its component at the registry, so the pairing is checked at the definition site.

## Notes

- The read path in `server.ts` keeps the base (structural) schema on purpose — see the comment on `dashboardSpecSchemaStrict`.
- The same pattern extends naturally to query plugins and `ListVariable` plugin specs later.
- Docs: added a note to `visualizations.mdx` documenting validate-on-apply / warn-on-render.