### PR TITLE
Linux support for the desktop app and CLI

### DIFF
--- a/.github/workflows/deploy-desktop-app.yml
+++ b/.github/workflows/deploy-desktop-app.yml
@@ -264,6 +264,98 @@ jobs:
           retention-days: 14
           compression-level: 0
 
+  # Builds installable Linux desktop bundles (deb/rpm/appimage) and uploads them
+  # as workflow artifacts. Intentionally NOT a dependency of package-release, so
+  # a failure here never blocks the macOS release. Publishing these to everr.dev
+  # is a follow-up (stage them into the release payload + teach everr-deploy to
+  # serve them, plus a Linux `latest.json` if auto-update is wanted).
+  build-linux-desktop:
+    name: Build Linux Desktop ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: arm64
+            runner: blacksmith-2vcpu-ubuntu-2404-arm
+          - name: x86_64
+            runner: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: . -> target
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: collector/go.mod
+          cache-dependency-path: |
+            collector/**/go.sum
+
+      - name: Install Linux build dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev libgtk-3-dev libsoup-3.0-dev \
+            libssl-dev librsvg2-dev libayatana-appindicator3-dev \
+            build-essential curl wget file
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Linux desktop bundles
+        env:
+          EVERR_INGEST_KEY: ${{ secrets.EVERR_INGEST_KEY }}
+        run: |
+          set -euo pipefail
+          # beforeBuildCommand runs desktop:prepare:release (embeds the Linux
+          # collector + chDB) and frontend:build. Skip updater artifacts: the
+          # Tauri auto-updater is macOS-only today.
+          pnpm --dir packages/desktop-app tauri build \
+            --bundles deb,rpm,appimage \
+            --config '{"bundle":{"createUpdaterArtifacts":false}}'
+
+      - name: Stage Linux desktop bundles
+        run: |
+          set -euo pipefail
+          out="target/linux-desktop-release"
+          mkdir -p "$out"
+          find target/release/bundle \
+            \( -name '*.deb' -o -name '*.rpm' -o -name '*.AppImage' \) \
+            -exec cp {} "$out"/ \;
+          (
+            cd "$out"
+            for f in *; do sha256sum "$f" > "$f.sha256"; done
+          )
+          ls -la "$out"
+
+      - name: Upload Linux desktop bundles
+        uses: actions/upload-artifact@v4
+        with:
+          name: everr-linux-desktop-${{ matrix.name }}-${{ github.sha }}
+          path: target/linux-desktop-release
+          if-no-files-found: error
+          retention-days: 14
+          compression-level: 0
+
   package-release:
     name: Package Release
     runs-on: ubuntu-24.04

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,48 @@
 
 ## Development
 
