### PR TITLE
Align desktop and CLI versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,9 +128,10 @@ For macOS distribution, use:
 pnpm --dir packages/desktop-app build:desktop
 ```
 
-CI derives the release identity from the commit SHA and generates the numeric
-Tauri/macOS updater version automatically, so release prep does not need a
-manual desktop version bump.
+CI derives the release identity from the commit SHA, but the desktop app,
+macOS updater, CLI, and production telemetry version come from
+`packages/desktop-app/src-tauri/tauri.conf.json`. Bump the desktop package
+version before shipping a production desktop release.
 
 If you also want that release flow to install the signed CLI into `~/.local/bin`, opt in explicitly:
 

--- a/packages/desktop-app/README.md
+++ b/packages/desktop-app/README.md
@@ -26,10 +26,10 @@ CI uses the same release path through:
 pnpm build:desktop:ci
 ```
 
-CI uses the commit SHA as the human release identity and generates the numeric
-Tauri/macOS updater version from the checked-in development version plus the
-workflow run number. The checked-in version stays as the local development
-fallback.
+CI uses the commit SHA as the human release identity. The app bundle, macOS
+updater manifest, CLI, and production telemetry version all use the checked-in
+desktop version from `src-tauri/tauri.conf.json`, which is synced from this
+package's `package.json`.
 
 Install the signed release CLI into `~/.local/bin` only when you explicitly opt in:
 

