### PR TITLE
feat(dashboards): stacked series option for TimeSeriesChart

### DIFF
--- a/crates/everr-core/assets/skills/everr-write-dashboards/SKILL.md
+++ b/crates/everr-core/assets/skills/everr-write-dashboards/SKILL.md
@@ -138,7 +138,7 @@ Each visualization has its own option set and behaviors. **Load the rule file fo
 
 | Visualization | Rule | Load when you need |
 | --- | --- | --- |
-| `TimeSeriesChart` | `rules/timeseries.md` | a line chart over time — units, legend, curve, gaps, per-series breakdown |
+| `TimeSeriesChart` | `rules/timeseries.md` | a line or stacked area chart over time — units, legend, curve, gaps, stacking, per-series breakdown |
 | `Table` | `rules/table.md` | a row/column table — sticky header, column formatting (SQL-side) |
 | `StatChart` | `rules/statchart.md` | big single-value tiles — calculations, sparklines, threshold coloring |
 | `GeoMap` | `rules/geomap.md` | a world map — lat/lon markers or country shading, aggregation, color/size scales |
@@ -314,7 +314,7 @@ Apply is **declarative and delete-by-default within the declared projects**: new
 | Forgetting the `everr.yaml` manifest, or a `metadata.project` not listed in it | Every apply dir needs `everr.yaml` listing projects; each dashboard's project must be in it. |
 | No `{from:String}`/`{to:String}` in the `WHERE` | Add `WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}` — it is not auto-injected. |
 | Time-series x-axis blank | Alias the time column to `ts`/`time`/`timestamp`/… so it's detected. |
-| Inventing viz options (`yAxis`, `legend`, `columnSettings`, `format.unit`, `calculation: last-number`, axis min/max, stacking) | Only the options in each viz's rule file (`rules/timeseries.md`, `rules/table.md`, `rules/statchart.md`, `rules/geomap.md`) exist. Format/round in SQL, not via spec. |
+| Inventing viz options (`yAxis`, `legend`, `columnSettings`, `format.unit`, `calculation: last-number`, axis min/max) | Only the options in each viz's rule file (`rules/timeseries.md`, `rules/table.md`, `rules/statchart.md`, `rules/geomap.md`) exist. Format/round in SQL, not via spec. |
 | `PrometheusLabelValuesVariable` or other variable plugins | Only `StaticListVariable` and `ClickHouseSQLVariable`. |
 | Single `ClickHouseSQL` in the query block | Both the query `kind` and the inner `plugin.kind` are `ClickHouseSQL`. |
 | `Duration` treated as ms/seconds | It's **nanoseconds** — divide by `1e6` (ms) or `1e9` (s). |

--- a/crates/everr-core/assets/skills/everr-write-dashboards/rules/timeseries.md
+++ b/crates/everr-core/assets/skills/everr-write-dashboards/rules/timeseries.md
@@ -1,6 +1,6 @@
 # TimeSeriesChart
 
-A line chart over time. It infers its structure from the columns you `SELECT` — there is no axis, color, stacking, or area configuration.
+A line chart over time (or a stacked area chart with `stacked: true`). It infers its structure from the columns you `SELECT` — there is no axis, color, or per-series configuration.
 
 ## Options (`plugin.spec`)
 
@@ -11,14 +11,15 @@ A line chart over time. It infers its structure from the columns you `SELECT` �
 | `lineWidth` | number | `1.5` | any number | Line stroke width. |
 | `curveType` | string | `monotone` | `monotone`, `linear`, `natural`, `stepBefore`, `stepAfter` | Line interpolation. An unknown value falls back to the renderer default. |
 | `connectNulls` | boolean | `false` | `true` | Bridge gaps instead of breaking the line at them. |
