### PR TITLE
refactor(dashboards): collapse panel data assembly into useDashboardPanelData

### DIFF
--- a/packages/app/src/components/dashboards/dashboard-panel.tsx
+++ b/packages/app/src/components/dashboards/dashboard-panel.tsx
@@ -3,15 +3,13 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@everr/ui/components/tooltip";
-import { resolveTimeRange } from "@everr/ui/lib/time-range";
 import { useNavigate } from "@tanstack/react-router";
 import { TriangleAlert } from "lucide-react";
 import type { ReactNode } from "react";
 import { useCallback, useMemo } from "react";
 import type { Panel } from "@/data/dashboards/schema";
-import { useTimeRange } from "@/hooks/use-time-range";
 import { PanelShell } from "../panel-shell";
-import { usePanelQueries } from "./use-panel-queries";
+import { useDashboardPanelData } from "./use-dashboard-panel-data";
 import {
   getVisualizationInset,
   getVisualizationSpecWarnings,
@@ -60,13 +58,9 @@ export function DashboardPanel({
 }: DashboardPanelProps) {
   const { display, plugin } = panel.spec;
   const navigate = useNavigate();
-  // Effective range: explicit URL params, else the dashboard's route defaults,
-  // else the global default — resolved before first render (no flash).
-  const { timeRange } = useTimeRange();
-  const { from, to } = timeRange;
 
-  const { data, status, errorMessage } = usePanelQueries(panel, { from, to });
-  const { fromDate, toDate } = resolveTimeRange(timeRange);
+  const { data, status, errorMessage, timeRange } =
+    useDashboardPanelData(panel);
 
   const specWarnings = useMemo(
     () => getVisualizationSpecWarnings(plugin),
@@ -111,7 +105,7 @@ export function DashboardPanel({
         <PanelVisualization
           plugin={plugin}
           data={data}
-          timeRange={{ from: fromDate, to: toDate }}
+          timeRange={timeRange}
           onTimeRangeChange={handleTimeRangeChange}
         />
       </PanelShell>

--- a/packages/app/src/components/dashboards/use-dashboard-panel-data.test.ts
+++ b/packages/app/src/components/dashboards/use-dashboard-panel-data.test.ts
@@ -11,7 +11,7 @@ import {
   buildPanelQueryRequests,
   combineQueryStates,
   type SingleQueryState,
-} from "./use-panel-queries";
+} from "./use-dashboard-panel-data";
 
 const ctx = {
   definedNames: new Set(["region"]),

--- a/packages/app/src/components/dashboards/use-dashboard-panel-data.ts
+++ b/packages/app/src/components/dashboards/use-dashboard-panel-data.ts
@@ -1,3 +1,4 @@
+import { resolveTimeRange } from "@everr/ui/lib/time-range";
 import { useQueries } from "@tanstack/react-query";
 import { useMemo } from "react";
 import {
@@ -8,9 +9,10 @@ import {
 import { panelQueryOptions } from "@/data/dashboards/options";
 import type { Panel } from "@/data/dashboards/schema";
 import { pickByNames } from "@/data/dashboards/variable-values";
+import { useTimeRange } from "@/hooks/use-time-range";
 import { getPanelQuerySources, type PanelQuerySource } from "./query-array";
 import { useDashboardVariables } from "./use-dashboard-variables";
-import type { QueryResultRow } from "./visualizations";
+import type { QueryResultRow, ResolvedTimeRange } from "./visualizations";
 
 export interface PanelQueryRequest {
   source: PanelQuerySource;
@@ -123,17 +125,29 @@ export function combineQueryStates(
   return { status: "success", data: active.map((s) => s.rows ?? []) };
 }
 
-export interface UsePanelQueriesOptions {
-  from?: string;
-  to?: string;
-  enabled?: boolean;
-  queryEnabled?: (source: PanelQuerySource, index: number) => boolean;
+export interface DashboardPanelData extends CombinedPanelResult {
+  /**
+   * Absolute range the visualization renders against (axis domain, brush).
+   * Resolved here from the effective time range so the panel never reads it a
+   * second time.
+   */
+  timeRange: ResolvedTimeRange;
 }
 
-export function usePanelQueries(
-  panel: Panel,
-  opts: UsePanelQueriesOptions = {},
-): CombinedPanelResult {
+/**
+ * Everything a dashboard panel needs to render, behind one interface: the
+ * effective time range, variable resolution, query building, execution, and
+ * result merging. The panel hands in its `panel` spec and gets back
+ * `{ status, data, errorMessage, timeRange }` — no time-range threading, no
+ * intermediate hooks to coordinate. The variable bar still uses
+ * `useDashboardVariables` directly for its pickers.
+ */
+export function useDashboardPanelData(panel: Panel): DashboardPanelData {
+  // Effective range: explicit URL params, else the dashboard's route defaults,
+  // else the global default — resolved before first render (no flash). The
+  // variable-options queries read the same range internally.
+  const { timeRange } = useTimeRange();
+
   const { variables, values, meta, pendingAllNames, allErrors } =
     useDashboardVariables();
   const definedNames = useMemo(
@@ -154,25 +168,23 @@ export function usePanelQueries(
   );
 
   const results = useQueries({
-    queries: requests.map((r, i) => ({
+    queries: requests.map((r) => ({
       ...panelQueryOptions(
         r.source,
-        opts.from,
-        opts.to,
+        timeRange.from,
+        timeRange.to,
         r.variables,
         r.variableMeta,
       ),
       enabled:
-        (opts.enabled ?? true) &&
         sourceIsActive(r.source) &&
         r.missingName === undefined &&
         r.optionsError === undefined &&
-        !r.waitingForOptions &&
-        (opts.queryEnabled?.(r.source, i) ?? true),
+        !r.waitingForOptions,
     })),
   });
 
-  return useMemo(
+  const combined = useMemo(
     () =>
       combineQueryStates(
         requests.map((r, i) => ({
@@ -187,4 +199,12 @@ export function usePanelQueries(
       ),
     [requests, results],
   );
+
+  // Memoize on the primitive bounds: `timeRange` is a fresh object each render,
+  // so depending on it directly would never hit the cache.
+  const viz = useMemo(
+    () => resolveTimeRange(timeRange),
+    [timeRange.from, timeRange.to],
+  );
+  return { ...combined, timeRange: { from: viz.fromDate, to: viz.toDate } };
 }

--- a/packages/app/src/data/notebooks/pages.ts
+++ b/packages/app/src/data/notebooks/pages.ts
@@ -209,8 +209,8 @@ export function resolveNotebookLink(
 
 /**
  * Adapt a notebook into a Dashboard-shaped document so the existing dashboard
- * machinery (DashboardProvider → useDashboardVariables → usePanelQueries →
- * VariableBar) works unchanged. `spec.panels` carries the notebook's shared
+ * machinery (DashboardProvider → useDashboardPanelData → VariableBar) works
+ * unchanged. `spec.panels` carries the notebook's shared
  * panels so `ref:` embeds resolve through the same context.
  */
 export function toDashboardDocument(


### PR DESCRIPTION
## What

A dashboard panel needed four coordinated pieces to render: the panel read the time range, threaded it into `usePanelQueries` as opts, while `useDashboardVariables` read the **same** range again internally, and the panel separately resolved the visualization range. Understanding "why is this panel empty/loading?" meant bouncing across the panel + four hook layers.

This collapses that into one hook:

- **`use-panel-queries.ts` → `use-dashboard-panel-data.ts`** (renamed, history preserved). The pure helpers (`buildPanelQueryRequest`, `combineQueryStates`, …) — the unit-tested surface — are **unchanged**.
- **`usePanelQueries(panel, opts)` → `useDashboardPanelData(panel)`**: reads the effective time range once, resolves variables, builds + runs the queries, merges, and returns `{ status, data, errorMessage, timeRange }`.
- **`dashboard-panel.tsx`** is now presentational — one hook call plus the navigation handler; it no longer reads `useTimeRange`/`resolveTimeRange`.
- `useDashboardVariables` stays public (the variable bar uses it for its pickers).

## Why

The time range crossed the seam twice and the panel owned assembly logic it shouldn't. Now schema knowledge for "what a panel needs to render" lives in one module: locality for debugging, and the panel can't drift out of sync with the query domain.

## Cleanup (from `/simplify`)

- Dropped the unused `enabled` / `queryEnabled` / `from` / `to` opts (no caller used them) — the interface shrank.
- Reuse the existing `ResolvedTimeRange` type for the viz range instead of an inline literal.
- Keyed the `resolveTimeRange` memo on the primitive bounds (`timeRange` is a fresh object each render, so depending on it directly never hit the cache) and dropped a return-value `useMemo` that bought nothing (the result is always destructured).

## Verification

- `tsc --noEmit` — clean
- `vitest run src/components/dashboards` — 209/209 pass
- `biome check` — clean on the two changed source files (5 pre-existing `noNonNullAssertion` **warnings** remain in the renamed test, untouched — non-fatal, outside this refactor's scope)

## Scope

`packages/app` only: +the new hook, the trimmed panel, a renamed test, and a prose comment in `notebooks/pages.ts`.