### PR TITLE
Fix CLI repos stale installation handling

### DIFF
--- a/packages/app/src/routes/api/cli/repos.test.ts
+++ b/packages/app/src/routes/api/cli/repos.test.ts
@@ -86,6 +86,36 @@ describe("/api/cli/repos", () => {
     expect(mockedListRepos).toHaveBeenCalledWith(99);
   });
 
+  it("returns empty array when the active installation is missing in GitHub", async () => {
+    mockDbInstallations(mockedDb, [{ status: "active", installationId: 99 }]);
+    mockedListRepos.mockRejectedValueOnce(
+      new Error(
+        'Failed to create installation token: status=404 body={"message":"Not Found"}',
+      ),
+    );
+
+    const response = await getHandler()({
+      request: new Request("http://localhost/api/cli/repos"),
+      context,
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual([]);
+    expect(mockedListRepos).toHaveBeenCalledWith(99);
+  });
+
+  it("rethrows unexpected GitHub repository lookup errors", async () => {
+    mockDbInstallations(mockedDb, [{ status: "active", installationId: 99 }]);
+    mockedListRepos.mockRejectedValueOnce(new Error("GitHub unavailable"));
+
+    await expect(
+      getHandler()({
+        request: new Request("http://localhost/api/cli/repos"),
+        context,
+      }),
+    ).rejects.toThrow("GitHub unavailable");
+  });
+
   it("returns empty array when tenant has no installations", async () => {
     mockDbInstallations(mockedDb, []);
 

--- a/packages/app/src/routes/api/cli/repos.ts
+++ b/packages/app/src/routes/api/cli/repos.ts
@@ -27,7 +27,16 @@ export const Route = createFileRoute("/api/cli/repos")({
           return Response.json([]);
         }
 
-        const repos = await listInstallationRepos(active.installationId);
+        let repos: Awaited<ReturnType<typeof listInstallationRepos>>;
+        try {
+          repos = await listInstallationRepos(active.installationId);
+        } catch (error) {
+          if (isMissingGitHubInstallation(error)) {
+            return Response.json([]);
+          }
+          throw error;
+        }
+
         return Response.json(
           repos.map((r) => ({ id: r.id, fullName: r.full_name })),
         );
@@ -35,3 +44,16 @@ export const Route = createFileRoute("/api/cli/repos")({
     },
   },
 });
+
+function isMissingGitHubInstallation(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+
+  const message = error.message;
+  return (
+    message.startsWith("Failed to create installation token: status=404") ||
+    (message.startsWith(
+      "GitHub API error: GET https://api.github.com/installation/repositories",
+    ) &&
+      message.includes(" status=404 "))
+  );
+}


### PR DESCRIPTION
## Summary

- Return an empty repo list when the saved active GitHub installation no longer exists upstream.
- Keep unexpected GitHub repository lookup failures bubbling as real errors.
- Cover the stale-installation path and the unexpected-error path in `/api/cli/repos` tests.

## Fixed error

- https://app.everr.dev/errors/13631941012082591895?from=now-14d

## Validation

- `pnpm --filter @everr/app exec vitest run src/routes/api/cli/repos.test.ts`
- `pnpm exec biome check packages/app/src/routes/api/cli/repos.ts packages/app/src/routes/api/cli/repos.test.ts`
- `pnpm --filter @everr/app exec tsc --noEmit`