+| `stacked` | boolean | `false` | `true` | Render the series as stacked filled areas instead of overlaid lines. A series with no sample at a timestamp contributes 0 there; `connectNulls` has no effect. |
 
 ```yaml
 plugin:
   kind: TimeSeriesChart
-  spec: { unit: ms, showLegend: true, lineWidth: 1.5, curveType: monotone, connectNulls: false }
+  spec: { unit: ms, showLegend: true, lineWidth: 1.5, curveType: monotone, connectNulls: false, stacked: false }
 ```
 
-These five are the complete set. There is **no** `yAxis` / `min` / `max`, `legend` object, `stack` / `stacking`, area / fill, `thresholds`, `decimals`, `pointRadius`, or per-series color. Series colors come from a fixed 6-color palette assigned by order (wrapping after 6) and are not configurable.
+These six are the complete set. There is **no** `yAxis` / `min` / `max`, `legend` object, separate area / fill option, `thresholds`, `decimals`, `pointRadius`, or per-series color. Series colors come from a fixed 6-color palette assigned by order (wrapping after 6) and are not configurable.
 
 ## Data shape
 

--- a/dashboards/viz-gallery/time-series.yaml
+++ b/dashboards/viz-gallery/time-series.yaml
@@ -7,7 +7,7 @@ spec:
     name: Visualization Gallery — Time Series
     description: >-
       TimeSeriesChart regression sheet — every option (unit, showLegend,
-      lineWidth, curveType, connectNulls) and behavior (grouped pivot,
+      lineWidth, curveType, connectNulls, stacked) and behavior (grouped pivot,
       multi-column, multi-query, null gaps, empty result) exercised with
       deterministic TestData.
   duration: 7d
@@ -138,6 +138,60 @@ spec:
                   seed: 9
                   series:
                     - { name: spans, start: 50, noise: 10, min: 0 }
+    ts-stacked-grouped:
+      kind: Panel
+      spec:
+        display:
+          name: "TS: stacked, grouped, legend"
+          description: "stacked: true · showLegend: true · grouped pivot (one band per StatusCode)"
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            unit: ""
+            showLegend: true
+            lineWidth: 1.5
+            curveType: monotone
+            connectNulls: false
+            stacked: true
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: random_walk
+                  seed: 11
+                  labelColumn: status
+                  series:
+                    - { name: Ok,    start: 800, noise: 60, min: 0 }
+                    - { name: Error, start: 40,  noise: 12, min: 0 }
+                    - { name: Unset, start: 120, noise: 20, min: 0 }
+    ts-stacked-sparse-step:
+      kind: Panel
+      spec:
+        display:
+          name: "TS: stacked, sparse series, stepAfter"
+          description: "stacked: true · curveType: stepAfter · sparse series contributes 0 where unsampled (no gaps when stacking)"
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            unit: ""
+            showLegend: true
+            lineWidth: 1
+            curveType: stepAfter
+            connectNulls: false
+            stacked: true
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: random_walk
+                  seed: 21
+                  series:
+                    - { name: requests, start: 300, noise: 30, min: 0 }
+                    - { name: retries,  start: 25,  noise: 15, min: 0, nullChance: 0.45 }
     # ── Data-shape behaviors + edge states ───────────────────────────
     ts-multi-query:
       kind: Panel
@@ -204,5 +258,7 @@ spec:
           - { x: 0,  y: 8,  width: 8,  height: 7, content: { $ref: "#/spec/panels/ts-linear-connect-nulls" } }
           - { x: 8,  y: 8,  width: 8,  height: 7, content: { $ref: "#/spec/panels/ts-natural" } }
           - { x: 16, y: 8,  width: 8,  height: 7, content: { $ref: "#/spec/panels/ts-step-before" } }
-          - { x: 0,  y: 15, width: 16, height: 8, content: { $ref: "#/spec/panels/ts-multi-query" } }
-          - { x: 16, y: 15, width: 8,  height: 8, content: { $ref: "#/spec/panels/ts-empty" } }
+          - { x: 0,  y: 15, width: 12, height: 8, content: { $ref: "#/spec/panels/ts-stacked-grouped" } }
+          - { x: 12, y: 15, width: 12, height: 8, content: { $ref: "#/spec/panels/ts-stacked-sparse-step" } }
+          - { x: 0,  y: 23, width: 16, height: 8, content: { $ref: "#/spec/panels/ts-multi-query" } }
+          - { x: 16, y: 23, width: 8,  height: 8, content: { $ref: "#/spec/panels/ts-empty" } }

