### PR TITLE
chore: reframe CI/CD-centric copy as unified observability

### DIFF
--- a/.changeset/cli-observability-positioning.md
+++ b/.changeset/cli-observability-positioning.md
@@ -1,0 +1,5 @@
+---
+"@everr/desktop-app": patch
+---
+
+Update CLI help text to reflect Everr's unified observability positioning instead of CI/CD-specific framing. The top-level `about` description now reads "CLI for observability in Everr" and the cloud `query` command describes running SQL against "cloud telemetry data" rather than "cloud CI data".

--- a/packages/desktop-app/src-cli/src/cli.rs
+++ b/packages/desktop-app/src-cli/src/cli.rs
@@ -14,7 +14,7 @@ pub const MAX_LOG_PAGE_SIZE: u32 = 5000;
     name = "everr",
     version = VERSION_OUTPUT,
     long_version = VERSION_OUTPUT,
-    about = "CLI for CI/CD observability in Everr, designed for humans and agent skills"
+    about = "CLI for observability in Everr, designed for humans and agent skills"
 )]
 pub struct Cli {
     #[command(subcommand)]
@@ -79,7 +79,7 @@ pub enum CloudSubcommand {
     Login(LoginArgs),
     /// Log out and clear the local session
     Logout,
-    /// Run a read-only SQL query against cloud CI data
+    /// Run a read-only SQL query against cloud telemetry data
     Query(TelemetryQueryArgs),
 }
 

--- a/packages/docs/src/routes/__root.tsx
+++ b/packages/docs/src/routes/__root.tsx
@@ -25,7 +25,7 @@ export const Route = createRootRoute({
         content: "width=device-width, initial-scale=1",
       },
       {
-        title: "Everr - Every second counts in CI/CD",
+        title: "Everr - Observability made simple",
       },
     ],
     links: [

--- a/packages/docs/src/routes/blog/index.tsx
+++ b/packages/docs/src/routes/blog/index.tsx
@@ -39,8 +39,8 @@ function BlogIndex() {
             Updates & insights
           </h1>
           <p className="mt-4 max-w-2xl text-lg text-fd-muted-foreground">
-            Product updates, engineering deep dives, and CI/CD best practices
-            from the Everr team.
+            Product updates, engineering deep dives, and observability best
+            practices from the Everr team.
           </p>
         </section>
 

--- a/packages/docs/src/routes/devlog/index.tsx
+++ b/packages/docs/src/routes/devlog/index.tsx
@@ -62,10 +62,11 @@ function DevlogIndex() {
           </h1>
           <div className="mt-6 max-w-2xl space-y-4 text-fd-muted-foreground">
             <p>
-              We're building a CI observability platform for developers and AI
-              agents, because debugging CI pipelines is still harder than it
-              should be, whether you're a person staring at a failed run or an
-              agent trying to validate the code it just shipped.
+              We're building an observability platform for developers and AI
+              agents, because understanding what your code is doing is still
+              harder than it should be, whether you're a person staring at a
+              failed run or an agent trying to validate the code it just
+              shipped.
             </p>
             <p>
               A growing share of code is written by AI. But when that code


### PR DESCRIPTION
## Summary

Sweep of outdated CI/CD-only positioning, reframing it toward Everr's unified observability story (local, CI, and production). Focused on the CLI help text plus the most CI-centric docs marketing copy.

### CLI (`@everr/desktop-app`)
- Top-level `about` string: "CLI for CI/CD observability" → "CLI for observability in Everr"
- Cloud `query` command description: "cloud CI data" → "cloud telemetry data"

### Docs
- Site `<title>`: "Every second counts in CI/CD" → "Observability made simple"
- Devlog intro: "CI observability platform" → "observability platform" (and softened the CI-specific framing)
- Blog subtitle: "CI/CD best practices" → "observability best practices"

A changeset is included for `@everr/desktop-app` (docs is not a published package).

### Deliberately left alone
- Desktop-app / web onboarding notification copy ("when your CI/CD pipelines fail") — accurate, the desktop app only notifies for CI failures.
- The `ci` subcommand description and "pipeline runs" wording — genuinely CI-specific.
- Nav label, workflows page subtitle, and log-inspector "CI/CD" detail-section header — UX-label judgment calls deferred.