### PR TITLE
feat(dashboards): BarChart visualization with stacking

### DIFF
--- a/crates/everr-core/assets/skills/everr-write-dashboards/SKILL.md
+++ b/crates/everr-core/assets/skills/everr-write-dashboards/SKILL.md
@@ -20,7 +20,7 @@ The file format mirrors [Perses](https://perses.dev), so the structure (`kind`/`
 
 1. **Queries are ClickHouse SQL, not PromQL.** The only query plugin is `ClickHouseSQL`. No Prometheus, no `rate()`, no `$__rate_interval`, no `PrometheusTimeSeriesQuery`.
 2. **Time range is two SQL params:** `{from:String}` and `{to:String}`. You must put them in your `WHERE`. There is no auto-injection.
-3. **Visualizations are four kinds with simple specs:** `TimeSeriesChart`, `Table`, `StatChart`, `GeoMap`. They infer structure from the columns you `SELECT` — there is no `yAxis`, `legend`, `columnSettings`, `format.unit`, etc.
+3. **Visualizations are five kinds with simple specs:** `TimeSeriesChart`, `BarChart`, `Table`, `StatChart`, `GeoMap`. They infer structure from the columns you `SELECT` — there is no `yAxis`, `legend`, `columnSettings`, `format.unit`, etc.
 4. **Variable options come from `StaticListVariable` or `ClickHouseSQLVariable` only** — not `PrometheusLabelValuesVariable`. `$name` interpolates to a quoted ClickHouse literal.
 
 ## File layout and the required manifest
@@ -72,7 +72,7 @@ panels:
     spec:
       display: { name: Error rate }      # description optional
       plugin:
-        kind: TimeSeriesChart            # TimeSeriesChart | Table | StatChart | GeoMap
+        kind: TimeSeriesChart            # TimeSeriesChart | BarChart | Table | StatChart | GeoMap
         spec: { unit: "%", showLegend: true }
       queries:
         - kind: ClickHouseSQL            # outer query kind
@@ -84,7 +84,7 @@ panels:
                   SELECT ...
 ```
 
-The double `ClickHouseSQL` (query `kind` **and** inner `plugin.kind`) is required, not a typo. Multiple queries are allowed: time-series overlays them, table shows a selector, stat renders one tile per series, geo-map overlays markers (points) or merges regions (choropleth). The panel `plugin.kind` is one of `TimeSeriesChart`, `Table`, `StatChart`, `GeoMap` — see [Visualization options](#visualization-options) for each kind's `spec`.
+The double `ClickHouseSQL` (query `kind` **and** inner `plugin.kind`) is required, not a typo. Multiple queries are allowed: time-series and bar charts overlay them on one axis, table shows a selector, stat renders one tile per series, geo-map overlays markers (points) or merges regions (choropleth). The panel `plugin.kind` is one of `TimeSeriesChart`, `BarChart`, `Table`, `StatChart`, `GeoMap` — see [Visualization options](#visualization-options) for each kind's `spec`.
 
 ### Layout — panels only render if a layout references them
 
@@ -128,6 +128,7 @@ Data shape per visualization (the viz infers everything from your columns):
 | Viz | Return |
 | --- | --- |
 | `TimeSeriesChart` | a time column (aliased above) + numeric series columns. A non-numeric **string** column pivots one value column into one line per label (e.g. `GROUP BY ts, ServiceName`) — but **only with exactly one numeric column** (see `rules/timeseries.md`). |
+| `BarChart` | same as `TimeSeriesChart` (time column + numeric series, string pivot with exactly one numeric column) — or, **without** a time column, the first string column becomes the category axis (see `rules/barchart.md`). |
 | `Table` | any columns, rendered as-is in query order (no formatting — do it in SQL). |
 | `StatChart` | one or more numeric columns — **one tile per numeric column** (each reduced by `calculation`). A string column creates no tile. Include a time column for per-tile sparklines. |
 | `GeoMap` | points mode: numeric lat/lon columns (+ optional value/label); choropleth mode: an ISO-3166 alpha-2/alpha-3 country-code column + a numeric value column (see `rules/geomap.md`). No time axis. |
@@ -139,6 +140,7 @@ Each visualization has its own option set and behaviors. **Load the rule file fo
 | Visualization | Rule | Load when you need |
 | --- | --- | --- |
 | `TimeSeriesChart` | `rules/timeseries.md` | a line or stacked area chart over time — units, legend, curve, gaps, stacking, per-series breakdown |
+| `BarChart` | `rules/barchart.md` | bars over time or categories — stacking, percent mode, orientation, value labels |
 | `Table` | `rules/table.md` | a row/column table — sticky header, column formatting (SQL-side) |
 | `StatChart` | `rules/statchart.md` | big single-value tiles — calculations, sparklines, threshold coloring |
 | `GeoMap` | `rules/geomap.md` | a world map — lat/lon markers or country shading, aggregation, color/size scales |

--- a/crates/everr-core/assets/skills/everr-write-dashboards/rules/barchart.md
+++ b/crates/everr-core/assets/skills/everr-write-dashboards/rules/barchart.md
@@ -1,0 +1,54 @@
+# BarChart
+
+A bar chart over time **or** over categories. It infers its structure from the columns you `SELECT` — there is no axis, color, or per-series configuration.
+
+## Options (`plugin.spec`)
+
+| Option | Type | Default | Values | Effect |
+| --- | --- | --- | --- | --- |
+| `unit` | string | `""` | any string | Suffix on value-axis ticks and tooltip values. Raw concatenation, **no space** — `unit: ms` renders `123ms`. |
+| `showLegend` | boolean | `false` | `true` | Show the series legend. Only the literal `true` enables it. |
+| `stacking` | string | `none` | `none`, `stacked`, `percent` | `none` draws series side by side; `stacked` piles them into one bar per x value; `percent` additionally normalizes each stack to 100% — the value axis becomes percentages while tooltips keep raw values. |
+| `orientation` | string | `vertical` | `vertical`, `horizontal` | `vertical` draws bars bottom-up; `horizontal` draws them left-to-right with categories on the y-axis — prefer it for categorical data with long labels. |
+| `showValues` | boolean | `false` | `true` | Draw each bar's value: on top (vertical) / to the right (horizontal) of grouped bars, centered inside stacked segments. |
+
+```yaml
+plugin:
+  kind: BarChart
+  spec: { unit: req, showLegend: true, stacking: stacked, orientation: vertical, showValues: false }
+```
+
+These five are the complete set. There is **no** `yAxis` / `min` / `max`, `barWidth`, `legend` object, `thresholds`, `decimals`, or per-series color. Series colors come from a fixed 6-color palette assigned by order (wrapping after 6) and are not configurable.
+
+## Data shape
+
+Two axis modes, picked automatically per query:
+
+- **Time axis** — a column aliased to a detected name (case-insensitive **exact** match): `ts`, `time`, or `timestamp`. Each bucket becomes one bar group, sorted ascending. Bucket with `toStartOfInterval(col, INTERVAL {step:UInt32} SECOND)` — but note every bucket renders a bar, so wide ranges get thin bars; bar charts read best with coarse buckets (consider `toStartOfDay` for fixed daily breakdowns).
+- **Category axis** — no time column: the **first non-numeric string column** is the category axis, in the query's row order (use `ORDER BY` + `LIMIT` to rank). Remaining numeric columns become series.
+
+The string pivot works exactly like `TimeSeriesChart` and has the same precondition: a remaining non-numeric **string** column pivots a value column into one series per label **only when the query returns exactly one numeric column**.
+
+```sql
+-- ✅ category axis: one bar per service, ranked
+SELECT ServiceName, count() AS spans
+FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+GROUP BY ServiceName ORDER BY spans DESC LIMIT 10
+```
+
+```sql
+-- ✅ stacked over time: one segment per status per bucket (pair with stacking: stacked)
+SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} SECOND) AS ts,
+       StatusCode, count() AS spans
+FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+GROUP BY ts, StatusCode ORDER BY ts
+```
+
+## Behaviors to know
+
+- **Multiple queries merge** onto one shared axis (rows sharing an x value merge into one bar group); series colors continue across queries. Don't mix a time-axis query with a category-axis query in one panel.
+- **Stacking applies across ALL series** in the panel, including across queries — there is no per-series stack opt-out.
+- **`percent` mode** needs ≥ 2 series to be meaningful; with one series every bar is 100%.
+- **A missing group at an x value is no bar, not a zero** — pivoted series simply skip x values where the label is absent.
+- **`showValues` on dense time-bucketed data overlaps** — use it for small categorical charts, not 500-bucket time axes.
+- No drag-to-zoom (unlike `TimeSeriesChart`).

--- a/dashboards/viz-gallery/bar-chart.yaml
+++ b/dashboards/viz-gallery/bar-chart.yaml
@@ -1,0 +1,232 @@
+kind: Dashboard
+metadata:
+  name: viz-gallery-bar-chart
+  project: demo
+spec:
+  display:
+    name: Visualization Gallery — Bar Chart
+    description: >-
+      BarChart regression sheet — every option (unit, showLegend, stacking
+      none/stacked/percent, orientation vertical/horizontal, showValues) and
+      behavior (time axis, categorical axis, grouped pivot, multi-query merge,
+      empty result) exercised with deterministic TestData.
+  duration: 7d
+  refreshInterval: 1m
+  panels:
+    # ── Options + core behaviors ─────────────────────────────────────
+    bar-time-stacked:
+      kind: Panel
+      spec:
+        display:
+          name: "Bar: stacked over time, grouped"
+          description: "stacking: stacked · showLegend: true · time axis · grouped pivot (one segment per status)"
+        plugin:
+          kind: BarChart
+          spec:
+            stacking: stacked
+            showLegend: true
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: csv
+                  columns: [ts, status, spans]
+                  rows:
+                    - ["2026-06-08 00:00:00", "Ok", 820]
+                    - ["2026-06-08 00:00:00", "Error", 35]
+                    - ["2026-06-08 00:00:00", "Unset", 110]
+                    - ["2026-06-08 04:00:00", "Ok", 760]
+                    - ["2026-06-08 04:00:00", "Error", 52]
+                    - ["2026-06-08 04:00:00", "Unset", 95]
+                    - ["2026-06-08 08:00:00", "Ok", 905]
+                    - ["2026-06-08 08:00:00", "Error", 41]
+                    - ["2026-06-08 08:00:00", "Unset", 130]
+                    - ["2026-06-08 12:00:00", "Ok", 1010]
+                    - ["2026-06-08 12:00:00", "Error", 88]
+                    - ["2026-06-08 12:00:00", "Unset", 142]
+                    - ["2026-06-08 16:00:00", "Ok", 930]
+                    - ["2026-06-08 16:00:00", "Error", 64]
+                    # Unset missing here on purpose: absent group → no bar, not 0
+                    - ["2026-06-08 20:00:00", "Ok", 845]
+                    - ["2026-06-08 20:00:00", "Error", 47]
+                    - ["2026-06-08 20:00:00", "Unset", 105]
+    bar-time-grouped:
+      kind: Panel
+      spec:
+        display:
+          name: "Bar: side-by-side over time, unit"
+          description: "stacking: none · unit: ms · two value columns from one query (grouped bars per bucket)"
+        plugin:
+          kind: BarChart
+          spec:
+            stacking: none
+            unit: ms
+            showLegend: true
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  seed: 22
+                  rows: 12
+                  columns:
+                    - { name: ts, time: true }
+                    - { name: p50_ms, walk: { start: 40,  noise: 5,  min: 0, round: 0 } }
+                    - { name: p95_ms, walk: { start: 120, noise: 12, min: 0, round: 0 } }
+    bar-percent:
+      kind: Panel
+      spec:
+        display:
+          name: "Bar: percent stacking"
+          description: "stacking: percent (axis 0–100%, tooltip keeps raw values) · showLegend: true"
+        plugin:
+          kind: BarChart
+          spec:
+            stacking: percent
+            showLegend: true
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: csv
+                  columns: [ts, status, requests]
+                  rows:
+                    - ["2026-06-08 00:00:00", "2xx", 940]
+                    - ["2026-06-08 00:00:00", "4xx", 85]
+                    - ["2026-06-08 00:00:00", "5xx", 12]
+                    - ["2026-06-08 04:00:00", "2xx", 810]
+                    - ["2026-06-08 04:00:00", "4xx", 120]
+                    - ["2026-06-08 04:00:00", "5xx", 45]
+                    - ["2026-06-08 08:00:00", "2xx", 1020]
+                    - ["2026-06-08 08:00:00", "4xx", 95]
+                    - ["2026-06-08 08:00:00", "5xx", 8]
+                    - ["2026-06-08 12:00:00", "2xx", 760]
+                    - ["2026-06-08 12:00:00", "4xx", 210]
+                    - ["2026-06-08 12:00:00", "5xx", 130]
+                    - ["2026-06-08 16:00:00", "2xx", 890]
+                    - ["2026-06-08 16:00:00", "4xx", 105]
+                    - ["2026-06-08 16:00:00", "5xx", 22]
+                    - ["2026-06-08 20:00:00", "2xx", 970]
+                    - ["2026-06-08 20:00:00", "4xx", 76]
+                    - ["2026-06-08 20:00:00", "5xx", 15]
+    bar-categorical-horizontal:
+      kind: Panel
+      spec:
+        display:
+          name: "Bar: horizontal categories, values"
+          description: "orientation: horizontal · showValues: true · unit: req · category axis (no time column), query order kept"
+        plugin:
+          kind: BarChart
+          spec:
+            orientation: horizontal
+            showValues: true
+            unit: req
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: csv
+                  columns: [endpoint, requests]
+                  rows:
+                    - ["/api/users", 1240]
+                    - ["/api/orders", 870]
+                    - ["/api/search", 605]
+                    - ["/api/login", 432]
+                    - ["/healthz", 121]
+    bar-categorical-pivot:
+      kind: Panel
+      spec:
+        display:
+          name: "Bar: categorical pivot, stacked values"
+          description: "category axis + string pivot (one series per method) · stacking: stacked · showValues: true (centered in segments)"
+        plugin:
+          kind: BarChart
+          spec:
+            stacking: stacked
+            showValues: true
+            showLegend: true
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: csv
+                  columns: [endpoint, method, requests]
+                  rows:
+                    - ["/api/users", "GET", 980]
+                    - ["/api/users", "POST", 260]
+                    - ["/api/orders", "GET", 560]
+                    - ["/api/orders", "POST", 310]
+                    - ["/api/search", "GET", 605]
+    # ── Data-shape behaviors + edge states ───────────────────────────
+    bar-multi-query:
+      kind: Panel
+      spec:
+        display:
+          name: "Bar: multi-query merge"
+          description: "Two queries merged onto shared categories (side-by-side series) · showLegend: true"
+        plugin:
+          kind: BarChart
+          spec:
+            showLegend: true
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: csv
+                  columns: [service, errors]
+                  rows:
+                    - ["api", 42]
+                    - ["worker", 17]
+                    - ["web", 8]
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: csv
+                  columns: [service, warnings]
+                  rows:
+                    - ["api", 130]
+                    - ["worker", 95]
+                    - ["web", 61]
+    bar-empty:
+      kind: Panel
+      spec:
+        display:
+          name: "Bar: empty result"
+          description: "Query returns no rows → 'No data in this time range' (the chart's single empty state)"
+        plugin:
+          kind: BarChart
+          spec: {}
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: csv
+                  columns: [endpoint, requests]
+                  rows: []
+  layouts:
+    - kind: Grid
+      spec:
+        items:
+          - { x: 0,  y: 0,  width: 12, height: 8, content: { $ref: "#/spec/panels/bar-time-stacked" } }
+          - { x: 12, y: 0,  width: 12, height: 8, content: { $ref: "#/spec/panels/bar-time-grouped" } }
+          - { x: 0,  y: 8,  width: 12, height: 8, content: { $ref: "#/spec/panels/bar-percent" } }
+          - { x: 12, y: 8,  width: 12, height: 8, content: { $ref: "#/spec/panels/bar-categorical-horizontal" } }
+          - { x: 0,  y: 16, width: 8,  height: 8, content: { $ref: "#/spec/panels/bar-categorical-pivot" } }
+          - { x: 8,  y: 16, width: 8,  height: 8, content: { $ref: "#/spec/panels/bar-multi-query" } }
+          - { x: 16, y: 16, width: 8,  height: 8, content: { $ref: "#/spec/panels/bar-empty" } }

--- a/packages/app/src/components/dashboards/visualizations/bar-chart/bar-chart-data.test.ts
+++ b/packages/app/src/components/dashboards/visualizations/bar-chart/bar-chart-data.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { buildBarChartModel } from "./bar-chart-data";
+
+const X_KEY = "__x";
+
+describe("buildBarChartModel", () => {
+  it("uses the time column as the x-axis and assigns opaque render keys", () => {
+    const model = buildBarChartModel([
+      [{ time: "2026-06-07T00:00:00", value: 5 }],
+    ]);
+    expect(model.isTimeAxis).toBe(true);
+    expect(model.valueKeys).toEqual(["s0"]);
+    expect(model.chartConfig.s0?.label).toBe("value");
+    expect(model.chartData[0]?.[X_KEY]).toBeTypeOf("number");
+    expect(model.chartData[0]?.s0).toBe(5);
+  });
+
+  it("falls back to the first string column as a category axis", () => {
+    const model = buildBarChartModel([
+      [
+        { endpoint: "/users", requests: 10 },
+        { endpoint: "/orders", requests: 7 },
+      ],
+    ]);
+    expect(model.isTimeAxis).toBe(false);
+    expect(model.chartData.map((r) => r[X_KEY])).toEqual(["/users", "/orders"]);
+    expect(model.chartData.map((r) => r.s0)).toEqual([10, 7]);
+  });
+
+  it("keeps category order as first seen instead of sorting", () => {
+    const model = buildBarChartModel([
+      [
+        { region: "zeta", value: 1 },
+        { region: "alpha", value: 2 },
+      ],
+    ]);
+    expect(model.chartData.map((r) => r[X_KEY])).toEqual(["zeta", "alpha"]);
+  });
+
+  it("sorts a time axis ascending across queries", () => {
+    const model = buildBarChartModel([
+      [{ time: "2026-06-07T00:01:00", a: 2 }],
+      [{ time: "2026-06-07T00:00:00", b: 1 }],
+    ]);
+    const xs = model.chartData.map((r) => r[X_KEY] as number);
+    expect(xs).toEqual([...xs].sort((a, b) => a - b));
+    expect(model.chartData).toHaveLength(2);
+  });
+
+  it("skips rows whose timestamp cannot be parsed", () => {
+    const model = buildBarChartModel([
+      [
+        { time: "garbage", value: 99 },
+        { time: "2026-06-07T00:00:00", value: 5 },
+      ],
+    ]);
+    expect(model.chartData).toHaveLength(1);
+    expect(model.chartData[0]?.s0).toBe(5);
+  });
+
+  it("pivots a string column into one series per label on a time axis", () => {
+    const model = buildBarChartModel([
+      [
+        { ts: "2026-06-07T00:00:00", status: "ok", count: 8 },
+        { ts: "2026-06-07T00:00:00", status: "error", count: 2 },
+        { ts: "2026-06-07T00:01:00", status: "ok", count: 9 },
+      ],
+    ]);
+    expect(model.valueKeys).toEqual(["s0", "s1"]);
+    // Pivoted series labels are sorted.
+    expect(model.chartConfig.s0?.label).toBe("error");
+    expect(model.chartConfig.s1?.label).toBe("ok");
+    expect(model.chartData).toHaveLength(2);
+    expect(model.chartData[0]?.s0).toBe(2);
+    expect(model.chartData[0]?.s1).toBe(8);
+    // "no bar here" stays absent, not 0.
+    expect(model.chartData[1]?.s0).toBeUndefined();
+  });
+
+  it("pivots remaining string columns on a category axis", () => {
+    const model = buildBarChartModel([
+      [
+        { endpoint: "/users", method: "GET", requests: 10 },
+        { endpoint: "/users", method: "POST", requests: 3 },
+        { endpoint: "/orders", method: "GET", requests: 7 },
+      ],
+    ]);
+    expect(model.chartConfig.s0?.label).toBe("GET");
+    expect(model.chartConfig.s1?.label).toBe("POST");
+    expect(model.chartData).toHaveLength(2);
+    expect(model.chartData[0]?.s0).toBe(10);
+    expect(model.chartData[0]?.s1).toBe(3);
+  });
+
+  it("merges queries sharing categories and assigns distinct keys/colors", () => {
+    const model = buildBarChartModel([
+      [{ service: "api", errors: 4 }],
+      [{ service: "api", warnings: 9 }],
+    ]);
+    expect(model.valueKeys).toEqual(["s0", "s1"]);
+    expect(model.chartData).toHaveLength(1);
+    expect(model.chartData[0]?.s0).toBe(4);
+    expect(model.chartData[0]?.s1).toBe(9);
+    expect(model.chartConfig.s0?.color).not.toBe(model.chartConfig.s1?.color);
+  });
+
+  it("coerces quoted ClickHouse aggregates to numbers", () => {
+    const model = buildBarChartModel([[{ service: "api", count: "42" }]]);
+    expect(model.chartData[0]?.s0).toBe(42);
+  });
+
+  it("returns an empty model for empty frames", () => {
+    const model = buildBarChartModel([[]]);
+    expect(model.chartData).toEqual([]);
+    expect(model.valueKeys).toEqual([]);
+  });
+});

--- a/packages/app/src/components/dashboards/visualizations/bar-chart/bar-chart-data.ts
+++ b/packages/app/src/components/dashboards/visualizations/bar-chart/bar-chart-data.ts
@@ -1,0 +1,125 @@
+import type { ChartConfig } from "@everr/ui/components/chart";
+import {
+  detectTimeKey,
+  getGroupKeys,
+  getValueKeys,
+  pivotByGroup,
+  SERIES_COLORS,
+  toNumber,
+  toTimestamp,
+} from "../data-utils";
+import type { QueryResultRow } from "../index";
+
+export const X_KEY = "__x";
+
+export interface BarChartModel {
+  /** One entry per x value (timestamp or category), merged across queries. */
+  chartData: Array<Record<string, unknown>>;
+  valueKeys: string[];
+  chartConfig: ChartConfig;
+  /** True when every contributing frame had a time column — x values are
+   * epoch ms and the axis labels format as times. */
+  isTimeAxis: boolean;
+}
+
+/**
+ * Builds a bar chart model by merging rows from every query result set onto a
+ * single x-axis. The x column is the frame's time column when it has one
+ * (detected like the time-series chart), otherwise its first non-numeric
+ * string column — so the same chart covers bars-over-time and categorical
+ * bars. Rows that share an x value are merged into one entry (last-write-wins
+ * within a series); that merge is how multiple queries' series land on one
+ * axis. Remaining string columns pivot a single value column into one series
+ * per label, exactly like the time-series chart.
+ *
+ * A time axis is sorted ascending; categories keep first-seen (query) order.
+ */
+export function buildBarChartModel(
+  dataSets: QueryResultRow[][],
+): BarChartModel {
+  const chartConfig: ChartConfig = {};
+  const valueKeys: string[] = [];
+  const byX = new Map<string | number, Record<string, unknown>>();
+  let seriesIndex = 0;
+  let sawTime = false;
+  let sawCategory = false;
+
+  dataSets.forEach((data) => {
+    if (!data || data.length === 0) return;
+
+    const timeKey = detectTimeKey(data);
+    let xKey: string;
+    if (timeKey) {
+      xKey = timeKey;
+      sawTime = true;
+    } else {
+      // No time column: the first string column is the category axis. A frame
+      // with only numeric columns falls back to its first column so something
+      // sensible still renders (e.g. numeric bucket labels).
+      xKey = getGroupKeys(data, [])[0] ?? Object.keys(data[0]!)[0]!;
+      sawCategory = true;
+    }
+
+    const groupKeys = getGroupKeys(data, [xKey]);
+    const rawValueKeys = getValueKeys(data, xKey).filter(
+      (k) => !groupKeys.includes(k),
+    );
+
+    let rows: QueryResultRow[];
+    // The series' source names: pivoted group values, or raw value-column names.
+    let seriesNames: string[];
+
+    if (groupKeys.length >= 1 && rawValueKeys.length === 1) {
+      const compositeKey = "__group__";
+      const keyed = data.map((row) => ({
+        ...row,
+        [compositeKey]: groupKeys.map((k) => row[k]).join(" · "),
+      }));
+      const piv = pivotByGroup(keyed, xKey, compositeKey, rawValueKeys[0]!);
+      rows = piv.pivoted;
+      seriesNames = piv.seriesKeys;
+    } else {
+      rows = data;
+      seriesNames = rawValueKeys;
+    }
+
+    // Render keys are opaque, sequential ids (`s0`, `s1`, …) — never derived
+    // from the name — so distinct names that would mangle to the same CSS-var
+    // identifier can't collide. The original name stays as the label.
+    const renderKeyByName = new Map<string, string>();
+    for (const name of seriesNames) {
+      const renderKey = `s${seriesIndex}`;
+      renderKeyByName.set(name, renderKey);
+      valueKeys.push(renderKey);
+      chartConfig[renderKey] = {
+        label: name,
+        color: SERIES_COLORS[seriesIndex % SERIES_COLORS.length],
+      };
+      seriesIndex++;
+    }
+
+    for (const row of rows) {
+      const x = timeKey ? toTimestamp(row[xKey]) : String(row[xKey] ?? "");
+      if (x === null) continue;
+      let entry = byX.get(x);
+      if (!entry) {
+        entry = { [X_KEY]: x };
+        byX.set(x, entry);
+      }
+      for (const name of seriesNames) {
+        // A pivoted row carries only the groups present at its x value, so a
+        // missing key is "no bar here" — don't record it as 0.
+        if (!(name in row)) continue;
+        entry[renderKeyByName.get(name)!] = toNumber(row[name]);
+      }
+    }
+  });
+
+  const isTimeAxis = sawTime && !sawCategory;
+  const chartData = [...byX.values()];
+  if (isTimeAxis) {
+    chartData.sort((a, b) => (a[X_KEY] as number) - (b[X_KEY] as number));
+  }
+
+  return { chartData, valueKeys, chartConfig, isTimeAxis };
+}

--- a/packages/app/src/components/dashboards/visualizations/bar-chart/bar-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/bar-chart/bar-chart-visualization.tsx
@@ -1,0 +1,183 @@
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+} from "@everr/ui/components/chart";
+import { BarChart3 } from "lucide-react";
+import { useMemo } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  LabelList,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { VisualizationProps } from "../index";
+import { SeriesTooltipCard } from "../series-tooltip";
+import { buildBarChartModel, X_KEY } from "./bar-chart-data";
+import type { BarChartSpec } from "./spec";
+
+const MAX_CATEGORY_TICKS = 8;
+
+function createTimeTickFormatter(spanMs: number) {
+  return (x: string | number) => {
+    const d = new Date(Number(x));
+    if (spanMs > 86_400_000) {
+      return d.toLocaleDateString(undefined, {
+        month: "short",
+        day: "numeric",
+      });
+    }
+    return d.toLocaleTimeString(undefined, {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  };
+}
+
+export function BarChartVisualization({
+  spec,
+  data,
+}: VisualizationProps<BarChartSpec>) {
+  const { unit, showLegend, stacking, orientation, showValues } = spec;
+
+  const { chartData, valueKeys, chartConfig, isTimeAxis } = useMemo(
+    () => buildBarChartModel(data ?? []),
+    [data],
+  );
+
+  // `valueKeys.length === 0` means rows came back but none had a numeric
+  // column to plot — guard on it explicitly instead of rendering an axis-only,
+  // bar-less chart.
+  if (!data || chartData.length === 0 || valueKeys.length === 0) {
+    const message = !data
+      ? "Configure a query to see results"
+      : chartData.length === 0
+        ? "No data in this time range"
+        : "No numeric data to plot";
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 text-muted-foreground">
+        <BarChart3 className="size-8" />
+        <p className="text-sm">{message}</p>
+      </div>
+    );
+  }
+
+  const horizontal = orientation === "horizontal";
+  const stacked = stacking !== "none";
+
+  const spanMs =
+    isTimeAxis && chartData.length > 1
+      ? (chartData.at(-1)![X_KEY] as number) - (chartData[0]![X_KEY] as number)
+      : 0;
+  const formatXTick = isTimeAxis
+    ? createTimeTickFormatter(spanMs)
+    : (x: string | number) => String(x);
+  // With percent stacking the value axis runs 0..1 (stackOffset="expand").
+  const formatValueTick = (v: number) =>
+    stacking === "percent"
+      ? `${Math.round(v * 100)}%`
+      : unit
+        ? `${v}${unit}`
+        : String(v);
+  const formatValue = (v: number) =>
+    unit ? `${v.toLocaleString()}${unit}` : v.toLocaleString();
+
+  // Dense (time-bucketed) data produces one category per bucket — thin the
+  // tick labels instead of letting them overlap.
+  const tickInterval = Math.max(
+    0,
+    Math.ceil(chartData.length / MAX_CATEGORY_TICKS) - 1,
+  );
+
+  const categoryAxisProps = {
+    dataKey: X_KEY,
+    type: "category" as const,
+    tickFormatter: formatXTick,
+    interval: tickInterval,
+  };
+  const valueAxisProps = {
+    type: "number" as const,
+    tickFormatter: formatValueTick,
+  };
+
+  return (
+    <ChartContainer
+      config={chartConfig}
+      className="h-full w-full"
+      debounce={100}
+    >
+      <BarChart
+        data={chartData}
+        // recharts naming: layout "vertical" = horizontal bars.
+        layout={horizontal ? "vertical" : "horizontal"}
+        margin={{ left: 12, right: 12, top: 8 }}
+        stackOffset={stacking === "percent" ? "expand" : undefined}
+      >
+        <CartesianGrid horizontal={!horizontal} vertical={horizontal} />
+        <XAxis
+          {...(horizontal ? valueAxisProps : categoryAxisProps)}
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+        />
+        <YAxis
+          {...(horizontal ? categoryAxisProps : valueAxisProps)}
+          width={horizontal ? 90 : 60}
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+        />
+        <ChartTooltip
+          content={({ active, payload }) => {
+            if (!active || !payload?.length) return null;
+            const x = payload[0]?.payload?.[X_KEY];
+            return (
+              <SeriesTooltipCard
+                title={
+                  isTimeAxis ? new Date(Number(x)).toLocaleString() : String(x)
+                }
+                rows={payload
+                  .filter((item) => typeof item.value === "number")
+                  .map((item) => {
+                    const key = String(item.dataKey);
+                    return {
+                      key,
+                      color: chartConfig[key]?.color,
+                      label: chartConfig[key]?.label ?? key,
+                      value: formatValue(item.value as number),
+                    };
+                  })}
+              />
+            );
+          }}
+        />
+        {showLegend && <ChartLegend content={<ChartLegendContent />} />}
+        {valueKeys.map((key) => (
+          <Bar
+            key={key}
+            dataKey={key}
+            stackId={stacked ? "stack" : undefined}
+            fill={`var(--color-${key})`}
+            maxBarSize={64}
+            isAnimationActive={false}
+          >
+            {showValues && (
+              <LabelList
+                dataKey={key}
+                position={stacked ? "center" : horizontal ? "right" : "top"}
+                className="fill-foreground"
+                fontSize={10}
+                formatter={(v: unknown) =>
+                  typeof v === "number" ? formatValue(v) : ""
+                }
+              />
+            )}
+          </Bar>
+        ))}
+      </BarChart>
+    </ChartContainer>
+  );
+}

--- a/packages/app/src/components/dashboards/visualizations/bar-chart/spec.ts
+++ b/packages/app/src/components/dashboards/visualizations/bar-chart/spec.ts
@@ -1,0 +1,19 @@
+import * as z from "zod";
+
+/**
+ * BarChart plugin options. Loose so unknown keys flow through verbatim
+ * (validation must never be stricter than Perses on shape); every known field
+ * is defaulted so `{}` always parses — the lenient render path relies on it.
+ */
+export const barChartSpec = z.looseObject({
+  unit: z.string().default(""),
+  showLegend: z.boolean().default(false),
+  /** `stacked` piles series into one bar per x value; `percent` additionally
+   * normalizes each stack to 100% (the value axis becomes percentages). */
+  stacking: z.enum(["none", "stacked", "percent"]).default("none"),
+  /** `horizontal` draws bars left-to-right with categories on the y-axis. */
+  orientation: z.enum(["vertical", "horizontal"]).default("vertical"),
+  showValues: z.boolean().default(false),
+});
+
+export type BarChartSpec = z.infer<typeof barChartSpec>;

--- a/packages/app/src/components/dashboards/visualizations/data-utils.ts
+++ b/packages/app/src/components/dashboards/visualizations/data-utils.ts
@@ -77,6 +77,63 @@ export function getValueKeys(
 }
 
 /**
+ * Grouping-dimension columns. A column is a grouping dimension if it carries
+ * non-numeric string content in *any* row. A string that parses as a number
+ * (e.g. a quoted ClickHouse aggregate) is a value, not a dimension — exclude
+ * it so it isn't double-counted. Scanning all rows mirrors getValueKeys: the
+ * leading bucket may be NULL for a dimension that is populated later.
+ */
+export function getGroupKeys(
+  rows: QueryResultRow[],
+  excludeKeys: string[],
+): string[] {
+  const first = rows[0];
+  if (!first) return [];
+  return Object.keys(first).filter(
+    (k) =>
+      !excludeKeys.includes(k) &&
+      rows.some((row) => typeof row[k] === "string" && !isNumericValue(row[k])),
+  );
+}
+
+/**
+ * Pivot long rows (`axis, group, value`) into wide rows keyed by the axis
+ * value, one column per distinct group.
+ */
+export function pivotByGroup(
+  rows: QueryResultRow[],
+  axisKey: string,
+  groupKey: string,
+  valueKey: string,
+): {
+  pivoted: QueryResultRow[];
+  seriesKeys: string[];
+} {
+  const byAxis = new Map<string | number, QueryResultRow>();
+  const seriesSet = new Set<string>();
+
+  for (const row of rows) {
+    const axis = row[axisKey];
+    // The raw group value is the series identifier — keep it intact (it's the
+    // label, and uniqueness comes from the Set, not from mangling the name).
+    const group = String(row[groupKey]);
+    const value = toNumber(row[valueKey]);
+    seriesSet.add(group);
+
+    let entry = byAxis.get(axis as string | number);
+    if (!entry) {
+      entry = { [axisKey]: axis };
+      byAxis.set(axis as string | number, entry);
+    }
+    entry[group] = value;
+  }
+
+  const seriesKeys = [...seriesSet].sort();
+  const pivoted = [...byAxis.values()];
+  return { pivoted, seriesKeys };
+}
+
+/**
  * Normalize a numeric epoch to milliseconds. ClickHouse `toUnixTimestamp(...)`
  * returns SECONDS (and `toUnixTimestamp64Milli` returns ms); disambiguate by
  * magnitude — any realistic date is < 1e12 in seconds and >= 1e12 in ms. Without

--- a/packages/app/src/components/dashboards/visualizations/index.tsx
+++ b/packages/app/src/components/dashboards/visualizations/index.tsx
@@ -1,6 +1,8 @@
 import { type ComponentType, lazy, Suspense, useMemo } from "react";
 import type * as z from "zod";
 import type { PanelPlugin } from "@/data/dashboards/schema";
+import { BarChartVisualization } from "./bar-chart/bar-chart-visualization";
+import { barChartSpec } from "./bar-chart/spec";
 import type { GeoMapSpec } from "./geo-map/spec";
 import { geoMapSpec } from "./geo-map/spec";
 import { parseSpecLenient } from "./parse-spec";
@@ -53,6 +55,10 @@ function defineVisualization<S extends z.ZodType>(entry: {
 }
 
 const registry: Record<string, VisualizationEntry> = {
+  BarChart: defineVisualization({
+    schema: barChartSpec,
+    component: BarChartVisualization,
+  }),
   GeoMap: defineVisualization({
     schema: geoMapSpec,
     component: GeoMapVisualization,

--- a/packages/app/src/components/dashboards/visualizations/series-tooltip.tsx
+++ b/packages/app/src/components/dashboards/visualizations/series-tooltip.tsx
@@ -1,0 +1,53 @@
+import { cn } from "@everr/ui/lib/utils";
+import { Fragment, type ReactNode } from "react";
+
+export interface SeriesTooltipRow {
+  key: string;
+  color?: string;
+  label: ReactNode;
+  value: string;
+}
+
+/**
+ * The shared tooltip card for chart visualizations: a title (timestamp or
+ * category) over a swatch · label · value grid. Purely presentational so it
+ * works both portaled at the cursor (time-series chart) and as recharts
+ * Tooltip content (bar chart) — positioning is the caller's concern.
+ */
+export function SeriesTooltipCard({
+  title,
+  rows,
+  className,
+  style,
+}: {
+  title: ReactNode;
+  rows: SeriesTooltipRow[];
+  className?: string;
+  style?: React.CSSProperties;
+}) {
+  return (
+    <div
+      className={cn(
+        "rounded-md border border-border bg-card px-3 py-2 text-xs shadow-md",
+        className,
+      )}
+      style={style}
+    >
+      <div className="mb-1 text-muted-foreground">{title}</div>
+      <div className="grid grid-cols-[auto_1fr_auto] items-center gap-x-2 gap-y-0.5">
+        {rows.map((row) => (
+          <Fragment key={row.key}>
+            <span
+              className="inline-block size-2.5 rounded-full"
+              style={{ backgroundColor: row.color }}
+            />
+            <span className="text-muted-foreground">{row.label}</span>
+            <span className="text-right font-medium tabular-nums">
+              {row.value}
+            </span>
+          </Fragment>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-chart-visualization.tsx
@@ -4,7 +4,7 @@ import {
   ChartLegendContent,
 } from "@everr/ui/components/chart";
 import { LineChart as LineChartIcon } from "lucide-react";
-import { Fragment, useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import {
   Area,
@@ -19,6 +19,7 @@ import {
 } from "recharts";
 import { SERIES_COLORS } from "../data-utils";
 import type { VisualizationProps } from "../index";
+import { SeriesTooltipCard } from "../series-tooltip";
 import type { TimeSeriesChartSpec } from "./spec";
 import { buildChartModel, buildStackedData, TS_KEY } from "./time-series-data";
 
@@ -339,37 +340,25 @@ export function TimeSeriesChartVisualization({
       </ChartContainer>
       {tooltipRow &&
         createPortal(
-          <div
-            className="pointer-events-none fixed z-50 rounded-md border border-border bg-card px-3 py-2 text-xs shadow-md"
+          <SeriesTooltipCard
+            className="pointer-events-none fixed z-50"
             style={{
               left: tooltipState!.clientX + 12,
               top: tooltipState!.clientY + 12,
             }}
-          >
-            <div className="mb-1 text-muted-foreground">
-              {new Date(tooltipTs!).toLocaleString()}
-            </div>
-            <div className="grid grid-cols-[auto_1fr_auto] items-center gap-x-2 gap-y-0.5">
-              {valueKeys.map((key) => {
+            title={new Date(tooltipTs!).toLocaleString()}
+            rows={valueKeys
+              .filter((key) => tooltipRow[key] != null)
+              .map((key) => {
                 const val = tooltipRow[key];
-                if (val == null) return null;
-                return (
-                  <Fragment key={key}>
-                    <span
-                      className="inline-block size-2.5 rounded-full"
-                      style={{ backgroundColor: chartConfig[key]?.color }}
-                    />
-                    <span className="text-muted-foreground">
-                      {chartConfig[key]?.label ?? key}
-                    </span>
-                    <span className="text-right font-medium tabular-nums">
-                      {unit ? `${val}${unit}` : String(val)}
-                    </span>
-                  </Fragment>
-                );
+                return {
+                  key,
+                  color: chartConfig[key]?.color,
+                  label: chartConfig[key]?.label ?? key,
+                  value: unit ? `${val}${unit}` : String(val),
+                };
               })}
-            </div>
-          </div>,
+          />,
           document.body,
         )}
     </div>

--- a/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-data.ts
+++ b/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-data.ts
@@ -1,8 +1,9 @@
 import type { ChartConfig } from "@everr/ui/components/chart";
 import {
   detectTimeKey,
+  getGroupKeys,
   getValueKeys,
-  isNumericValue,
+  pivotByGroup,
   SERIES_COLORS,
   toNumber,
   toTimestamp,
@@ -10,54 +11,6 @@ import {
 import type { QueryResultRow } from "../index";
 
 export const TS_KEY = "__ts";
-
-function getGroupKeys(rows: QueryResultRow[], timeKey: string): string[] {
-  const first = rows[0];
-  if (!first) return [];
-  // A column is a grouping dimension if it carries non-numeric string content in
-  // *any* row. A string that parses as a number (e.g. a quoted ClickHouse
-  // aggregate) is a value, not a dimension — exclude it so it isn't
-  // double-counted. Scanning all rows mirrors getValueKeys: the leading bucket
-  // may be NULL for a dimension that is populated later.
-  return Object.keys(first).filter(
-    (k) =>
-      k !== timeKey &&
-      rows.some((row) => typeof row[k] === "string" && !isNumericValue(row[k])),
-  );
-}
-
-function pivotByGroup(
-  rows: QueryResultRow[],
-  timeKey: string,
-  groupKey: string,
-  valueKey: string,
-): {
-  pivoted: QueryResultRow[];
-  seriesKeys: string[];
-} {
-  const byTimestamp = new Map<string | number, QueryResultRow>();
-  const seriesSet = new Set<string>();
-
-  for (const row of rows) {
-    const ts = row[timeKey];
-    // The raw group value is the series identifier — keep it intact (it's the
-    // label, and uniqueness comes from the Set, not from mangling the name).
-    const group = String(row[groupKey]);
-    const value = toNumber(row[valueKey]);
-    seriesSet.add(group);
-
-    let entry = byTimestamp.get(ts as string | number);
-    if (!entry) {
-      entry = { [timeKey]: ts };
-      byTimestamp.set(ts as string | number, entry);
-    }
-    entry[group] = value;
-  }
-
-  const seriesKeys = [...seriesSet].sort();
-  const pivoted = [...byTimestamp.values()];
-  return { pivoted, seriesKeys };
-}
 
 function detectInterval(timestamps: number[]): number | null {
   if (timestamps.length < 2) return null;
@@ -189,7 +142,7 @@ export function buildChartModel(
     const tk = detectTimeKey(data);
     if (!tk) return;
 
-    const groupKeys = getGroupKeys(data, tk);
+    const groupKeys = getGroupKeys(data, [tk]);
     const rawValueKeys = getValueKeys(data, tk);
 
     let rows: QueryResultRow[];

--- a/packages/app/src/data/dashboards/plugin-specs.ts
+++ b/packages/app/src/data/dashboards/plugin-specs.ts
@@ -1,4 +1,5 @@
 import type * as z from "zod";
+import { barChartSpec } from "@/components/dashboards/visualizations/bar-chart/spec";
 import { geoMapSpec } from "@/components/dashboards/visualizations/geo-map/spec";
 import { statChartSpec } from "@/components/dashboards/visualizations/stat-chart/spec";
 import { tableSpec } from "@/components/dashboards/visualizations/table/spec";
@@ -13,6 +14,7 @@ import { testDataSpec } from "./testdata/spec";
  * "Unknown visualization" placeholder for them instead of failing validation.
  */
 export const panelPluginSpecs: Record<string, z.ZodType> = {
+  BarChart: barChartSpec,
   GeoMap: geoMapSpec,
   StatChart: statChartSpec,
   Table: tableSpec,

--- a/packages/docs/content/docs/dashboards/panels-and-visualizations.mdx
+++ b/packages/docs/content/docs/dashboards/panels-and-visualizations.mdx
@@ -32,9 +32,9 @@ panels:
                   GROUP BY ts ORDER BY ts
 ```
 
