### PR TITLE
Suppress expected production telemetry noise

### DIFF
--- a/.changeset/quiet-production-telemetry.md
+++ b/.changeset/quiet-production-telemetry.md
@@ -1,0 +1,5 @@
+---
+"@everr/desktop-app": patch
+---
+
+Suppress expected production telemetry noise from auth/control-flow paths, SQL API query errors, stale GitHub installations, and desktop notifier reconnects.

--- a/packages/app/src/routes/_authenticated/_dashboard/alerts_.$alertId.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/alerts_.$alertId.tsx
@@ -109,8 +109,14 @@ export const Route = createFileRoute(
   head: () => ({ meta: [{ title: "Everr - Alert detail" }] }),
   loaderDeps: ({ search }) => withTimeRange(search),
   loader: async ({ context: { queryClient }, params, deps }) => {
-    const [detail] = await Promise.all([
-      queryClient.ensureQueryData(alertDetailQueryOptions(params.alertId)),
+    await queryClient.prefetchQuery(alertDetailQueryOptions(params.alertId));
+    const detail = queryClient.getQueryData(
+      alertDetailQueryOptions(params.alertId).queryKey,
+    );
+
+    if (!detail) return {};
+
+    await Promise.all([
       queryClient.prefetchQuery(
         alertInstancesQueryOptions(params.alertId, deps.timeRange),
       ),
@@ -119,6 +125,7 @@ export const Route = createFileRoute(
         alertEventsQueryOptions(params.alertId, deps.timeRange),
       ),
     ]);
+
     return { slug: detail.slug };
   },
   component: AlertDetailPage,
@@ -136,9 +143,19 @@ function AlertDetailPage() {
   const queryClient = useQueryClient();
   const { timeRange } = useTimeRange();
   const alert = useQuery(alertDetailQueryOptions(alertId));
-  const instances = useQuery(alertInstancesQueryOptions(alertId, timeRange));
-  const silences = useQuery(alertSilencesQueryOptions(alertId));
-  const events = useQuery(alertEventsQueryOptions(alertId, timeRange));
+  const hasAlert = Boolean(alert.data);
+  const instances = useQuery({
+    ...alertInstancesQueryOptions(alertId, timeRange),
+    enabled: hasAlert,
+  });
+  const silences = useQuery({
+    ...alertSilencesQueryOptions(alertId),
+    enabled: hasAlert,
+  });
+  const events = useQuery({
+    ...alertEventsQueryOptions(alertId, timeRange),
+    enabled: hasAlert,
+  });
   const [silenceTarget, setSilenceTarget] = useState<SilenceTarget | null>(
     null,
   );

--- a/packages/app/src/server/github-events/tasks.test.ts
+++ b/packages/app/src/server/github-events/tasks.test.ts
@@ -28,6 +28,9 @@ const taskMocks = vi.hoisted(() => {
     serverLoggerError: vi.fn(() => {
       logActiveSpan.push(activeSpan);
     }),
+    serverLoggerInfo: vi.fn(() => {
+      logActiveSpan.push(activeSpan);
+    }),
     span,
     startActiveSpan: vi.fn(
       async (
@@ -63,7 +66,7 @@ vi.mock("@/telemetry/logger", () => ({
     reason instanceof Error ? reason.message : String(reason),
   serverLogger: {
     error: taskMocks.serverLoggerError,
-    info: vi.fn(),
+    info: taskMocks.serverLoggerInfo,
   },
 }));
 
@@ -133,6 +136,7 @@ beforeEach(() => {
   taskMocks.replayWebhookToCollector.mockReset().mockResolvedValue(undefined);
   taskMocks.resolveOrganizationId.mockReset().mockResolvedValue("org-1");
   taskMocks.serverLoggerError.mockClear();
+  taskMocks.serverLoggerInfo.mockClear();
   taskMocks.span.end.mockClear();
   taskMocks.span.recordException.mockClear();
   taskMocks.span.setStatus.mockClear();
@@ -221,6 +225,34 @@ describe("github events tasks", () => {
     );
     expect(taskMocks.logActiveSpan).toEqual([true]);
     expect(taskMocks.span.end).toHaveBeenCalledOnce();
+  });
+
+  it("drops stale installation terminal events without error telemetry", async () => {
+    const data = workflowRunData();
+    const error = new TerminalEventError(
+      "organization not found for installation",
+    );
+    taskMocks.resolveOrganizationId.mockRejectedValue(error);
+
+    await runTask(COLLECTOR_TASK_IDENTIFIER, data, "collector-job-1");
+    await runTask(COLLECTOR_TASK_IDENTIFIER, data, "collector-job-2");
+
+    expect(taskMocks.span.recordException).not.toHaveBeenCalled();
+    expect(taskMocks.span.setStatus).not.toHaveBeenCalled();
+    expect(taskMocks.serverLoggerError).not.toHaveBeenCalled();
+    expect(taskMocks.serverLoggerInfo).toHaveBeenCalledOnce();
+    expect(taskMocks.serverLoggerInfo).toHaveBeenCalledWith(
+      "github_events.jobs.stale_installation_dropped",
+      expect.objectContaining({
+        "error.message": "organization not found for installation",
+        "error.type": "TerminalEventError",
+        "github.event.type": "workflow_run",
+        "github.installation.id": 123,
+        "graphile_worker.job.id": "collector-job-1",
+      }),
+    );
+    expect(taskMocks.logActiveSpan).toEqual([true]);
+    expect(taskMocks.span.end).toHaveBeenCalledTimes(2);
   });
 
   it("records status terminal errors on the status span without throwing", async () => {

--- a/packages/app/src/server/github-events/tasks.ts
+++ b/packages/app/src/server/github-events/tasks.ts
@@ -24,6 +24,7 @@ import type { WebhookJobData } from "./types";
 import { TerminalEventError } from "./types";
 
 const tracer = getTelemetryTracer("everr-app.github_events");
+const loggedStaleInstallationIds = new Set<number>();
 
 type ParsedQueuedEvent = ReturnType<typeof parseQueuedWorkflowEvent>;
 
@@ -62,6 +63,26 @@ function makeWebhookTask(
           await action({ body, data, organizationId, parsed });
         } catch (error) {
           const err = error instanceof Error ? error : new Error(String(error));
+          const terminalAttributes = {
+            ...(eventType ? { "github.event.type": eventType } : {}),
+            ...installationAttribute(parsed),
+            "graphile_worker.job.id": jobId,
+          };
+
+          if (isStaleInstallationTerminalError(error)) {
+            if (shouldLogStaleInstallation(parsed)) {
+              serverLogger.info(
+                "github_events.jobs.stale_installation_dropped",
+                {
+                  ...terminalAttributes,
+                  "error.message": err.message,
+                  "error.type": err.name,
+                },
+              );
+            }
+            return;
+          }
+
           span.recordException(err);
           span.setStatus({
             code: SpanStatusCode.ERROR,
@@ -70,9 +91,8 @@ function makeWebhookTask(
 
           if (error instanceof TerminalEventError) {
             serverLogger.error(terminalLogKey, {
-              ...(eventType ? { "github.event.type": eventType } : {}),
               ...exceptionAttributes(error),
-              "graphile_worker.job.id": jobId,
+              ...terminalAttributes,
             });
             return;
           }
@@ -84,6 +104,34 @@ function makeWebhookTask(
       },
     );
   };
+}
+
+function isStaleInstallationTerminalError(error: unknown): boolean {
+  return (
+    error instanceof TerminalEventError &&
+    error.message === "organization not found for installation"
+  );
+}
+
+function installationId(parsed: ParsedQueuedEvent): number | null {
+  try {
+    return installationIdFromQueuedEvent(parsed);
+  } catch {
+    return null;
+  }
+}
+
+function installationAttribute(parsed: ParsedQueuedEvent) {
+  const id = installationId(parsed);
+  return id === null ? {} : { "github.installation.id": id };
+}
+
+function shouldLogStaleInstallation(parsed: ParsedQueuedEvent): boolean {
+  const id = installationId(parsed);
+  if (id === null) return true;
+  if (loggedStaleInstallationIds.has(id)) return false;
+  loggedStaleInstallationIds.add(id);
+  return true;
 }
 
 const processCollectorTask = makeWebhookTask(

--- a/packages/app/src/telemetry/clickhouse.test.ts
+++ b/packages/app/src/telemetry/clickhouse.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const telemetryMocks = vi.hoisted(() => {
+  const span = {
+    end: vi.fn(),
+  };
+
+  return {
+    captureError: vi.fn(),
+    span,
+    startActiveSpan: vi.fn(
+      async (
+        _name: string,
+        _options: unknown,
+        run: (span: { end: () => void }) => Promise<unknown>,
+      ) => run(span),
+    ),
+  };
+});
+
+vi.mock("./node", () => ({
+  captureError: telemetryMocks.captureError,
+  getTelemetryTracer: () => ({
+    startActiveSpan: telemetryMocks.startActiveSpan,
+  }),
+  SpanKind: { CLIENT: 2 },
+}));
+
+import { instrumentClickhouseOperation } from "./clickhouse";
+
+describe("instrumentClickhouseOperation", () => {
+  beforeEach(() => {
+    telemetryMocks.captureError.mockClear();
+    telemetryMocks.span.end.mockClear();
+    telemetryMocks.startActiveSpan.mockClear();
+  });
+
+  it("records unexpected app ClickHouse errors", async () => {
+    const error = new Error("database unavailable");
+
+    await expect(
+      instrumentClickhouseOperation(
+        { client: "app", operation: "QUERY" },
+        async () => {
+          throw error;
+        },
+      ),
+    ).rejects.toThrow("database unavailable");
+
+    expect(telemetryMocks.captureError).toHaveBeenCalledWith(error, {
+      "clickhouse.client": "app",
+      "db.operation.name": "QUERY",
+      "db.system.name": "clickhouse",
+      "error.handled": false,
+      "error.source": "clickhouse",
+    });
+    expect(telemetryMocks.span.end).toHaveBeenCalledOnce();
+  });
+
+  it("does not record expected SQL API query errors", async () => {
+    const error = Object.assign(
+      new Error("Unknown table expression identifier 'alert_eventss'"),
+      { code: "60", type: "UNKNOWN_TABLE" },
+    );
+
+    await expect(
+      instrumentClickhouseOperation(
+        { client: "sql_api", operation: "QUERY" },
+        async () => {
+          throw error;
+        },
+      ),
+    ).rejects.toThrow("Unknown table");
+
+    expect(telemetryMocks.captureError).not.toHaveBeenCalled();
+    expect(telemetryMocks.span.end).toHaveBeenCalledOnce();
+  });
+
+  it("still records unexpected SQL API infrastructure errors", async () => {
+    const error = new Error("connection refused");
+
+    await expect(
+      instrumentClickhouseOperation(
+        { client: "sql_api", operation: "QUERY" },
+        async () => {
+          throw error;
+        },
+      ),
+    ).rejects.toThrow("connection refused");
+
+    expect(telemetryMocks.captureError).toHaveBeenCalledWith(error, {
+      "clickhouse.client": "sql_api",
+      "db.operation.name": "QUERY",
+      "db.system.name": "clickhouse",
+      "error.handled": false,
+      "error.source": "clickhouse",
+    });
+  });
+});

--- a/packages/app/src/telemetry/clickhouse.ts
+++ b/packages/app/src/telemetry/clickhouse.ts
@@ -1,4 +1,5 @@
 import type { Attributes } from "@opentelemetry/api";
+import { isExpectedSqlApiQueryError } from "./expected-errors";
 import { captureError, getTelemetryTracer, SpanKind } from "./node";
 
 type ClickhouseClient = "admin" | "app" | "sql_api";
@@ -26,11 +27,13 @@ export async function instrumentClickhouseOperation<T>(
       try {
         return await run();
       } catch (error) {
-        captureError(error, {
-          ...spanAttributes,
-          "error.handled": false,
-          "error.source": "clickhouse",
-        });
+        if (!isExpectedSqlApiQueryError(attributes, error)) {
+          captureError(error, {
+            ...spanAttributes,
+            "error.handled": false,
+            "error.source": "clickhouse",
+          });
+        }
         throw error;
       } finally {
         span.end();

--- a/packages/app/src/telemetry/expected-errors.ts
+++ b/packages/app/src/telemetry/expected-errors.ts
@@ -1,0 +1,77 @@
+const EXPECTED_SERVER_FUNCTION_MESSAGES = new Set([
+  "Alert not found",
+  "No active organization",
+  "Unauthenticated",
+]);
+
+const EXPECTED_SQL_API_ERROR_TYPES = new Set([
+  "ACCESS_DENIED",
+  "BAD_ARGUMENTS",
+  "ILLEGAL_TYPE_OF_ARGUMENT",
+  "QUERY_IS_TOO_LARGE",
+  "QUERY_WAS_CANCELLED",
+  "SYNTAX_ERROR",
+  "TIMEOUT_EXCEEDED",
+  "TOO_MANY_ROWS_OR_BYTES",
+  "UNKNOWN_DATABASE",
+  "UNKNOWN_IDENTIFIER",
+  "UNKNOWN_TABLE",
+]);
+
+const EXPECTED_SQL_API_ERROR_CODES = new Set([
+  "47", // UNKNOWN_IDENTIFIER
+  "60", // UNKNOWN_TABLE
+  "62", // SYNTAX_ERROR
+  "81", // UNKNOWN_DATABASE
+  "159", // TIMEOUT_EXCEEDED
+  "241", // MEMORY_LIMIT_EXCEEDED
+  "396", // TOO_MANY_ROWS_OR_BYTES
+  "497", // ACCESS_DENIED
+]);
+
+const EXPECTED_SQL_API_MESSAGES = [
+  /column .* is not under aggregate function/i,
+  /limit for result exceeded/i,
+  /not enough privileges/i,
+  /query is too large/i,
+  /quota/i,
+  /read[- ]only/i,
+  /syntax error/i,
+  /unknown (?:column|database|expression|identifier|table)/i,
+];
+
+type ClickhouseTelemetryAttributes = {
+  client: string;
+};
+
+export function isExpectedServerFunctionError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    EXPECTED_SERVER_FUNCTION_MESSAGES.has(error.message)
+  );
+}
+
+export function isExpectedSqlApiQueryError(
+  attributes: ClickhouseTelemetryAttributes,
+  error: unknown,
+): boolean {
+  if (attributes.client !== "sql_api") return false;
+
+  const errorType = readErrorField(error, "type");
+  if (errorType && EXPECTED_SQL_API_ERROR_TYPES.has(errorType)) return true;
+
+  const errorCode = readErrorField(error, "code");
+  if (errorCode && EXPECTED_SQL_API_ERROR_CODES.has(errorCode)) return true;
+
+  const message = error instanceof Error ? error.message : String(error);
+  return EXPECTED_SQL_API_MESSAGES.some((pattern) => pattern.test(message));
+}
+
+function readErrorField(error: unknown, field: "code" | "type") {
+  if (!error || typeof error !== "object") return "";
+
+  const value = (error as Record<string, unknown>)[field];
+  return typeof value === "string" || typeof value === "number"
+    ? String(value)
+    : "";
+}

--- a/packages/app/src/telemetry/server-fn-runtime.ts
+++ b/packages/app/src/telemetry/server-fn-runtime.ts
@@ -1,4 +1,5 @@
 import type { Attributes } from "@opentelemetry/api";
+import { isExpectedServerFunctionError } from "./expected-errors";
 import { captureError, getTelemetryTracer, SpanKind } from "./node";
 import { parameterizeTelemetryPath } from "./paths";
 
@@ -27,11 +28,13 @@ export async function instrumentServerFunction<T>(
       try {
         return await run();
       } catch (error) {
-        captureError(error, {
-          ...attributes,
-          "error.handled": false,
-          "error.source": "server_fn",
-        });
+        if (!isExpectedServerFunctionError(error)) {
+          captureError(error, {
+            ...attributes,
+            "error.handled": false,
+            "error.source": "server_fn",
+          });
+        }
         throw error;
       } finally {
         span.end();

--- a/packages/app/src/telemetry/server-fn.test.ts
+++ b/packages/app/src/telemetry/server-fn.test.ts
@@ -40,8 +40,8 @@ describe("instrumentServerFunction", () => {
     telemetryMocks.span.setAttribute.mockClear();
   });
 
-  it("records errors before TanStack serializes them into serverFn responses", async () => {
-    const error = new Error("Unauthenticated");
+  it("records unexpected errors before TanStack serializes them into serverFn responses", async () => {
+    const error = new Error("database unavailable");
 
     await expect(
       instrumentServerFunction(
@@ -55,7 +55,7 @@ describe("instrumentServerFunction", () => {
           throw error;
         },
       ),
-    ).rejects.toThrow("Unauthenticated");
+    ).rejects.toThrow("database unavailable");
 
     expect(telemetryMocks.captureError).toHaveBeenCalledWith(error, {
       "error.handled": false,
@@ -78,6 +78,29 @@ describe("instrumentServerFunction", () => {
       },
       expect.any(Function),
     );
+    expect(telemetryMocks.span.end).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    "Unauthenticated",
+    "No active organization",
+    "Alert not found",
+  ])("does not record expected serverFn control-flow errors: %s", async (message) => {
+    await expect(
+      instrumentServerFunction(
+        new Request("http://localhost/_serverFn/c4d3d0c28997f144965eeaca"),
+        {
+          filename: "src/lib/auth.server.ts",
+          id: "c4d3d0c28997f144965eeaca",
+          name: "getActiveOrganization",
+        },
+        () => {
+          throw new Error(message);
+        },
+      ),
+    ).rejects.toThrow(message);
+
+    expect(telemetryMocks.captureError).not.toHaveBeenCalled();
     expect(telemetryMocks.span.end).toHaveBeenCalledOnce();
   });
 

--- a/packages/desktop-app/src-tauri/src/notifications.rs
+++ b/packages/desktop-app/src-tauri/src/notifications.rs
@@ -50,6 +50,32 @@ fn notifier_span(name: &'static str, trace_id: &str) -> tracing::Span {
     tracing::info_span!(target: "notifier", "notifier_event", name, trace_id)
 }
 
+fn log_notifier_reauthentication_required(error: &anyhow::Error) {
+    tracing::event!(
+        target: "notifier",
+        tracing::Level::INFO,
+        {
+            event.name = "everr.notifier.sse.reauthentication_required",
+            error.message = %error,
+        },
+        "everr.notifier.sse.reauthentication_required"
+    );
+}
+
+fn log_notifier_sse_reconnect(error: &anyhow::Error, backoff: Duration) {
+    let backoff_ms = backoff.as_millis() as u64;
+    tracing::event!(
+        target: "notifier",
+        tracing::Level::DEBUG,
+        {
+            event.name = "everr.notifier.sse.reconnect",
+            error.message = %error,
+            everr.notifier.backoff_ms = backoff_ms,
+        },
+        "everr.notifier.sse.reconnect"
+    );
+}
+
 #[cfg(test)]
 pub(crate) fn notification_window_uses_native_panel() -> bool {
     cfg!(target_os = "macos")
@@ -74,7 +100,7 @@ pub(crate) fn start_notifier_loop(app: AppHandle, state: RuntimeState) {
                 }
                 Err(error) => {
                     if is_reauthentication_required(&error) {
-                        crate::crash_log::log_error("notifier SSE auth", &error);
+                        log_notifier_reauthentication_required(&error);
                         if let Err(reset_error) = handle_notifier_auth_failure(&app, &state) {
                             crate::crash_log::log_error("notifier auth reset", &reset_error);
                         }
@@ -82,7 +108,7 @@ pub(crate) fn start_notifier_loop(app: AppHandle, state: RuntimeState) {
                         continue;
                     }
 
-                    crate::crash_log::log_error("notifier SSE", &error);
+                    log_notifier_sse_reconnect(&error, backoff);
                     tokio::time::sleep(backoff).await;
                     backoff = (backoff * 2).min(max_backoff);
                 }

--- a/packages/desktop-app/src-tauri/tests/desktop_otel_wiring.rs
+++ b/packages/desktop-app/src-tauri/tests/desktop_otel_wiring.rs
@@ -133,6 +133,7 @@ fn rust_network_telemetry_is_removed_from_tauri_backend() {
 #[test]
 fn rust_errors_emit_exception_logs() {
     let crash_log = include_str!("../src/crash_log.rs");
+    let notifications = include_str!("../src/notifications.rs");
 
     assert!(crash_log.contains("everr.rust.error"));
     assert!(!crash_log.contains("desktop.rust.error"));
@@ -141,6 +142,10 @@ fn rust_errors_emit_exception_logs() {
     assert!(crash_log.contains("exception.message"));
     assert!(crash_log.contains("exception.stacktrace"));
     assert!(crash_log.contains("error.handled"));
+    assert!(notifications.contains("log_notifier_sse_reconnect"));
+    assert!(notifications.contains("everr.notifier.sse.reconnect"));
+    assert!(!notifications.contains("log_error(\"notifier SSE\""));
+    assert!(!notifications.contains("log_error(\"notifier SSE auth\""));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- suppress expected server function control-flow errors before error capture
- suppress expected SQL API user/query failures while preserving infrastructure errors
- stop stale GitHub installation jobs and desktop notifier SSE reconnect/auth cases from reporting as errors
- avoid alert-detail dependent prefetches when the alert itself is missing

## Validation

- pnpm --filter @everr/app exec vitest run src/telemetry/server-fn.test.ts src/telemetry/clickhouse.test.ts src/telemetry/server.test.ts src/routes/api/cli/repos.test.ts src/server/github-events/tasks.test.ts src/data/alerts/server.test.ts
- pnpm --filter @everr/app typecheck
- pnpm exec biome check packages/app/src/routes/_authenticated/_dashboard/alerts_.$alertId.tsx packages/app/src/server/github-events/tasks.ts packages/app/src/server/github-events/tasks.test.ts packages/app/src/telemetry/clickhouse.ts packages/app/src/telemetry/clickhouse.test.ts packages/app/src/telemetry/expected-errors.ts packages/app/src/telemetry/server-fn-runtime.ts packages/app/src/telemetry/server-fn.test.ts
- cargo test -p everr-app --test desktop_otel_wiring --test telemetry_sidecar
- git diff --check
