### PR TITLE
fix(desktop): preserve collector failure reason in telemetry

### DIFF
--- a/.changeset/collector-failure-reason.md
+++ b/.changeset/collector-failure-reason.md
@@ -1,0 +1,5 @@
+---
+"@everr/desktop-app": patch
+---
+
+Preserve collector failure reason (exit status, spawn error) in telemetry as `everr.collector.failure_reason` attribute instead of discarding it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "everr-app"
-version = "0.4.2"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/packages/desktop-app/src-tauri/src/telemetry/sidecar.rs
+++ b/packages/desktop-app/src-tauri/src/telemetry/sidecar.rs
@@ -34,6 +34,7 @@ pub enum TelemetryState {
 struct CollectorFailureException {
     exception_type: &'static str,
     exception_message: &'static str,
+    reason: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -261,6 +262,7 @@ fn log_collector_status_change(previous: Option<&TelemetryState>, next: &Telemet
                 everr.collector.status = status,
                 exception.type = exception.exception_type,
                 exception.message = exception.exception_message,
+                everr.collector.failure_reason = exception.reason.as_str(),
                 error.handled = false,
             },
             "{}",
@@ -315,6 +317,7 @@ fn collector_failure_exception(reason: &str) -> CollectorFailureException {
         return CollectorFailureException {
             exception_type: "CollectorExitError",
             exception_message: "collector exited unexpectedly",
+            reason: reason.to_owned(),
         };
     }
 
@@ -322,12 +325,14 @@ fn collector_failure_exception(reason: &str) -> CollectorFailureException {
         return CollectorFailureException {
             exception_type: "CollectorWaitError",
             exception_message: "collector process wait failed",
+            reason: reason.to_owned(),
         };
     }
 
     CollectorFailureException {
         exception_type: "CollectorStartError",
         exception_message: "collector failed to start",
+        reason: reason.to_owned(),
     }
 }
 
@@ -600,11 +605,16 @@ mod tests {
         let exit = collector_failure_exception("collector CLI terminated: exit status: 1");
         assert_eq!(exit.exception_type, "CollectorExitError");
         assert_eq!(exit.exception_message, "collector exited unexpectedly");
+        assert_eq!(exit.reason, "collector CLI terminated: exit status: 1");
 
         let spawn =
             collector_failure_exception("CLI collector spawn: /Users/alice/secret/path missing");
         assert_eq!(spawn.exception_type, "CollectorStartError");
         assert_eq!(spawn.exception_message, "collector failed to start");
         assert!(!spawn.exception_message.contains("/Users/alice"));
+        assert_eq!(
+            spawn.reason,
+            "CLI collector spawn: /Users/alice/secret/path missing"
+        );
     }
 }


### PR DESCRIPTION
The collector failure reason (exit status, spawn error) was being discarded and replaced with a generic message. Now the full reason is emitted as `everr.collector.failure_reason` attribute for diagnostics.

Before: `"collector exited unexpectedly"` (no exit code)
After: `"collector exited unexpectedly"` + `everr.collector.failure_reason: "collector CLI terminated: exit status: 1"`

The `exception.message` stays sanitized (no paths), but the new attribute gives the full context — exit codes for crashes, OS errors for spawn failures, etc.
