### PR TITLE
fix(collector): add TimestampTime column to chDB logs tables

### DIFF
--- a/.changeset/fix-chdb-logs-timestamptime.md
+++ b/.changeset/fix-chdb-logs-timestamptime.md
@@ -1,0 +1,5 @@
+---
+"@everr/desktop-app": patch
+---
+
+Fix "Failed to load logs" in the logs explorer. The embedded collector's local `otel_logs` table was missing the `TimestampTime` column that log queries filter on, so every query failed with `Unknown identifier TimestampTime`. New installs now create the column, and existing installs are migrated on startup with an idempotent `ADD COLUMN IF NOT EXISTS`.

--- a/collector/exporter/chdbexporter/exporter_logs.go
+++ b/collector/exporter/chdbexporter/exporter_logs.go
@@ -61,6 +61,9 @@ func (e *logsExporter) start(ctx context.Context, _ component.Host) error {
 		if createTableErr := createLogsTable(ctx, e.cfg, e.db, e.logger); createTableErr != nil {
 			return createTableErr
 		}
+		if migrateErr := migrateLogsTable(ctx, e.cfg, e.db); migrateErr != nil {
+			return migrateErr
+		}
 		if createViewErr := createLocalLogsView(ctx, e.cfg, e.db); createViewErr != nil {
 			return createViewErr
 		}
@@ -267,6 +270,43 @@ func createLogsTable(ctx context.Context, cfg *Config, db driver.Conn, logger *z
 
 	if err := db.Exec(ctx, sql); err != nil {
 		return fmt.Errorf("exec create logs table sql: %w", err)
+	}
+
+	return nil
+}
+
+// logsColumnMigrations lists columns that logs tables created by older collector
+// versions may be missing. New installs already get them from the create-table
+// template; this brings existing tables up to the current column set.
+var logsColumnMigrations = []struct {
+	name       string
+	definition string
+}{
+	// TimestampTime mirrors the production schema, which partitions and queries
+	// logs on this column. Older chDB tables lack it, breaking the logs explorer.
+	{name: "TimestampTime", definition: "DateTime DEFAULT toDateTime(Timestamp)"},
+}
+
+// migrateLogsTable applies logsColumnMigrations to an existing logs table. It is
+// safe to run on every startup because each ALTER uses ADD COLUMN IF NOT EXISTS,
+// a cheap metadata no-op once the column is present.
+func migrateLogsTable(ctx context.Context, cfg *Config, db driver.Conn) error {
+	for _, col := range logsColumnMigrations {
+		data := sqltemplates.AddColumnData{
+			Database:         cfg.database(),
+			TableName:        cfg.LogsTableName,
+			ClusterString:    cfg.clusterString(),
+			ColumnName:       col.name,
+			ColumnDefinition: col.definition,
+		}
+
+		var buf bytes.Buffer
+		if err := sqltemplates.LogsAddColumnTmpl.Execute(&buf, data); err != nil {
+			return fmt.Errorf("execute logs add column template: %w", err)
+		}
+		if err := db.Exec(ctx, buf.String()); err != nil {
+			return fmt.Errorf("exec logs table migration %q: %w", col.name, err)
+		}
 	}
 
 	return nil

--- a/collector/exporter/chdbexporter/exporter_logs_json.go
+++ b/collector/exporter/chdbexporter/exporter_logs_json.go
@@ -67,6 +67,9 @@ func (e *logsJSONExporter) start(ctx context.Context, _ component.Host) error {
 		if createTableErr := createLogsJSONTable(ctx, e.cfg, e.db); createTableErr != nil {
 			return createTableErr
 		}
+		if migrateErr := migrateLogsTable(ctx, e.cfg, e.db); migrateErr != nil {
+			return migrateErr
+		}
 		if createViewErr := createLocalLogsView(ctx, e.cfg, e.db); createViewErr != nil {
 			return createViewErr
 		}

--- a/collector/exporter/chdbexporter/exporter_logs_test.go
+++ b/collector/exporter/chdbexporter/exporter_logs_test.go
@@ -66,7 +66,7 @@ func TestRenderCreateLogsTableSQL(t *testing.T) {
 
 		require.Contains(t, sql, "toStartOfFiveMinutes(Timestamp)")
 		require.Contains(t, sql, "`test_db`.`otel_logs`")
-		require.NotContains(t, sql, "TimestampTime")
+		require.Contains(t, sql, "`TimestampTime` DateTime DEFAULT toDateTime(Timestamp)")
 		require.Contains(t, sql, "EventName")
 		require.Contains(t, sql, "__otel_materialized_k8s.namespace.name")
 		require.Contains(t, sql, "__otel_materialized_deployment.environment.name")
@@ -84,7 +84,7 @@ func TestRenderCreateLogsTableSQL(t *testing.T) {
 
 		require.Contains(t, sql, "toStartOfFiveMinutes(Timestamp)")
 		require.Contains(t, sql, "`test_db`.`otel_logs`")
-		require.NotContains(t, sql, "TimestampTime")
+		require.Contains(t, sql, "`TimestampTime` DateTime DEFAULT toDateTime(Timestamp)")
 		require.Contains(t, sql, "EventName")
 		require.Contains(t, sql, "__otel_materialized_k8s.namespace.name")
 	})
@@ -115,6 +115,7 @@ func TestRenderCreateLogsJSONTableSQL(t *testing.T) {
 	require.Contains(t, sql, "`ResourceAttributes` JSON")
 	require.Contains(t, sql, "`ScopeAttributes` JSON")
 	require.Contains(t, sql, "`LogAttributes` JSON")
+	require.Contains(t, sql, "`TimestampTime` DateTime DEFAULT toDateTime(Timestamp)")
 
 	require.Contains(t, sql, "toStartOfFiveMinutes(Timestamp)")
 	require.Contains(t, sql, "`test_db`.`otel_logs_json`")

--- a/collector/exporter/chdbexporter/factory_chdb_test.go
+++ b/collector/exporter/chdbexporter/factory_chdb_test.go
@@ -109,6 +109,33 @@ func TestFactoryWithHandleCreatesProductionFacingLocalViews(t *testing.T) {
 	require.Contains(t, queries, `CREATE VIEW IF NOT EXISTS "default"."metrics_summary" AS SELECT * FROM "default"."otel_metrics_summary"`)
 }
 
+func TestFactoryRunsLogsSchemaMigrationOnStart(t *testing.T) {
+	t.Cleanup(chdb.ResetForTesting)
+	session := &fakeChDBSession{}
+	handle, err := chdb.Open(filepath.Join(t.TempDir(), "chdb"), chdb.WithSessionFactory(func(path string) (chdb.Session, error) {
+		session.path = path
+		return session, nil
+	}))
+	require.NoError(t, err)
+
+	factory := NewFactoryWithHandle(handle)
+	cfg := withDefaultConfig()
+	params := exportertest.NewNopSettings(metadata.Type)
+
+	logsExporter, err := factory.CreateLogs(t.Context(), params, cfg)
+	require.NoError(t, err)
+	require.NoError(t, logsExporter.Start(t.Context(), nil))
+	require.NoError(t, logsExporter.Shutdown(t.Context()))
+
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	queries := joinedQueries(session.queries)
+	// Existing installs created their logs table before TimestampTime existed;
+	// startup must issue an idempotent migration to add the production column.
+	require.Contains(t, queries, "ALTER TABLE `default`.`otel_logs`")
+	require.Contains(t, queries, "ADD COLUMN IF NOT EXISTS `TimestampTime` DateTime DEFAULT toDateTime(Timestamp)")
+}
+
 func TestFactoryWithHandleSkipsLocalViewsWhenRawNamesMatch(t *testing.T) {
 	t.Cleanup(chdb.ResetForTesting)
 	session := &fakeChDBSession{}

--- a/collector/exporter/chdbexporter/internal/sqltemplates/embed.go
+++ b/collector/exporter/chdbexporter/internal/sqltemplates/embed.go
@@ -36,13 +36,26 @@ var LogsJSONCreateTable string
 //go:embed logs_json_insert.sql
 var LogsJSONInsert string
 
+//go:embed logs_add_column.sql
+var LogsAddColumn string
+
 // Parsed templates for logs (text/template).
 var (
 	LogsCreateTableTmpl     = newTemplate("logs_table", LogsCreateTable)
 	LogsInsertTmpl          = newTemplate("logs_insert", LogsInsert)
 	LogsJSONCreateTableTmpl = newTemplate("logs_json_table", LogsJSONCreateTable)
 	LogsJSONInsertTmpl      = newTemplate("logs_json_insert", LogsJSONInsert)
+	LogsAddColumnTmpl       = newTemplate("logs_add_column", LogsAddColumn)
 )
+
+// AddColumnData contains the template parameters for an idempotent ADD COLUMN.
+type AddColumnData struct {
+	Database         string
+	TableName        string
+	ClusterString    string
+	ColumnName       string
+	ColumnDefinition string
+}
 
 // CreateTableData contains the template parameters for creating a logs table.
 type CreateTableData struct {

--- a/collector/exporter/chdbexporter/internal/sqltemplates/logs_add_column.sql
+++ b/collector/exporter/chdbexporter/internal/sqltemplates/logs_add_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE {{ident .Database}}.{{ident .TableName}} {{.ClusterString}} ADD COLUMN IF NOT EXISTS {{ident .ColumnName}} {{.ColumnDefinition}}

--- a/collector/exporter/chdbexporter/internal/sqltemplates/logs_json_table.sql
+++ b/collector/exporter/chdbexporter/internal/sqltemplates/logs_json_table.sql
@@ -1,5 +1,6 @@
 CREATE TABLE IF NOT EXISTS {{ident .Database}}.{{ident .TableName}} {{.ClusterString}} (
     `Timestamp` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    `TimestampTime` DateTime DEFAULT toDateTime(Timestamp),
     `TraceId` String CODEC(ZSTD(1)),
     `SpanId` String CODEC(ZSTD(1)),
     `TraceFlags` UInt8,

--- a/collector/exporter/chdbexporter/internal/sqltemplates/logs_table.sql
+++ b/collector/exporter/chdbexporter/internal/sqltemplates/logs_table.sql
@@ -1,5 +1,6 @@
 CREATE TABLE IF NOT EXISTS {{ident .Database}}.{{ident .TableName}} {{.ClusterString}} (
     `Timestamp` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    `TimestampTime` DateTime DEFAULT toDateTime(Timestamp),
     `TraceId` String CODEC(ZSTD(1)),
     `SpanId` String CODEC(ZSTD(1)),
     `TraceFlags` UInt8,


### PR DESCRIPTION
## Problem

Users hit **"Failed to load logs"** in the app's logs explorer. The underlying error from ClickHouse:

```
Code: 47. DB::Exception: Unknown expression identifier `TimestampTime` ... (UNKNOWN_IDENTIFIER)
```

The app's logs queries filter the time range on a `TimestampTime` column, which exists in the **production** ClickHouse schema (`clickhouse/init/03-create-otel-tables.sql` — it even partitions/orders on it). But the **embedded chDB collector** auto-creates its `otel_logs` table from a template (`internal/sqltemplates/logs_table.sql`) that never had that column. The two schema sources drifted, so every logs query against a chDB-created table failed.

Because `create_schema` only runs `CREATE TABLE IF NOT EXISTS`, existing installs keep the old shape forever — adding the column to the template alone fixes new installs but not the ones already in the field.

## Change

- Add `TimestampTime DateTime DEFAULT toDateTime(Timestamp)` to both the map and JSON logs table templates, matching production. (Traces and all 5 metrics tables already matched 1:1 — logs was the only drift.)
- Run an idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` migration on collector startup so **existing** chDB tables converge on the same column set. It's gated by `shouldCreateSchema()`, so externally-managed (production) schemas are never altered.
- The columns to backfill live in a small `logsColumnMigrations` list, so the next drift is a one-line addition.

The `logs` view is `CREATE VIEW ... AS SELECT *`, which ClickHouse re-expands at query time, so the new column flows through without recreating the view.

## Why a template instead of a dead-simple SQL string

The obvious version is a one-line literal:

```go
db.Exec(ctx, `ALTER TABLE otel_logs ADD COLUMN IF NOT EXISTS TimestampTime DateTime DEFAULT toDateTime(Timestamp)`)
```

That doesn't work safely here. The target table is **not fixed**: `database`, `logs_table_name`, and `cluster_name` are all config-driven, and the migration must hit *exactly* the table `createLogsTable` created. A hardcoded name silently breaks any non-default config and risks `ALTER`/`DESC` against a wrong or nonexistent table.

So the identifiers have to be interpolated. The first cut used `fmt.Sprintf("ALTER TABLE %q.%q %s ADD COLUMN ...", ...)`, but format-string SQL is exactly what the rest of this package deliberately avoids: every other DDL — `logs_table.sql`, `traces_table.sql`, the metrics tables — lives in `internal/sqltemplates/` and is rendered through `text/template` with the shared `ident` helper that backtick-quotes identifiers correctly. Putting the `ALTER` in `logs_add_column.sql` next to the `CREATE` it mirrors keeps it reading like SQL, gets correct quoting for free, and keeps one consistent DDL mechanism instead of a second hand-rolled one.

It's a few more lines than a literal, but it buys correctness (config-driven names), consistency (one DDL path), and safe quoting — and it's the only place a literal would have been actively wrong.

## Why no migration journal

`ADD COLUMN IF NOT EXISTS` is a metadata-only no-op once the column is present (microseconds, no data rewrite), so running it every startup is cheap. A `schema_migrations` journal would add a table plus a read on every start (no round-trip saved) and a new failure mode — it can desync from the real schema. The table's own column list is a more reliable source of truth than a separate ledger, so we skip the journal.

## Testing

- `make test` green (incl. a new `TestFactoryRunsLogsSchemaMigrationOnStart` asserting the `ALTER` is issued on startup, and updated render assertions for both templates).
- `gofmt` / `go vet` / `golangci-lint` clean (pre-commit hooks pass).