### PR TITLE
style(dashboards): wrap treemap legend filter to satisfy formatter

### DIFF
--- a/packages/app/src/components/dashboards/visualizations/treemap/treemap-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/treemap/treemap-visualization.tsx
@@ -44,7 +44,9 @@ export function TreemapVisualization({
       group,
       color: tiles.find((t) => t.group === group)?.color,
     }))
-    .filter((g): g is { group: string; color: string } => g.color !== undefined);
+    .filter(
+      (g): g is { group: string; color: string } => g.color !== undefined,
+    );
 
   return (
     <div className="flex h-full flex-col border-t border-border">


### PR DESCRIPTION
Fixes the biome formatter error on `main` introduced by the treemap legend dedup in #211 — the `legendGroups` `.filter(...)` call needed wrapping. Lint-only change; biome `check` exits 0 locally.