--- a/packages/desktop-app/scripts/build-desktop.ts
+++ b/packages/desktop-app/scripts/build-desktop.ts
@@ -64,10 +64,10 @@ export async function buildDesktop(args = process.argv.slice(2)) {
 
   await rm(desktopReleaseDir, { recursive: true, force: true });
 
-  const fallbackVersion = await readDesktopTauriConfigVersion();
+  const desktopVersion = await readDesktopTauriConfigVersion();
   const gitShaResult = await $({ nothrow: true })`git -C ${repoDir} rev-parse HEAD`;
   const identity = resolveDesktopReleaseIdentity({
-    fallbackVersion,
+    desktopVersion,
     fallbackSha: gitShaResult.exitCode === 0 ? gitShaResult.stdout.trim() : undefined,
   });
   Object.assign(process.env, {
@@ -79,7 +79,7 @@ export async function buildDesktop(args = process.argv.slice(2)) {
   if (ciBuild) {
     const overridePath = await writeDesktopReleaseTauriConfigOverride({
       outputPath: path.join(repoDir, "target", "desktop-build", "tauri-release.conf.json"),
-      platformVersion: identity.platformVersion,
+      desktopVersion: identity.desktopVersion,
     });
     tauriArgs.push("--config", overridePath);
   }

--- a/packages/desktop-app/scripts/build-desktop.ts
+++ b/packages/desktop-app/scripts/build-desktop.ts
@@ -36,11 +36,11 @@ export async function buildDesktop(args = process.argv.slice(2)) {
     }
 
     if (arg === "--release") {
-      throw new Error("Desktop release versions are derived from the CI commit SHA.");
+      throw new Error("Desktop release versions are derived from src-tauri/tauri.conf.json.");
     }
 
     if (arg === "--version" || arg.startsWith("--version=")) {
-      throw new Error("Desktop release versions are derived from the CI commit SHA.");
+      throw new Error("Desktop release versions are derived from src-tauri/tauri.conf.json.");
     }
 
     if (arg === "--bundles" || arg.startsWith("--bundles=")) {
@@ -71,7 +71,6 @@ export async function buildDesktop(args = process.argv.slice(2)) {
     fallbackSha: gitShaResult.exitCode === 0 ? gitShaResult.stdout.trim() : undefined,
   });
   Object.assign(process.env, {
-    EVERR_PLATFORM_VERSION: identity.platformVersion,
     EVERR_RELEASE_SHA: identity.releaseSha,
     EVERR_RELEASE_SHORT_SHA: identity.releaseShortSha,
     ...(releaseIngestKey ? { EVERR_INGEST_KEY: releaseIngestKey } : {}),
@@ -90,7 +89,6 @@ export async function buildDesktop(args = process.argv.slice(2)) {
     env: {
       ...process.env,
       CI: process.env.CI || "true",
-      EVERR_PLATFORM_VERSION: identity.platformVersion,
       EVERR_RELEASE_SHA: identity.releaseSha,
       EVERR_RELEASE_SHORT_SHA: identity.releaseShortSha,
     },

--- a/packages/desktop-app/scripts/build-support.test.ts
+++ b/packages/desktop-app/scripts/build-support.test.ts
@@ -61,7 +61,7 @@ afterEach(async () => {
 });
 
 describe("build-support version helpers", () => {
-  it("derives CI release identity from GitHub Actions env vars", () => {
+  it("keeps the checked-in desktop version for GitHub Actions release identity", () => {
     expect(
       resolveDesktopReleaseIdentity({
         env: {
@@ -72,7 +72,7 @@ describe("build-support version helpers", () => {
         fallbackSha: "localsha",
       }),
     ).toEqual({
-      platformVersion: "0.1.1264",
+      platformVersion: "0.1.30",
       releaseSha: "82efe1cf1358e8395b2862c4ee9f93567f10c16e",
       releaseShortSha: "82efe1c",
       source: "github-actions",
@@ -94,7 +94,7 @@ describe("build-support version helpers", () => {
     });
   });
 
-  it("uses pre-resolved release env without adding the GitHub run number again", () => {
+  it("uses pre-resolved release SHA env without changing the checked-in desktop version", () => {
     expect(
       resolveDesktopReleaseIdentity({
         env: {
@@ -107,39 +107,39 @@ describe("build-support version helpers", () => {
         fallbackVersion: "0.1.30",
       }),
     ).toEqual({
-      platformVersion: "0.1.1264",
+      platformVersion: "0.1.30",
       releaseSha: "82efe1cf1358e8395b2862c4ee9f93567f10c16e",
       releaseShortSha: "82efe1c",
       source: "github-actions",
     });
   });
 
-  it("rejects invalid generated platform versions", () => {
+  it("rejects invalid GitHub release SHAs", () => {
     expect(() =>
       resolveDesktopReleaseIdentity({
         env: {
-          GITHUB_SHA: "82efe1cf1358e8395b2862c4ee9f93567f10c16e",
-          GITHUB_RUN_NUMBER: "not-a-number",
+          GITHUB_SHA: "not-a-sha",
+          GITHUB_RUN_NUMBER: "1234",
         },
         fallbackVersion: "0.1.30",
         fallbackSha: "localsha",
       }),
-    ).toThrow(/GITHUB_RUN_NUMBER/);
+    ).toThrow(/GITHUB_SHA/);
   });
 
-  it("writes a Tauri config override with the generated platform version", async () => {
+  it("writes a Tauri config override with the desktop version", async () => {
     const rootDir = await makeTempDir();
     const overridePath = path.join(rootDir, "release-tauri.conf.json");
 
     await expect(
       writeDesktopReleaseTauriConfigOverride({
         outputPath: overridePath,
-        platformVersion: "0.1.1264",
+        platformVersion: "0.1.31",
       }),
     ).resolves.toBe(overridePath);
 
     await expect(readFile(overridePath, "utf8")).resolves.toBe(
-      `${JSON.stringify({ version: "0.1.1264" }, null, 2)}\n`,
+      `${JSON.stringify({ version: "0.1.31" }, null, 2)}\n`,
     );
   });
 

--- a/packages/desktop-app/scripts/build-support.test.ts
+++ b/packages/desktop-app/scripts/build-support.test.ts
@@ -68,11 +68,11 @@ describe("build-support version helpers", () => {
           GITHUB_SHA: "82efe1cf1358e8395b2862c4ee9f93567f10c16e",
           GITHUB_RUN_NUMBER: "1234",
         },
-        fallbackVersion: "0.1.30",
+        desktopVersion: "0.1.30",
         fallbackSha: "localsha",
       }),
     ).toEqual({
-      platformVersion: "0.1.30",
+      desktopVersion: "0.1.30",
       releaseSha: "82efe1cf1358e8395b2862c4ee9f93567f10c16e",
       releaseShortSha: "82efe1c",
       source: "github-actions",
@@ -83,11 +83,11 @@ describe("build-support version helpers", () => {
     expect(
       resolveDesktopReleaseIdentity({
         env: {},
-        fallbackVersion: "0.1.30",
+        desktopVersion: "0.1.30",
         fallbackSha: "localsha123456",
       }),
     ).toEqual({
-      platformVersion: "0.1.30",
+      desktopVersion: "0.1.30",
       releaseSha: "localsha123456",
       releaseShortSha: "localsh",
       source: "local",
@@ -104,10 +104,10 @@ describe("build-support version helpers", () => {
           EVERR_RELEASE_SHA: "82efe1cf1358e8395b2862c4ee9f93567f10c16e",
           EVERR_RELEASE_SHORT_SHA: "82efe1c",
         },
-        fallbackVersion: "0.1.30",
+        desktopVersion: "0.1.30",
       }),
     ).toEqual({
-      platformVersion: "0.1.30",
+      desktopVersion: "0.1.30",
       releaseSha: "82efe1cf1358e8395b2862c4ee9f93567f10c16e",
       releaseShortSha: "82efe1c",
       source: "github-actions",
@@ -121,7 +121,7 @@ describe("build-support version helpers", () => {
           GITHUB_SHA: "not-a-sha",
           GITHUB_RUN_NUMBER: "1234",
         },
-        fallbackVersion: "0.1.30",
+        desktopVersion: "0.1.30",
         fallbackSha: "localsha",
       }),
     ).toThrow(/GITHUB_SHA/);
@@ -134,12 +134,12 @@ describe("build-support version helpers", () => {
     await expect(
       writeDesktopReleaseTauriConfigOverride({
         outputPath: overridePath,
-        platformVersion: "0.1.31",
+        desktopVersion: "1.2.3",
       }),
     ).resolves.toBe(overridePath);
 
     await expect(readFile(overridePath, "utf8")).resolves.toBe(
-      `${JSON.stringify({ version: "0.1.31" }, null, 2)}\n`,
+      `${JSON.stringify({ version: "1.2.3" }, null, 2)}\n`,
     );
   });
 
@@ -149,7 +149,7 @@ describe("build-support version helpers", () => {
     await expect(
       writeDesktopReleaseTauriConfigOverride({
         outputPath: path.join(rootDir, "bad.conf.json"),
-        platformVersion: "82efe1c",
+        desktopVersion: "82efe1c",
       }),
     ).rejects.toThrow(/semantic version/);
   });

--- a/packages/desktop-app/scripts/build-support.ts
+++ b/packages/desktop-app/scripts/build-support.ts
@@ -332,7 +332,7 @@ function normalizeDesktopVersion(version: string) {
 }
 
 export type DesktopReleaseIdentity = {
-  platformVersion: string;
+  desktopVersion: string;
   releaseSha: string;
   releaseShortSha: string;
   source: "github-actions" | "local";
@@ -353,22 +353,22 @@ function normalizeReleaseSha(value: string) {
 
 export function resolveDesktopReleaseIdentity({
   env = process.env,
-  fallbackVersion,
+  desktopVersion,
   fallbackSha,
 }: {
   env?: NodeJS.ProcessEnv;
-  fallbackVersion: string;
+  desktopVersion: string;
   fallbackSha?: string;
 }): DesktopReleaseIdentity {
   const envReleaseSha = env.EVERR_RELEASE_SHA?.trim();
   const envReleaseShortSha = env.EVERR_RELEASE_SHORT_SHA?.trim();
-  const platformVersion = normalizeDesktopVersion(fallbackVersion);
+  const normalizedDesktopVersion = normalizeDesktopVersion(desktopVersion);
 
   if (envReleaseSha) {
     const releaseSha = envReleaseSha;
 
     return {
-      platformVersion,
+      desktopVersion: normalizedDesktopVersion,
       releaseSha,
       releaseShortSha: envReleaseShortSha || releaseShortSha(releaseSha),
       source: env.GITHUB_SHA ? "github-actions" : "local",
@@ -381,7 +381,7 @@ export function resolveDesktopReleaseIdentity({
     const releaseSha = normalizeReleaseSha(githubSha);
 
     return {
-      platformVersion,
+      desktopVersion: normalizedDesktopVersion,
       releaseSha,
       releaseShortSha: releaseShortSha(releaseSha),
       source: "github-actions",
@@ -391,7 +391,7 @@ export function resolveDesktopReleaseIdentity({
   const releaseSha = fallbackSha?.trim() || "unknown";
 
   return {
-    platformVersion,
+    desktopVersion: normalizedDesktopVersion,
     releaseSha,
     releaseShortSha: releaseShortSha(releaseSha),
     source: "local",
@@ -421,12 +421,12 @@ export function resolveDesktopReleaseIngestKey({
 
 export async function writeDesktopReleaseTauriConfigOverride({
   outputPath,
-  platformVersion,
+  desktopVersion,
 }: {
   outputPath: string;
-  platformVersion: string;
+  desktopVersion: string;
 }) {
-  const version = normalizeDesktopVersion(platformVersion);
+  const version = normalizeDesktopVersion(desktopVersion);
   await mkdir(path.dirname(outputPath), { recursive: true });
   await writeFile(outputPath, `${JSON.stringify({ version }, null, 2)}\n`);
   return outputPath;

--- a/packages/desktop-app/scripts/build-support.ts
+++ b/packages/desktop-app/scripts/build-support.ts
@@ -15,7 +15,7 @@ import path from "node:path";
 import { pipeline } from "node:stream/promises";
 import { fileURLToPath } from "node:url";
 import { createGzip } from "node:zlib";
-import { parse as parseVersion, valid as validVersion } from "semver";
+import { valid as validVersion } from "semver";
 import { $ } from "zx";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
@@ -342,30 +342,6 @@ function releaseShortSha(releaseSha: string) {
   return releaseSha === "unknown" ? "unknown" : releaseSha.slice(0, 7);
 }
 
-function normalizeGithubRunNumber(value: string) {
-  const trimmed = value.trim();
-  if (!/^[1-9][0-9]*$/.test(trimmed)) {
-    throw new Error(
-      `GITHUB_RUN_NUMBER must be a positive integer to generate a desktop platform version; got "${value}".`,
-    );
-  }
-
-  return trimmed;
-}
-
-function buildGithubActionsPlatformVersion(fallbackVersion: string, githubRunNumber: string) {
-  const parsed = parseVersion(normalizeDesktopVersion(fallbackVersion));
-  if (!parsed) {
-    throw new Error(
-      `Unsupported desktop app version "${fallbackVersion}". Expected a semantic version in the form X.Y.Z.`,
-    );
-  }
-
-  return normalizeDesktopVersion(
-    `${parsed.major}.${parsed.minor}.${parsed.patch + Number(githubRunNumber)}`,
-  );
-}
-
 function normalizeReleaseSha(value: string) {
   const trimmed = value.trim();
   if (!/^[0-9a-f]{7,40}$/i.test(trimmed)) {
@@ -384,31 +360,25 @@ export function resolveDesktopReleaseIdentity({
   fallbackVersion: string;
   fallbackSha?: string;
 }): DesktopReleaseIdentity {
-  const envPlatformVersion = env.EVERR_PLATFORM_VERSION?.trim();
   const envReleaseSha = env.EVERR_RELEASE_SHA?.trim();
   const envReleaseShortSha = env.EVERR_RELEASE_SHORT_SHA?.trim();
+  const platformVersion = normalizeDesktopVersion(fallbackVersion);
 
-  if (envPlatformVersion) {
-    const platformVersion = normalizeDesktopVersion(envPlatformVersion);
-    const releaseSha = envReleaseSha || fallbackSha?.trim() || "unknown";
+  if (envReleaseSha) {
+    const releaseSha = envReleaseSha;
 
     return {
       platformVersion,
       releaseSha,
       releaseShortSha: envReleaseShortSha || releaseShortSha(releaseSha),
-      source: env.GITHUB_SHA && env.GITHUB_RUN_NUMBER ? "github-actions" : "local",
+      source: env.GITHUB_SHA ? "github-actions" : "local",
     };
   }
 
   const githubSha = env.GITHUB_SHA?.trim();
-  const githubRunNumber = env.GITHUB_RUN_NUMBER?.trim();
 
-  if (githubSha && githubRunNumber) {
+  if (githubSha) {
     const releaseSha = normalizeReleaseSha(githubSha);
-    const platformVersion = buildGithubActionsPlatformVersion(
-      fallbackVersion,
-      normalizeGithubRunNumber(githubRunNumber),
-    );
 
     return {
       platformVersion,
@@ -418,7 +388,6 @@ export function resolveDesktopReleaseIdentity({
     };
   }
 
-  const platformVersion = normalizeDesktopVersion(fallbackVersion);
   const releaseSha = fallbackSha?.trim() || "unknown";
 
   return {

--- a/packages/desktop-app/scripts/copy-release-artifact.test.ts
+++ b/packages/desktop-app/scripts/copy-release-artifact.test.ts
@@ -50,7 +50,7 @@ describe("copy-release-artifact helpers", () => {
 
   it("builds a static updater manifest with an embedded signature", () => {
     const manifest = buildUpdaterManifest({
-      version: "0.1.1264",
+      version: "0.1.31",
       releaseShortSha: "82efe1c",
       pubDate: "2026-03-14T17:00:00Z",
       downloadUrl: "https://everr.dev/everr-app/everr-macos-arm64.app.tar.gz",
@@ -59,7 +59,7 @@ describe("copy-release-artifact helpers", () => {
     });
 
     expect(JSON.parse(manifest)).toEqual({
-      version: "0.1.1264",
+      version: "0.1.31",
       notes: "Everr desktop release 82efe1c",
       pub_date: "2026-03-14T17:00:00Z",
       platforms: {
@@ -83,7 +83,7 @@ describe("copy-release-artifact helpers", () => {
   it("builds release metadata for the deploy artifact bundle", () => {
     const metadata = buildReleaseMetadata({
       releaseVersion: "0.1.31",
-      platformVersion: "0.1.1264",
+      platformVersion: "0.1.31",
       releaseSha: "82efe1cf1358e8395b2862c4ee9f93567f10c16e",
       releaseShortSha: "82efe1c",
       publicBaseUrl: "https://everr.dev/everr-app",
@@ -102,7 +102,7 @@ describe("copy-release-artifact helpers", () => {
       schema_version: 1,
       product: "Everr",
       version: "0.1.31",
-      platform_version: "0.1.1264",
+      platform_version: "0.1.31",
       release_sha: "82efe1cf1358e8395b2862c4ee9f93567f10c16e",
       release_short_sha: "82efe1c",
       public_base_url: "https://everr.dev/everr-app",

--- a/packages/desktop-app/scripts/copy-release-artifact.test.ts
+++ b/packages/desktop-app/scripts/copy-release-artifact.test.ts
@@ -82,8 +82,8 @@ describe("copy-release-artifact helpers", () => {
 
   it("builds release metadata for the deploy artifact bundle", () => {
     const metadata = buildReleaseMetadata({
-      releaseVersion: "0.1.31",
-      platformVersion: "0.1.31",
+      packageVersion: "0.1.31",
+      desktopVersion: "0.1.31",
       releaseSha: "82efe1cf1358e8395b2862c4ee9f93567f10c16e",
       releaseShortSha: "82efe1c",
       publicBaseUrl: "https://everr.dev/everr-app",

--- a/packages/desktop-app/scripts/copy-release-artifact.ts
+++ b/packages/desktop-app/scripts/copy-release-artifact.ts
@@ -128,8 +128,8 @@ export function buildUpdaterManifest({
 }
 
 export function buildReleaseMetadata({
-  releaseVersion,
-  platformVersion,
+  packageVersion,
+  desktopVersion,
   releaseSha,
   releaseShortSha,
   publicBaseUrl,
@@ -137,8 +137,8 @@ export function buildReleaseMetadata({
   files,
   createdAt,
 }: {
-  releaseVersion: string;
-  platformVersion: string;
+  packageVersion: string;
+  desktopVersion: string;
   releaseSha: string;
   releaseShortSha: string;
   publicBaseUrl: string;
@@ -150,8 +150,8 @@ export function buildReleaseMetadata({
     {
       schema_version: 1,
       product: "Everr",
-      version: releaseVersion,
-      platform_version: platformVersion,
+      version: packageVersion,
+      platform_version: desktopVersion,
       release_sha: releaseSha,
       release_short_sha: releaseShortSha,
       public_base_url: publicBaseUrl,
@@ -433,10 +433,10 @@ export async function stageReleaseArtifacts() {
   const bundleDir = await findBundleDir();
   const artifacts = await findReleaseArtifacts(bundleDir);
   const appDestDir = path.join(desktopReleaseDir, "everr-app");
-  const releaseVersion = await readDesktopPackageVersion();
-  const fallbackVersion = await readDesktopTauriVersion();
+  const packageVersion = await readDesktopPackageVersion();
+  const desktopVersion = await readDesktopTauriVersion();
   const identity = resolveDesktopReleaseIdentity({
-    fallbackVersion,
+    desktopVersion,
     fallbackSha: process.env.EVERR_RELEASE_SHA ?? process.env.GITHUB_SHA,
   });
   const publicBaseUrl = resolvePublicBaseUrl();
@@ -471,7 +471,7 @@ export async function stageReleaseArtifacts() {
     assetName: target.updaterArchiveName,
   });
   const manifest = buildUpdaterManifest({
-    version: identity.platformVersion,
+    version: identity.desktopVersion,
     releaseShortSha: identity.releaseShortSha,
     pubDate: createdAt,
     downloadUrl: updaterArchiveUrl,
@@ -485,8 +485,8 @@ export async function stageReleaseArtifacts() {
   await writeFile(
     path.join(desktopReleaseDir, RELEASE_METADATA_NAME),
     buildReleaseMetadata({
-      releaseVersion,
-      platformVersion: identity.platformVersion,
+      packageVersion,
+      desktopVersion: identity.desktopVersion,
       releaseSha: identity.releaseSha,
       releaseShortSha: identity.releaseShortSha,
       publicBaseUrl,
@@ -498,7 +498,7 @@ export async function stageReleaseArtifacts() {
   await writeReleaseChecksums(desktopReleaseDir);
 
   console.log(
-    `Staged desktop ${identity.releaseShortSha} (${identity.platformVersion}) release artifacts in ${desktopReleaseDir}`,
+    `Staged desktop ${identity.releaseShortSha} (${identity.desktopVersion}) release artifacts in ${desktopReleaseDir}`,
   );
   console.log(`Wrote updater manifest to ${path.join(appDestDir, "latest.json")}`);
 }

--- a/packages/desktop-app/scripts/copy-release-artifact.ts
+++ b/packages/desktop-app/scripts/copy-release-artifact.ts
@@ -436,7 +436,7 @@ export async function stageReleaseArtifacts() {
   const releaseVersion = await readDesktopPackageVersion();
   const fallbackVersion = await readDesktopTauriVersion();
   const identity = resolveDesktopReleaseIdentity({
-    fallbackVersion: process.env.EVERR_PLATFORM_VERSION ?? fallbackVersion,
+    fallbackVersion,
     fallbackSha: process.env.EVERR_RELEASE_SHA ?? process.env.GITHUB_SHA,
   });
   const publicBaseUrl = resolvePublicBaseUrl();

--- a/packages/desktop-app/src-cli/build.rs
+++ b/packages/desktop-app/src-cli/build.rs
@@ -16,7 +16,6 @@ fn main() {
     println!("cargo:rerun-if-env-changed=EVERR_EMBEDDED_COLLECTOR_GZ");
     println!("cargo:rerun-if-env-changed=EVERR_EMBEDDED_CHDB_GZ");
     println!("cargo:rerun-if-env-changed=EVERR_REQUIRE_EMBEDDED_COLLECTOR");
-    println!("cargo:rerun-if-env-changed=EVERR_PLATFORM_VERSION");
     println!("cargo:rerun-if-env-changed=EVERR_RELEASE_SHA");
     println!("cargo:rerun-if-env-changed=EVERR_RELEASE_SHORT_SHA");
     println!("cargo:rustc-check-cfg=cfg(everr_embedded_collector_assets)");
@@ -27,8 +26,7 @@ fn main() {
     let fallback_version = json["version"]
         .as_str()
         .expect("missing 'version' in tauri.conf.json");
-    let version =
-        std::env::var("EVERR_PLATFORM_VERSION").unwrap_or_else(|_| fallback_version.into());
+    let version = fallback_version;
     let release_sha = std::env::var("EVERR_RELEASE_SHA").unwrap_or_else(|_| "unknown".into());
     let release_short_sha = std::env::var("EVERR_RELEASE_SHORT_SHA")
         .unwrap_or_else(|_| release_sha.chars().take(7).collect());

--- a/packages/desktop-app/src-tauri/build.rs
+++ b/packages/desktop-app/src-tauri/build.rs
@@ -4,7 +4,6 @@ fn main() {
     let tauri_conf = Path::new(env!("CARGO_MANIFEST_DIR")).join("tauri.conf.json");
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed={}", tauri_conf.display());
-    println!("cargo:rerun-if-env-changed=EVERR_PLATFORM_VERSION");
     println!("cargo:rerun-if-env-changed=EVERR_RELEASE_SHA");
     println!("cargo:rerun-if-env-changed=EVERR_RELEASE_SHORT_SHA");
     println!("cargo:rerun-if-env-changed=EVERR_INGEST_KEY");
@@ -15,8 +14,7 @@ fn main() {
     let fallback_version = json["version"]
         .as_str()
         .expect("missing 'version' in tauri.conf.json");
-    let version =
-        std::env::var("EVERR_PLATFORM_VERSION").unwrap_or_else(|_| fallback_version.into());
+    let version = fallback_version;
     let release_sha = std::env::var("EVERR_RELEASE_SHA").unwrap_or_else(|_| "unknown".into());
     let release_short_sha = std::env::var("EVERR_RELEASE_SHORT_SHA")
         .unwrap_or_else(|_| release_sha.chars().take(7).collect());


### PR DESCRIPTION
## Summary

- Align the desktop app, CLI, updater manifest, and desktop telemetry version source with `packages/desktop-app/src-tauri/tauri.conf.json`.
- Stop deriving the app-visible version from the GitHub Actions run number or `EVERR_PLATFORM_VERSION`.
- Keep release SHA metadata separate from the product version and update release docs/tests.

## Why

The production app was compiling `EVERR_VERSION` from the generated release/platform version, so "About Everr" and desktop `service.version` could drift from `packages/desktop-app/package.json`.

## Validation

- `pnpm --filter @everr/desktop-app test -- scripts/build-support.test.ts scripts/copy-release-artifact.test.ts`
- `cargo test -p everr-cli --test help_output version_output_includes_build_type`
- `cargo test -p everr-app --test desktop_otel_wiring`
