### PR TITLE
Desktop: shared Explore topbar with Service/Environment filters

### DIFF
--- a/.changeset/desktop-explore-topbar.md
+++ b/.changeset/desktop-explore-topbar.md
@@ -1,0 +1,5 @@
+---
+"@everr/desktop-app": minor
+---
+
+Add a shared Explore topbar to the desktop app: Service and Environment filters move out of each page's sidebar into a toolbar above Logs, Errors, and Traces, and persist as you navigate between the three pages.

--- a/packages/desktop-app/src/features/errors/errors-page.tsx
+++ b/packages/desktop-app/src/features/errors/errors-page.tsx
@@ -15,13 +15,8 @@ import {
   TracesRepository,
 } from "@everr/telemetry-explorer/traces";
 import { buttonVariants } from "@everr/ui/components/button";
-import {
-  getRefreshIntervalMs,
-  RefreshPicker,
-} from "@everr/ui/components/refresh-picker";
-import { TimeRangePicker } from "@everr/ui/components/time-range-picker";
-import { type TimeRange, withTimeRange } from "@everr/ui/lib/time-range";
-import { useIsFetching, useQuery, useQueryClient } from "@tanstack/react-query";
+import { withTimeRange } from "@everr/ui/lib/time-range";
+import { useQuery } from "@tanstack/react-query";
 import {
   Link,
   Outlet,
@@ -30,15 +25,21 @@ import {
   useParams,
   useSearch,
 } from "@tanstack/react-router";
-import { type ReactNode, useEffect, useMemo, useRef } from "react";
 import {
   DetailRouteDialog,
   useDetailRouteDialogClose,
 } from "@/components/detail-route-dialog";
+import { ExploreSearchShape } from "../explore/explore-search";
+import { ExploreShell } from "../explore/explore-shell";
 import { LocalTelemetryGate } from "../local-telemetry/collector-status";
 import { localSqlClient } from "../logs/local-sql-client";
 
 export { ErrorIssueSearchSchema };
+
+// service/environment live in the shared Explore topbar but must also be in the
+// route schema so the leaf route's validateSearch doesn't strip them.
+export const ErrorsListSearchSchema =
+  ErrorIssueSearchSchema.extend(ExploreSearchShape);
 
 const localErrorsRepo = new ErrorsRepository(localSqlClient);
 const localTracesRepo = new TracesRepository(localSqlClient);
@@ -72,16 +73,21 @@ export function ErrorsPage() {
 }
 
 function ErrorsListView() {
-  const search = useSearch({ strict: false }) as ErrorIssueSearch;
+  const search = useSearch({ strict: false }) as ErrorIssueSearch & {
+    environment?: string[];
+  };
   const navigate = useNavigate();
   const { timeRange, q, service, fingerprint, sort, refresh, attributes } =
     withTimeRange(search);
+  const environment = search.environment ?? [];
 
   return (
-    <ErrorsPageShell
+    <ExploreShell
       title="Errors"
       timeRange={timeRange}
       refresh={refresh ?? ""}
+      service={service}
+      environment={environment}
       onTimeRangeChange={(range) =>
         navigate({
           to: "/errors",
@@ -96,6 +102,20 @@ function ErrorsListView() {
           replace: true,
         })
       }
+      onServiceChange={(values) =>
+        navigate({
+          to: "/errors",
+          search: { ...search, service: values },
+          replace: true,
+        })
+      }
+      onEnvironmentChange={(values) =>
+        navigate({
+          to: "/errors",
+          search: { ...search, environment: values },
+          replace: true,
+        })
+      }
     >
       <LocalTelemetryGate>
         <ErrorIssues
@@ -103,6 +123,8 @@ function ErrorsListView() {
           timeRange={timeRange}
           refresh={refresh ?? ""}
           search={{ q, service, fingerprint, sort, attributes }}
+          environment={environment}
+          hideSharedFilters
           onSearchChange={(patch) =>
             navigate({
               to: "/errors",
@@ -122,7 +144,7 @@ function ErrorsListView() {
           )}
         />
       </LocalTelemetryGate>
-    </ErrorsPageShell>
+    </ExploreShell>
   );
 }
 
@@ -233,72 +255,5 @@ function DesktopErrorTracePanel({
         </Link>
       )}
     />
-  );
-}
-
-function ErrorsPageShell({
-  title,
-  timeRange,
-  refresh,
-  onTimeRangeChange,
-  onRefreshChange,
-  children,
-}: {
-  title: string;
-  timeRange: TimeRange;
-  refresh: string;
-  onTimeRangeChange: (range: TimeRange) => void;
-  onRefreshChange: (value: string) => void;
-  children: ReactNode;
-}) {
-  const queryClient = useQueryClient();
-  const isFetching = useIsFetching() > 0;
-  const refreshMs = useMemo(
-    () => (refresh ? getRefreshIntervalMs(refresh) : null),
-    [refresh],
-  );
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  useEffect(() => {
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = null;
-    }
-    if (refreshMs) {
-      intervalRef.current = setInterval(
-        () => void queryClient.invalidateQueries(),
-        refreshMs,
-      );
-    }
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, [refreshMs, queryClient]);
-
-  return (
-    <div className="flex h-full flex-col overflow-hidden">
-      <header className="relative z-10 flex h-12 shrink-0 items-center justify-between border-b border-white/[0.06] px-3">
-        <div
-          data-tauri-drag-region
-          className="flex flex-1 items-center self-stretch pl-[var(--titlebar-inset)]"
-        >
-          <span className="text-sm font-medium text-[var(--settings-text)]">
-            {title}
-          </span>
-        </div>
-        <div className="flex items-center gap-1.5">
-          <TimeRangePicker value={timeRange} onChange={onTimeRangeChange} />
-          <RefreshPicker
-            value={refresh}
-            onChange={onRefreshChange}
-            onRefresh={() => void queryClient.invalidateQueries()}
-            isFetching={isFetching}
-          />
-        </div>
-      </header>
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        {children}
-      </div>
-    </div>
   );
 }

--- a/packages/desktop-app/src/features/explore/explore-search.ts
+++ b/packages/desktop-app/src/features/explore/explore-search.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+// Shared shape for the Explore section's cross-page filters (Service +
+// Environment). Spread into the `authenticated` layout (where the sidebar lives
+// and `retainSearchParams` runs) AND every explore page schema so a page's
+// validateSearch never strips them on arrival.
+//
+// Declared WITHOUT `.default([])` on purpose — the default is the difference
+// between a filter you can clear and one you can't:
+//
+//   - `retainSearchParams` only refills keys ABSENT from the destination search.
+//     With a default, every destination already carries `[]`, so retain can
+//     never fire and cross-page persistence silently breaks.
+//   - With the key optional, an unset filter is genuinely absent — retain copies
+//     the live value across navigation — while an explicit clear (`service: []`)
+//     stays present so `stripSearchParams` can drop it as a default, yielding a
+//     clean URL that reflects the cleared state.
+//
+// `.optional().catch(undefined)` leaves the key absent when unset and tolerates
+// malformed URLs. Read sites coalesce to `[]` (e.g. `service ?? []`).
+export const ExploreSearchShape = {
+  service: z.array(z.string()).optional().catch(undefined),
+  environment: z.array(z.string()).optional().catch(undefined),
+} as const;
+
+export const ExploreSearchSchema = z.object(ExploreSearchShape);

--- a/packages/desktop-app/src/features/explore/explore-shell.tsx
+++ b/packages/desktop-app/src/features/explore/explore-shell.tsx
@@ -1,0 +1,112 @@
+import { ExploreGlobalFilters } from "@everr/telemetry-explorer/filters";
+import { LogsRepository } from "@everr/telemetry-explorer/logs";
+import { TracesRepository } from "@everr/telemetry-explorer/traces";
+import {
+  getRefreshIntervalMs,
+  RefreshPicker,
+} from "@everr/ui/components/refresh-picker";
+import { TimeRangePicker } from "@everr/ui/components/time-range-picker";
+import type { TimeRange } from "@everr/ui/lib/time-range";
+import { useIsFetching, useQueryClient } from "@tanstack/react-query";
+import { type ReactNode, useEffect, useMemo, useRef } from "react";
+import { localSqlClient } from "../logs/local-sql-client";
+
+// The Explore topbar's Service/Environment option lists are the UNION across
+// logs + traces, so they stay identical on every Explore page. These repos exist
+// only to feed those option dropdowns; the pages keep their own repos for data.
+const filterLogsRepo = new LogsRepository(localSqlClient);
+const filterTracesRepo = new TracesRepository(localSqlClient);
+
+// Shared header for the Explore pages (Logs / Errors / Traces). Renders the page
+// title plus the global Service + Environment filters on the left, and the time
+// range + refresh controls on the right. Service/Environment are cross-page
+// search params that persist as you navigate between the three pages.
+export function ExploreShell({
+  title,
+  timeRange,
+  refresh,
+  service,
+  environment,
+  onTimeRangeChange,
+  onRefreshChange,
+  onServiceChange,
+  onEnvironmentChange,
+  children,
+}: {
+  title: string;
+  timeRange: TimeRange;
+  refresh: string;
+  service: string[];
+  environment: string[];
+  onTimeRangeChange: (range: TimeRange) => void;
+  onRefreshChange: (value: string) => void;
+  onServiceChange: (values: string[]) => void;
+  onEnvironmentChange: (values: string[]) => void;
+  children: ReactNode;
+}) {
+  const queryClient = useQueryClient();
+  const isFetching = useIsFetching() > 0;
+  const refreshMs = useMemo(
+    () => (refresh ? getRefreshIntervalMs(refresh) : null),
+    [refresh],
+  );
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    if (refreshMs) {
+      intervalRef.current = setInterval(
+        () => void queryClient.invalidateQueries(),
+        refreshMs,
+      );
+    }
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [refreshMs, queryClient]);
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <header className="relative z-10 flex h-12 shrink-0 items-center justify-between border-b border-white/[0.06] px-3">
+        {/* flex-1 so the empty space stays a window drag handle (Tauri). */}
+        <div
+          data-tauri-drag-region
+          className="flex flex-1 items-center self-stretch pl-[var(--titlebar-inset)]"
+        >
+          <span className="text-sm font-medium text-[var(--settings-text)]">
+            {title}
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <TimeRangePicker value={timeRange} onChange={onTimeRangeChange} />
+          <RefreshPicker
+            value={refresh}
+            onChange={onRefreshChange}
+            onRefresh={() => void queryClient.invalidateQueries()}
+            isFetching={isFetching}
+          />
+        </div>
+      </header>
+      {/* Service/Environment get their own toolbar so the header keeps its full
+          drag region. The trailing filler stays draggable too. */}
+      <div className="relative z-10 flex h-11 shrink-0 items-center gap-2 border-b border-white/[0.06] px-3">
+        <ExploreGlobalFilters
+          logsRepo={filterLogsRepo}
+          tracesRepo={filterTracesRepo}
+          timeRange={timeRange}
+          service={service}
+          environment={environment}
+          onServiceChange={onServiceChange}
+          onEnvironmentChange={onEnvironmentChange}
+        />
+        <div data-tauri-drag-region className="h-full flex-1" />
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/packages/desktop-app/src/features/logs/logs-page.tsx
+++ b/packages/desktop-app/src/features/logs/logs-page.tsx
@@ -4,41 +4,42 @@ import {
   LogsRepository,
   LogsSearchFiltersShape,
 } from "@everr/telemetry-explorer/logs";
-import {
-  getRefreshIntervalMs,
-  RefreshPicker,
-} from "@everr/ui/components/refresh-picker";
-import {
-  type TimeRange,
-  TimeRangePicker,
-} from "@everr/ui/components/time-range-picker";
+import type { TimeRange } from "@everr/ui/components/time-range-picker";
 import { DEFAULT_TIME_RANGE } from "@everr/ui/lib/time-range";
-import { useIsFetching, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useSearch } from "@tanstack/react-router";
-import { useEffect, useMemo, useRef } from "react";
+import { useMemo } from "react";
 import { z } from "zod";
+import { ExploreSearchShape } from "../explore/explore-search";
+import { ExploreShell } from "../explore/explore-shell";
 import { LocalTelemetryGate } from "../local-telemetry/collector-status";
 import { localSqlClient } from "./local-sql-client";
 
-export const LogsSearchSchema = z.object({
-  from: z.string().optional(),
-  to: z.string().optional(),
-  refresh: z.string().optional(),
-  q: z.string().optional(),
-  ...LogsSearchFiltersShape,
-  traceId: z.string().optional(),
-  showVolume: z.boolean().default(true),
-});
+// `services` lives in the shared topbar now (as the cross-page `service` param),
+// so it is omitted from the per-page schema and the sidebar service control is
+// hidden via `hideSharedFilters`.
+export const LogsSearchSchema = z
+  .object({
+    from: z.string().optional(),
+    to: z.string().optional(),
+    refresh: z.string().optional(),
+    q: z.string().optional(),
+    ...LogsSearchFiltersShape,
+    ...ExploreSearchShape,
+    traceId: z.string().optional(),
+    showVolume: z.boolean().default(true),
+  })
+  .omit({ services: true });
 
 type LogsSearch = z.infer<typeof LogsSearchSchema>;
 
 export function LogsPage() {
   const search = useSearch({ strict: false }) as LogsSearch;
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
-  const isFetching = useIsFetching() > 0;
 
   const repo = useMemo(() => new LogsRepository(localSqlClient), []);
+
+  const service = search.service ?? [];
+  const environment = search.environment ?? [];
 
   const timeRange: TimeRange = {
     from: search.from ?? DEFAULT_TIME_RANGE.from,
@@ -48,92 +49,75 @@ export function LogsPage() {
   const explorerSearch: LogsExplorerSearch = {
     q: search.q,
     levels: search.levels,
-    services: search.services,
+    services: service,
     attributes: search.attributes,
     traceId: search.traceId,
     showVolume: search.showVolume,
   };
 
-  const setTimeRange = (range: TimeRange) =>
-    navigate({
-      to: "/logs",
-      search: (prev) => ({ ...prev, from: range.from, to: range.to }),
-      replace: true,
-    });
-
-  const setRefreshInterval = (value: string) =>
-    navigate({
-      to: "/logs",
-      search: (prev) => ({ ...prev, refresh: value || undefined }),
-      replace: true,
-    });
-
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  useEffect(() => {
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = null;
-    }
-    const ms = search.refresh ? getRefreshIntervalMs(search.refresh) : null;
-    if (ms) {
-      intervalRef.current = setInterval(
-        () => void queryClient.invalidateQueries(),
-        ms,
-      );
-    }
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, [search.refresh, queryClient]);
-
   return (
-    <div className="flex h-full flex-col overflow-hidden">
-      <header className="relative z-10 flex h-12 shrink-0 items-center justify-between border-b border-white/[0.06] px-3">
-        <div
-          data-tauri-drag-region
-          className="flex flex-1 items-center self-stretch pl-[var(--titlebar-inset)]"
-        >
-          <span className="text-sm font-medium text-[var(--settings-text)]">
-            Logs
-          </span>
-        </div>
-        <div className="flex items-center gap-1.5">
-          <TimeRangePicker value={timeRange} onChange={setTimeRange} />
-          <RefreshPicker
-            value={search.refresh ?? ""}
-            onChange={setRefreshInterval}
-            onRefresh={() => void queryClient.invalidateQueries()}
-            isFetching={isFetching}
-          />
-        </div>
-      </header>
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        <LocalTelemetryGate>
-          <LogsExplorer
-            repo={repo}
-            timeRange={timeRange}
-            search={explorerSearch}
-            onSearchChange={(next) =>
-              navigate({
-                to: "/logs",
-                search: (prev) => ({ ...prev, ...next }),
-                replace: true,
-              })
-            }
-            onTimeRangeSelect={(from, to) =>
-              navigate({
-                to: "/logs",
-                search: (prev) => ({
-                  ...prev,
-                  from: from.toISOString(),
-                  to: to.toISOString(),
-                }),
-                replace: true,
-              })
-            }
-          />
-        </LocalTelemetryGate>
-      </div>
-    </div>
+    <ExploreShell
+      title="Logs"
+      timeRange={timeRange}
+      refresh={search.refresh ?? ""}
+      service={service}
+      environment={environment}
+      onTimeRangeChange={(range) =>
+        navigate({
+          to: "/logs",
+          search: (prev) => ({ ...prev, from: range.from, to: range.to }),
+          replace: true,
+        })
+      }
+      onRefreshChange={(value) =>
+        navigate({
+          to: "/logs",
+          search: (prev) => ({ ...prev, refresh: value || undefined }),
+          replace: true,
+        })
+      }
+      onServiceChange={(values) =>
+        navigate({
+          to: "/logs",
+          search: (prev) => ({ ...prev, service: values }),
+          replace: true,
+        })
+      }
+      onEnvironmentChange={(values) =>
+        navigate({
+          to: "/logs",
+          search: (prev) => ({ ...prev, environment: values }),
+          replace: true,
+        })
+      }
+    >
+      <LocalTelemetryGate>
+        <LogsExplorer
+          repo={repo}
+          timeRange={timeRange}
+          search={explorerSearch}
+          environment={environment}
+          hideSharedFilters
+          onSearchChange={({ services: _ignored, ...next }) =>
+            navigate({
+              to: "/logs",
+              search: (prev) => ({ ...prev, ...next }),
+              replace: true,
+            })
+          }
+          onTimeRangeSelect={(from, to) =>
+            navigate({
+              to: "/logs",
+              search: (prev) => ({
+                ...prev,
+                from: from.toISOString(),
+                to: to.toISOString(),
+              }),
+              replace: true,
+            })
+          }
+        />
+      </LocalTelemetryGate>
+    </ExploreShell>
   );
 }

--- a/packages/desktop-app/src/features/traces/traces-page.test.tsx
+++ b/packages/desktop-app/src/features/traces/traces-page.test.tsx
@@ -12,8 +12,8 @@ import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import {
   TraceDetailPage,
-  TraceDetailParamsSchema,
-  TraceSearchParamsSchema,
+  TraceDetailSearchSchema,
+  TracesListSearchSchema,
   TracesPage,
 } from "./traces-page";
 
@@ -64,13 +64,13 @@ describe("desktop traces routes", () => {
     const tracesRoute = createRoute({
       getParentRoute: () => authenticatedRoute,
       path: "/traces",
-      validateSearch: TraceSearchParamsSchema,
+      validateSearch: TracesListSearchSchema,
       component: TracesPage,
     });
     const traceDetailRoute = createRoute({
       getParentRoute: () => tracesRoute,
       path: "$traceId",
-      validateSearch: TraceDetailParamsSchema,
+      validateSearch: TraceDetailSearchSchema,
       component: TraceDetailPage,
     });
     const routeTree = rootRoute.addChildren([

--- a/packages/desktop-app/src/features/traces/traces-page.tsx
+++ b/packages/desktop-app/src/features/traces/traces-page.tsx
@@ -8,13 +8,7 @@ import {
   TracesSearch,
   toTraceListSearch,
 } from "@everr/telemetry-explorer/traces";
-import {
-  getRefreshIntervalMs,
-  RefreshPicker,
-} from "@everr/ui/components/refresh-picker";
-import { TimeRangePicker } from "@everr/ui/components/time-range-picker";
-import { type TimeRange, withTimeRange } from "@everr/ui/lib/time-range";
-import { useIsFetching, useQueryClient } from "@tanstack/react-query";
+import { withTimeRange } from "@everr/ui/lib/time-range";
 import {
   Link,
   Outlet,
@@ -23,15 +17,21 @@ import {
   useParams,
   useSearch,
 } from "@tanstack/react-router";
-import { type ReactNode, useEffect, useMemo, useRef } from "react";
 import {
   DetailRouteDialog,
   useDetailRouteDialogClose,
 } from "@/components/detail-route-dialog";
+import { ExploreSearchShape } from "../explore/explore-search";
+import { ExploreShell } from "../explore/explore-shell";
 import { LocalTelemetryGate } from "../local-telemetry/collector-status";
 import { localSqlClient } from "../logs/local-sql-client";
 
-export { TraceDetailParamsSchema, TraceSearchParamsSchema };
+// service/environment live in the shared Explore topbar but must also be in the
+// route schemas so the leaf route's validateSearch doesn't strip them.
+export const TracesListSearchSchema =
+  TraceSearchParamsSchema.extend(ExploreSearchShape);
+export const TraceDetailSearchSchema =
+  TraceDetailParamsSchema.extend(ExploreSearchShape);
 
 const localTracesRepo = new TracesRepository(localSqlClient);
 
@@ -64,16 +64,23 @@ export function TracesPage() {
 }
 
 function TracesListView() {
-  const search = useSearch({ strict: false }) as TraceSearchParams;
+  const search = useSearch({ strict: false }) as TraceSearchParams & {
+    service?: string[];
+    environment?: string[];
+  };
   const navigate = useNavigate();
   const { timeRange } = withTimeRange(search);
   const refresh = search.refresh ?? "";
+  const service = search.service ?? [];
+  const environment = search.environment ?? [];
 
   return (
-    <TracePageShell
+    <ExploreShell
       title="Traces"
       timeRange={timeRange}
       refresh={refresh}
+      service={service}
+      environment={environment}
       onTimeRangeChange={(range) =>
         navigate({
           to: "/traces",
@@ -88,6 +95,20 @@ function TracesListView() {
           replace: true,
         })
       }
+      onServiceChange={(values) =>
+        navigate({
+          to: "/traces",
+          search: (prev) => ({ ...prev, service: values }),
+          replace: true,
+        })
+      }
+      onEnvironmentChange={(values) =>
+        navigate({
+          to: "/traces",
+          search: (prev) => ({ ...prev, environment: values }),
+          replace: true,
+        })
+      }
     >
       <LocalTelemetryGate>
         <TracesSearch
@@ -96,13 +117,15 @@ function TracesListView() {
           refresh={refresh}
           search={{
             namespace: search.namespace,
-            service: search.service,
+            service,
             name: search.name,
             minMs: search.minMs,
             maxMs: search.maxMs,
             status: search.status,
             attributes: search.attributes,
           }}
+          environment={environment}
+          hideSharedFilters
           onSearchChange={(patch) =>
             navigate({
               to: "/traces",
@@ -122,7 +145,7 @@ function TracesListView() {
           )}
         />
       </LocalTelemetryGate>
-    </TracePageShell>
+    </ExploreShell>
   );
 }
 
@@ -156,72 +179,5 @@ export function TraceDetailPage() {
         }
       />
     </LocalTelemetryGate>
-  );
-}
-
-function TracePageShell({
-  title,
-  timeRange,
-  refresh,
-  onTimeRangeChange,
-  onRefreshChange,
-  children,
-}: {
-  title: string;
-  timeRange: TimeRange;
-  refresh: string;
-  onTimeRangeChange: (range: TimeRange) => void;
-  onRefreshChange: (value: string) => void;
-  children: ReactNode;
-}) {
-  const queryClient = useQueryClient();
-  const isFetching = useIsFetching() > 0;
-  const refreshMs = useMemo(
-    () => (refresh ? getRefreshIntervalMs(refresh) : null),
-    [refresh],
-  );
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  useEffect(() => {
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = null;
-    }
-    if (refreshMs) {
-      intervalRef.current = setInterval(
-        () => void queryClient.invalidateQueries(),
-        refreshMs,
-      );
-    }
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, [refreshMs, queryClient]);
-
-  return (
-    <div className="flex h-full flex-col overflow-hidden">
-      <header className="relative z-10 flex h-12 shrink-0 items-center justify-between border-b border-white/[0.06] px-3">
-        <div
-          data-tauri-drag-region
-          className="flex flex-1 items-center self-stretch pl-[var(--titlebar-inset)]"
-        >
-          <span className="text-sm font-medium text-[var(--settings-text)]">
-            {title}
-          </span>
-        </div>
-        <div className="flex items-center gap-1.5">
-          <TimeRangePicker value={timeRange} onChange={onTimeRangeChange} />
-          <RefreshPicker
-            value={refresh}
-            onChange={onRefreshChange}
-            onRefresh={() => void queryClient.invalidateQueries()}
-            isFetching={isFetching}
-          />
-        </div>
-      </header>
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        {children}
-      </div>
-    </div>
   );
 }

--- a/packages/desktop-app/src/router.ts
+++ b/packages/desktop-app/src/router.ts
@@ -3,6 +3,8 @@ import {
   createRoute,
   createRouter,
   redirect,
+  retainSearchParams,
+  stripSearchParams,
 } from "@tanstack/react-router";
 import { AuthenticatedGuard } from "./features/desktop-shell/authenticated-guard";
 import { DesktopWindow } from "./features/desktop-shell/desktop-window";
@@ -10,16 +12,17 @@ import { SettingsPage } from "./features/desktop-shell/settings-page";
 import { DeveloperPage } from "./features/developer/developer-page";
 import {
   ErrorDetailPage,
-  ErrorIssueSearchSchema,
+  ErrorsListSearchSchema,
   ErrorsPage,
 } from "./features/errors/errors-page";
+import { ExploreSearchSchema } from "./features/explore/explore-search";
 import { LogsPage, LogsSearchSchema } from "./features/logs/logs-page";
 import { NotificationsPage } from "./features/notifications/notifications-page";
 import { OnboardingPage } from "./features/onboarding/onboarding-page";
 import {
   TraceDetailPage,
-  TraceDetailParamsSchema,
-  TraceSearchParamsSchema,
+  TraceDetailSearchSchema,
+  TracesListSearchSchema,
   TracesPage,
 } from "./features/traces/traces-page";
 
@@ -36,6 +39,20 @@ const onboardingRoute = createRoute({
 const authenticatedRoute = createRoute({
   getParentRoute: () => rootRoute,
   id: "authenticated",
+  // The Explore section's Service/Environment filters are retained HERE because
+  // the sidebar lives in this layout (AppShell): only a retain declared at this
+  // level engages on a sidebar click. strip-then-retain, paired with the
+  // default-free ExploreSearchShape, makes the filters both persistent AND
+  // clearable — a cleared `[]` is stripped to a clean URL, while an unset value
+  // arrives absent so retain copies the live selection forward. The explore page
+  // schemas include these keys so the destination route doesn't strip them.
+  validateSearch: ExploreSearchSchema,
+  search: {
+    middlewares: [
+      stripSearchParams({ service: [], environment: [] }),
+      retainSearchParams(["service", "environment"]),
+    ],
+  },
   component: AuthenticatedGuard,
 });
 
@@ -74,7 +91,7 @@ const logsRoute = createRoute({
 const tracesRoute = createRoute({
   getParentRoute: () => authenticatedRoute,
   path: "/traces",
-  validateSearch: TraceSearchParamsSchema,
+  validateSearch: TracesListSearchSchema,
   component: TracesPage,
 });
 
@@ -83,21 +100,21 @@ const tracesRoute = createRoute({
 const traceDetailRoute = createRoute({
   getParentRoute: () => tracesRoute,
   path: "$traceId",
-  validateSearch: TraceDetailParamsSchema,
+  validateSearch: TraceDetailSearchSchema,
   component: TraceDetailPage,
 });
 
 const errorsRoute = createRoute({
   getParentRoute: () => authenticatedRoute,
   path: "/errors",
-  validateSearch: ErrorIssueSearchSchema,
+  validateSearch: ErrorsListSearchSchema,
   component: ErrorsPage,
 });
 
 const errorDetailRoute = createRoute({
   getParentRoute: () => errorsRoute,
   path: "$fingerprint",
-  validateSearch: ErrorIssueSearchSchema,
+  validateSearch: ErrorsListSearchSchema,
   component: ErrorDetailPage,
 });
 

--- a/packages/telemetry-explorer/src/filters/ui/explore-filter-pill.tsx
+++ b/packages/telemetry-explorer/src/filters/ui/explore-filter-pill.tsx
@@ -148,7 +148,9 @@ export function ExploreFilterPill<TData>({
             <ChevronDownIcon className="text-muted-foreground size-3 shrink-0" />
           )}
         </TooltipTrigger>
-        <TooltipContent>
+        {/* Open downward: these pills sit in a topbar, so a top-side tooltip can
+            collide with window chrome above (e.g. the desktop traffic lights). */}
+        <TooltipContent side="bottom">
           {isActive
             ? `${label}: ${values.join(", ")}`
             : `Filter by ${label.toLowerCase()}`}


### PR DESCRIPTION
## Summary

Ports the unified **Explore topbar** from the web app (#229) to `@everr/desktop-app`. **Service** and **Environment** move out of each page's filter sidebar into a shared toolbar above **Logs / Errors / Traces**, and now **persist across navigation** between the three pages.

The shared UI primitives (`ExploreGlobalFilters`, the `environment` prop, `hideSharedFilters`, union option builders) already shipped in `@everr/telemetry-explorer` with #229 — this change is the desktop adoption + routing wiring (the desktop uses a code-based router rather than the web app's file-based one).

## What changed

- **`ExploreSearchShape`** — `service`/`environment` as **default-free** optional `string[]` (`.catch(undefined)`). The missing default is what lets `retainSearchParams` carry the live value across navigation while an explicit clear (`[]`) still strips to a clean URL.
- **`ExploreShell`** — a shared page header (title + time range/refresh) with a **dedicated filter toolbar** below it. Replaces the three near-identical per-page shells. The header keeps its full Tauri drag region; the toolbar adds a trailing draggable filler so empty space still drags the window.
- **Persistence** — `stripSearchParams` + `retainSearchParams(["service","environment"])` on the `authenticated` layout (where the sidebar lives), so sidebar clicks preserve the filters. The explore page schemas include the keys so destinations don't strip them on arrival.
- **Per-page wiring** — shared `service`/`environment` feed each explorer with `hideSharedFilters` (Service leaves the sidebars); the errors detail view reads the shared `service` too.
- **Tooltip direction** — the shared `ExploreFilterPill` tooltip now opens `side="bottom"` so it doesn't collide with window chrome above the topbar (the macOS traffic lights occluded the top-anchored tooltip on desktop). Sensible for the web app too, since the pills live in a topbar there as well.

## Verification

- `tsc --noEmit` clean (desktop has no `typecheck` script), `biome` clean.
- Desktop tests: 65/65 pass — the traces/errors route tests now mount `ExploreShell` + `ExploreGlobalFilters`, confirming the topbar renders.
- Not exercised live: the native Tauri shell (auth + local collector) isn't run in CI/tests; the persistence/clear logic mirrors the verified #229 pattern.