### PR TITLE
fix(sql-api): stop leaking schema via ClickHouse error messages

### DIFF
--- a/packages/app/src/routes/api/cli/sql.test.ts
+++ b/packages/app/src/routes/api/cli/sql.test.ts
@@ -1,3 +1,4 @@
+import { ClickHouseError } from "@clickhouse/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/clickhouse", () => ({
@@ -105,6 +106,83 @@ describe("/api/cli/sql", () => {
     expect(response.status).toBe(400);
     expect(await response.json()).toEqual({
       error: "Syntax error near nope",
+    });
+  });
+
+  const SCHEMA_PROBE_MESSAGE =
+    "Query references a table that doesn't exist or isn't available to you. " +
+    "Readable tables: traces, logs, metrics_gauge, metrics_sum, " +
+    "metrics_histogram, metrics_exponential_histogram, metrics_summary.";
+
+  async function postSql(body: string) {
+    return getHandler()({
+      request: new Request("http://localhost/api/cli/sql", {
+        method: "POST",
+        body,
+        headers: { "content-type": "text/plain" },
+      }),
+      context,
+    });
+  }
+
+  it.each([
+    [
+      "ACCESS_DENIED",
+      "497",
+      "sql_api_org_PKeXt: Not enough privileges. To execute this query, it's " +
+        "necessary to have the grant SELECT(tenant_id, traces_days, logs_days, " +
+        "metrics_days) ON app.tenant_retention. ",
+    ],
+    [
+      "UNKNOWN_TABLE",
+      "60",
+      "Unknown table expression identifier 'app.tenant_retention' in scope " +
+        "SELECT * FROM app.tenant_retention",
+    ],
+    ["UNKNOWN_DATABASE", "81", "Database secret_db does not exist."],
+  ])("collapses %s into a uniform message that leaks no schema", async (type, code, rawMessage) => {
+    mockedQuerySqlApi.mockRejectedValue(
+      new ClickHouseError({ message: rawMessage, code, type }),
+    );
+
+    const response = await postSql("SELECT * FROM app.tenant_retention");
+    const body = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe(SCHEMA_PROBE_MESSAGE);
+    // The raw error must not reach the client: no table/column names, no
+    // per-org ClickHouse username, no "exists vs not" distinction.
+    expect(body.error).not.toContain("tenant_retention");
+    expect(body.error).not.toContain("traces_days");
+    expect(body.error).not.toContain("sql_api_org_");
+  });
+
+  it("matches schema-probe errors even when the type is unparsed", async () => {
+    mockedQuerySqlApi.mockRejectedValue(
+      new ClickHouseError({
+        message: "Not enough privileges ... ON app.tenant_retention.",
+        code: "497",
+        type: undefined,
+      }),
+    );
+
+    const response = await postSql("SELECT * FROM app.tenant_retention");
+    expect(await response.json()).toEqual({ error: SCHEMA_PROBE_MESSAGE });
+  });
+
+  it("passes through non-schema ClickHouse errors so callers can self-correct", async () => {
+    mockedQuerySqlApi.mockRejectedValue(
+      new ClickHouseError({
+        message: "Unknown identifier 'srvice_name' in scope SELECT srvice_name",
+        code: "47",
+        type: "UNKNOWN_IDENTIFIER",
+      }),
+    );
+
+    const response = await postSql("SELECT srvice_name FROM traces");
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "Unknown identifier 'srvice_name' in scope SELECT srvice_name",
     });
   });
 });

--- a/packages/app/src/routes/api/cli/sql.ts
+++ b/packages/app/src/routes/api/cli/sql.ts
@@ -1,3 +1,4 @@
+import { ClickHouseError } from "@clickhouse/client";
 import { createFileRoute } from "@tanstack/react-router";
 import { querySqlApi } from "@/lib/clickhouse";
 
@@ -7,6 +8,45 @@ function toNdjson(rows: Array<Record<string, unknown>>): string {
   }
 
   return `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`;
