### PR TITLE
feat(dashboards): harden time-column detection and extend the StatChart

### DIFF
--- a/packages/app/src/components/dashboards/visualizations/data-utils.test.ts
+++ b/packages/app/src/components/dashboards/visualizations/data-utils.test.ts
@@ -1,10 +1,44 @@
 import { describe, expect, it } from "vitest";
 import {
+  detectTimeKey,
   getValueKeys,
   isNumericValue,
   toNumber,
   toTimestamp,
 } from "./data-utils";
+
+describe("detectTimeKey", () => {
+  it("matches ts, time, and timestamp exactly, case-insensitively", () => {
+    expect(detectTimeKey([{ ts: "t", v: 1 }])).toBe("ts");
+    expect(detectTimeKey([{ time: "t", v: 1 }])).toBe("time");
+    expect(detectTimeKey([{ Timestamp: "t", v: 1 }])).toBe("Timestamp");
+  });
+
+  it("does not prefix-match look-alike columns", () => {
+    // `timezone` used to match the old /^time.../ prefix pattern and claim a
+    // text column as the time axis.
+    expect(detectTimeKey([{ timezone: "UTC", v: 1 }])).toBeUndefined();
+    expect(detectTimeKey([{ timestamp_label: "a", v: 1 }])).toBeUndefined();
+    expect(detectTimeKey([{ ts_count: 3, v: 1 }])).toBeUndefined();
+  });
+
+  it("no longer matches the retired alias names", () => {
+    for (const name of [
+      "date",
+      "datetime",
+      "created_at",
+      "period",
+      "bucket",
+      "interval",
+    ]) {
+      expect(detectTimeKey([{ [name]: "t", v: 1 }])).toBeUndefined();
+    }
+  });
+
+  it("returns undefined for no rows", () => {
+    expect(detectTimeKey([])).toBeUndefined();
+  });
+});
 
 describe("isNumericValue", () => {
   it("accepts numbers and numeric strings", () => {
@@ -73,9 +107,10 @@ describe("toTimestamp", () => {
     expect(toTimestamp("2026-06-07")).toBe(utc);
   });
 
-  it("returns 0 for unparseable input", () => {
-    expect(toTimestamp("not a date")).toBe(0);
-    expect(toTimestamp(null)).toBe(0);
+  it("returns null for unparseable input (0 would be a valid 1970 instant)", () => {
+    expect(toTimestamp("not a date")).toBeNull();
+    expect(toTimestamp(null)).toBeNull();
+    expect(toTimestamp(Number.NaN)).toBeNull();
   });
 });
 

--- a/packages/app/src/components/dashboards/visualizations/data-utils.ts
+++ b/packages/app/src/components/dashboards/visualizations/data-utils.ts
@@ -1,14 +1,19 @@
 import { parseTimestampAsUTC } from "@everr/ui/lib/timestamp";
 import type { QueryResultRow } from "./index";
 
+/**
+ * The time-axis column, detected by EXACT name (case-insensitive). A prefix
+ * match would claim columns like `timezone` or `timestamp_label` as the time
+ * axis and silently poison the chart, so queries must alias their time column
+ * to one of these names. Keep the docs' list in sync.
+ */
 export function detectTimeKey(rows: QueryResultRow[]): string | undefined {
   const first = rows[0];
   if (!first) return undefined;
 
-  const timePatterns =
-    /^(time|timestamp|date|datetime|created_at|ts|period|bucket|interval)/i;
+  const timeNames = /^(ts|time|timestamp)$/i;
   for (const key of Object.keys(first)) {
-    if (timePatterns.test(key)) return key;
+    if (timeNames.test(key)) return key;
   }
   return undefined;
 }
@@ -65,12 +70,17 @@ export function getValueKeys(
  * this, a seconds value is read as ms and lands near 1970, then gets filtered
  * out of the selected range.
  */
-function epochToMs(n: number): number {
-  if (!Number.isFinite(n)) return 0;
+function epochToMs(n: number): number | null {
+  if (!Number.isFinite(n)) return null;
   return n < 1e12 ? n * 1000 : n;
 }
 
-export function toTimestamp(value: unknown): number {
+/**
+ * Milliseconds since epoch, or null when the value isn't a timestamp. Callers
+ * must drop null rows — a sentinel like 0 would be a valid instant (1970) that
+ * sorts to the front and corrupts first/last calculations and sparklines.
+ */
+export function toTimestamp(value: unknown): number | null {
   if (typeof value === "number") return epochToMs(value);
   if (typeof value === "string") {
     const trimmed = value.trim();
@@ -81,5 +91,5 @@ export function toTimestamp(value: unknown): number {
     const parsed = parseTimestampAsUTC(trimmed);
     if (parsed) return parsed.getTime();
   }
-  return 0;
+  return null;
 }

--- a/packages/app/src/components/dashboards/visualizations/stat-chart/spec.ts
+++ b/packages/app/src/components/dashboards/visualizations/stat-chart/spec.ts
@@ -6,9 +6,15 @@ const thresholdStep = z.looseObject({
 });
 
 const thresholdsSpec = z.looseObject({
-  mode: z.enum(["absolute", "percent"]).optional(),
+  mode: z.enum(["absolute", "percent"]).default("absolute"),
   defaultColor: z.string().optional(),
   steps: z.array(thresholdStep).optional(),
+  /**
+   * Reference value for `percent` mode: steps compare against value/max*100.
+   * Falls back to the series' own max when omitted — set it (e.g. to an SLA
+   * ceiling) for percentages that stay stable across time windows.
+   */
+  max: z.number().optional(),
 });
 
 /**
@@ -18,11 +24,29 @@ const thresholdsSpec = z.looseObject({
  */
 export const statChartSpec = z.looseObject({
   calculation: z
-    .enum(["last", "first", "mean", "min", "max", "sum"])
+    .enum([
+      "last",
+      "first",
+      "mean",
+      "min",
+      "max",
+      "sum",
+      "count",
+      "range",
+      "diff",
+    ])
     .default("last"),
   unit: z.string().default(""),
+  /** Fixed fraction digits; omitted = up to 2, trailing zeros dropped. */
+  decimals: z.number().int().min(0).max(10).optional(),
   sparkline: z.boolean().default(false),
   thresholds: thresholdsSpec.optional(),
+  /** "background" fills the tile with the threshold color instead of tinting the value text. */
+  colorMode: z.enum(["value", "background"]).default("value"),
+  /** Show the series label even on a single-tile panel (multi-tile always shows it). */
+  showLabel: z.boolean().default(false),
+  /** Text shown for a query that produced no value. */
+  noValue: z.string().default("–"),
 });
 
 export type StatChartSpec = z.infer<typeof statChartSpec>;

--- a/packages/app/src/components/dashboards/visualizations/stat-chart/stat-calculations.test.ts
+++ b/packages/app/src/components/dashboards/visualizations/stat-chart/stat-calculations.test.ts
@@ -14,6 +14,9 @@ describe("calculate", () => {
   it("min", () => expect(calculate(values, "min")).toBe(2));
   it("max", () => expect(calculate(values, "max")).toBe(8));
   it("sum", () => expect(calculate(values, "sum")).toBe(20));
+  it("count", () => expect(calculate(values, "count")).toBe(4));
+  it("range", () => expect(calculate(values, "range")).toBe(6));
+  it("diff", () => expect(calculate(values, "diff")).toBe(2));
   it("returns undefined for an empty series", () => {
     expect(calculate([], "last")).toBeUndefined();
   });
@@ -68,6 +71,21 @@ describe("resolveThresholdColor", () => {
     const pct = { ...thresholds, mode: "percent" as const };
     expect(resolveThresholdColor(0, pct, 0)).toBe("#888888");
   });
+
+  it("percent mode with a negative series max falls back to defaultColor", () => {
+    // An all-negative series used to invert the comparison: -50 / -10 = 500%.
+    const pct = { ...thresholds, mode: "percent" as const };
+    expect(resolveThresholdColor(-50, pct, -10)).toBe("#888888");
+  });
+
+  it("percent mode prefers the configured max over the series max", () => {
+    const pct = { ...thresholds, mode: "percent" as const, max: 200 };
+    // value 60 of configured max 200 → 30% → below all steps, even though the
+    // series max (60) would make it 100%.
+    expect(resolveThresholdColor(60, pct, 60)).toBe("#888888");
+    // value 170 of 200 → 85% → crosses the 80 step.
+    expect(resolveThresholdColor(170, pct, 60)).toBe("#ef4444");
+  });
 });
 
 describe("formatStatValue", () => {
@@ -75,7 +93,30 @@ describe("formatStatValue", () => {
     // compare against toLocaleString so the test is locale-independent
     expect(formatStatValue(Math.PI)).toBe((3.14).toLocaleString());
   });
-  it("groups thousands", () => {
-    expect(formatStatValue(1234567)).toBe((1234567).toLocaleString());
+  it("groups thousands below the abbreviation cutoff", () => {
+    expect(formatStatValue(123456)).toBe((123456).toLocaleString());
+  });
+  it("abbreviates millions, billions, and trillions", () => {
+    expect(formatStatValue(1234567)).toBe(`${(1.23).toLocaleString()}M`);
+    expect(formatStatValue(2_500_000_000)).toBe(`${(2.5).toLocaleString()}B`);
+    expect(formatStatValue(7.2e12)).toBe(`${(7.2).toLocaleString()}T`);
+  });
+  it("abbreviates negative magnitudes", () => {
+    expect(formatStatValue(-1500000)).toBe(`${(-1.5).toLocaleString()}M`);
+  });
+  it("fixes fraction digits when decimals is set", () => {
+    expect(formatStatValue(3, 2)).toBe(
+      (3).toLocaleString(undefined, {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      }),
+    );
+    expect(formatStatValue(3.4567, 0)).toBe((3).toLocaleString());
+    expect(formatStatValue(1234567, 1)).toBe(
+      `${(1.2).toLocaleString(undefined, {
+        minimumFractionDigits: 1,
+        maximumFractionDigits: 1,
+      })}M`,
+    );
   });
 });

--- a/packages/app/src/components/dashboards/visualizations/stat-chart/stat-calculations.ts
+++ b/packages/app/src/components/dashboards/visualizations/stat-chart/stat-calculations.ts
@@ -20,6 +20,17 @@ export function calculate(
       return Math.max(...values);
     case "sum":
       return values.reduce((a, b) => a + b, 0);
+    case "count":
+      return values.length;
+    case "range":
+      return Math.max(...values) - Math.min(...values);
+    case "diff": {
+      const first = values[0];
+      const last = values[values.length - 1];
+      return first === undefined || last === undefined
+        ? undefined
+        : last - first;
+    }
   }
 }
 
@@ -30,12 +41,12 @@ export function resolveThresholdColor(
 ): string | undefined {
   if (!thresholds) return undefined;
   const steps = [...(thresholds.steps ?? [])].sort((a, b) => a.value - b.value);
+  // Percent mode divides by the configured max, else the series' own max. A
+  // non-positive divisor would invert the comparison (e.g. an all-negative
+  // series), so it degrades to "no step crossed" instead.
+  const max = thresholds.max ?? seriesMax;
   const compare =
-    thresholds.mode === "percent"
-      ? seriesMax !== 0
-        ? (value / seriesMax) * 100
-        : 0
-      : value;
+    thresholds.mode === "percent" ? (max > 0 ? (value / max) * 100 : 0) : value;
   let color = thresholds.defaultColor;
   for (const step of steps) {
     if (compare >= step.value) color = step.color ?? color;
@@ -43,6 +54,27 @@ export function resolveThresholdColor(
   return color;
 }
 
-export function formatStatValue(value: number): string {
-  return value.toLocaleString(undefined, { maximumFractionDigits: 2 });
+const ABBREVIATIONS: ReadonlyArray<[number, string]> = [
+  [1e12, "T"],
+  [1e9, "B"],
+  [1e6, "M"],
+];
+
+/**
+ * Locale-formatted value for the stat tile. Magnitudes >= 1e6 abbreviate
+ * (1234567 -> "1.23M") so large counts don't overflow the tile; thousands
+ * stay exact with grouping. `decimals` fixes the fraction digits; omitted
+ * means up to 2 with trailing zeros dropped.
+ */
+export function formatStatValue(value: number, decimals?: number): string {
+  const fraction: Intl.NumberFormatOptions =
+    decimals !== undefined
+      ? { minimumFractionDigits: decimals, maximumFractionDigits: decimals }
+      : { maximumFractionDigits: 2 };
+  for (const [factor, suffix] of ABBREVIATIONS) {
+    if (Math.abs(value) >= factor) {
+      return `${(value / factor).toLocaleString(undefined, fraction)}${suffix}`;
+    }
+  }
+  return value.toLocaleString(undefined, fraction);
 }

--- a/packages/app/src/components/dashboards/visualizations/stat-chart/stat-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/stat-chart/stat-chart-visualization.tsx
@@ -1,27 +1,51 @@
 import { ChartContainer } from "@everr/ui/components/chart";
+import { cn } from "@everr/ui/lib/utils";
 import { Hash } from "lucide-react";
 import { useMemo } from "react";
-import { Area, AreaChart } from "recharts";
+import { Area, AreaChart, XAxis } from "recharts";
 import type { VisualizationProps } from "../index";
 import type { StatChartSpec } from "./spec";
 import { formatStatValue, resolveThresholdColor } from "./stat-calculations";
 import { computeStatTiles } from "./stat-series";
 
 const SPARKLINE_COLOR = "hsl(217, 91%, 60%)";
+const QUERY_LABELS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+/** Value text scales down as tiles crowd the panel. */
+function valueSizeClass(tileCount: number): string {
+  if (tileCount <= 2) return "text-4xl";
+  if (tileCount <= 4) return "text-3xl";
+  return "text-2xl";
+}
+
+function unitSizeClass(tileCount: number): string {
+  if (tileCount <= 2) return "text-2xl";
+  if (tileCount <= 4) return "text-xl";
+  return "text-lg";
+}
 
 export function StatChartVisualization({
   spec,
   data,
 }: VisualizationProps<StatChartSpec>) {
-  const { calculation, unit, sparkline: showSparkline, thresholds } = spec;
+  const {
+    calculation,
+    unit,
+    decimals,
+    sparkline: showSparkline,
+    thresholds,
+    colorMode,
+    showLabel,
+    noValue,
+  } = spec;
 
   const tiles = useMemo(
     () => (data ? computeStatTiles(data, calculation) : []),
     [data, calculation],
   );
-  const renderable = tiles.filter((t) => t.value !== undefined);
+  const hasAnyValue = tiles.some((t) => t.value !== undefined);
 
-  if (!data || renderable.length === 0) {
+  if (!data || !hasAnyValue) {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-2 text-muted-foreground">
         <Hash className="size-8" />
@@ -32,31 +56,62 @@ export function StatChartVisualization({
     );
   }
 
-  const multi = renderable.length > 1;
+  const multi = tiles.length > 1;
+  const valueSize = valueSizeClass(tiles.length);
+  const unitSize = unitSizeClass(tiles.length);
 
   return (
     <div className="flex h-full flex-wrap items-stretch justify-center gap-4">
-      {renderable.map((tile, i) => {
-        const value = tile.value as number;
+      {tiles.map((tile) => {
+        const value = tile.value;
+        const label =
+          tile.label || `Query ${QUERY_LABELS[tile.frame] ?? tile.frame + 1}`;
         const seriesMax = tile.values.length > 0 ? Math.max(...tile.values) : 0;
-        const color = resolveThresholdColor(value, thresholds, seriesMax);
+        const color =
+          value !== undefined
+            ? resolveThresholdColor(value, thresholds, seriesMax)
+            : undefined;
+        const background = colorMode === "background" && color !== undefined;
         return (
           <div
-            // biome-ignore lint/suspicious/noArrayIndexKey: tile order is stable within a render
-            key={i}
-            className="flex min-w-24 flex-1 flex-col"
+            key={`${tile.frame}-${tile.label}`}
+            className={cn(
+              "flex min-w-24 flex-1 flex-col",
+              background && "rounded-md p-2",
+            )}
+            style={background ? { backgroundColor: color } : undefined}
           >
             <div className="flex min-h-0 flex-1 flex-col items-center justify-center">
-              {multi && (
-                <p className="text-xs text-muted-foreground">{tile.label}</p>
+              {(multi || showLabel) && (
+                <p
+                  className={cn(
+                    "text-xs",
+                    background ? "text-white/80" : "text-muted-foreground",
+                  )}
+                >
+                  {label}
+                </p>
               )}
               <p
-                className="text-4xl font-semibold tabular-nums"
-                style={color ? { color } : undefined}
+                className={cn(
+                  valueSize,
+                  "font-semibold tabular-nums",
+                  background && "text-white",
+                  value === undefined && !background && "text-muted-foreground",
+                )}
+                style={!background && color ? { color } : undefined}
               >
-                {formatStatValue(value)}
-                {unit && (
-                  <span className="ml-1 text-2xl text-muted-foreground">
+                {value === undefined
+                  ? noValue
+                  : formatStatValue(value, decimals)}
+                {value !== undefined && unit && (
+                  <span
+                    className={cn(
+                      unitSize,
+                      "ml-1",
+                      background ? "text-white/70" : "text-muted-foreground",
+                    )}
+                  >
                     {unit}
                   </span>
                 )}
@@ -66,7 +121,12 @@ export function StatChartVisualization({
               <div className="h-1/3 max-h-24 w-full">
                 <ChartContainer
                   config={{
-                    value: { label: "value", color: color ?? SPARKLINE_COLOR },
+                    value: {
+                      label: "value",
+                      color: background
+                        ? "rgba(255, 255, 255, 0.9)"
+                        : (color ?? SPARKLINE_COLOR),
+                    },
                   }}
                   className="aspect-auto h-full w-full"
                 >
@@ -74,6 +134,15 @@ export function StatChartVisualization({
                     data={tile.points}
                     margin={{ top: 2, left: 0, right: 0, bottom: 0 }}
                   >
+                    {/* Real time axis (hidden): without it recharts spaces
+                        points by index and missing buckets compress the
+                        timeline. */}
+                    <XAxis
+                      dataKey="ts"
+                      type="number"
+                      domain={["dataMin", "dataMax"]}
+                      hide
+                    />
                     <Area
                       dataKey="value"
                       type="monotone"

--- a/packages/app/src/components/dashboards/visualizations/stat-chart/stat-series.test.ts
+++ b/packages/app/src/components/dashboards/visualizations/stat-chart/stat-series.test.ts
@@ -43,8 +43,42 @@ describe("computeStatTiles", () => {
     expect(tiles[0]?.points).toEqual([]);
   });
 
-  it("skips empty result sets", () => {
-    expect(computeStatTiles([[]], "last")).toEqual([]);
+  it("emits a placeholder tile for an empty result set", () => {
+    const tiles = computeStatTiles([[]], "last");
+    expect(tiles).toHaveLength(1);
+    expect(tiles[0]).toMatchObject({ frame: 0, label: "", value: undefined });
+  });
+
+  it("emits a placeholder for a query with no numeric column", () => {
+    const tiles = computeStatTiles(
+      [[{ ts: "2026-06-07T00:00:00", value: 5 }], [{ service: "api" }]],
+      "last",
+    );
+    expect(tiles).toHaveLength(2);
+    expect(tiles[0]?.value).toBe(5);
+    expect(tiles[1]).toMatchObject({ frame: 1, label: "", value: undefined });
+  });
+
+  it("records the originating query index on each tile", () => {
+    const tiles = computeStatTiles([[{ a: 1, b: 2 }], [{ c: 3 }]], "last");
+    expect(tiles.map((t) => t.frame)).toEqual([0, 0, 1]);
+  });
+
+  it("drops rows whose timestamp cannot be parsed", () => {
+    const tiles = computeStatTiles(
+      [
+        [
+          { ts: "N/A", value: 99 },
+          { ts: "2026-06-07T00:00:00", value: 1 },
+          { ts: "2026-06-07T00:01:00", value: 3 },
+        ],
+      ],
+      "first",
+    );
+    // The unparseable row must not become the chronological "first" (it used
+    // to land at epoch 0 and sort to the front).
+    expect(tiles[0]?.value).toBe(1);
+    expect(tiles[0]?.points).toHaveLength(2);
   });
 
   it("detects a metric that is NULL in the first bucket but numeric later", () => {

--- a/packages/app/src/components/dashboards/visualizations/stat-chart/stat-series.ts
+++ b/packages/app/src/components/dashboards/visualizations/stat-chart/stat-series.ts
@@ -8,6 +8,9 @@ import type { QueryResultRow } from "../index";
 import { type CalculationType, calculate } from "./stat-calculations";
 
 export interface StatTile {
+  /** Index of the query (frame) this tile came from — stable tile identity. */
+  frame: number;
+  /** Column name; empty for a placeholder tile of a query with no data. */
   label: string;
   value: number | undefined;
   values: number[];
@@ -20,43 +23,63 @@ export function computeStatTiles(
 ): StatTile[] {
   const tiles: StatTile[] = [];
 
-  for (const rows of dataSets) {
+  dataSets.forEach((rows, frame) => {
+    const before = tiles.length;
     const first = rows[0];
-    if (!first) continue;
 
-    const timeKey = detectTimeKey(rows);
-    const valueKeys = getValueKeys(rows, timeKey ?? "");
+    if (first) {
+      const timeKey = detectTimeKey(rows);
+      const valueKeys = getValueKeys(rows, timeKey ?? "");
 
-    for (const valueKey of valueKeys) {
-      if (!timeKey) {
-        const values = rows
-          .map((row) => toNumber(row[valueKey]))
-          .filter((v): v is number => v !== null);
+      for (const valueKey of valueKeys) {
+        if (!timeKey) {
+          const values = rows
+            .map((row) => toNumber(row[valueKey]))
+            .filter((v): v is number => v !== null);
+          tiles.push({
+            frame,
+            label: valueKey,
+            value: calculate(values, calculation),
+            values,
+            points: [],
+          });
+          continue;
+        }
+
+        const points = rows
+          .map((row) => ({
+            ts: toTimestamp(row[timeKey]),
+            value: toNumber(row[valueKey]),
+          }))
+          .filter(
+            (p): p is { ts: number; value: number } =>
+              p.value !== null && p.ts !== null,
+          )
+          .sort((a, b) => a.ts - b.ts);
+        const values = points.map((p) => p.value);
         tiles.push({
+          frame,
           label: valueKey,
           value: calculate(values, calculation),
           values,
-          points: [],
+          points,
         });
-        continue;
       }
+    }
 
-      const points = rows
-        .map((row) => ({
-          ts: toTimestamp(row[timeKey]),
-          value: toNumber(row[valueKey]),
-        }))
-        .filter((p): p is { ts: number; value: number } => p.value !== null)
-        .sort((a, b) => a.ts - b.ts);
-      const values = points.map((p) => p.value);
+    // A query that yielded no tile (no rows, or no numeric column) still gets
+    // a placeholder so its tile doesn't silently vanish from a multi-query
+    // panel — the renderer shows the configured no-value text instead.
+    if (tiles.length === before) {
       tiles.push({
-        label: valueKey,
-        value: calculate(values, calculation),
-        values,
-        points,
+        frame,
+        label: "",
+        value: undefined,
+        values: [],
+        points: [],
       });
     }
-  }
+  });
 
   return tiles;
 }

--- a/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-data.test.ts
+++ b/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-data.test.ts
@@ -16,6 +16,22 @@ describe("buildChartModel", () => {
     expect(model.seriesData.s0?.[0]?.s0).toBe(5);
   });
 
+  it("skips rows whose timestamp cannot be parsed", () => {
+    const model = buildChartModel(
+      [
+        [
+          { time: "garbage", value: 99 },
+          { time: "2026-06-07T00:00:00", value: 5 },
+        ],
+      ],
+      undefined,
+    );
+    // The bad row must not become a point at epoch 0.
+    expect(model.chartData).toHaveLength(1);
+    expect(model.chartData[0]?.s0).toBe(5);
+    expect(model.seriesData.s0).toHaveLength(1);
+  });
+
   it("gives each series a distinct key across two queries and merges by time", () => {
     const model = buildChartModel(
       [

--- a/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-data.ts
+++ b/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-data.ts
@@ -222,6 +222,7 @@ export function buildChartModel(
 
     for (const row of rows) {
       const ts = toTimestamp(row[tk]);
+      if (ts === null) continue;
       let entry = byTs.get(ts);
       if (!entry) {
         entry = { [TS_KEY]: ts };

--- a/packages/docs/content/docs/dashboards/first-dashboard.mdx
+++ b/packages/docs/content/docs/dashboards/first-dashboard.mdx
@@ -83,7 +83,7 @@ A few things worth noting:
 
 - `metadata.name` is the **slug** — the dashboard's stable identity and its URL. Use lowercase letters, digits, and hyphens.
 - `metadata.project` groups dashboards into a named set. It defaults to `default` when omitted. A dashboard's URL is `/dashboards/<project>/<slug>`, so two projects can share the same slug without colliding.
-- The panel's query must alias its time column to a recognized name (`ts`, `time`, `timestamp`, `bucket`, …). The time-series chart uses that column for the x-axis and treats the remaining numeric columns as series. See [Panels and visualizations](/docs/dashboards/panels-and-visualizations).
+- The panel's query must alias its time column to a recognized name (`ts`, `time`, or `timestamp`). The time-series chart uses that column for the x-axis and treats the remaining numeric columns as series. See [Panels and visualizations](/docs/dashboards/panels-and-visualizations).
 - The `{from:String}` / `{to:String}` parameters carry the dashboard's selected time range. They aren't injected automatically, so include the `WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}` filter — otherwise the query scans all history and ignores the picker.
 - `{step:UInt32}` is an adaptive bucket width in seconds — Everr sizes it so the chart renders ~500 points at any range. See [Adaptive bucketing](/docs/dashboards/panels-and-visualizations#adaptive-bucketing).
 - The `layouts` grid places the panel. `content.$ref` points at the panel key under `spec.panels` (here, `p99`). The grid is 24 columns wide.

--- a/packages/docs/content/docs/dashboards/panels-and-visualizations.mdx
+++ b/packages/docs/content/docs/dashboards/panels-and-visualizations.mdx
@@ -57,7 +57,7 @@ What you `SELECT` determines what renders. The visualizations infer their struct
 
 ### Time series
 
-- One column must be the **time axis**. It's detected by name — alias it to `ts`, `time`, `timestamp`, `date`, `datetime`, `created_at`, `period`, `bucket`, or `interval`.
+- One column must be the **time axis**. It's detected by exact name (case-insensitive) — alias it to `ts`, `time`, or `timestamp`.
 - Remaining **numeric** columns become series (lines).
 - A remaining **string** column is treated as a series label, pivoting one value column into multiple lines. For example, grouping by `ServiceName`:
 

--- a/packages/docs/content/docs/dashboards/visualizations.mdx
+++ b/packages/docs/content/docs/dashboards/visualizations.mdx
@@ -11,7 +11,7 @@ Options are validated: `everr apply` rejects a dashboard whose option values don
 
 ## TimeSeriesChart
 
-Line chart over time. The query's time column (detected by name: `ts`, `time`, `timestamp`, `date`, `datetime`, `created_at`, `period`, `bucket`, `interval`) is the x-axis; numeric columns become series, and a string column pivots a value column into one line per label. Supports drag-to-zoom (writes the new range to the URL).
+Line chart over time. The query's time column (detected by exact name, case-insensitive: `ts`, `time`, or `timestamp`) is the x-axis; numeric columns become series, and a string column pivots a value column into one line per label. Supports drag-to-zoom (writes the new range to the URL).
 
 ```yaml
 plugin:
@@ -49,7 +49,9 @@ plugin:
 
 ## StatChart
 
-Reduces a numeric column to a single big value via a calculation, with an optional sparkline and threshold coloring. Return one numeric column; include a time column to enable the sparkline. Multiple resulting series render as multiple tiles.
+Reduces a numeric column to a single big value via a calculation, with an optional sparkline and threshold coloring. Return one numeric column; include a time column to enable the sparkline. Multiple resulting series render as multiple tiles; a query that returns no value renders its tile with the `noValue` text instead of disappearing.
+
+Values at or above one million abbreviate (`1234567` → `1.23M`); smaller values keep thousands grouping. The tile label is shown automatically with multiple tiles and hidden for a single tile unless `showLabel` is set.
 
 ```yaml
 plugin:
@@ -57,21 +59,28 @@ plugin:
   spec:
     calculation: last
     unit: ms
+    decimals: 1
     sparkline: true
     thresholds:
-      mode: absolute
+      mode: percent
+      max: 500
       defaultColor: "#22c55e"
       steps:
-        - { value: 200, color: "#f59e0b" }
-        - { value: 500, color: "#ef4444" }
+        - { value: 40, color: "#f59e0b" }
+        - { value: 80, color: "#ef4444" }
 ```
 
 | Option | Type | Default | Notes |
 | --- | --- | --- | --- |
-| `calculation` | enum | `last` | One of `last`, `first`, `mean`, `min`, `max`, `sum`. |
+| `calculation` | enum | `last` | One of `last`, `first`, `mean`, `min`, `max`, `sum`, `count`, `range`, `diff`. |
 | `unit` | string | `""` | Suffix appended to the value. |
+| `decimals` | number | — | Fixed fraction digits (0–10). Omitted: up to 2, trailing zeros dropped. |
 | `sparkline` | boolean | `false` | Draw a sparkline (needs a time column). |
+| `colorMode` | enum | `value` | `value` tints the number; `background` fills the whole tile with the threshold color. |
+| `showLabel` | boolean | `false` | Show the series label on a single-tile panel too. |
+| `noValue` | string | `–` | Text shown for a query that produced no value. |
 | `thresholds` | object | — | Color the value (and sparkline) by thresholds. |
-| `thresholds.mode` | enum | `absolute` | `absolute` compares the raw value; `percent` compares against the series max. |
-| `thresholds.defaultColor` | string | — | Color below the first step. |
+| `thresholds.mode` | enum | `absolute` | `absolute` compares the raw value; `percent` compares against `thresholds.max`. |
+| `thresholds.max` | number | series max | Reference for `percent` mode. Set it (e.g. an SLA ceiling) for percentages that don't shift with the time window. |
+| `thresholds.defaultColor` | string | — | Color when no step is crossed. |
 | `thresholds.steps[]` | `{ value, color }` | — | Ascending thresholds; the highest crossed step's color wins. |


### PR DESCRIPTION
## What

Correctness fixes for the StatChart plugin (plus the shared time-column helpers) and a batch of StatChart option/UX improvements, from a review sweep of the plugin.

Stacked on #200 (which is stacked on #198) — retarget to `main` as the stack merges.

## Correctness

- **Exact time-column names.** Detection is now an exact, case-insensitive match on `ts` / `time` / `timestamp`. The old unanchored prefix regex (`/^(time|timestamp|date|...)/i`) claimed columns like `timezone` or `period_name` as the time axis. Applies to both the time-series chart and the stat chart; docs updated (`visualizations.mdx`, `panels-and-visualizations.mdx`, `first-dashboard.mdx`). The demo dashboards all alias to `ts`, so nothing breaks.
- **Unparseable timestamps drop the row.** `toTimestamp` returns `null` instead of `0` — an epoch-0 sentinel is a valid 1970 instant that sorted to the front and corrupted `first`/`last` calculations and sparklines.
- **Percent thresholds.** New `thresholds.max` (e.g. an SLA ceiling) takes precedence over the series' own max so percentages don't shift with the time window; a non-positive divisor now degrades to "no step crossed" instead of inverting the comparison for all-negative series.
- **Stable tile identity.** Tiles are keyed by query index + column name instead of position in a filtered array.

## StatChart improvements

- Calculations: `count`, `range`, `diff`
- `decimals` option; values >= 1e6 abbreviate (`1.23M` / `B` / `T`)
- `colorMode: background` fills the tile with the threshold color
- `showLabel` shows the label on single-tile panels; `noValue` text renders for a query with no data instead of the tile silently vanishing
- Value text scales down as tiles crowd the panel
- Sparkline uses a real (hidden) time axis instead of index spacing, so missing buckets don't compress the timeline

## Notes

- All new options ride on the per-plugin zod spec schemas from #200, so `everr apply` validates them and the docs table in `visualizations.mdx` matches the schema.
- The `everr-write-dashboards` skill was synced on #199's branch (`ae4d8202`) — merge order: #198 → #200 → this → #199.