### PR TITLE
fix(cli): embed collector assets in Linux CLI release and auto-configure PATH on install

### DIFF
--- a/.changeset/linux-cli-embed-collector-assets.md
+++ b/.changeset/linux-cli-embed-collector-assets.md
@@ -1,0 +1,5 @@
+---
+"@everr/desktop-app": patch
+---
+
+Fix `everr local start` on Linux by embedding the collector and chDB assets in the published Linux CLI release (the build now fails if the assets are missing). Also make the install script configure your shell PATH automatically instead of only printing a hint.

--- a/.github/workflows/deploy-desktop-app.yml
+++ b/.github/workflows/deploy-desktop-app.yml
@@ -235,6 +235,15 @@ jobs:
         with:
           check-run-id: ${{ job.check_run_id }}
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
@@ -243,11 +252,23 @@ jobs:
         with:
           workspaces: . -> target
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: collector/go.mod
+          cache-dependency-path: |
+            collector/**/go.sum
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Test
         run: cargo test --manifest-path packages/desktop-app/src-cli/Cargo.toml
 
       - name: Build release binary
-        run: cargo build --release --manifest-path packages/desktop-app/src-cli/Cargo.toml
+        env:
+          EVERR_INGEST_KEY: ${{ secrets.EVERR_INGEST_KEY }}
+        run: pnpm --dir packages/desktop-app build:cli:release
 
       - name: Stage Linux CLI binary
         run: |

--- a/packages/docs/public/install-dev.sh
+++ b/packages/docs/public/install-dev.sh
@@ -60,9 +60,33 @@ echo "  Installed to ${INSTALL_PATH}"
 case ":${PATH}:" in
   *":${INSTALL_DIR}:"*) ;;
   *)
+    line="export PATH=\"${INSTALL_DIR}:\$PATH\""
+    case "$(basename "${SHELL:-sh}")" in
+      zsh) rc="${ZDOTDIR:-$HOME}/.zshrc" ;;
+      bash)
+        if [ "${os}" = "Darwin" ]; then rc="${HOME}/.bash_profile"; else rc="${HOME}/.bashrc"; fi
+        ;;
+      fish)
+        rc="${HOME}/.config/fish/config.fish"
+        line="fish_add_path ${INSTALL_DIR}"
+        ;;
+      *) rc="${HOME}/.profile" ;;
+    esac
+
     echo
-    echo "  Add ${INSTALL_DIR} to your PATH:"
-    echo "    export PATH=\"${INSTALL_DIR}:\$PATH\""
+    if [ -f "${rc}" ] && grep -qF "${INSTALL_DIR}" "${rc}" 2>/dev/null; then
+      echo "  ${INSTALL_DIR} is already configured in ${rc} but not active in this shell."
+      echo "  Restart your shell or run: ${line}"
+    else
+      mkdir -p "$(dirname "${rc}")"
+      printf '\n# Added by Everr installer\n%s\n' "${line}" >> "${rc}"
+      echo "  Added ${INSTALL_DIR} to your PATH in ${rc}"
+      echo "  Restart your shell or run: ${line}"
+    fi
+
+    # Make everr available on PATH for the guided setup below.
+    PATH="${INSTALL_DIR}:${PATH}"
+    export PATH
     ;;
 esac
 

--- a/packages/docs/public/install.sh
+++ b/packages/docs/public/install.sh
@@ -60,9 +60,33 @@ echo "  Installed to ${INSTALL_PATH}"
 case ":${PATH}:" in
   *":${INSTALL_DIR}:"*) ;;
   *)
+    line="export PATH=\"${INSTALL_DIR}:\$PATH\""
+    case "$(basename "${SHELL:-sh}")" in
+      zsh) rc="${ZDOTDIR:-$HOME}/.zshrc" ;;
+      bash)
+        if [ "${os}" = "Darwin" ]; then rc="${HOME}/.bash_profile"; else rc="${HOME}/.bashrc"; fi
+        ;;
+      fish)
+        rc="${HOME}/.config/fish/config.fish"
+        line="fish_add_path ${INSTALL_DIR}"
+        ;;
+      *) rc="${HOME}/.profile" ;;
+    esac
+
     echo
-    echo "  Add ${INSTALL_DIR} to your PATH:"
-    echo "    export PATH=\"${INSTALL_DIR}:\$PATH\""
+    if [ -f "${rc}" ] && grep -qF "${INSTALL_DIR}" "${rc}" 2>/dev/null; then
+      echo "  ${INSTALL_DIR} is already configured in ${rc} but not active in this shell."
+      echo "  Restart your shell or run: ${line}"
+    else
+      mkdir -p "$(dirname "${rc}")"
+      printf '\n# Added by Everr installer\n%s\n' "${line}" >> "${rc}"
+      echo "  Added ${INSTALL_DIR} to your PATH in ${rc}"
+      echo "  Restart your shell or run: ${line}"
+    fi
+
+    # Make everr available on PATH for the guided setup below.
+    PATH="${INSTALL_DIR}:${PATH}"
+    export PATH
     ;;
 esac
 


### PR DESCRIPTION
## Problem

Two issues reported from a fresh Linux install (`curl -fsSL https://everr.dev/install.sh | sh`):

1. **`everr local start` fails on Linux** with:
   ```
   Error: extract embedded collector assets
   Caused by:
       collector assets are not embedded in this CLI build; rebuild with `pnpm --dir packages/desktop-app build:cli:debug`
   ```
2. **`everr: command not found` after install** — the installer printed a "Add … to your PATH" hint but never actually configured it.

## Root causes

**1. Linux CLI ships without embedded collector assets.**
`build.rs` only embeds the collector + chDB assets when `EVERR_EMBEDDED_COLLECTOR_GZ` / `EVERR_EMBEDDED_CHDB_GZ` point at prepared files; otherwise the `COLLECTOR_GZ`/`CHDB_GZ` constants are empty and `collector.rs` bails. The macOS CLI is built via `pnpm build:cli:release` (which runs `prepareCliEmbeddedAssets` → builds the collector, downloads `libchdb.so`, gzips, sets the env vars). The `build-linux-cli` job instead ran a bare `cargo build --release` with none of that — so every Linux binary served by `install.sh` was missing the assets.

**2. `install.sh` was print-only for PATH.**
It only echoed the `export PATH=…` line; it never wrote it to any rc file, so `~/.local/bin` wasn't on PATH after install.

## Changes

- **`deploy-desktop-app.yml`** — `build-linux-cli` now sets up the pnpm/Node/Go toolchain and builds via `pnpm --dir packages/desktop-app build:cli:release`, mirroring the macOS path. This embeds the assets and sets `EVERR_REQUIRE_EMBEDDED_COLLECTOR=1`, so the build now **fails loudly** if assets are ever missing again (no silent regression). chDB assets already exist for `linux-aarch64`/`linux-x86_64`. Output path (`target/release/everr`) is unchanged, so the existing stage/smoke/upload steps keep working.
- **`install.sh` / `install-dev.sh`** — detect the shell's rc file (zsh → `.zshrc`, bash → `.bashrc`/`.bash_profile`, fish → `config.fish` via `fish_add_path`, else `.profile`), append the export idempotently, and export it for the same session so the guided `setup` works.

## Testing

- Shell syntax: `sh -n` passes on both install scripts.
- Workflow YAML parses; `build-linux-cli` step list verified.
- PATH logic exercised in a sandbox across zsh/bash(macOS)/fish/unknown: correct rc file chosen, session PATH updated, idempotent on re-run (single marker after two runs).