+}
+
+// ClickHouse spells out the exact table and column names in its access-denied
+// errors ("necessary to have the grant SELECT(col1, col2) ON db.table"), and
+// returns a *distinct* error for "exists but you can't read it" (ACCESS_DENIED)
+// vs "doesn't exist" (UNKNOWN_TABLE/UNKNOWN_DATABASE). Forwarding those verbatim
+// turns the /sql endpoint into a schema-enumeration oracle: a caller can probe
+// table names, learn which exist, and read off the columns of internal,
+// non-granted tables (plus the per-org CH username, which prefixes the message).
+// Collapse every schema-probing error into one uniform message so the response
+// reveals nothing beyond the tables the caller is already allowed to read.
+//
+// Match on both error type and numeric code for robustness (`type` can be
+// undefined on errors the client couldn't fully parse).
+const SCHEMA_PROBE_ERROR_TYPES = new Set([
+  "ACCESS_DENIED",
+  "UNKNOWN_TABLE",
+  "UNKNOWN_DATABASE",
+]);
+const SCHEMA_PROBE_ERROR_CODES = new Set(["497", "60", "81"]);
+
+// Naming the readable tables is safe — they are the caller's own tenant-scoped
+// tables by design. Keep in sync with SQL_API_TENANT_TABLES in @/lib/clickhouse.
+const SCHEMA_PROBE_MESSAGE =
+  "Query references a table that doesn't exist or isn't available to you. " +
+  "Readable tables: traces, logs, metrics_gauge, metrics_sum, " +
+  "metrics_histogram, metrics_exponential_histogram, metrics_summary.";
+
+function sanitizeSqlApiError(error: unknown): string {
+  if (
+    error instanceof ClickHouseError &&
+    (SCHEMA_PROBE_ERROR_TYPES.has(error.type ?? "") ||
+      SCHEMA_PROBE_ERROR_CODES.has(error.code))
+  ) {
+    return SCHEMA_PROBE_MESSAGE;
+  }
+  return error instanceof Error
+    ? error.message
+    : "Failed to execute SQL query.";
 }
 
 export const Route = createFileRoute("/api/cli/sql")({
@@ -35,12 +75,7 @@ export const Route = createFileRoute("/api/cli/sql")({
           });
         } catch (error) {
           return Response.json(
-            {
-              error:
-                error instanceof Error
-                  ? error.message
-                  : "Failed to execute SQL query.",
-            },
+            { error: sanitizeSqlApiError(error) },
             { status: 400 },
           );
         }


### PR DESCRIPTION
## Problem

The `/api/cli/sql` handler (`everr cloud query`) forwarded ClickHouse's raw error message straight back to the caller. For a denied or unknown table, that message is a schema-enumeration oracle:

- **Leaks table + column names** — `Not enough privileges. ... necessary to have the grant SELECT(tenant_id, traces_days, logs_days, metrics_days) ON app.tenant_retention`
- **Leaks the per-org ClickHouse username** — the message is prefixed with `sql_api_org_<id>:`
- **Distinguishes "exists but denied" from "doesn't exist"** — `ACCESS_DENIED` (497) vs `UNKNOWN_TABLE` (60) / `UNKNOWN_DATABASE` (81)

So any authenticated org can probe table names, confirm which exist, and read off the columns of internal, non-granted tables. Row data stays protected by grants + RLS — this is schema/metadata disclosure, not a data breach — but it shouldn't be exposed.

Verified locally against ClickHouse 26: the column leak is inherent to ClickHouse's `ACCESS_DENIED` and cannot be closed with grants or by moving tables to a separate database (`SHOW TABLES`/`SHOW DATABASES` are correctly access-filtered; only direct references leak). The fix has to be at the app layer.

## Fix

`sanitizeSqlApiError` collapses the three schema-probing error classes (`ACCESS_DENIED`, `UNKNOWN_TABLE`, `UNKNOWN_DATABASE`) into one uniform message that names only the caller's own readable tables. Every other error (syntax, type, unknown-identifier) passes through unchanged so callers/LLMs can still self-correct. Matches on both error `type` and numeric `code` for robustness when the client can't fully parse the type.

## Tests

10 passing, including a parametrized case proving all three error types produce an identical response with no table/column names and no `sql_api_org_` prefix, an unparsed-`type` (code-only) case, and a pass-through case for non-schema errors.

`vitest` 10/10 · `tsc --noEmit` clean · `biome check` clean

## Note

The readable-tables list in the message is hardcoded with a comment pointing to `SQL_API_TENANT_TABLES` in `@/lib/clickhouse`. Kept the change contained to the route rather than exporting that constant from the security-sensitive `clickhouse.ts`; happy to wire it up if reviewers prefer no drift risk.