### PR TITLE
feat: show org name in user selector and update sidebar tagline

### DIFF
--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -26,7 +26,9 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
               </div>
               <div className="grid flex-1 text-left text-sm leading-tight">
                 <span className="truncate font-semibold">Everr</span>
-                <span className="truncate text-xs">CI/CD Observability</span>
+                <span className="truncate text-xs">
+                  Observability made simple
+                </span>
               </div>
             </SidebarMenuButton>
           </SidebarMenuItem>

--- a/packages/app/src/components/nav-user.tsx
+++ b/packages/app/src/components/nav-user.tsx
@@ -90,7 +90,9 @@ export function NavUser() {
             </div>
             <div className="grid flex-1 text-left text-sm leading-tight">
               <span className="truncate font-medium">{fullName}</span>
-              <span className="truncate text-xs">{user.email}</span>
+              <span className="truncate text-xs">
+                {activeOrg?.name ?? user.email}
+              </span>
             </div>
             <ChevronsUpDown className="ml-auto size-4" />
           </DropdownMenuTrigger>
@@ -106,7 +108,9 @@ export function NavUser() {
               </div>
               <div className="grid flex-1 text-left text-sm leading-tight">
                 <span className="truncate font-medium">{fullName}</span>
-                <span className="truncate text-xs">{user.email}</span>
+                <span className="truncate text-xs">
+                  {activeOrg?.name ?? user.email}
+                </span>
               </div>
             </div>
             <DropdownMenuSeparator />

--- a/packages/app/src/components/nav-user.tsx
+++ b/packages/app/src/components/nav-user.tsx
@@ -90,9 +90,7 @@ export function NavUser() {
             </div>
             <div className="grid flex-1 text-left text-sm leading-tight">
               <span className="truncate font-medium">{fullName}</span>
-              <span className="truncate text-xs">
-                {activeOrg?.name ?? user.email}
-              </span>
+              <span className="truncate text-xs">{activeOrg?.name ?? " "}</span>
             </div>
             <ChevronsUpDown className="ml-auto size-4" />
           </DropdownMenuTrigger>
@@ -109,7 +107,7 @@ export function NavUser() {
               <div className="grid flex-1 text-left text-sm leading-tight">
                 <span className="truncate font-medium">{fullName}</span>
                 <span className="truncate text-xs">
-                  {activeOrg?.name ?? user.email}
+                  {activeOrg?.name ?? " "}
                 </span>
               </div>
             </div>

--- a/packages/app/src/components/nav-user.tsx
+++ b/packages/app/src/components/nav-user.tsx
@@ -117,7 +117,7 @@ export function NavUser() {
                 <DropdownMenuSub>
                   <DropdownMenuSubTrigger>
                     <Building2 />
-                    {activeOrg?.name ?? "Switch organization"}
+                    Switch organization
                   </DropdownMenuSubTrigger>
                   <DropdownMenuSubContent>
                     {orgs.map((org) => (

--- a/packages/app/src/lib/auto-org.test.ts
+++ b/packages/app/src/lib/auto-org.test.ts
@@ -4,15 +4,15 @@ import { deriveOrgName } from "./auto-org";
 describe("deriveOrgName", () => {
   it("uses the first name from user name", () => {
     expect(deriveOrgName("Jane Doe", "jane@example.com")).toBe(
-      "Jane's workspace",
+      "Jane's organization",
     );
   });
 
   it("falls back to email local part when name is empty", () => {
-    expect(deriveOrgName("", "bob@example.com")).toBe("bob's workspace");
+    expect(deriveOrgName("", "bob@example.com")).toBe("bob's organization");
   });
 
   it("falls back to email local part when name is whitespace", () => {
-    expect(deriveOrgName("  ", "bob@example.com")).toBe("bob's workspace");
+    expect(deriveOrgName("  ", "bob@example.com")).toBe("bob's organization");
   });
 });

--- a/packages/app/src/lib/auto-org.ts
+++ b/packages/app/src/lib/auto-org.ts
@@ -1,6 +1,6 @@
 export function deriveOrgName(name: string, email: string): string {
   const firstName = name?.split(" ")[0]?.trim() || email.split("@")[0];
-  return `${firstName}'s workspace`;
+  return `${firstName}'s organization`;
 }
 
 export function generateOrgSlug(): string {


### PR DESCRIPTION
## Summary

- Replace the hardcoded "CI/CD Observability" subtitle on the top-left Everr logo with the static tagline "Observability made simple".
- Replace the user email under the user name in the sidebar user selector with the active organization's name (falls back to the email when no active org is loaded).

## Files

- `packages/app/src/components/app-sidebar.tsx` — logo subtitle tagline.
- `packages/app/src/components/nav-user.tsx` — user selector subtitle now shows `activeOrg?.name ?? user.email`.