-- **`plugin.kind`** selects the visualization: `TimeSeriesChart`, `Table`, `StatChart`, or `GeoMap`. Its `spec` holds visualization options — see the [Visualizations reference](/docs/dashboards/visualizations).
+- **`plugin.kind`** selects the visualization: `TimeSeriesChart`, `BarChart`, `Table`, `StatChart`, or `GeoMap`. Its `spec` holds visualization options — see the [Visualizations reference](/docs/dashboards/visualizations).
 - **`queries`** is a list. Each entry is a `ClickHouseSQL` query whose SQL lives at `spec.plugin.spec.query`. ClickHouse SQL is the query plugin for real data; a deterministic [`TestData`](#testdata-query-kind-development--test) plugin is also available for development and visual testing.
-- Multiple queries are supported: the time-series chart overlays all of them, the table shows a per-query selector, and the stat chart renders one tile per resulting series.
+- Multiple queries are supported: the time-series and bar charts overlay all of them on one axis, the table shows a per-query selector, and the stat chart renders one tile per resulting series.
 
 ## Placing panels on the grid
 
@@ -80,6 +80,21 @@ This produces one line per service.
   value column and renders as its own line instead of pivoting. Make the label
   unambiguous, for example `concat('status-', toString(StatusCode))`.
 </Callout>
+
+### Bar
+
+Same column rules as the time series — a time column (`ts`/`time`/`timestamp`) makes one bar group per bucket, numeric columns become series, and a remaining string column pivots a single value column into one series per label. Without a time column the **first string column** becomes the category axis instead:
+
+```sql
+SELECT ServiceName, count() AS spans
+FROM traces
+WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+GROUP BY ServiceName
+ORDER BY spans DESC
+LIMIT 10
+```
+
+This produces one bar per service, in the query's order.
 
 ### Table
 
@@ -239,4 +254,4 @@ lat/lon/value rows; `shape: regions` emits region/value rows.
 
 ## Unknown visualizations
 
-If a panel's `plugin.kind` isn't a registered visualization, the panel renders a clear "Unknown visualization: &lt;kind&gt;" placeholder instead of failing the whole dashboard. Stick to `TimeSeriesChart`, `Table`, `StatChart`, and `GeoMap`.
+If a panel's `plugin.kind` isn't a registered visualization, the panel renders a clear "Unknown visualization: &lt;kind&gt;" placeholder instead of failing the whole dashboard. Stick to `TimeSeriesChart`, `BarChart`, `Table`, `StatChart`, and `GeoMap`.

--- a/packages/docs/content/docs/dashboards/visualizations.mdx
+++ b/packages/docs/content/docs/dashboards/visualizations.mdx
@@ -3,7 +3,7 @@ title: Visualizations
 description: The built-in panel visualizations and the spec options each one accepts.
 ---
 
-A panel's `plugin.kind` selects its visualization and `plugin.spec` configures it. Everr ships four visualizations. An unrecognized `kind` renders an "Unknown visualization" placeholder rather than breaking the dashboard.
+A panel's `plugin.kind` selects its visualization and `plugin.spec` configures it. Everr ships five visualizations. An unrecognized `kind` renders an "Unknown visualization" placeholder rather than breaking the dashboard.
 
 They infer their structure from the columns your query returns — see [Panels and visualizations](/docs/dashboards/panels-and-visualizations#shaping-data-for-each-visualization) for the data shapes.
 
@@ -33,6 +33,29 @@ plugin:
 | `curveType` | enum | `monotone` | One of `monotone`, `linear`, `natural`, `stepBefore`, `stepAfter`. |
 | `connectNulls` | boolean | `false` | Bridge gaps instead of breaking the line. |
 | `stacked` | boolean | `false` | Stack series on top of each other as filled areas. A series with no sample at a timestamp contributes 0 there, and `connectNulls` has no effect. |
+
+## BarChart
+
+Bar chart over time or over categories. When the query returns a time column (detected like the time-series chart: `ts`, `time`, or `timestamp`), each bucket becomes one bar group; without one, the first string column becomes the category axis. Numeric columns become series, and any remaining string column pivots a single value column into one series per label — same pivot rule as `TimeSeriesChart`. Multiple queries merge onto one axis.
+
+```yaml
+plugin:
+  kind: BarChart
+  spec:
+    unit: req
+    showLegend: true
+    stacking: stacked
+    orientation: vertical
+    showValues: false
+```
+
+| Option | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `unit` | string | `""` | Suffix appended to axis/values. |
+| `showLegend` | boolean | `false` | Show the series legend. |
+| `stacking` | enum | `none` | `none` draws series side by side; `stacked` piles them into one bar per x value; `percent` additionally normalizes each stack to 100% (the value axis becomes percentages, tooltips keep raw values). |
+| `orientation` | enum | `vertical` | `vertical` draws bars bottom-up; `horizontal` draws them left-to-right with categories on the y-axis (best for categorical data with long labels). |
+| `showValues` | boolean | `false` | Draw the value on each bar (on top/right of grouped bars, centered inside stacked segments). |
 
 ## Table
 


### PR DESCRIPTION
Stacked on #209.

Adds a `BarChart` panel visualization with the common options, including stacking:

- **Spec options** (all defaulted, validated at apply time): `unit`, `showLegend`, `stacking` (`none` / `stacked` / `percent`), `orientation` (`vertical` / `horizontal`), `showValues`. Percent mode normalizes each stack to 100% (`stackOffset="expand"`) — the value axis reads as percentages while tooltips keep raw values.
- **Two axis modes, inferred per query**: a time column (`ts`/`time`/`timestamp`) makes time-bucketed bar groups sorted ascending; otherwise the first string column becomes a categorical axis in query order. The grouped string-pivot (exactly one numeric column) and multi-query merge semantics match `TimeSeriesChart`.
- **Shared helpers**: `getGroupKeys`/`pivotByGroup` move from `time-series-data.ts` into the shared `data-utils.ts`; the time-series tooltip card is extracted into a shared `SeriesTooltipCard` so both charts render an identical tooltip (which is why this stacks on #209 — they touch the same files).
- **Registration**: render registry + `plugin-specs.ts` so `everr apply` rejects invalid option values.
- **Docs & skill**: BarChart sections in `visualizations.mdx` / `panels-and-visualizations.mdx`, new `rules/barchart.md` in the everr-write-dashboards skill, kind lists updated to five.
- **Gallery**: `dashboards/viz-gallery/bar-chart.yaml` with 7 TestData-driven panels covering every option/enum value plus grouped pivot, categorical pivot, absent-group-is-no-bar, multi-query merge, and the empty state.

Tested with 10 new unit tests for the data model (122 visualization tests green), and verified visually against the applied gallery dashboard: stacking/percent/orientation/value labels, tooltip parity with the time-series chart, and all empty states.