### PR TITLE
Fix desktop Errors page crash when no Service filter is selected

### DIFF
--- a/.changeset/desktop-errors-filter-crash.md
+++ b/.changeset/desktop-errors-filter-crash.md
@@ -1,0 +1,5 @@
+---
+"@everr/desktop-app": patch
+---
+
+Fix a crash when opening the Errors page in the desktop app with no Service filter selected (the shared Service/Environment filters read an undefined value).

--- a/packages/desktop-app/src/features/errors/errors-page.tsx
+++ b/packages/desktop-app/src/features/errors/errors-page.tsx
@@ -77,8 +77,18 @@ function ErrorsListView() {
     environment?: string[];
   };
   const navigate = useNavigate();
-  const { timeRange, q, service, fingerprint, sort, refresh, attributes } =
-    withTimeRange(search);
+  const {
+    timeRange,
+    q,
+    service: searchService,
+    fingerprint,
+    sort,
+    refresh,
+    attributes,
+  } = withTimeRange(search);
+  // `service`/`environment` are default-free in the schema (so retainSearchParams
+  // can persist them), so coalesce to [] before the filters read `.length`.
+  const service = searchService ?? [];
   const environment = search.environment ?? [];
 
   return (
@@ -166,7 +176,7 @@ export function ErrorDetailPage() {
         fingerprint={fingerprint}
         timeRange={timeRange}
         refresh={refresh ?? ""}
-        service={service}
+        service={service ?? []}
         occurrence={search.occurrence}
         onClose={() => {
           if (closeDialog) {


### PR DESCRIPTION
## Summary

Follow-up to the desktop Explore topbar (#232, merged). Opening the **Errors** page in the desktop app crashed with `undefined is not an object (evaluating 'values.length')` when no Service filter was selected.

## Root cause

The errors route schema extends `ExploreSearchShape`, which overrides `service` to be **optional and default-free** — that's required so `retainSearchParams` can persist the filter across navigation. As a result `search.service` is `undefined` when you land on `/errors` without a selection. The errors page passed it straight into the shared `ExploreFilterPill`, which reads `values.length` and threw. Logs and Traces already coalesced to `[]`; the errors list and detail views didn't.

## Fix

Coalesce `service` (and confirm `environment`) to `[]` on both the errors list and detail views, matching the logs/traces pages.

## Verification

- `tsc --noEmit` clean, `biome` clean, desktop tests 65/65 pass.