### PR TITLE
Add CLI update notice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1221,6 +1221,7 @@ dependencies = [
  "predicates",
  "regex",
  "reqwest 0.12.28",
+ "semver",
  "serde",
  "serde_json",
  "sha2",

--- a/packages/desktop-app/src-cli/Cargo.toml
+++ b/packages/desktop-app/src-cli/Cargo.toml
@@ -20,6 +20,7 @@ futures-util = "0.3"
 reqwest = { version = "0.12.15", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
+semver = "1"
 regex = "1"
 sha2 = "0.10.9"
 strip-ansi-escapes = "0.2"

--- a/packages/desktop-app/src-cli/src/cli.rs
+++ b/packages/desktop-app/src-cli/src/cli.rs
@@ -45,6 +45,28 @@ pub enum Commands {
     Apply(ApplyArgs),
 }
 
+impl Cli {
+    pub fn prints_human_stdout(&self, stdout_is_terminal: bool) -> bool {
+        self.command.prints_human_stdout(stdout_is_terminal)
+    }
+}
+
+impl Commands {
+    fn prints_human_stdout(&self, stdout_is_terminal: bool) -> bool {
+        match self {
+            Commands::Uninstall => true,
+            Commands::Cloud(args) => args.command.prints_human_stdout(stdout_is_terminal),
+            Commands::Ci(args) => args.command.prints_human_stdout(stdout_is_terminal),
+            Commands::Local(args) => args.command.prints_human_stdout(stdout_is_terminal),
+            Commands::Wrap(_) => false,
+            Commands::Setup => true,
+            Commands::Init => true,
+            Commands::Skills(_) => true,
+            Commands::Apply(_) => true,
+        }
+    }
+}
+
 #[derive(Args, Debug)]
 pub struct CloudArgs {
     #[command(subcommand)]
@@ -59,6 +81,17 @@ pub enum CloudSubcommand {
     Logout,
     /// Run a read-only SQL query against cloud CI data
     Query(TelemetryQueryArgs),
+}
+
+impl CloudSubcommand {
+    fn prints_human_stdout(&self, stdout_is_terminal: bool) -> bool {
+        match self {
+            CloudSubcommand::Login(_) | CloudSubcommand::Logout => true,
+            CloudSubcommand::Query(args) => {
+                telemetry_query_prints_human_stdout(args, stdout_is_terminal)
+            }
+        }
+    }
 }
 
 #[derive(Args, Debug)]
@@ -81,6 +114,18 @@ pub enum CiSubcommand {
     Logs(GetLogsArgs),
 }
 
+impl CiSubcommand {
+    fn prints_human_stdout(&self, _stdout_is_terminal: bool) -> bool {
+        match self {
+            CiSubcommand::Watch(_) => true,
+            CiSubcommand::Status(_)
+            | CiSubcommand::Runs(_)
+            | CiSubcommand::Show(_)
+            | CiSubcommand::Logs(_) => false,
+        }
+    }
+}
+
 #[derive(Args, Debug)]
 pub struct LocalArgs {
     #[command(subcommand)]
@@ -95,6 +140,17 @@ pub enum LocalSubcommand {
     Query(TelemetryQueryArgs),
     /// Check whether the local collector is running.
     Status,
+}
+
+impl LocalSubcommand {
+    fn prints_human_stdout(&self, stdout_is_terminal: bool) -> bool {
+        match self {
+            LocalSubcommand::Start(_) | LocalSubcommand::Status => true,
+            LocalSubcommand::Query(args) => {
+                telemetry_query_prints_human_stdout(args, stdout_is_terminal)
+            }
+        }
+    }
 }
 
 #[derive(Args, Debug)]
@@ -225,6 +281,17 @@ pub enum TelemetryFormat {
     Json,
     Ndjson,
     Table,
+}
+
+fn telemetry_query_prints_human_stdout(
+    args: &TelemetryQueryArgs,
+    stdout_is_terminal: bool,
+) -> bool {
+    match args.format {
+        Some(TelemetryFormat::Table) => true,
+        Some(TelemetryFormat::Json | TelemetryFormat::Ndjson) => false,
+        None => stdout_is_terminal,
+    }
 }
 
 #[derive(Args, Debug, Default)]
@@ -809,6 +876,46 @@ mod tests {
         assert_eq!(branch, None);
         assert_eq!(commit, None);
         assert_eq!(run_id, None);
+    }
+
+    #[test]
+    fn update_notice_is_allowed_for_human_commands() {
+        let cli = Cli::try_parse_from(["everr", "skills", "list"]).expect("skills list command");
+        assert!(cli.prints_human_stdout(false));
+
+        let cli = Cli::try_parse_from(["everr", "ci", "watch"]).expect("ci watch command");
+        assert!(cli.prints_human_stdout(false));
+
+        let cli = Cli::try_parse_from(["everr", "local", "query", "SELECT 1", "--format", "table"])
+            .expect("local query table command");
+        assert!(cli.prints_human_stdout(false));
+    }
+
+    #[test]
+    fn update_notice_is_skipped_for_stream_and_json_commands() {
+        let cli =
+            Cli::try_parse_from(["everr", "wrap", "--", "echo", "hello"]).expect("wrap command");
+        assert!(!cli.prints_human_stdout(true));
+
+        let cli = Cli::try_parse_from(["everr", "local", "query", "SELECT 1", "--format", "json"])
+            .expect("local query json command");
+        assert!(!cli.prints_human_stdout(true));
+
+        let cli = Cli::try_parse_from(["everr", "local", "query", "SELECT 1"])
+            .expect("local query default command");
+        assert!(!cli.prints_human_stdout(false));
+
+        let cli = Cli::try_parse_from([
+            "everr",
+            "ci",
+            "logs",
+            "trace-1",
+            "--job-name",
+            "build",
+            "--log-failed",
+        ])
+        .expect("ci logs command");
+        assert!(!cli.prints_human_stdout(true));
     }
 
     #[test]

--- a/packages/desktop-app/src-cli/src/main.rs
+++ b/packages/desktop-app/src-cli/src/main.rs
@@ -7,6 +7,7 @@ mod onboarding;
 mod skills;
 mod telemetry;
 mod uninstall;
+mod update_notice;
 mod wrap;
 
 use anyhow::Result;
@@ -16,6 +17,7 @@ use cli::{CiSubcommand, Cli, CloudSubcommand, Commands};
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
+    update_notice::maybe_print(&cli).await;
 
     match cli.command {
         Commands::Uninstall => uninstall::run_uninstall()?,

--- a/packages/desktop-app/src-cli/src/update_notice.rs
+++ b/packages/desktop-app/src-cli/src/update_notice.rs
@@ -13,6 +13,7 @@ use crate::cli::Cli;
 const CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
 const FETCH_TIMEOUT: Duration = Duration::from_millis(750);
 const RELEASE_METADATA_PATH: &str = "/everr-app/release-metadata.json";
+const UPGRADE_COMMAND: &str = "curl -fsSL https://everr.dev/upgrade.sh | bash";
 
 #[cfg(debug_assertions)]
 const RELEASE_METADATA_URL_OVERRIDE_ENV: &str = "EVERR_RELEASE_METADATA_URL_FOR_TESTS";
@@ -46,6 +47,7 @@ pub async fn maybe_print(cli: &Cli) {
 
     if status.update_available {
         println!("A new version is available: {}", status.latest_version);
+        println!("Run: {UPGRADE_COMMAND}");
     }
 }
 

--- a/packages/desktop-app/src-cli/src/update_notice.rs
+++ b/packages/desktop-app/src-cli/src/update_notice.rs
@@ -1,0 +1,163 @@
+use std::fs;
+use std::io::IsTerminal;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use semver::Version;
+use serde::{Deserialize, Serialize};
+
+use crate::cli::Cli;
+
+const CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
+const FETCH_TIMEOUT: Duration = Duration::from_millis(750);
+const RELEASE_METADATA_PATH: &str = "/everr-app/release-metadata.json";
+
+#[cfg(debug_assertions)]
+const RELEASE_METADATA_URL_OVERRIDE_ENV: &str = "EVERR_RELEASE_METADATA_URL_FOR_TESTS";
+
+#[cfg(debug_assertions)]
+const CACHE_FILE_NAME: &str = "cli-update-check-dev.json";
+
+#[cfg(not(debug_assertions))]
+const CACHE_FILE_NAME: &str = "cli-update-check.json";
+
+#[derive(Debug, Deserialize)]
+struct ReleaseMetadata {
+    version: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct CacheFile {
+    last_checked_at: String,
+    latest_version: String,
+    update_available: bool,
+}
+
+pub async fn maybe_print(cli: &Cli) {
+    if !cli.prints_human_stdout(std::io::stdout().is_terminal()) {
+        return;
+    }
+
+    let Ok(status) = check().await else {
+        return;
+    };
+
+    if status.update_available {
+        println!("A new version is available: {}", status.latest_version);
+    }
+}
+
+async fn check() -> Result<CacheFile> {
+    let path = cache_path()?;
+    let cached = read_cache(&path);
+
+    if let Some(cache) = cached.as_ref() {
+        let cache = cache.for_current_version();
+        if cache.update_available || !is_stale(&cache) {
+            return Ok(cache);
+        }
+    }
+
+    match fetch_latest_version().await {
+        Ok(latest_version) => {
+            let update_available = is_newer(&latest_version, env!("EVERR_VERSION"));
+            let cache = CacheFile {
+                last_checked_at: Utc::now().to_rfc3339(),
+                latest_version,
+                update_available,
+            };
+            let _ = write_cache(&path, &cache);
+            Ok(cache)
+        }
+        Err(err) => {
+            if let Some(cache) = cached {
+                return Ok(cache.for_current_version());
+            }
+            Err(err)
+        }
+    }
+}
+
+impl CacheFile {
+    fn for_current_version(&self) -> Self {
+        Self {
+            last_checked_at: self.last_checked_at.clone(),
+            latest_version: self.latest_version.clone(),
+            update_available: is_newer(&self.latest_version, env!("EVERR_VERSION")),
+        }
+    }
+}
+
+fn read_cache(path: &PathBuf) -> Option<CacheFile> {
+    let body = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&body).ok()
+}
+
+fn write_cache(path: &PathBuf, cache: &CacheFile) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+    fs::write(path, serde_json::to_string_pretty(cache)?)
+        .with_context(|| format!("write {}", path.display()))
+}
+
+fn is_stale(cache: &CacheFile) -> bool {
+    let Ok(last_checked) = DateTime::parse_from_rfc3339(&cache.last_checked_at) else {
+        return true;
+    };
+    let elapsed = Utc::now().signed_duration_since(last_checked.with_timezone(&Utc));
+    elapsed
+        .to_std()
+        .map_or(true, |elapsed| elapsed >= CHECK_INTERVAL)
+}
+
+async fn fetch_latest_version() -> Result<String> {
+    let url = release_metadata_url();
+    let client = reqwest::Client::builder()
+        .timeout(FETCH_TIMEOUT)
+        .build()
+        .context("build release metadata client")?;
+    let metadata: ReleaseMetadata = client
+        .get(&url)
+        .send()
+        .await
+        .with_context(|| format!("GET {url}"))?
+        .json()
+        .await
+        .with_context(|| format!("parse {url}"))?;
+    Ok(metadata.version)
+}
+
+fn release_metadata_url() -> String {
+    #[cfg(debug_assertions)]
+    if let Ok(url) = std::env::var(RELEASE_METADATA_URL_OVERRIDE_ENV) {
+        if !url.trim().is_empty() {
+            return url;
+        }
+    }
+
+    format!(
+        "{}{}",
+        everr_core::build::default_docs_base_url(),
+        RELEASE_METADATA_PATH
+    )
+}
+
+fn cache_path() -> Result<PathBuf> {
+    let base = dirs::data_local_dir().context("failed to resolve user local data dir")?;
+    Ok(base
+        .join(everr_core::build::session_namespace())
+        .join(CACHE_FILE_NAME))
+}
+
+fn is_newer(latest: &str, current: &str) -> bool {
+    let Ok(latest) = Version::parse(latest) else {
+        return false;
+    };
+    let Ok(current) = Version::parse(current) else {
+        return false;
+    };
+    latest > current
+}

--- a/packages/desktop-app/src-cli/tests/support/mod.rs
+++ b/packages/desktop-app/src-cli/tests/support/mod.rs
@@ -47,10 +47,22 @@ impl CliTestEnv {
         cmd
     }
 
+    pub fn command_with_release_metadata_url(&self, url: &str) -> Command {
+        let mut cmd = self.command();
+        cmd.env("EVERR_RELEASE_METADATA_URL_FOR_TESTS", url);
+        cmd
+    }
+
     pub fn session_path(&self) -> PathBuf {
         self.config_dir
             .join(build::session_namespace())
             .join(build::default_session_file_name())
+    }
+
+    pub fn update_cache_path(&self) -> PathBuf {
+        platform_data_local_dir(&self.home_dir)
+            .join(build::session_namespace())
+            .join("cli-update-check-dev.json")
     }
 
     pub fn telemetry_dir(&self) -> PathBuf {
@@ -115,6 +127,18 @@ fn platform_config_dir(home_dir: &Path) -> PathBuf {
     #[cfg(not(target_os = "macos"))]
     {
         home_dir.join(".config")
+    }
+}
+
+fn platform_data_local_dir(home_dir: &Path) -> PathBuf {
+    #[cfg(target_os = "macos")]
+    {
+        home_dir.join("Library").join("Application Support")
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        home_dir.join(".local").join("share")
     }
 }
 

--- a/packages/desktop-app/src-cli/tests/update_notice.rs
+++ b/packages/desktop-app/src-cli/tests/update_notice.rs
@@ -17,7 +17,10 @@ fn cached_update_prints_notice_without_network() {
         .args(["skills", "list"])
         .assert()
         .success()
-        .stdout(contains("A new version is available: 2099.1.0"));
+        .stdout(contains("A new version is available: 2099.1.0"))
+        .stdout(contains(
+            "Run: curl -fsSL https://everr.dev/upgrade.sh | bash",
+        ));
 }
 
 #[test]
@@ -41,7 +44,10 @@ fn stale_cache_fetches_release_metadata_and_records_update() {
     .args(["skills", "list"])
     .assert()
     .success()
-    .stdout(contains("A new version is available: 2099.1.0"));
+    .stdout(contains("A new version is available: 2099.1.0"))
+    .stdout(contains(
+        "Run: curl -fsSL https://everr.dev/upgrade.sh | bash",
+    ));
 
     mock.assert();
     let cache = fs::read_to_string(env.update_cache_path()).expect("read cache");
@@ -59,7 +65,10 @@ fn cached_update_continues_to_print_before_next_check_interval() {
         .args(["skills", "list"])
         .assert()
         .success()
-        .stdout(contains("A new version is available: 2099.1.0"));
+        .stdout(contains("A new version is available: 2099.1.0"))
+        .stdout(contains(
+            "Run: curl -fsSL https://everr.dev/upgrade.sh | bash",
+        ));
 }
 
 #[test]

--- a/packages/desktop-app/src-cli/tests/update_notice.rs
+++ b/packages/desktop-app/src-cli/tests/update_notice.rs
@@ -1,0 +1,121 @@
+mod support;
+
+use std::fs;
+
+use mockito::Matcher;
+use predicates::prelude::PredicateBooleanExt;
+use predicates::str::{contains, diff};
+use serde_json::json;
+use support::{CliTestEnv, mock_api_server};
+
+#[test]
+fn cached_update_prints_notice_without_network() {
+    let env = CliTestEnv::new();
+    write_cache(&env, "2099.1.0", true, "2099-01-01T00:00:00Z");
+
+    env.command()
+        .args(["skills", "list"])
+        .assert()
+        .success()
+        .stdout(contains("A new version is available: 2099.1.0"));
+}
+
+#[test]
+fn stale_cache_fetches_release_metadata_and_records_update() {
+    let env = CliTestEnv::new();
+    write_cache(&env, "0.0.1", false, "2000-01-01T00:00:00Z");
+    let mut server = mock_api_server();
+    let mock = server
+        .mock("GET", "/everr-app/release-metadata.json")
+        .match_query(Matcher::Missing)
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"version":"2099.1.0"}"#)
+        .expect(1)
+        .create();
+
+    env.command_with_release_metadata_url(&format!(
+        "{}/everr-app/release-metadata.json",
+        server.url()
+    ))
+    .args(["skills", "list"])
+    .assert()
+    .success()
+    .stdout(contains("A new version is available: 2099.1.0"));
+
+    mock.assert();
+    let cache = fs::read_to_string(env.update_cache_path()).expect("read cache");
+    let cache: serde_json::Value = serde_json::from_str(&cache).expect("parse cache");
+    assert_eq!(cache["latest_version"], "2099.1.0");
+    assert_eq!(cache["update_available"], true);
+}
+
+#[test]
+fn cached_update_continues_to_print_before_next_check_interval() {
+    let env = CliTestEnv::new();
+    write_cache(&env, "2099.1.0", true, "2099-01-01T00:00:00Z");
+
+    env.command()
+        .args(["skills", "list"])
+        .assert()
+        .success()
+        .stdout(contains("A new version is available: 2099.1.0"));
+}
+
+#[test]
+fn cached_current_version_does_not_print_notice() {
+    let env = CliTestEnv::new();
+    write_cache(&env, env!("EVERR_VERSION"), true, "2099-01-01T00:00:00Z");
+
+    env.command()
+        .args(["skills", "list"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("A new version is available").not());
+}
+
+#[test]
+fn wrap_stdout_is_not_prefixed_by_update_notice() {
+    let env = CliTestEnv::new();
+    write_cache(&env, "2099.1.0", true, "2099-01-01T00:00:00Z");
+
+    env.command()
+        .args(["wrap", "--", "sh", "-c", "printf 'child stdout\\n'"])
+        .env("EVERR_OTLP_HTTP_ORIGIN", "http://127.0.0.1:9")
+        .assert()
+        .code(2)
+        .stdout(diff(""));
+}
+
+#[test]
+fn version_flag_remains_available_without_notice() {
+    let env = CliTestEnv::new();
+    write_cache(&env, "2099.1.0", true, "2099-01-01T00:00:00Z");
+
+    env.command()
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(contains("everr"))
+        .stdout(predicates::str::contains("A new version is available").not());
+}
+
+fn write_cache(
+    env: &CliTestEnv,
+    latest_version: &str,
+    update_available: bool,
+    last_checked_at: &str,
+) {
+    let path = env.update_cache_path();
+    fs::create_dir_all(path.parent().expect("cache parent")).expect("create cache parent");
+    fs::write(
+        path,
+        serde_json::to_string_pretty(&json!({
+            "last_checked_at": last_checked_at,
+            "latest_version": latest_version,
+            "update_available": update_available,
+        }))
+        .expect("serialize cache"),
+    )
+    .expect("write cache");
+}

--- a/packages/docs/public/upgrade.sh
+++ b/packages/docs/public/upgrade.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOWNLOAD_BASE_URL="https://everr.dev/everr-app"
+INSTALL_DIR="${HOME}/.local/bin"
+INSTALL_PATH="${INSTALL_DIR}/everr"
+
+os="$(uname -s)"
+arch="$(uname -m)"
+
+case "${os}:${arch}" in
+  Darwin:arm64)
+    BINARY_NAME="everr"
+    ;;
+  Linux:aarch64|Linux:arm64)
+    BINARY_NAME="everr-linux-arm64"
+    ;;
+  Linux:x86_64|Linux:amd64)
+    BINARY_NAME="everr-linux-x86_64"
+    ;;
+  *)
+    echo "everr upgrade script does not support ${os} ${arch}." >&2
+    exit 1
+    ;;
+esac
+
+CHECKSUM_NAME="${BINARY_NAME}.sha256"
+
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT
+
+binary_url="${DOWNLOAD_BASE_URL%/}/${BINARY_NAME}"
+checksum_url="${DOWNLOAD_BASE_URL%/}/${CHECKSUM_NAME}"
+
+echo "Downloading Everr CLI..."
+curl -fsSL "${binary_url}" -o "${tmp_dir}/${BINARY_NAME}"
+curl -fsSL "${checksum_url}" -o "${tmp_dir}/${CHECKSUM_NAME}"
+
+(
+  cd "${tmp_dir}"
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -c "${CHECKSUM_NAME}" >/dev/null
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c "${CHECKSUM_NAME}" >/dev/null
+  else
+    echo "No SHA-256 checksum tool found. Install shasum or sha256sum." >&2
+    exit 1
+  fi
+)
+
+mkdir -p "${INSTALL_DIR}"
+mv "${tmp_dir}/${BINARY_NAME}" "${INSTALL_PATH}"
+chmod +x "${INSTALL_PATH}"
+
+echo "  Upgraded ${INSTALL_PATH}"


### PR DESCRIPTION
## Summary

Adds a cached CLI update notice that prints `A new version is available: <version> \n Run: curl -fsSL https://everr.dev/upgrade.sh | bash` for human-facing commands, plus an upgrade command users can run immediately.

## Details

- reads `https://everr.dev/everr-app/release-metadata.json` as the online version source
- persists update-check state locally so the network check only runs periodically
- keeps showing the notice from cache once an update has been detected
- prints `Run: curl -fsSL https://everr.dev/upgrade.sh | bash` with the notice
- adds `packages/docs/public/upgrade.sh` to replace the installed CLI without running setup/onboarding
- skips the notice for `wrap`, JSON/NDJSON output, log/data commands, and `--version`
- keeps the existing `--version` behavior

## Validation

- `bash -n packages/docs/public/upgrade.sh`
- `cargo check -p everr-cli`
- `cargo test -p everr-cli --test update_notice`
- `cargo test -p everr-cli cli::tests::update_notice_`
- `cargo test -p everr-cli --test help_output version_output_includes_build_type`