### PR TITLE
feat: download CLI from everr.dev and add macOS resource tracking

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -17,6 +17,7 @@
   "entry": [
     // CI scripts invoked directly by GitHub Actions workflows.
     ".github/actions/everr-action/scripts/build-readme.mjs",
+    ".github/actions/everr-action/scripts/sampler-macos.mjs",
     // Nitro scans these folders as file-based server entry points for docs.
     "packages/docs/middleware/**/*.{ts,tsx}",
     "packages/docs/routes/**/*.{ts,tsx}",

--- a/.github/actions/everr-action/action.yml
+++ b/.github/actions/everr-action/action.yml
@@ -3,7 +3,7 @@ description: Everr CI helpers. Capabilities are toggled via inputs.
 
 inputs:
   install-cli:
-    description: Add the bundled Everr CLI to PATH for later workflow steps. Supports macOS arm64, Linux arm64, and Linux x64 runners when the matching binary is bundled.
+    description: Download the Everr CLI from everr.dev and add it to PATH for later workflow steps. Supports macOS arm64, Linux arm64, and Linux x64 runners.
     required: false
     default: "false"
   resource-usage:

--- a/.github/actions/everr-action/dist/index.js
+++ b/.github/actions/everr-action/dist/index.js
@@ -127912,10 +127912,11 @@ __nccwpck_require__.d(__webpack_exports__, {
   UU: () => (/* binding */ artifactNameForCheckRun),
   Bd: () => (/* binding */ buildRuntimePaths),
   FD: () => (/* binding */ bundledCliTargetForRuntime),
+  $q: () => (/* binding */ cliDownloadBinaryName),
   kB: () => (/* binding */ ensureSamplesFile),
   iA: () => (/* binding */ finalizeAndUploadResourceUsage),
   Wk: () => (/* binding */ src_formatError),
-  c4: () => (/* binding */ installBundledCli),
+  sE: () => (/* binding */ installCli),
   h: () => (/* binding */ isCliInstallEnabled),
   zB: () => (/* binding */ isResourceUsageEnabled),
   Y3: () => (/* binding */ normalizeCheckRunId),
@@ -127928,6 +127929,8 @@ __nccwpck_require__.d(__webpack_exports__, {
 
 ;// CONCATENATED MODULE: external "node:child_process"
 const external_node_child_process_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("node:child_process");
+// EXTERNAL MODULE: external "node:crypto"
+var external_node_crypto_ = __nccwpck_require__(77598);
 // EXTERNAL MODULE: ../../../node_modules/.pnpm/@actions+artifact@2.2.2/node_modules/@actions/artifact/lib/artifact.js
 var artifact = __nccwpck_require__(92785);
 // EXTERNAL MODULE: ../../../node_modules/.pnpm/@actions+core@1.11.1/node_modules/@actions/core/lib/core.js
@@ -128109,7 +128112,9 @@ async function finalizePartialArtifact({ samplesPath, outputDir, metadata, }) {
 
 
 
+
 const artifactClient = new artifact.DefaultArtifactClient();
+const CLI_DOWNLOAD_BASE_URL = "https://everr.dev/everr-app";
 const defaultSampleIntervalSeconds = "5";
 function artifactNameForCheckRun(checkRunId) {
     return `everr-resource-usage-v2-${checkRunId}`;
@@ -128161,7 +128166,36 @@ function bundledCliTargetForRuntime(platform = process.platform, arch = process.
     }
     return null;
 }
-async function installBundledCli({ actionRoot = resolveActionRoot(), addPath = core.addPath, arch = process.arch, fspModule = promises_, getInput = core.getInput, info = core.info, platform = process.platform, warning = core.warning, } = {}) {
+function cliDownloadBinaryName(target) {
+    switch (target) {
+        case "darwin-arm64":
+            return "everr";
+        case "linux-arm64":
+            return "everr-linux-arm64";
+        case "linux-x64":
+            return "everr-linux-x86_64";
+        default:
+            return null;
+    }
+}
+async function downloadFile(fetchImpl, url, destPath, fspModule) {
+    const response = await fetchImpl(url);
+    if (!response.ok) {
+        throw new Error(`HTTP ${response.status} for ${url}`);
+    }
+    const buffer = Buffer.from(await response.arrayBuffer());
+    await fspModule.writeFile(destPath, buffer);
+}
+async function verifyChecksum(filePath, checksumPath, fspModule) {
+    const checksumContent = await fspModule.readFile(checksumPath, "utf8");
+    const expectedHash = checksumContent.trim().split(/\s+/)[0];
+    const fileBuffer = await fspModule.readFile(filePath);
+    const actualHash = (0,external_node_crypto_.createHash)("sha256").update(fileBuffer).digest("hex");
+    if (expectedHash !== actualHash) {
+        throw new Error(`SHA-256 mismatch: expected ${expectedHash}, got ${actualHash}`);
+    }
+}
+async function installCli({ addPath = core.addPath, arch = process.arch, env = process.env, fetchImpl = fetch, fspModule = promises_, getInput = core.getInput, info = core.info, platform = process.platform, warning = core.warning, } = {}) {
     if (!isCliInstallEnabled(getInput)) {
         return { enabled: false };
     }
@@ -128170,23 +128204,29 @@ async function installBundledCli({ actionRoot = resolveActionRoot(), addPath = c
         warning(`install-cli skipped: unsupported runner ${platform}-${arch}`);
         return { enabled: true, failed: true };
     }
-    const binDir = external_node_path_.join(actionRoot, "bin", target);
-    const cliPath = external_node_path_.join(binDir, "everr");
+    const binaryName = cliDownloadBinaryName(target);
+    if (!binaryName) {
+        warning(`install-cli skipped: no binary name for target ${target}`);
+        return { enabled: true, failed: true, target };
+    }
+    const binaryUrl = `${CLI_DOWNLOAD_BASE_URL}/${binaryName}`;
+    const checksumUrl = `${CLI_DOWNLOAD_BASE_URL}/${binaryName}.sha256`;
+    const installDir = external_node_path_.join(env.RUNNER_TEMP || external_node_os_.tmpdir(), "everr-cli");
+    const cliPath = external_node_path_.join(installDir, "everr");
     try {
-        await fspModule.access(cliPath, external_node_fs_.constants.X_OK);
+        await fspModule.mkdir(installDir, { recursive: true });
+        await downloadFile(fetchImpl, binaryUrl, cliPath, fspModule);
+        await downloadFile(fetchImpl, checksumUrl, external_node_path_.join(installDir, `${binaryName}.sha256`), fspModule);
+        await verifyChecksum(cliPath, external_node_path_.join(installDir, `${binaryName}.sha256`), fspModule);
+        await fspModule.chmod(cliPath, 0o755);
+        addPath(installDir);
+        info(`installed Everr CLI for ${target} from ${binaryUrl}`);
+        return { enabled: true, path: cliPath, target };
     }
-    catch {
-        try {
-            await fspModule.chmod(cliPath, 0o755);
-        }
-        catch (error) {
-            warning(`install-cli skipped: bundled Everr CLI is unavailable: ${src_formatError(error)}`);
-            return { enabled: true, failed: true, target };
-        }
+    catch (error) {
+        warning(`install-cli skipped: failed to install Everr CLI: ${src_formatError(error)}`);
+        return { enabled: true, failed: true, target };
     }
-    addPath(binDir);
-    info(`installed bundled Everr CLI for ${target}`);
-    return { enabled: true, path: cliPath, target };
 }
 async function startResourceUsage({ env = process.env, fsModule = external_node_fs_, fspModule = promises_, saveState = core.saveState, getInput = core.getInput, info = core.info, warning = core.warning, now = () => new Date(), spawnImpl = external_node_child_process_namespaceObject.spawn, } = {}) {
     if (!isResourceUsageEnabled(getInput)) {
@@ -128194,8 +128234,9 @@ async function startResourceUsage({ env = process.env, fsModule = external_node_
         return { enabled: false };
     }
     const actionRoot = resolveActionRoot();
-    if (env.RUNNER_OS !== "Linux") {
-        info("resource-usage sampling is supported only on Linux runners");
+    const runnerOs = env.RUNNER_OS || "";
+    if (runnerOs !== "Linux" && runnerOs !== "macOS") {
+        info("resource-usage sampling is supported only on Linux and macOS runners");
         saveState("enabled", "0");
         return { enabled: false };
     }
@@ -128206,14 +128247,19 @@ async function startResourceUsage({ env = process.env, fsModule = external_node_
     }
     saveState("checkRunId", checkRunId);
     const { baseDir, samplesPath, pidPath, logPath } = buildRuntimePaths(env);
-    const samplerPath = external_node_path_.join(actionRoot, "scripts", "sampler.sh");
     const workspacePath = env.GITHUB_WORKSPACE || process.cwd();
     const startedAt = now().toISOString();
+    const isMacOS = runnerOs === "macOS";
+    const samplerPath = isMacOS
+        ? external_node_path_.join(actionRoot, "scripts", "sampler-macos.mjs")
+        : external_node_path_.join(actionRoot, "scripts", "sampler.sh");
+    const spawnFile = isMacOS ? "node" : "bash";
+    const spawnArgs = [samplerPath, samplesPath, workspacePath, defaultSampleIntervalSeconds];
     try {
         await fspModule.mkdir(baseDir, { recursive: true });
         await fspModule.writeFile(samplesPath, "", "utf8");
         const logFd = fsModule.openSync(logPath, "a");
-        const child = spawnImpl("bash", [samplerPath, samplesPath, workspacePath, defaultSampleIntervalSeconds], {
+        const child = spawnImpl(spawnFile, spawnArgs, {
             detached: true,
             stdio: ["ignore", logFd, logFd],
         });
@@ -128246,10 +128292,6 @@ async function startResourceUsage({ env = process.env, fsModule = external_node_
 async function finalizeAndUploadResourceUsage({ env = process.env, fspModule = promises_, readState = core.getState, info = core.info, warning = core.warning, now = () => new Date(), finalizeImpl = finalizePartialArtifact, resolveFilesystemInfo = resolveWorkspaceFilesystemInfo, uploadArtifactImpl = (name, files, rootDirectory, options) => artifactClient.uploadArtifact(name, files, rootDirectory, options), } = {}) {
     if (readState("enabled") !== "1") {
         return { enabled: false };
-    }
-    if (env.RUNNER_OS !== "Linux") {
-        warning("resource-usage finalization skipped: non-Linux runner (filesystem discovery uses GNU-only df flags)");
-        return { enabled: true, failed: true };
     }
     const checkRunId = readState("checkRunId");
     const samplesPath = readState("samplesPath");
@@ -128356,8 +128398,18 @@ function src_formatError(error) {
     }
     return String(error);
 }
-async function resolveWorkspaceFilesystemInfo(workspacePath) {
-    const { stdout } = await execFileWithOutput("df", ["-PkT", "--", workspacePath]);
+async function resolveWorkspaceFilesystemInfo(workspacePath, runnerOs = process.env.RUNNER_OS || "") {
+    if (runnerOs === "macOS") {
+        return resolveFilesystemInfoMacOS(workspacePath);
+    }
+    return resolveFilesystemInfoLinux(workspacePath);
+}
+async function resolveFilesystemInfoLinux(workspacePath) {
+    const { stdout } = await execFileWithOutput("df", [
+        "-PkT",
+        "--",
+        workspacePath,
+    ]);
     const lines = stdout
         .split("\n")
         .map((line) => line.trim())
@@ -128374,6 +128426,43 @@ async function resolveWorkspaceFilesystemInfo(workspacePath) {
         type: fields[1] || "",
         mountpoint: fields[6] || "",
     };
+}
+async function resolveFilesystemInfoMacOS(workspacePath) {
+    const { stdout } = await execFileWithOutput("df", [
+        "-Pk",
+        "--",
+        workspacePath,
+    ]);
+    const lines = stdout
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean);
+    if (lines.length < 2) {
+        throw new Error("df output did not include a filesystem row");
+    }
+    const fields = lines[1].split(/\s+/);
+    if (fields.length < 6) {
+        throw new Error("df output did not include device and mountpoint");
+    }
+    const device = fields[0] || "";
+    const mountpoint = fields[5] || "";
+    let type = "";
+    try {
+        const { stdout: mountOutput } = await execFileWithOutput("mount", []);
+        for (const line of mountOutput.split("\n")) {
+            if (line.includes(` on ${mountpoint} `)) {
+                const match = line.match(/\(([^,)]+)/);
+                if (match) {
+                    type = match[1];
+                }
+                break;
+            }
+        }
+    }
+    catch {
+        // filesystem type is best-effort on macOS
+    }
+    return { device, type, mountpoint };
 }
 async function execFileWithOutput(file, args) {
     return await new Promise((resolve, reject) => {
@@ -128393,7 +128482,7 @@ async function run() {
     const isPost = core.getState("isPost") === "true";
     if (!isPost) {
         core.saveState("isPost", "true");
-        await installBundledCli();
+        await installCli();
         await startResourceUsage();
         return;
     }
@@ -128410,10 +128499,11 @@ if (entrypointPath === (0,external_node_url_.fileURLToPath)(import.meta.url)) {
 var __webpack_exports__artifactNameForCheckRun = __webpack_exports__.UU;
 var __webpack_exports__buildRuntimePaths = __webpack_exports__.Bd;
 var __webpack_exports__bundledCliTargetForRuntime = __webpack_exports__.FD;
+var __webpack_exports__cliDownloadBinaryName = __webpack_exports__.$q;
 var __webpack_exports__ensureSamplesFile = __webpack_exports__.kB;
 var __webpack_exports__finalizeAndUploadResourceUsage = __webpack_exports__.iA;
 var __webpack_exports__formatError = __webpack_exports__.Wk;
-var __webpack_exports__installBundledCli = __webpack_exports__.c4;
+var __webpack_exports__installCli = __webpack_exports__.sE;
 var __webpack_exports__isCliInstallEnabled = __webpack_exports__.h;
 var __webpack_exports__isResourceUsageEnabled = __webpack_exports__.zB;
 var __webpack_exports__normalizeCheckRunId = __webpack_exports__.Y3;
@@ -128422,4 +128512,4 @@ var __webpack_exports__resolveCheckRunIdInput = __webpack_exports__.dI;
 var __webpack_exports__resolveWorkspaceFilesystemInfo = __webpack_exports__.RH;
 var __webpack_exports__startResourceUsage = __webpack_exports__.sk;
 var __webpack_exports__stopSampler = __webpack_exports__.X6;
-export { __webpack_exports__artifactNameForCheckRun as artifactNameForCheckRun, __webpack_exports__buildRuntimePaths as buildRuntimePaths, __webpack_exports__bundledCliTargetForRuntime as bundledCliTargetForRuntime, __webpack_exports__ensureSamplesFile as ensureSamplesFile, __webpack_exports__finalizeAndUploadResourceUsage as finalizeAndUploadResourceUsage, __webpack_exports__formatError as formatError, __webpack_exports__installBundledCli as installBundledCli, __webpack_exports__isCliInstallEnabled as isCliInstallEnabled, __webpack_exports__isResourceUsageEnabled as isResourceUsageEnabled, __webpack_exports__normalizeCheckRunId as normalizeCheckRunId, __webpack_exports__resolveActionRoot as resolveActionRoot, __webpack_exports__resolveCheckRunIdInput as resolveCheckRunIdInput, __webpack_exports__resolveWorkspaceFilesystemInfo as resolveWorkspaceFilesystemInfo, __webpack_exports__startResourceUsage as startResourceUsage, __webpack_exports__stopSampler as stopSampler };
+export { __webpack_exports__artifactNameForCheckRun as artifactNameForCheckRun, __webpack_exports__buildRuntimePaths as buildRuntimePaths, __webpack_exports__bundledCliTargetForRuntime as bundledCliTargetForRuntime, __webpack_exports__cliDownloadBinaryName as cliDownloadBinaryName, __webpack_exports__ensureSamplesFile as ensureSamplesFile, __webpack_exports__finalizeAndUploadResourceUsage as finalizeAndUploadResourceUsage, __webpack_exports__formatError as formatError, __webpack_exports__installCli as installCli, __webpack_exports__isCliInstallEnabled as isCliInstallEnabled, __webpack_exports__isResourceUsageEnabled as isResourceUsageEnabled, __webpack_exports__normalizeCheckRunId as normalizeCheckRunId, __webpack_exports__resolveActionRoot as resolveActionRoot, __webpack_exports__resolveCheckRunIdInput as resolveCheckRunIdInput, __webpack_exports__resolveWorkspaceFilesystemInfo as resolveWorkspaceFilesystemInfo, __webpack_exports__startResourceUsage as startResourceUsage, __webpack_exports__stopSampler as stopSampler };

--- a/.github/actions/everr-action/scripts/sampler-macos.mjs
+++ b/.github/actions/everr-action/scripts/sampler-macos.mjs
@@ -1,0 +1,166 @@
+import { execFileSync } from "node:child_process";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { cpus, freemem, totalmem } from "node:os";
+import { dirname } from "node:path";
+
+const samplesPath = process.argv[2];
+const workspacePath = process.argv[3];
+const intervalMs = (parseInt(process.argv[4], 10) || 5) * 1000;
+
+let previousTimes = cpus().map((cpu) => cpu.times);
+let filesystemType = "unknown";
+let filesystemDevice = "";
+let filesystemMountpoint = "";
+
+function resolveFilesystemInfo() {
+  try {
+    const dfOutput = execFileSync("df", ["-Pk", workspacePath], {
+      encoding: "utf8",
+    });
+    const dfLines = dfOutput.trim().split("\n");
+    if (dfLines.length < 2) return;
+    const fields = dfLines[1].trim().split(/\s+/);
+    if (fields.length < 6) return;
+    filesystemDevice = fields[0];
+    filesystemMountpoint = fields[5];
+
+    const mountOutput = execFileSync("mount", [], { encoding: "utf8" });
+    for (const line of mountOutput.split("\n")) {
+      if (line.includes(` on ${filesystemMountpoint} `)) {
+        const match = line.match(/\(([^,)]+)/);
+        if (match) filesystemType = match[1];
+        break;
+      }
+    }
+  } catch {
+    // filesystem info is best-effort
+  }
+}
+
+function readFilesystemStats() {
+  try {
+    const dfOutput = execFileSync("df", ["-Pk", workspacePath], {
+      encoding: "utf8",
+    });
+    const dfLines = dfOutput.trim().split("\n");
+    if (dfLines.length < 2) {
+      return { limitBytes: 0, usedBytes: 0, freeBytes: 0, utilization: 0 };
+    }
+    const fields = dfLines[1].trim().split(/\s+/);
+    if (fields.length < 6) {
+      return { limitBytes: 0, usedBytes: 0, freeBytes: 0, utilization: 0 };
+    }
+    const totalKb = parseInt(fields[1], 10);
+    const usedKb = parseInt(fields[2], 10);
+    const freeKb = parseInt(fields[3], 10);
+    const limitBytes = totalKb * 1024;
+    const usedBytes = usedKb * 1024;
+    const freeBytes = freeKb * 1024;
+    const utilization = limitBytes > 0 ? usedBytes / limitBytes : 0;
+    return { limitBytes, usedBytes, freeBytes, utilization };
+  } catch {
+    return { limitBytes: 0, usedBytes: 0, freeBytes: 0, utilization: 0 };
+  }
+}
+
+function readNetworkInterfaces() {
+  const interfaces = [];
+  try {
+    const output = execFileSync("netstat", ["-ibn"], { encoding: "utf8" });
+    const lines = output.split("\n").slice(1);
+    for (const line of lines) {
+      const fields = line.trim().split(/\s+/);
+      if (fields.length < 7) continue;
+      const name = fields[0];
+      if (name === "lo0" || name === "") continue;
+      const receiveBytes = parseInt(fields[fields.length - 6], 10);
+      const transmitBytes = parseInt(fields[fields.length - 3], 10);
+      if (Number.isNaN(receiveBytes) || Number.isNaN(transmitBytes)) continue;
+      interfaces.push({ name, receiveBytes, transmitBytes });
+    }
+  } catch {
+    // network stats are best-effort
+  }
+  return interfaces;
+}
+
+function buildCPULogicalJson(currentTimes) {
+  const items = currentTimes.map((times, i) => {
+    const prev = previousTimes[i];
+    const prevTotal = prev
+      ? prev.user + prev.nice + prev.sys + prev.idle + prev.irq
+      : times.user + times.nice + times.sys + times.idle + times.irq;
+    const prevIdle = prev ? prev.idle + prev.irq : times.idle + times.irq;
+    const currentTotal =
+      times.user + times.nice + times.sys + times.idle + times.irq;
+    const currentIdle = times.idle + times.irq;
+    const deltaTotal = currentTotal - prevTotal;
+    const deltaIdle = currentIdle - prevIdle;
+    const utilization = deltaTotal > 0 ? (deltaTotal - deltaIdle) / deltaTotal : 0;
+    return {
+      logicalNumber: i,
+      utilization: Number(utilization.toFixed(6)),
+    };
+  });
+  return JSON.stringify(items);
+}
+
+function buildNetworkInterfacesJSON() {
+  return JSON.stringify(readNetworkInterfaces());
+}
+
+function emitSample() {
+  const currentTimes = cpus().map((cpu) => cpu.times);
+  const cpuLogicalJson = buildCPULogicalJson(currentTimes);
+
+  const totalMemory = totalmem();
+  const freeMemory = freemem();
+  const usedMemory = totalMemory - freeMemory;
+  const memoryUtilization = totalMemory > 0 ? usedMemory / totalMemory : 0;
+
+  const fsStats = readFilesystemStats();
+  const networkJson = buildNetworkInterfacesJSON();
+  const timestamp = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+
+  const sample = JSON.stringify({
+    timestamp,
+    cpu: { logical: JSON.parse(cpuLogicalJson) },
+    memory: {
+      limitBytes: totalMemory,
+      usedBytes: usedMemory,
+      availableBytes: freeMemory,
+      utilization: Number(memoryUtilization.toFixed(6)),
+    },
+    filesystem: {
+      device: filesystemDevice,
+      mountpoint: filesystemMountpoint,
+      type: filesystemType,
+      limitBytes: fsStats.limitBytes,
+      usedBytes: fsStats.usedBytes,
+      freeBytes: fsStats.freeBytes,
+      utilization: Number(fsStats.utilization.toFixed(6)),
+    },
+    network: {
+      interfaces: JSON.parse(networkJson),
+    },
+  });
+
+  appendFileSync(samplesPath, sample + "\n");
+  previousTimes = currentTimes;
+}
+
+function shutdown() {
+  emitSample();
+  process.exit(0);
+}
+
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);
+
+mkdirSync(dirname(samplesPath), { recursive: true });
+resolveFilesystemInfo();
+
+setTimeout(() => {
+  emitSample();
+  setInterval(emitSample, intervalMs);
+}, intervalMs);

--- a/.github/actions/everr-action/src/index.test.ts
+++ b/.github/actions/everr-action/src/index.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import * as fsp from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -9,8 +10,9 @@ import {
   artifactNameForCheckRun,
   buildRuntimePaths,
   bundledCliTargetForRuntime,
+  cliDownloadBinaryName,
   finalizeAndUploadResourceUsage,
-  installBundledCli,
+  installCli,
   isCliInstallEnabled,
   isResourceUsageEnabled,
   normalizeCheckRunId,
@@ -95,10 +97,17 @@ test("bundledCliTargetForRuntime supports bundled release targets", () => {
   assert.equal(bundledCliTargetForRuntime("win32", "x64"), null);
 });
 
-test("installBundledCli no-ops when install-cli input is disabled", async () => {
+test("cliDownloadBinaryName maps targets to everr.dev asset names", () => {
+  assert.equal(cliDownloadBinaryName("darwin-arm64"), "everr");
+  assert.equal(cliDownloadBinaryName("linux-arm64"), "everr-linux-arm64");
+  assert.equal(cliDownloadBinaryName("linux-x64"), "everr-linux-x86_64");
+  assert.equal(cliDownloadBinaryName("darwin-x64"), null);
+});
+
+test("installCli no-ops when install-cli input is disabled", async () => {
   let didAddPath = false;
 
-  const result = await installBundledCli({
+  const result = await installCli({
     getInput: inputResolver({ "install-cli": "false" }),
     addPath: () => {
       didAddPath = true;
@@ -109,10 +118,10 @@ test("installBundledCli no-ops when install-cli input is disabled", async () => 
   assert.equal(didAddPath, false);
 });
 
-test("installBundledCli warns on unsupported runners", async () => {
+test("installCli warns on unsupported runners", async () => {
   const warnings: string[] = [];
 
-  const result = await installBundledCli({
+  const result = await installCli({
     getInput: inputResolver({ "install-cli": "true" }),
     platform: "win32",
     arch: "x64",
@@ -123,33 +132,117 @@ test("installBundledCli warns on unsupported runners", async () => {
   assert.match(warnings[0], /unsupported runner win32-x64/);
 });
 
-test("installBundledCli adds the bundled CLI directory to PATH", async () => {
-  const actionRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "everr-action-cli-"));
-  const binDir = path.join(actionRoot, "bin", "darwin-arm64");
-  const cliPath = path.join(binDir, "everr");
+test("installCli downloads from everr.dev and adds to PATH", async () => {
+  const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "everr-action-cli-"));
+  const installDir = path.join(tempDir, "everr-cli");
+  const cliPath = path.join(installDir, "everr");
   const paths: string[] = [];
   const infos: string[] = [];
 
-  try {
-    await fsp.mkdir(binDir, { recursive: true });
-    await fsp.writeFile(cliPath, "#!/bin/sh\n", { mode: 0o755 });
+  const binaryContent = Buffer.from("fake-everr-binary");
+  const binaryHash = createHash("sha256").update(binaryContent).digest("hex");
 
-    const result = await installBundledCli({
-      actionRoot,
+  const fileStore = new Map<string, Buffer>();
+  const fetchCalls: Array<{ url: string }> = [];
+
+  const fetchImpl = async (url: string) => {
+    fetchCalls.push({ url });
+    const isChecksum = url.endsWith(".sha256");
+    const content = isChecksum
+      ? Buffer.from(`${binaryHash}  everr\n`)
+      : binaryContent;
+    return {
+      ok: true,
+      status: 200,
+      arrayBuffer: async () =>
+        new Uint8Array(content).buffer as ArrayBuffer,
+    };
+  };
+
+  const fspMock = {
+    mkdir: async (_dir: string, _opts?: unknown) => {},
+    writeFile: async (p: string, data: Buffer) => {
+      fileStore.set(p, data);
+    },
+    readFile: async (p: string, _encoding?: any) => {
+      if (p.endsWith("everr.sha256")) {
+        const content = `${binaryHash}  everr\n`;
+        return _encoding ? content : Buffer.from(content);
+      }
+      if (p === cliPath) {
+        return _encoding
+          ? binaryContent.toString(_encoding)
+          : binaryContent;
+      }
+      throw new Error(`unexpected read: ${p}`);
+    },
+    chmod: async (_filePath: string, _mode: number) => {},
+  };
+
+  try {
+    const result = await installCli({
+      env: { RUNNER_TEMP: tempDir },
+      fetchImpl,
+      fspModule: fspMock as any,
       getInput: inputResolver({ "install-cli": "true" }),
       platform: "darwin",
       arch: "arm64",
-      addPath: (inputPath: string) => paths.push(inputPath),
-      info: (message: string) => infos.push(message),
+      addPath: (p: string) => paths.push(p),
+      info: (m: string) => infos.push(m),
       warning: () => {},
     });
 
     assert.equal(result.enabled, true);
     assert.equal(result.path, cliPath);
-    assert.deepEqual(paths, [binDir]);
-    assert.match(infos[0], /installed bundled Everr CLI for darwin-arm64/);
+    assert.equal(result.target, "darwin-arm64");
+    assert.deepEqual(paths, [installDir]);
+    assert.match(infos[0], /installed Everr CLI for darwin-arm64/);
+    assert.equal(
+      fetchCalls[0].url,
+      "https://everr.dev/everr-app/everr",
+    );
+    assert.equal(
+      fetchCalls[1].url,
+      "https://everr.dev/everr-app/everr.sha256",
+    );
   } finally {
-    await fsp.rm(actionRoot, { recursive: true, force: true });
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("installCli warns on download failure", async () => {
+  const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "everr-action-cli-"));
+  const warnings: string[] = [];
+
+  const fetchImpl = async (_url: string) => {
+    throw new Error("network error");
+  };
+  const fspMock = {
+    mkdir: async (_dir: string, _opts?: unknown) => {},
+    writeFile: async () => {},
+    readFile: async () => Buffer.alloc(0),
+    chmod: async () => {},
+  };
+
+  try {
+    const result = await installCli({
+      env: { RUNNER_TEMP: tempDir },
+      fetchImpl,
+      fspModule: fspMock as any,
+      getInput: inputResolver({ "install-cli": "true" }),
+      platform: "linux",
+      arch: "x64",
+      addPath: () => {},
+      info: () => {},
+      warning: (m: string) => warnings.push(m),
+    });
+
+    assert.equal(result.enabled, true);
+    assert.equal(result.failed, true);
+    assert.equal(result.target, "linux-x64");
+    assert.match(warnings[0], /failed to install Everr CLI: network error/);
+  } finally {
+    await fsp.rm(tempDir, { recursive: true, force: true });
   }
 });
 
@@ -172,7 +265,7 @@ test("startResourceUsage no-ops when resource-usage input is not enabled", async
   assert.equal(infoMessages.length, 0);
 });
 
-test("startResourceUsage no-ops on non-linux runners", async () => {
+test("startResourceUsage no-ops on unsupported runners", async () => {
   const savedState = new Map<string, string>();
   const infoMessages: string[] = [];
 
@@ -188,7 +281,7 @@ test("startResourceUsage no-ops on non-linux runners", async () => {
 
   assert.equal(result.enabled, false);
   assert.equal(savedState.get("enabled"), "0");
-  assert.match(infoMessages[0], /supported only on Linux runners/);
+  assert.match(infoMessages[0], /supported only on Linux and macOS runners/);
 });
 
 test("startResourceUsage skips sampling when check-run-id is missing", async () => {
@@ -243,7 +336,7 @@ test("startResourceUsage downgrades sampler startup failures to warnings", async
   }
 });
 
-test("startResourceUsage resolves sampler path without GITHUB_ACTION_PATH", async () => {
+test("startResourceUsage resolves sampler path without GITHUB_ACTION_PATH on Linux", async () => {
   const savedState = new Map<string, string>();
   const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "everr-ru-spawn-"));
   let spawnInvocation:
@@ -286,6 +379,53 @@ test("startResourceUsage resolves sampler path without GITHUB_ACTION_PATH", asyn
     );
     assert.equal(savedState.get("checkRunId"), "222");
     assert.equal(savedState.get("actionPath"), undefined);
+  } finally {
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("startResourceUsage spawns node with sampler-macos.mjs on macOS", async () => {
+  const savedState = new Map<string, string>();
+  const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "everr-ru-macos-"));
+  let spawnInvocation:
+    | {
+        args: readonly string[];
+        file: string;
+      }
+    | undefined;
+
+  try {
+    const result = await startResourceUsage({
+      env: {
+        RUNNER_OS: "macOS",
+        RUNNER_TEMP: tempDir,
+        GITHUB_RUN_ID: "12",
+        GITHUB_RUN_ATTEMPT: "1",
+        GITHUB_JOB: "lint",
+        GITHUB_REPOSITORY: "everr-labs/everr",
+        GITHUB_WORKSPACE: tempDir,
+      },
+      getInput: inputResolver({ "resource-usage": "true", "check-run-id": "333" }),
+      saveState: (key: string, value: string) => savedState.set(key, value),
+      info: () => {},
+      warning: () => {},
+      spawnImpl: ((file: string, args: readonly string[]) => {
+        spawnInvocation = { file, args };
+        return {
+          pid: 456,
+          unref() {},
+        } as any;
+      }) as typeof import("node:child_process").spawn,
+    });
+
+    assert.equal(result.enabled, true);
+    assert.equal(result.checkRunId, "333");
+    assert.equal(spawnInvocation?.file, "node");
+    assert.equal(
+      spawnInvocation?.args[0],
+      path.join(resolveActionRoot(fileURLToPath(import.meta.url)), "scripts", "sampler-macos.mjs"),
+    );
+    assert.equal(savedState.get("checkRunId"), "333");
   } finally {
     await fsp.rm(tempDir, { recursive: true, force: true });
   }
@@ -417,41 +557,81 @@ test(
   },
 );
 
-test("finalizeAndUploadResourceUsage skips finalization on non-Linux runners", async () => {
-  const warnings: string[] = [];
-  let finalizeCalled = false;
+test("finalizeAndUploadResourceUsage succeeds on macOS runners", async () => {
+  const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "everr-ru-finalize-macos-"));
+  const outputDir = path.join(
+    tempDir,
+    "everr-resource-usage",
+    "123-1-lint",
+    "artifact",
+  );
+  const uploaded: Array<{
+    files: string[];
+    name: string;
+    options: { retentionDays: number };
+    rootDirectory: string;
+  }> = [];
+  const infos: string[] = [];
 
-  const result = await finalizeAndUploadResourceUsage({
-    env: {
-      RUNNER_OS: "macOS",
-      RUNNER_TEMP: os.tmpdir(),
-      GITHUB_RUN_ID: "123",
-      GITHUB_RUN_ATTEMPT: "1",
-      GITHUB_JOB: "lint",
-    },
-    readState: (key: string) =>
-      (
-        {
-          enabled: "1",
-          checkRunId: "777",
-          samplesPath: path.join(os.tmpdir(), "missing.ndjson"),
-          pidPath: path.join(os.tmpdir(), "missing.pid"),
-          startedAt: "2026-03-10T10:00:00.000Z",
-        } as Record<string, string>
-      )[key] || "",
-    finalizeImpl: (async () => {
-      finalizeCalled = true;
-      return {} as any;
-    }) as typeof import("../scripts/finalize.ts").finalizePartialArtifact,
-    resolveFilesystemInfo: async () => {
-      throw new Error("df should not be called on non-Linux");
-    },
-    uploadArtifactImpl: async () => {},
-    info: () => {},
-    warning: (message: string) => warnings.push(message),
-  });
+  try {
+    const result = await finalizeAndUploadResourceUsage({
+      env: {
+        RUNNER_TEMP: tempDir,
+        GITHUB_RUN_ID: "123",
+        GITHUB_RUN_ATTEMPT: "1",
+        GITHUB_JOB: "lint",
+        GITHUB_REPOSITORY: "everr-labs/everr",
+        RUNNER_OS: "macOS",
+        RUNNER_ARCH: "ARM64",
+        RUNNER_NAME: "GitHub Actions 1",
+      },
+      readState: (key: string) =>
+        (
+          {
+            enabled: "1",
+            checkRunId: "888",
+            samplesPath: path.join(tempDir, "samples.ndjson"),
+            pidPath: path.join(tempDir, "missing.pid"),
+            startedAt: "2026-03-10T10:00:00.000Z",
+          } as Record<string, string>
+        )[key] || "",
+      finalizeImpl: (async (options) => {
+        await fsp.mkdir(outputDir, { recursive: true });
+        await fsp.writeFile(path.join(outputDir, "metadata.json"), "{}\n", "utf8");
+        await fsp.writeFile(path.join(outputDir, "samples.ndjson"), "", "utf8");
+        return {} as any;
+      }) as typeof import("../scripts/finalize.ts").finalizePartialArtifact,
+      resolveFilesystemInfo: async () => ({
+        device: "/dev/disk3s1",
+        mountpoint: "/",
+        type: "apfs",
+      }),
+      uploadArtifactImpl: async (
+        name: string,
+        files: string[],
+        rootDirectory: string,
+        options: { retentionDays: number },
+      ) => {
+        uploaded.push({ name, files, rootDirectory, options });
+      },
+      info: (message: string) => infos.push(message),
+      warning: () => {},
+    });
 
-  assert.equal(result.failed, true);
-  assert.equal(finalizeCalled, false);
-  assert.match(warnings[0], /non-Linux runner/);
+    assert.equal(result.artifactName, "everr-resource-usage-v2-888");
+    assert.deepEqual(uploaded[0], {
+      name: "everr-resource-usage-v2-888",
+      files: [
+        path.join(outputDir, "metadata.json"),
+        path.join(outputDir, "samples.ndjson"),
+      ],
+      rootDirectory: outputDir,
+      options: { retentionDays: 7 },
+    });
+    assert.match(infos[0], /uploaded resource-usage artifact/);
+  } finally {
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  }
 });
+
+

--- a/.github/actions/everr-action/src/index.ts
+++ b/.github/actions/everr-action/src/index.ts
@@ -1,4 +1,5 @@
 import { execFile, spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import * as artifact from "@actions/artifact";
 import * as core from "@actions/core";
 import * as fs from "node:fs";
@@ -33,6 +34,9 @@ type Log = (message: string) => void;
 type Now = () => Date;
 type AddPath = (inputPath: string) => void;
 type FinalizePartialArtifactImpl = typeof finalizePartialArtifact;
+type FetchImpl = (
+  url: string,
+) => Promise<{ ok: boolean; status: number; arrayBuffer: () => Promise<ArrayBuffer> }>;
 type ResolveFilesystemInfo = (workspacePath: string) => Promise<FilesystemInfo>;
 type UploadArtifactImpl = (
   name: string,
@@ -40,6 +44,8 @@ type UploadArtifactImpl = (
   rootDirectory: string,
   options: { retentionDays: number },
 ) => Promise<unknown>;
+
+const CLI_DOWNLOAD_BASE_URL = "https://everr.dev/everr-app";
 
 const defaultSampleIntervalSeconds = "5";
 
@@ -55,10 +61,11 @@ interface StartResourceUsageOptions {
   warning?: Log;
 }
 
-interface InstallBundledCliOptions {
-  actionRoot?: string;
+interface InstallCliOptions {
   addPath?: AddPath;
   arch?: string;
+  env?: Env;
+  fetchImpl?: FetchImpl;
   fspModule?: typeof fsp;
   getInput?: GetInput;
   info?: Log;
@@ -155,16 +162,60 @@ function bundledCliTargetForRuntime(
   return null;
 }
 
-async function installBundledCli({
-  actionRoot = resolveActionRoot(),
+function cliDownloadBinaryName(target: string): string | null {
+  switch (target) {
+    case "darwin-arm64":
+      return "everr";
+    case "linux-arm64":
+      return "everr-linux-arm64";
+    case "linux-x64":
+      return "everr-linux-x86_64";
+    default:
+      return null;
+  }
+}
+
+async function downloadFile(
+  fetchImpl: FetchImpl,
+  url: string,
+  destPath: string,
+  fspModule: typeof fsp,
+): Promise<void> {
+  const response = await fetchImpl(url);
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} for ${url}`);
+  }
+  const buffer = Buffer.from(await response.arrayBuffer());
+  await fspModule.writeFile(destPath, buffer);
+}
+
+async function verifyChecksum(
+  filePath: string,
+  checksumPath: string,
+  fspModule: typeof fsp,
+): Promise<void> {
+  const checksumContent = await fspModule.readFile(checksumPath, "utf8");
+  const expectedHash = checksumContent.trim().split(/\s+/)[0];
+  const fileBuffer = await fspModule.readFile(filePath);
+  const actualHash = createHash("sha256").update(fileBuffer).digest("hex");
+  if (expectedHash !== actualHash) {
+    throw new Error(
+      `SHA-256 mismatch: expected ${expectedHash}, got ${actualHash}`,
+    );
+  }
+}
+
+async function installCli({
   addPath = core.addPath,
   arch = process.arch,
+  env = process.env,
+  fetchImpl = fetch,
   fspModule = fsp,
   getInput = core.getInput,
   info = core.info,
   platform = process.platform,
   warning = core.warning,
-}: InstallBundledCliOptions = {}): Promise<{
+}: InstallCliOptions = {}): Promise<{
   enabled: boolean;
   failed?: boolean;
   path?: string;
@@ -180,23 +231,35 @@ async function installBundledCli({
     return { enabled: true, failed: true };
   }
 
-  const binDir = path.join(actionRoot, "bin", target);
-  const cliPath = path.join(binDir, "everr");
-
-  try {
-    await fspModule.access(cliPath, fs.constants.X_OK);
-  } catch {
-    try {
-      await fspModule.chmod(cliPath, 0o755);
-    } catch (error) {
-      warning(`install-cli skipped: bundled Everr CLI is unavailable: ${formatError(error)}`);
-      return { enabled: true, failed: true, target };
-    }
+  const binaryName = cliDownloadBinaryName(target);
+  if (!binaryName) {
+    warning(`install-cli skipped: no binary name for target ${target}`);
+    return { enabled: true, failed: true, target };
   }
 
-  addPath(binDir);
-  info(`installed bundled Everr CLI for ${target}`);
-  return { enabled: true, path: cliPath, target };
+  const binaryUrl = `${CLI_DOWNLOAD_BASE_URL}/${binaryName}`;
+  const checksumUrl = `${CLI_DOWNLOAD_BASE_URL}/${binaryName}.sha256`;
+  const installDir = path.join(
+    env.RUNNER_TEMP || os.tmpdir(),
+    "everr-cli",
+  );
+  const cliPath = path.join(installDir, "everr");
+
+  try {
+    await fspModule.mkdir(installDir, { recursive: true });
+    await downloadFile(fetchImpl, binaryUrl, cliPath, fspModule);
+    await downloadFile(fetchImpl, checksumUrl, path.join(installDir, `${binaryName}.sha256`), fspModule);
+    await verifyChecksum(cliPath, path.join(installDir, `${binaryName}.sha256`), fspModule);
+    await fspModule.chmod(cliPath, 0o755);
+    addPath(installDir);
+    info(`installed Everr CLI for ${target} from ${binaryUrl}`);
+    return { enabled: true, path: cliPath, target };
+  } catch (error) {
+    warning(
+      `install-cli skipped: failed to install Everr CLI: ${formatError(error)}`,
+    );
+    return { enabled: true, failed: true, target };
+  }
 }
 
 async function startResourceUsage({
@@ -221,8 +284,11 @@ async function startResourceUsage({
 
   const actionRoot = resolveActionRoot();
 
-  if (env.RUNNER_OS !== "Linux") {
-    info("resource-usage sampling is supported only on Linux runners");
+  const runnerOs = env.RUNNER_OS || "";
+  if (runnerOs !== "Linux" && runnerOs !== "macOS") {
+    info(
+      "resource-usage sampling is supported only on Linux and macOS runners",
+    );
     saveState("enabled", "0");
     return { enabled: false };
   }
@@ -235,23 +301,25 @@ async function startResourceUsage({
 
   saveState("checkRunId", checkRunId);
   const { baseDir, samplesPath, pidPath, logPath } = buildRuntimePaths(env);
-  const samplerPath = path.join(actionRoot, "scripts", "sampler.sh");
   const workspacePath = env.GITHUB_WORKSPACE || process.cwd();
   const startedAt = now().toISOString();
+
+  const isMacOS = runnerOs === "macOS";
+  const samplerPath = isMacOS
+    ? path.join(actionRoot, "scripts", "sampler-macos.mjs")
+    : path.join(actionRoot, "scripts", "sampler.sh");
+  const spawnFile = isMacOS ? "node" : "bash";
+  const spawnArgs = [samplerPath, samplesPath, workspacePath, defaultSampleIntervalSeconds];
 
   try {
     await fspModule.mkdir(baseDir, { recursive: true });
     await fspModule.writeFile(samplesPath, "", "utf8");
 
     const logFd = fsModule.openSync(logPath, "a");
-    const child = spawnImpl(
-      "bash",
-      [samplerPath, samplesPath, workspacePath, defaultSampleIntervalSeconds],
-      {
-        detached: true,
-        stdio: ["ignore", logFd, logFd],
-      },
-    );
+    const child = spawnImpl(spawnFile, spawnArgs, {
+      detached: true,
+      stdio: ["ignore", logFd, logFd],
+    });
     child.unref();
     fsModule.closeSync(logFd);
 
@@ -300,13 +368,6 @@ async function finalizeAndUploadResourceUsage({
 }> {
   if (readState("enabled") !== "1") {
     return { enabled: false };
-  }
-
-  if (env.RUNNER_OS !== "Linux") {
-    warning(
-      "resource-usage finalization skipped: non-Linux runner (filesystem discovery uses GNU-only df flags)",
-    );
-    return { enabled: true, failed: true };
   }
 
   const checkRunId = readState("checkRunId");
@@ -433,8 +494,22 @@ function formatError(error: unknown): string {
 
 async function resolveWorkspaceFilesystemInfo(
   workspacePath: string,
+  runnerOs: string = process.env.RUNNER_OS || "",
 ): Promise<FilesystemInfo> {
-  const { stdout } = await execFileWithOutput("df", ["-PkT", "--", workspacePath]);
+  if (runnerOs === "macOS") {
+    return resolveFilesystemInfoMacOS(workspacePath);
+  }
+  return resolveFilesystemInfoLinux(workspacePath);
+}
+
+async function resolveFilesystemInfoLinux(
+  workspacePath: string,
+): Promise<FilesystemInfo> {
+  const { stdout } = await execFileWithOutput("df", [
+    "-PkT",
+    "--",
+    workspacePath,
+  ]);
   const lines = stdout
     .split("\n")
     .map((line) => line.trim())
@@ -454,6 +529,50 @@ async function resolveWorkspaceFilesystemInfo(
     type: fields[1] || "",
     mountpoint: fields[6] || "",
   };
+}
+
+async function resolveFilesystemInfoMacOS(
+  workspacePath: string,
+): Promise<FilesystemInfo> {
+  const { stdout } = await execFileWithOutput("df", [
+    "-Pk",
+    "--",
+    workspacePath,
+  ]);
+  const lines = stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  if (lines.length < 2) {
+    throw new Error("df output did not include a filesystem row");
+  }
+
+  const fields = lines[1].split(/\s+/);
+  if (fields.length < 6) {
+    throw new Error("df output did not include device and mountpoint");
+  }
+
+  const device = fields[0] || "";
+  const mountpoint = fields[5] || "";
+
+  let type = "";
+  try {
+    const { stdout: mountOutput } = await execFileWithOutput("mount", []);
+    for (const line of mountOutput.split("\n")) {
+      if (line.includes(` on ${mountpoint} `)) {
+        const match = line.match(/\(([^,)]+)/);
+        if (match) {
+          type = match[1];
+        }
+        break;
+      }
+    }
+  } catch {
+    // filesystem type is best-effort on macOS
+  }
+
+  return { device, type, mountpoint };
 }
 
 async function execFileWithOutput(
@@ -481,7 +600,7 @@ async function run(): Promise<void> {
   const isPost = core.getState("isPost") === "true";
   if (!isPost) {
     core.saveState("isPost", "true");
-    await installBundledCli();
+    await installCli();
     await startResourceUsage();
     return;
   }
@@ -501,10 +620,11 @@ export {
   artifactNameForCheckRun,
   buildRuntimePaths,
   bundledCliTargetForRuntime,
+  cliDownloadBinaryName,
   ensureSamplesFile,
   finalizeAndUploadResourceUsage,
   formatError,
-  installBundledCli,
+  installCli,
   isCliInstallEnabled,
   isResourceUsageEnabled,
   normalizeCheckRunId,

--- a/.github/workflows/build-and-push-images.yml
+++ b/.github/workflows/build-and-push-images.yml
@@ -37,6 +37,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Collect resource usage
+        uses: ./.github/actions/everr-action
+        with:
+          check-run-id: ${{ job.check_run_id }}
+
       - name: Detect changed paths
         id: filter
         uses: dorny/paths-filter@v4
@@ -195,6 +200,14 @@ jobs:
        needs.detect-changes.outputs.docs == 'true') &&
       !contains(needs.*.result, 'failure')
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Collect resource usage
+        uses: ./.github/actions/everr-action
+        with:
+          check-run-id: ${{ job.check_run_id }}
+
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@v3

--- a/.github/workflows/deploy-desktop-app.yml
+++ b/.github/workflows/deploy-desktop-app.yml
@@ -26,6 +26,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Collect resource usage
+        uses: ./.github/actions/everr-action
+        with:
+          check-run-id: ${{ job.check_run_id }}
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 
@@ -225,6 +230,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Collect resource usage
+        uses: ./.github/actions/everr-action
+        with:
+          check-run-id: ${{ job.check_run_id }}
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
@@ -367,6 +377,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Collect resource usage
+        uses: ./.github/actions/everr-action
+        with:
+          check-run-id: ${{ job.check_run_id }}
+
       - name: Download desktop payload
         uses: actions/download-artifact@v4
         with:
@@ -403,24 +418,6 @@ jobs:
             cp "target/linux-cli-release/$asset" "target/desktop-release/$asset"
             cp "target/linux-cli-release/$asset.sha256" "target/desktop-release/$asset.sha256"
           done
-
-      - name: Stage action bundled CLI assets
-        if: false
-        run: |
-          set -euo pipefail
-
-          action_bin="target/action-bundled-cli"
-          rm -rf "$action_bin"
-          mkdir -p "$action_bin/darwin-arm64" "$action_bin/linux-arm64" "$action_bin/linux-x64"
-
-          cp target/desktop-release/everr "$action_bin/darwin-arm64/everr"
-          cp target/desktop-release/everr.sha256 "$action_bin/darwin-arm64/everr.sha256"
-          cp target/desktop-release/everr-linux-arm64 "$action_bin/linux-arm64/everr"
-          cp target/desktop-release/everr-linux-arm64.sha256 "$action_bin/linux-arm64/everr.sha256"
-          cp target/desktop-release/everr-linux-x86_64 "$action_bin/linux-x64/everr"
-          cp target/desktop-release/everr-linux-x86_64.sha256 "$action_bin/linux-x64/everr.sha256"
-
-          chmod +x "$action_bin/darwin-arm64/everr" "$action_bin/linux-arm64/everr" "$action_bin/linux-x64/everr"
 
       - name: Refresh release metadata and checksums
         run: |
@@ -504,59 +501,6 @@ jobs:
           retention-days: 14
           compression-level: 0
 
-      - name: Upload action bundled CLI artifact
-        if: false
-        uses: actions/upload-artifact@v4
-        with:
-          name: everr-action-bundled-cli-${{ steps.version.outputs.version }}
-          path: target/action-bundled-cli
-          if-no-files-found: error
-          retention-days: 14
-          compression-level: 0
-
-      - name: Generate GitHub App token for action repo
-        if: false
-        id: action-repo-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.EVERR_DEPLOY_BOT_APP_ID }}
-          private-key: ${{ secrets.EVERR_DEPLOY_BOT_PRIVATE_KEY }}
-          owner: everr-labs
-          repositories: everr-action
-
-      - name: Push bundled CLI assets to action repo
-        if: false
-        env:
-          GH_TOKEN: ${{ steps.action-repo-token.outputs.token }}
-          SRC_SHA: ${{ github.sha }}
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          set -euo pipefail
-
-          work="${RUNNER_TEMP}/everr-action-clone"
-          rm -rf "$work"
-          git clone --depth 1 --branch main \
-            "https://x-access-token:${GH_TOKEN}@github.com/everr-labs/everr-action.git" "$work"
-
-          cd "$work"
-          git config user.name "everr-action-bot"
-          git config user.email "everr-action-bot@users.noreply.github.com"
-
-          rm -rf bin
-          mkdir -p bin
-          cp -R "${GITHUB_WORKSPACE}/target/action-bundled-cli"/. bin/
-
-          git add -A bin
-          if git diff --cached --quiet; then
-            echo "No bundled CLI asset changes to publish."
-          else
-            git commit -m "Update bundled CLI ${VERSION} (from everr-labs/everr@${SRC_SHA})"
-            git push origin main || {
-              git pull --rebase origin main
-              git push origin main
-            }
-          fi
-
   notify-deploy:
     name: Notify Deploy Repo
     runs-on: blacksmith-2vcpu-ubuntu-2404
@@ -564,6 +508,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Collect resource usage
+        uses: ./.github/actions/everr-action
+        with:
+          check-run-id: ${{ job.check_run_id }}
 
       - name: Read desktop app version
         id: version

--- a/.github/workflows/release-action.yml
+++ b/.github/workflows/release-action.yml
@@ -23,6 +23,11 @@ jobs:
       - name: Checkout monorepo
         uses: actions/checkout@v4
 
+      - name: Collect resource usage
+        uses: ./.github/actions/everr-action
+        with:
+          check-run-id: ${{ job.check_run_id }}
+
       - name: Extract version from tag
         id: version
         run: |
@@ -77,6 +82,7 @@ jobs:
           cp -R "$action_root/dist" "$staging/dist"
           mkdir -p "$staging/scripts"
           cp "$action_root/scripts/sampler.sh" "$staging/scripts/sampler.sh"
+          cp "$action_root/scripts/sampler-macos.mjs" "$staging/scripts/sampler-macos.mjs"
           cp "$action_root/README.generated.md" "$staging/README.md"
           if [[ -f LICENSE ]]; then
             cp LICENSE "$staging/LICENSE"
@@ -112,19 +118,10 @@ jobs:
           git config user.name "everr-action-bot"
           git config user.email "everr-action-bot@users.noreply.github.com"
 
-          preserved_bin="${RUNNER_TEMP}/everr-action-preserved-bin"
-          rm -rf "$preserved_bin"
-          if [[ -d bin ]]; then
-            cp -R bin "$preserved_bin"
-          fi
-
           # Replace the mirror contents with the staged tree.
           git rm -rf . >/dev/null 2>&1 || true
           rm -rf -- *
           cp -R "$STAGING"/. .
-          if [[ -d "$preserved_bin" ]]; then
-            cp -R "$preserved_bin" bin
-          fi
 
           git add -A
           if git diff --cached --quiet; then

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -34,6 +34,11 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
+      - name: Collect resource usage
+        uses: ./.github/actions/everr-action
+        with:
+          check-run-id: ${{ job.check_run_id }}
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 


### PR DESCRIPTION
## Summary

### Part 1 — Download CLI from everr.dev
- Replace bundled CLI binary with download from `https://everr.dev/everr-app/{binary}` plus SHA-256 checksum verification, avoiding the 100 MB commit limit.
- Remove all disabled bundled-CLI staging/push steps from release pipelines.
- Clean up `bin/` preservation logic in `release-action.yml`.

### Part 2 — macOS resource tracking
- Add `sampler-macos.mjs` — a Node.js-based sampler using `os.cpus()`, `os.totalmem()`/`os.freemem()`, `df -Pk`, `mount`, and `netstat -ibn` for macOS runners.
- Make `resolveWorkspaceFilesystemInfo` platform-aware (`df -PkT` on Linux, `df -Pk` + `mount` on macOS).
- Remove Linux-only guards from both `startResourceUsage` and `finalizeAndUploadResourceUsage`.

### Part 3 — Everr action coverage
- Add `Collect resource usage` step to 11 jobs across 4 workflows that were missing it: `build-and-push-images`, `release-action`, `deploy-desktop-app`, `release-pr`.