--- a/packages/app/src/components/dashboards/visualizations/time-series-chart/spec.ts
+++ b/packages/app/src/components/dashboards/visualizations/time-series-chart/spec.ts
@@ -13,6 +13,7 @@ export const timeSeriesChartSpec = z.looseObject({
     .enum(["monotone", "linear", "natural", "stepBefore", "stepAfter"])
     .default("monotone"),
   connectNulls: z.boolean().default(false),
+  stacked: z.boolean().default(false),
 });
 
 export type TimeSeriesChartSpec = z.infer<typeof timeSeriesChartSpec>;

--- a/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-chart-visualization.tsx
@@ -7,9 +7,10 @@ import { LineChart as LineChartIcon } from "lucide-react";
 import { Fragment, useCallback, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import {
+  Area,
   CartesianGrid,
+  ComposedChart,
   Line,
-  LineChart,
   ReferenceArea,
   ReferenceDot,
   ReferenceLine,
@@ -19,7 +20,7 @@ import {
 import { SERIES_COLORS } from "../data-utils";
 import type { VisualizationProps } from "../index";
 import type { TimeSeriesChartSpec } from "./spec";
-import { buildChartModel, TS_KEY } from "./time-series-data";
+import { buildChartModel, buildStackedData, TS_KEY } from "./time-series-data";
 
 const BRUSH_COLOR = SERIES_COLORS[0]!;
 const MAX_X_TICKS = 6;
@@ -103,7 +104,8 @@ export function TimeSeriesChartVisualization({
   timeRange,
   onTimeRangeChange,
 }: VisualizationProps<TimeSeriesChartSpec>) {
-  const { showLegend, connectNulls, lineWidth, unit, curveType } = spec;
+  const { showLegend, connectNulls, lineWidth, unit, curveType, stacked } =
+    spec;
 
   const containerRef = useRef<HTMLDivElement>(null);
   const plotRectRef = useRef<DOMRect | null>(null);
@@ -123,6 +125,11 @@ export function TimeSeriesChartVisualization({
   const { chartData, valueKeys, chartConfig, seriesData } = useMemo(
     () => buildChartModel(data ?? [], domain),
     [data, domain],
+  );
+
+  const stackedData = useMemo(
+    () => (stacked ? buildStackedData(chartData, valueKeys) : null),
+    [stacked, chartData, valueKeys],
   );
 
   const ticks = useMemo(() => generateTicks(domain, MAX_X_TICKS), [domain]);
@@ -227,7 +234,10 @@ export function TimeSeriesChartVisualization({
         className="h-full w-full"
         debounce={100}
       >
-        <LineChart data={chartData} margin={{ left: 12, right: 12, top: 8 }}>
+        <ComposedChart
+          data={stackedData ?? chartData}
+          margin={{ left: 12, right: 12, top: 8 }}
+        >
           <CartesianGrid vertical={false} />
           <XAxis
             dataKey={TS_KEY}
@@ -251,21 +261,39 @@ export function TimeSeriesChartVisualization({
             tickFormatter={(v) => (unit ? `${v}${unit}` : String(v))}
           />
           {showLegend && <ChartLegend content={<ChartLegendContent />} />}
-          {valueKeys.map((key) => (
-            <Line
-              key={key}
-              // Each line renders from its own data so it connects its own
-              // points regardless of where other series have samples.
-              data={seriesData[key]}
-              dataKey={key}
-              type={curveType}
-              stroke={`var(--color-${key})`}
-              strokeWidth={lineWidth}
-              dot={false}
-              connectNulls={connectNulls}
-              isAnimationActive={false}
-            />
-          ))}
+          {valueKeys.map((key) =>
+            stacked ? (
+              // Stacked areas must all read from the chart-level data (the
+              // zero-filled merged timeline) — recharts accumulates stackId
+              // offsets across that shared array, not across per-series ones.
+              <Area
+                key={key}
+                stackId="stack"
+                dataKey={key}
+                type={curveType}
+                stroke={`var(--color-${key})`}
+                fill={`var(--color-${key})`}
+                fillOpacity={0.4}
+                strokeWidth={lineWidth}
+                dot={false}
+                isAnimationActive={false}
+              />
+            ) : (
+              <Line
+                key={key}
+                // Each line renders from its own data so it connects its own
+                // points regardless of where other series have samples.
+                data={seriesData[key]}
+                dataKey={key}
+                type={curveType}
+                stroke={`var(--color-${key})`}
+                strokeWidth={lineWidth}
+                dot={false}
+                connectNulls={connectNulls}
+                isAnimationActive={false}
+              />
+            ),
+          )}
           {tooltipTs !== undefined && (
             <ReferenceLine
               x={tooltipTs}
@@ -274,21 +302,29 @@ export function TimeSeriesChartVisualization({
             />
           )}
           {tooltipTs !== undefined &&
-            valueKeys.map((key) => {
-              const val = tooltipRow?.[key];
-              if (typeof val !== "number") return null;
-              return (
-                <ReferenceDot
-                  key={key}
-                  x={tooltipTs}
-                  y={val}
-                  r={4}
-                  fill={chartConfig[key]?.color}
-                  stroke="var(--card)"
-                  strokeWidth={2}
-                />
-              );
-            })}
+            (() => {
+              // In stacked mode each dot sits at the series' cumulative top
+              // (the running sum in render order), matching where the band
+              // edge is drawn — not at the raw value.
+              let stackTop = 0;
+              return valueKeys.map((key) => {
+                const val = tooltipRow?.[key];
+                const raw = typeof val === "number" ? val : 0;
+                stackTop += raw;
+                if (typeof val !== "number") return null;
+                return (
+                  <ReferenceDot
+                    key={key}
+                    x={tooltipTs}
+                    y={stacked ? stackTop : val}
+                    r={4}
+                    fill={chartConfig[key]?.color}
+                    stroke="var(--card)"
+                    strokeWidth={2}
+                  />
+                );
+              });
+            })()}
           {brushStart != null && brushEnd != null && (
             <ReferenceArea
               x1={brushStart}
@@ -299,7 +335,7 @@ export function TimeSeriesChartVisualization({
               strokeOpacity={0.3}
             />
           )}
-        </LineChart>
+        </ComposedChart>
       </ChartContainer>
       {tooltipRow &&
         createPortal(

--- a/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-data.test.ts
+++ b/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-data.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildChartModel } from "./time-series-data";
+import { buildChartModel, buildStackedData } from "./time-series-data";
 
 const TS_KEY = "__ts";
 
@@ -266,5 +266,25 @@ describe("buildChartModel", () => {
     expect(model.seriesData.s0).toHaveLength(6);
     expect(model.seriesData.s0?.filter((r) => r.s0 === null)).toHaveLength(1);
     expect(model.chartData).toHaveLength(5);
+  });
+});
+
+describe("buildStackedData", () => {
+  it("fills missing and null samples with 0 so every row carries every series", () => {
+    const model = buildChartModel(
+      [
+        [
+          { time: "2026-06-07T00:00:00", a: 1, b: 10 },
+          { time: "2026-06-07T00:01:00", a: 2, b: "oops" }, // non-numeric → null sample
+        ],
+        [{ time: "2026-06-07T00:00:00", c: 100 }], // absent at 00:01
+      ],
+      WIDE,
+    );
+    const stacked = buildStackedData(model.chartData, model.valueKeys);
+    expect(stacked).toHaveLength(2);
+    expect(stacked[0]).toMatchObject({ s0: 1, s1: 10, s2: 100 });
+    expect(stacked[1]).toMatchObject({ s0: 2, s1: 0, s2: 0 });
+    expect(stacked[0]?.[TS_KEY]).toBe(model.chartData[0]?.[TS_KEY]);
   });
 });

--- a/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-data.ts
+++ b/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-data.ts
@@ -131,6 +131,28 @@ function buildSeriesData(
   return result;
 }
 
+/**
+ * Stacking renders every series from ONE shared array (recharts accumulates
+ * `stackId` series row-by-row across the chart-level data), so each merged
+ * timestamp must carry a number for every series. A missing or null sample
+ * means "this series contributes nothing to the bucket" — fill it with 0;
+ * leaving it undefined would corrupt the running stack offset for the series
+ * above it.
+ */
+export function buildStackedData(
+  chartData: Array<Record<string, unknown>>,
+  valueKeys: string[],
+): Array<Record<string, unknown>> {
+  return chartData.map((row) => {
+    const filled: Record<string, unknown> = { [TS_KEY]: row[TS_KEY] };
+    for (const key of valueKeys) {
+      const value = row[key];
+      filled[key] = typeof value === "number" ? value : 0;
+    }
+    return filled;
+  });
+}
+
 export interface ChartModel {
   /** Merged timeline (all series by timestamp). Drives the x-axis domain and
    * the crosshair/tooltip lookup — NOT the lines. */

--- a/packages/docs/content/docs/dashboards/visualizations.mdx
+++ b/packages/docs/content/docs/dashboards/visualizations.mdx
@@ -22,6 +22,7 @@ plugin:
     lineWidth: 1.5
     curveType: monotone
     connectNulls: false
+    stacked: false
 ```
 
 | Option | Type | Default | Notes |
@@ -31,6 +32,7 @@ plugin:
 | `lineWidth` | number | `1.5` | Stroke width. |
 | `curveType` | enum | `monotone` | One of `monotone`, `linear`, `natural`, `stepBefore`, `stepAfter`. |
 | `connectNulls` | boolean | `false` | Bridge gaps instead of breaking the line. |
+| `stacked` | boolean | `false` | Stack series on top of each other as filled areas. A series with no sample at a timestamp contributes 0 there, and `connectNulls` has no effect. |
 
 ## Table
 


### PR DESCRIPTION
## What

Adds a `stacked: true` option to the `TimeSeriesChart` panel spec that renders the series as stacked filled areas instead of overlaid lines.

## How

- **`spec.ts`** — new `stacked` boolean, defaulted to `false` (`{}` still parses; apply-time validation picks it up automatically since the kind is already registered).
- **`time-series-data.ts`** — new `buildStackedData()` helper. Recharts accumulates `stackId` offsets across one shared data array, so stacked mode renders from the merged timeline with missing/null samples zero-filled — a series absent at a bucket contributes nothing instead of corrupting the stack above it. Line mode is unchanged (each series still renders from its own samples).
- **`time-series-chart-visualization.tsx`** — the chart is now a `ComposedChart`; `stacked: true` renders `Area`s with a shared `stackId` (fill at 0.4 opacity), otherwise the existing per-series `Line`s. Crosshair dots sit at each series' cumulative top to match the drawn band edges; the tooltip keeps raw per-series values. `connectNulls` has no effect when stacking (zero-fill leaves no gaps).

## Docs & gallery

- Option documented in `visualizations.mdx` and the `everr-write-dashboards` skill (`rules/timeseries.md`; removed the now-stale 'no stacking' claims in `SKILL.md`).
- Two new viz-gallery panels: a grouped-pivot stack (one band per StatusCode) and a sparse-series `stepAfter` stack exercising the zero-fill behavior.

## Testing

- New unit test for `buildStackedData` (zero-fill of missing and non-numeric samples); full visualization suite passes; `tsc --noEmit` clean.
- Applied the gallery with the CLI and verified in the browser: stacking order, band fills, cumulative-top hover dots, and tooltip values all render correctly.