+### System prerequisites
+
+You need the standard toolchains on every platform: Rust (stable), Node + pnpm,
+Go (for the collector), and Docker with the Compose plugin.
+
+On **macOS** no extra system packages are required beyond the Xcode command line
+tools. On **Linux**, the Tauri desktop app needs the GTK/WebKit development
+libraries to build, plus `libayatana-appindicator3` at runtime for the system
+tray (without it the app panics on launch).
+
+**Fedora** (verified on Fedora 44):
+
+```bash
+# Desktop app build dependencies
+sudo dnf install -y \
+  webkit2gtk4.1-devel gtk3-devel libsoup3-devel glib2-devel \
+  cairo-devel pango-devel gdk-pixbuf2-devel atk-devel \
+  openssl-devel librsvg2-devel
+
+# System tray runtime dependency
+sudo dnf install -y libayatana-appindicator-gtk3
+```
+
+To **build** the Linux desktop bundles (`deb`/`rpm`/`appimage`) you also need the
+appindicator development package — the Tauri bundler probes for the unversioned
+`.so` and panics with "Can't detect any appindicator library" without it:
+
+```bash
+sudo dnf install -y libayatana-appindicator-gtk3-devel   # Fedora
+# Debian/Ubuntu: the libayatana-appindicator3-dev package below already covers this
+```
+
+**Debian/Ubuntu**:
+
+```bash
+sudo apt update
+sudo apt install -y \
+  libwebkit2gtk-4.1-dev libgtk-3-dev libsoup-3.0-dev \
+  libssl-dev librsvg2-dev libayatana-appindicator3-dev \
+  build-essential curl wget file
+```
+
 ### Set up GitHub webhook forwarding
 
 The web app starts a [`smee`](https://smee.io/) client during Vite dev when `SMEE_CHANNEL` is set.
@@ -14,11 +56,19 @@ The web app starts a [`smee`](https://smee.io/) client during Vite dev when `SME
    ```
 4. Start the web app with `pnpm dev:web`. The dev server forwards events from `https://smee.io/<SMEE_CHANNEL>` to `http://localhost:5173/webhook/github`.
 
-### Start ClickHouse
+### Start the local services (Postgres, ClickHouse, collector, mail)
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
+
+> [!NOTE]
+> **Fedora / SELinux:** the bind mounts in `docker-compose.yaml` carry the `:Z`
+> / `:z` flag, so Docker relabels the host paths for SELinux automatically — no
+> manual `chcon` is needed (the flag is ignored on macOS/Docker Desktop). Just
+> install the Compose plugin from Fedora's repositories
+> (`sudo dnf install docker-compose`) rather than the docker-ce
+> `docker-compose-plugin`, which conflicts with Fedora's `docker-buildx`.
 
 ### Install dependencies and build
 
@@ -143,3 +193,19 @@ The Apple signing and notarization inputs are documented in `packages/desktop-ap
 CI secret setup is documented in `docs/desktop-release-secrets.md`.
 `packages/desktop-app/.env` is sourced automatically by the package-native build scripts.
 That release flow stages the DMG, updater artifacts, checksums, release metadata, and signed CLI files into `target/desktop-release/`.
+
+For **Linux**, build installable bundles directly with the Tauri CLI (requires
+the build dependencies from [System prerequisites](#system-prerequisites),
+including the appindicator `-devel`/`-dev` package):
+
+```bash
+pnpm --dir packages/desktop-app tauri build \
+  --bundles deb,rpm,appimage \
+  --config '{"bundle":{"createUpdaterArtifacts":false}}'
+```
+
+Bundles land in `target/release/bundle/{deb,rpm,appimage}/`. The packages declare
+their runtime dependencies (WebKitGTK, GTK, and `libayatana-appindicator3`), so a
+package-manager install pulls in the system tray library automatically. The
+`build-linux-desktop` CI job produces the same bundles as downloadable artifacts;
+publishing them to everr.dev is a separate follow-up.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1368,6 +1368,7 @@ dependencies = [
  "futures-util",
  "libloading 0.8.9",
  "nix",
+ "notify-rust",
  "objc2",
  "objc2-app-kit",
  "opentelemetry",
@@ -2838,6 +2839,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04fd0110fd05744c3c904acf1a8ca624a721d75a35638f127cd5fb6b7ccfb1bf"
+dependencies = [
+ "cc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3102,6 +3117,20 @@ dependencies = [
  "notify-types",
  "walkdir",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-rust"
+version = "4.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50ff2e74231b72c832d82982193b417f230945be6bdb5575b251d941d31adb00"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
 ]
 
 [[package]]
@@ -3855,7 +3884,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.0",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -4078,6 +4107,15 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quick-xml"
@@ -5591,6 +5629,18 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml 0.37.5",
+ "thiserror 2.0.18",
+ "windows",
+ "windows-version",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,126 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +408,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -582,6 +715,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1124,6 +1266,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,6 +1326,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "eventsource-stream"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,6 +1366,7 @@ dependencies = [
  "dirs 6.0.0",
  "everr-core",
  "futures-util",
+ "libloading 0.8.9",
  "nix",
  "objc2",
  "objc2-app-kit",
@@ -1190,6 +1381,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tempfile",
  "time",
@@ -1199,6 +1391,7 @@ dependencies = [
  "url",
  "uuid",
  "webbrowser",
+ "zbus",
 ]
 
 [[package]]
@@ -1477,6 +1670,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1919,6 +2125,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2535,7 +2747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
 dependencies = [
  "gtk-sys",
- "libloading",
+ "libloading 0.7.4",
  "once_cell",
 ]
 
@@ -2562,6 +2774,16 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3314,6 +3536,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "osakit"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3351,6 +3583,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -3587,6 +3825,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3635,6 +3884,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5181,6 +5444,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8f29386f5e9fdc699182388a33ee80a56de436d91b67459e86afef426282af"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-plugin-updater"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5807,6 +6085,17 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -6798,6 +7087,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7026,6 +7324,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.3",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+dependencies = [
+ "serde",
+ "winnow 1.0.3",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7150,4 +7509,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.3",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 1.0.3",
 ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
       APP_RO_PASSWORD: app-dev
       WEB_APP_ADMIN_PASSWORD: web-app-admin-dev
     volumes:
-      - ./volumes/clickhouse:/var/lib/clickhouse
+      - ./volumes/clickhouse:/var/lib/clickhouse:Z
 
   postgres:
     image: postgres:18.3-alpine3.23
@@ -31,7 +31,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
     volumes:
-      - ./volumes/postgres:/var/lib/postgresql
+      - ./volumes/postgres:/var/lib/postgresql:Z
 
   collector:
     build: ./collector
@@ -45,15 +45,15 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
-      - ./collector/config.yml:/etc/everr-collector/config.yaml:ro
-      - ./collector/dev-everr-app.pem:/etc/everr-collector/dev-everr-app.pem:ro
+      - ./collector/config.yml:/etc/everr-collector/config.yaml:ro,z
+      - ./collector/dev-everr-app.pem:/etc/everr-collector/dev-everr-app.pem:ro,z
 
   mailpit:
     image: axllent/mailpit
     container_name: mailpit
     restart: unless-stopped
     volumes:
-      - ./volumes/mailpit:/data
+      - ./volumes/mailpit:/data:Z
     ports:
       - 8025:8025
       - 1025:1025

--- a/packages/desktop-app/scripts/build-support.test.ts
+++ b/packages/desktop-app/scripts/build-support.test.ts
@@ -3,10 +3,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
-  CHDB_LIB_ARCHIVE_SHA256,
-  CHDB_LIB_ASSET_NAME,
+  CHDB_PLATFORM_ASSETS,
   CHDB_RELEASE_VERSION,
   chdbReleaseAssetUrl,
+  resolveChdbAsset,
   defaultDesktopVersionPaths,
   publishCliArtifact,
   readDesktopTauriConfigVersion,
@@ -183,11 +183,19 @@ describe("build-support version helpers", () => {
 });
 
 describe("build-support chDB helpers", () => {
-  it("pins the official macOS arm64 chDB release asset", () => {
+  it("pins official chDB release assets per platform", () => {
     expect(CHDB_RELEASE_VERSION).toBe("v4.0.2");
-    expect(CHDB_LIB_ASSET_NAME).toBe("macos-arm64-libchdb.tar.gz");
-    expect(CHDB_LIB_ARCHIVE_SHA256).toMatch(/^[a-f0-9]{64}$/);
-    expect(chdbReleaseAssetUrl()).toBe(
+    for (const [key, asset] of Object.entries(CHDB_PLATFORM_ASSETS)) {
+      expect(asset.assetName, key).toMatch(/libchdb\.tar\.gz$/);
+      expect(asset.sha256, key).toMatch(/^[a-f0-9]{64}$/);
+    }
+
+    expect(resolveChdbAsset("darwin", "arm64").assetName).toBe("macos-arm64-libchdb.tar.gz");
+    expect(resolveChdbAsset("linux", "arm64").assetName).toBe("linux-aarch64-libchdb.tar.gz");
+    expect(resolveChdbAsset("linux", "x64").assetName).toBe("linux-x86_64-libchdb.tar.gz");
+    expect(() => resolveChdbAsset("win32", "x64")).toThrow(/No bundled chDB release asset/);
+
+    expect(chdbReleaseAssetUrl("macos-arm64-libchdb.tar.gz")).toBe(
       "https://github.com/chdb-io/chdb/releases/download/v4.0.2/macos-arm64-libchdb.tar.gz",
     );
   });

--- a/packages/desktop-app/scripts/build-support.ts
+++ b/packages/desktop-app/scripts/build-support.ts
@@ -32,9 +32,45 @@ const desktopResourceDir = path.join(repoDir, "target", "desktop-resources");
 export const desktopReleaseDir = path.join(repoDir, "target", "desktop-release");
 const cliEmbeddedAssetsDir = path.join(repoDir, "target", "cli-embedded-assets");
 export const CHDB_RELEASE_VERSION = "v4.0.2";
-export const CHDB_LIB_ASSET_NAME = "macos-arm64-libchdb.tar.gz";
-export const CHDB_LIB_ARCHIVE_SHA256 =
-  "54b4da9c4d71f09b8a37e823a7addba392c4789a7034192a4863a1edd452f9e8";
+
+export type ChdbAsset = { assetName: string; sha256: string };
+
+/**
+ * Pinned chDB release assets keyed by `${process.platform}-${process.arch}`.
+ * Each desktop/CLI target embeds the matching prebuilt `libchdb.so`.
+ */
+export const CHDB_PLATFORM_ASSETS: Record<string, ChdbAsset> = {
+  "darwin-arm64": {
+    assetName: "macos-arm64-libchdb.tar.gz",
+    sha256: "54b4da9c4d71f09b8a37e823a7addba392c4789a7034192a4863a1edd452f9e8",
+  },
+  "linux-arm64": {
+    assetName: "linux-aarch64-libchdb.tar.gz",
+    sha256: "ed43e29314f8337f858420354d88d5db4cce9c38155aff43f7816d1112cd7465",
+  },
+  "linux-x64": {
+    assetName: "linux-x86_64-libchdb.tar.gz",
+    sha256: "fb722f81c61c1fb2eb3511f17a5adc85b231f6bbc2415de6aea3ad9b73bb272e",
+  },
+};
+
+export function resolveChdbAsset(
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+): ChdbAsset {
+  const key = `${platform}-${arch}`;
+  const asset = CHDB_PLATFORM_ASSETS[key];
+  if (!asset) {
+    throw new Error(
+      `No bundled chDB release asset for ${key}. Supported platforms: ${Object.keys(
+        CHDB_PLATFORM_ASSETS,
+      ).join(", ")}.`,
+    );
+  }
+
+  return asset;
+}
+
 const LOCAL_COLLECTOR_BIN_NAME = "everr-local-collector";
 const CHDB_LIB_FILE_NAME = "libchdb.so";
 
@@ -61,8 +97,8 @@ function getEnv(name: string) {
 }
 
 export function chdbReleaseAssetUrl(
+  assetName = resolveChdbAsset().assetName,
   version = CHDB_RELEASE_VERSION,
-  assetName = CHDB_LIB_ASSET_NAME,
 ) {
   return `https://github.com/chdb-io/chdb/releases/download/${version}/${assetName}`;
 }
@@ -98,16 +134,18 @@ async function findFileByName(rootDir: string, fileName: string): Promise<string
   return undefined;
 }
 
