### PR TITLE
Fix install scripts for sh compatibility

### DIFF
--- a/packages/docs/public/install-dev.sh
+++ b/packages/docs/public/install-dev.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/bin/sh
+set -eu
 
 DOWNLOAD_BASE_URL="http://localhost:3000/everr-app"
 INSTALL_DIR="${HOME}/.local/bin"

--- a/packages/docs/public/install.sh
+++ b/packages/docs/public/install.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/bin/sh
+set -eu
 
 DOWNLOAD_BASE_URL="https://everr.dev/everr-app"
 INSTALL_DIR="${HOME}/.local/bin"


### PR DESCRIPTION
## Summary
- Make the public and dev install scripts match the documented pipe-to-sh invocation.
- Replace the bash-only pipefail setting with POSIX sh-compatible strict mode.

## Root cause
Ubuntu 24.04 uses dash for /bin/sh, and dash rejects set -o pipefail before the installer can run.

## Validation
- dash -n packages/docs/public/install.sh
- dash -n packages/docs/public/install-dev.sh
- Executed both installers under dash with mocked uname/curl downloads and real checksum verification.