-async function downloadChdbArchive(archivePath: string) {
+async function downloadChdbArchive(archivePath: string, asset: ChdbAsset) {
   await mkdir(path.dirname(archivePath), { recursive: true });
   const tmpPath = `${archivePath}.tmp`;
   await rm(tmpPath, { force: true });
-  await $`curl --fail --location --silent --show-error --output ${tmpPath} ${chdbReleaseAssetUrl()}`;
+  await $`curl --fail --location --silent --show-error --output ${tmpPath} ${chdbReleaseAssetUrl(
+    asset.assetName,
+  )}`;
   const digest = await sha256File(tmpPath);
-  if (digest !== CHDB_LIB_ARCHIVE_SHA256) {
+  if (digest !== asset.sha256) {
     await rm(tmpPath, { force: true });
     throw new Error(
-      `Downloaded ${CHDB_LIB_ASSET_NAME} has sha256 ${digest}; expected ${CHDB_LIB_ARCHIVE_SHA256}.`,
+      `Downloaded ${asset.assetName} has sha256 ${digest}; expected ${asset.sha256}.`,
     );
   }
   await rm(archivePath, { force: true });
@@ -115,18 +153,18 @@ async function downloadChdbArchive(archivePath: string) {
   await rm(tmpPath, { force: true });
 }
 
-async function ensureChdbArchive(archivePath: string) {
+async function ensureChdbArchive(archivePath: string, asset: ChdbAsset) {
   if (await pathExists(archivePath)) {
     const digest = await sha256File(archivePath);
-    if (digest === CHDB_LIB_ARCHIVE_SHA256) {
+    if (digest === asset.sha256) {
       return;
     }
     console.error(
-      `Ignoring cached ${archivePath} because sha256 is ${digest}; expected ${CHDB_LIB_ARCHIVE_SHA256}.`,
+      `Ignoring cached ${archivePath} because sha256 is ${digest}; expected ${asset.sha256}.`,
     );
   }
 
-  await downloadChdbArchive(archivePath);
+  await downloadChdbArchive(archivePath, asset);
 }
 
 async function prepareChdbLibAt(mode: string, destLib: string) {
@@ -134,25 +172,20 @@ async function prepareChdbLibAt(mode: string, destLib: string) {
     throw new Error(`Unsupported mode: ${mode}`);
   }
 
-  if (process.platform !== "darwin") {
-    throw new Error("Bundled chDB resources are currently only supported on macOS.");
-  }
-  if (process.arch !== "arm64") {
-    throw new Error("Bundled chDB resources are currently only supported on macOS arm64.");
-  }
+  const asset = resolveChdbAsset();
 
   const chdbCacheDir = path.join(repoDir, "target", "chdb");
-  const archivePath = path.join(chdbCacheDir, `${CHDB_RELEASE_VERSION}-${CHDB_LIB_ASSET_NAME}`);
+  const archivePath = path.join(chdbCacheDir, `${CHDB_RELEASE_VERSION}-${asset.assetName}`);
   const extractDir = path.join(chdbCacheDir, `${CHDB_RELEASE_VERSION}-extract`);
 
-  await ensureChdbArchive(archivePath);
+  await ensureChdbArchive(archivePath, asset);
   await rm(extractDir, { recursive: true, force: true });
   await mkdir(extractDir, { recursive: true });
   await $`tar -xzf ${archivePath} -C ${extractDir}`;
 
   const extractedLib = await findFileByName(extractDir, "libchdb.so");
   if (!extractedLib) {
-    throw new Error(`${CHDB_LIB_ASSET_NAME} did not contain libchdb.so.`);
+    throw new Error(`${asset.assetName} did not contain libchdb.so.`);
   }
 
   const extractedStat = await stat(extractedLib);

--- a/packages/desktop-app/src-cli/src/telemetry/collector.rs
+++ b/packages/desktop-app/src-cli/src/telemetry/collector.rs
@@ -121,8 +121,11 @@ fn ensure_supported_platform() -> Result<()> {
     if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
         return Ok(());
     }
+    if cfg!(all(target_os = "linux", any(target_arch = "aarch64", target_arch = "x86_64"))) {
+        return Ok(());
+    }
 
-    bail!("embedded local collector is currently supported only on macOS arm64");
+    bail!("embedded local collector is currently supported only on macOS arm64 and Linux arm64/x86_64");
 }
 
 async fn spawn_collector(assets: &ExtractedAssets, telemetry_dir: &Path) -> Result<Child> {

--- a/packages/desktop-app/src-tauri/Cargo.toml
+++ b/packages/desktop-app/src-tauri/Cargo.toml
@@ -80,6 +80,11 @@ features = [ "time", "sync", "macros", "process", "io-util" ]
 objc2 = "0.6.4"
 objc2-app-kit = "0.3.2"
 
+[target."cfg(target_os = \"linux\")".dependencies]
+libloading = "0.8"
+tauri-plugin-single-instance = "2"
+zbus = "5"
+
 [dev-dependencies]
 tempfile = "3.18.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/packages/desktop-app/src-tauri/Cargo.toml
+++ b/packages/desktop-app/src-tauri/Cargo.toml
@@ -82,6 +82,7 @@ objc2-app-kit = "0.3.2"
 
 [target."cfg(target_os = \"linux\")".dependencies]
 libloading = "0.8"
+notify-rust = "4"
 tauri-plugin-single-instance = "2"
 zbus = "5"
 

--- a/packages/desktop-app/src-tauri/src/lib.rs
+++ b/packages/desktop-app/src-tauri/src/lib.rs
@@ -193,7 +193,20 @@ pub fn run() {
     let startup_telemetry_context = telemetry_context.clone();
     let shutdown_telemetry_context = telemetry_context.clone();
 
-    tauri::Builder::default()
+    #[cfg_attr(not(target_os = "linux"), allow(unused_mut))]
+    let mut builder = tauri::Builder::default();
+
+    // Single-instance must be the first plugin registered. On Linux it doubles
+    // as the recovery path when the tray is missing/invisible: re-launching the
+    // app focuses the existing window instead of spawning a second instance.
+    #[cfg(target_os = "linux")]
+    {
+        builder = builder.plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            let _ = tray::open_main_window(app);
+        }));
+    }
+
+    builder
         .manage(relay_state)
         .manage(telemetry_context.clone())
         .plugin(tauri_plugin_updater::Builder::new().build())
@@ -212,6 +225,7 @@ pub fn run() {
                 } else {
                     let _ = window.hide();
 
+                    #[cfg(target_os = "macos")]
                     let _ = window
                         .app_handle()
                         .set_activation_policy(tauri::ActivationPolicy::Accessory);
@@ -224,7 +238,9 @@ pub fn run() {
             #[cfg(target_os = "macos")]
             app.set_activation_policy(tauri::ActivationPolicy::Accessory);
 
-            let mut autostart = tauri_plugin_autostart::Builder::new().app_name(current_app_name());
+            #[cfg_attr(not(target_os = "macos"), allow(unused_mut))]
+            let mut autostart =
+                tauri_plugin_autostart::Builder::new().app_name(current_app_name());
             #[cfg(target_os = "macos")]
             {
                 autostart = autostart.macos_launcher(MacosLauncher::LaunchAgent);
@@ -258,9 +274,38 @@ pub fn run() {
                 collector_state,
             );
 
-            build_tray(app.handle())?;
+            // A missing/unsupported tray must never take down the app, so any
+            // failure building it is logged and recovered from.
+            #[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
+            let tray_built = match build_tray(app.handle()) {
+                Ok(()) => true,
+                Err(err) => {
+                    tracing::warn!(
+                        target: "everr.app",
+                        error = %err,
+                        "system tray unavailable",
+                    );
+                    false
+                }
+            };
+
             if wizard_incomplete(&runtime)? {
                 open_settings_window(app.handle())?;
+            } else {
+                // On Linux the tray can be absent (no appindicator library) or
+                // present-but-invisible (e.g. stock GNOME with no StatusNotifier
+                // host). When no tray icon will actually be shown, surface the
+                // main window on launch so users can tell the app is running.
+                #[cfg(target_os = "linux")]
+                if !(tray_built && tray::status_notifier_host_available()) {
+                    if let Err(err) = tray::open_main_window(app.handle()) {
+                        tracing::warn!(
+                            target: "everr.app",
+                            error = %err,
+                            "failed to show main window on launch",
+                        );
+                    }
+                }
             }
             start_notifier_loop(app.handle().clone(), runtime.clone());
             start_state_change_loop(app.handle().clone(), runtime);

--- a/packages/desktop-app/src-tauri/src/notifications.rs
+++ b/packages/desktop-app/src-tauri/src/notifications.rs
@@ -1,3 +1,8 @@
+// On Linux the custom top-right notification window can't be positioned under
+// Wayland, so we present native freedesktop notifications instead and the
+// window helpers below are intentionally unused on that platform.
+#![cfg_attr(target_os = "linux", allow(dead_code, unused_imports))]
+
 #[cfg(target_os = "macos")]
 use std::sync::Mutex;
 use std::time::Duration;
@@ -395,23 +400,134 @@ pub(crate) fn open_notification_target_inner(app: &AppHandle, state: &RuntimeSta
 }
 
 pub(crate) fn sync_notification_window(app: &AppHandle, state: &RuntimeState) -> Result<()> {
-    let has_active_notification = {
-        let notifier = state
-            .notifier
-            .lock()
-            .map_err(|_| anyhow!("failed to lock notifier state"))?;
-        notifier.queue.active().is_some()
-    };
-
-    if has_active_notification {
-        show_notification_window(app)?;
-        app.emit(NOTIFICATION_CHANGED_EVENT, ())
-            .context("failed to emit notification update")
-    } else {
-        // Slide-out first, then emit the changed event + hide once animation completes.
-        // This keeps the card content visible during the exit animation.
-        hide_notification_window(app)
+    // GNOME/Wayland forbids clients from positioning their own top-level windows,
+    // so the custom top-right card lands wherever the compositor decides. Fall back
+    // to native freedesktop notifications instead.
+    #[cfg(target_os = "linux")]
+    {
+        return sync_native_notification(app, state);
     }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let has_active_notification = {
+            let notifier = state
+                .notifier
+                .lock()
+                .map_err(|_| anyhow!("failed to lock notifier state"))?;
+            notifier.queue.active().is_some()
+        };
+
+        if has_active_notification {
+            show_notification_window(app)?;
+            app.emit(NOTIFICATION_CHANGED_EVENT, ())
+                .context("failed to emit notification update")
+        } else {
+            // Slide-out first, then emit the changed event + hide once animation completes.
+            // This keeps the card content visible during the exit animation.
+            hide_notification_window(app)
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn sync_native_notification(app: &AppHandle, state: &RuntimeState) -> Result<()> {
+    // GNOME keeps notifications resident in its tray and ignores client expiry
+    // timeouts, so the macOS one-card-at-a-time queue would stall here. The OS
+    // stacks native notifications itself, so drain the queue and present each one.
+    loop {
+        let notification = {
+            let mut notifier = state
+                .notifier
+                .lock()
+                .map_err(|_| anyhow!("failed to lock notifier state"))?;
+            let active = notifier.queue.active().cloned();
+            if active.is_some() {
+                notifier.queue.advance();
+            }
+            active
+        };
+
+        let Some(notification) = notification else {
+            break;
+        };
+
+        present_native_notification(notification);
+    }
+
+    // Keep settings/dev pages in sync with the now-empty active slot.
+    let _ = app.emit(NOTIFICATION_CHANGED_EVENT, ());
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn present_native_notification(notification: FailureNotification) {
+    use notify_rust::{Notification, Timeout};
+
+    // Build the auto-fix prompt up front so the "Copy fix prompt" action stays
+    // tied to this notification even after the queue has advanced past it.
+    let details_url = notification.details_url.clone();
+    let fix_prompt = build_notification_auto_fix_prompt(&notification);
+    let trace_id = notification.trace_id.clone();
+
+    std::thread::spawn(move || {
+        let span = notifier_span("notifier.native_present", &trace_id);
+        let _enter = span.enter();
+
+        let summary = format!("{} failed", notification.workflow_name);
+        let mut body = format!("{} · {}", notification.repo, notification.branch);
+        if let Some(job) = notification.failed_jobs.first() {
+            body.push('\n');
+            body.push_str(&job.job_name);
+        }
+
+        let result = Notification::new()
+            .appname(crate::current_app_name())
+            .summary(&summary)
+            .body(&body)
+            .icon(crate::current_app_name())
+            .action("default", "View run")
+            .action("open", "View run")
+            .action("copy", "Copy fix prompt")
+            .timeout(Timeout::Never)
+            .show();
+
+        match result {
+            Ok(handle) => {
+                handle.wait_for_action(|action| match action {
+                    "default" | "open" => {
+                        if let Err(error) = webbrowser::open(&details_url) {
+                            crate::crash_log::log_error(
+                                "native notification open",
+                                &anyhow::Error::from(error),
+                            );
+                        }
+                    }
+                    "copy" => {
+                        if let Err(error) = copy_text_to_clipboard(&fix_prompt) {
+                            crate::crash_log::log_error("native notification copy", &error);
+                        }
+                    }
+                    _ => {}
+                });
+            }
+            Err(error) => {
+                crate::crash_log::log_error(
+                    "native notification show",
+                    &anyhow!("failed to show desktop notification: {error}"),
+                );
+            }
+        }
+    });
+}
+
+#[cfg(target_os = "linux")]
+fn copy_text_to_clipboard(text: &str) -> Result<()> {
+    let mut clipboard = Clipboard::new().context("failed to access clipboard")?;
+    clipboard
+        .set_text(text.to_string())
+        .context("failed to copy text to clipboard")?;
+    Ok(())
 }
 
 fn show_notification_window(app: &AppHandle) -> Result<()> {

--- a/packages/desktop-app/src-tauri/src/notifications.rs
+++ b/packages/desktop-app/src-tauri/src/notifications.rs
@@ -1,3 +1,4 @@
+#[cfg(target_os = "macos")]
 use std::sync::Mutex;
 use std::time::Duration;
 
@@ -49,6 +50,7 @@ pub(crate) fn notification_window_uses_native_panel() -> bool {
     cfg!(target_os = "macos")
 }
 
+#[cfg(target_os = "macos")]
 pub(crate) fn notification_hover_uses_native_panel_geometry() -> bool {
     cfg!(target_os = "macos")
 }

--- a/packages/desktop-app/src-tauri/src/tray.rs
+++ b/packages/desktop-app/src-tauri/src/tray.rs
@@ -8,7 +8,55 @@ use crate::{current_app_name, QUIT_MENU_ID, SETTINGS_MENU_ID, TRAY_ICON_ID};
 
 const OPEN_MENU_ID: &str = "open";
 
+/// On Linux the tray backend (`libappindicator-sys`) `dlopen`s the appindicator
+/// library when the tray is built and **panics** if it is missing. Probe for it
+/// first so a missing library degrades into a recoverable error instead of
+/// aborting the process (the main window is shown on launch as a fallback). The
+/// candidate sonames mirror the ones the backend itself tries.
+#[cfg(target_os = "linux")]
+fn appindicator_available() -> bool {
+    const CANDIDATES: [&str; 4] = [
+        "libayatana-appindicator3.so.1",
+        "libappindicator3.so.1",
+        "libayatana-appindicator3.so",
+        "libappindicator3.so",
+    ];
+
+    CANDIDATES
+        .iter()
+        .any(|name| unsafe { libloading::Library::new(name) }.is_ok())
+}
+
+/// A tray icon (StatusNotifierItem) is only *rendered* when a StatusNotifier
+/// host/watcher is registered on the session bus. KDE Plasma provides one
+/// natively; stock GNOME does not (it needs the AppIndicator extension), so the
+/// icon would be invisible even though the library loads. Returns whether a
+/// watcher is present so callers can decide to show the window instead.
+#[cfg(target_os = "linux")]
+pub(crate) fn status_notifier_host_available() -> bool {
+    use zbus::blocking::{fdo::DBusProxy, Connection};
+    use zbus::names::BusName;
+
+    let Ok(connection) = Connection::session() else {
+        return false;
+    };
+    let Ok(dbus) = DBusProxy::new(&connection) else {
+        return false;
+    };
+    let Ok(name) = BusName::try_from("org.kde.StatusNotifierWatcher") else {
+        return false;
+    };
+    dbus.name_has_owner(name).unwrap_or(false)
+}
+
 pub(crate) fn build_tray(app: &AppHandle) -> Result<()> {
+    #[cfg(target_os = "linux")]
+    if !appindicator_available() {
+        anyhow::bail!(
+            "system tray unavailable: libayatana-appindicator3 / libappindicator3 is not installed"
+        );
+    }
+
     let open = MenuItem::with_id(app, OPEN_MENU_ID, "Open", true, None::<&str>)?;
     let separator = PredefinedMenuItem::separator(app)?;
     let settings = MenuItem::with_id(app, SETTINGS_MENU_ID, "Settings", true, None::<&str>)?;
@@ -44,7 +92,7 @@ pub(crate) fn build_tray(app: &AppHandle) -> Result<()> {
     Ok(())
 }
 
-fn open_main_window(app: &AppHandle) -> Result<()> {
+pub(crate) fn open_main_window(app: &AppHandle) -> Result<()> {
     if let Some(window) = app.get_webview_window("main") {
         #[cfg(target_os = "macos")]
         let _ = app.set_activation_policy(tauri::ActivationPolicy::Regular);

--- a/packages/desktop-app/src-tauri/tauri.conf.json
+++ b/packages/desktop-app/src-tauri/tauri.conf.json
@@ -58,6 +58,15 @@
       "icons/128x128.png",
       "icons/128x128@2x.png",
       "icons/icon.icns"
-    ]
+    ],
+    "linux": {
+      "rpm": {
+        "depends": [
+          "webkit2gtk4.1",
+          "gtk3",
+          "libayatana-appindicator-gtk3"
+        ]
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Makes the Everr desktop app and CLI build, run, and package on Linux. Previously the Tauri app did not compile on Linux, and the bundled collector was hardcoded to macOS arm64.

Verified end-to-end on Fedora 44 (aarch64): the app launches, the collector sidecar runs with the Linux chDB lib (`local query "SELECT 1"` → `{"ok":1}`), the system tray works, and a `.deb` builds with the correct `Depends`.

## What's included

**Build & run** (`feat(desktop): build and run the Tauri app on Linux`)
- Gate macOS-only code (`set_activation_policy`, AppKit notification helpers, `MacosLauncher`) behind `#[cfg(target_os = "macos")]` — fixes the compile errors.
- Make the system tray non-fatal: probe for `libayatana-appindicator`/`libappindicator` before building it, so a missing library degrades gracefully instead of panicking.
- Show the main window on launch **only when no tray icon will be visible** — detected by querying the session bus for a `StatusNotifierWatcher` host (absent on stock GNOME). KDE / GNOME-with-AppIndicator keep the tray-only experience.
- Register the single-instance plugin on Linux so re-launching focuses the existing window (recovery path when there's no tray).

**Notifications** (`feat(desktop): show native notifications on Linux`)
- The custom top-right notification card positions a top-level window, which Wayland forbids clients from doing — so on GNOME/Wayland it lands wherever the compositor decides instead of top-right.
- On Linux, present native freedesktop notifications via `notify-rust` instead of the custom webview window. Each failure becomes a notification with a **View run** action (opens the run) and a **Copy fix prompt** action.
- Drain the queue immediately rather than serializing one card at a time: GNOME keeps notifications resident in its tray and ignores client expiry, so it stacks them itself.

**Collector** (`feat(cli): bundle the local collector on Linux`)
- Resolve the chDB release asset per platform (adds Linux arm64/x86_64 + checksums) and allow Linux in the runtime platform guard.

**Packaging & CI** (`feat(desktop): declare Linux runtime deps and build bundles in CI`)
- Declare rpm runtime deps so a package install pulls in the tray library automatically (deb relies on Tauri's auto-detection, verified correct).
- Add a `build-linux-desktop` CI job (arm64 + x86_64) producing deb/rpm/appimage artifacts. **Not** wired into `package-release`, so it can't block the macOS release.

**Docs** (`docs: document Linux dev setup`)
- Fedora/Debian system prerequisites, Fedora/SELinux notes for the Docker dev stack, and `:Z`/`:z` relabel flags on the compose bind mounts (no-op on macOS).

## Not done (by design)
- **Publishing** the Linux bundles to everr.dev — needs staging into the release payload + changes in the separate `everr-deploy` repo, plus a Linux `latest.json` if auto-update is wanted.
- The `build-linux-desktop` CI job is authored but **not yet validated by a CI run**; the apt deps, `tauri build` invocation, and AppImage-on-arm64 are the parts most likely to need a tweak on first run.
- Native notifications appear top-center on GNOME (shell-controlled placement), not top-right; the custom corner card remains the macOS experience.

## Test plan
- [x] `cargo build` + `cargo test` for the desktop app and CLI on Linux (green)
- [x] App launches, collector sidecar runs, chDB query works
- [x] System tray builds; single-instance re-focus works; window shown when no host present
- [x] `.deb` builds with `Depends: libayatana-appindicator3-1, libwebkit2gtk-4.1-0, libgtk-3-0`
- [x] Native notification renders on GNOME with View run / Copy fix prompt actions
- [ ] `build-linux-desktop` CI job validated on a real run
- [ ] macOS build still green
