### PR TITLE
docs: refresh devlog home page framing

### DIFF
--- a/packages/docs/src/routes/devlog/index.tsx
+++ b/packages/docs/src/routes/devlog/index.tsx
@@ -62,10 +62,10 @@ function DevlogIndex() {
           </h1>
           <div className="mt-6 max-w-2xl space-y-4 text-fd-muted-foreground">
             <p>
-              With Everr we want to bring AI into the software development
-              lifecycle, making observability a natural part of your stack
-              instead of a separate discipline, and guiding your team toward the
-              best practices that have always been too complicated to apply
+              We want to bring AI into the software development lifecycle,
+              making observability a natural part of your stack instead of a
+              separate discipline, and guiding your team toward the best
+              practices that have always been too complicated to apply
               everywhere.
             </p>
             <p>

--- a/packages/docs/src/routes/devlog/index.tsx
+++ b/packages/docs/src/routes/devlog/index.tsx
@@ -62,13 +62,6 @@ function DevlogIndex() {
           </h1>
           <div className="mt-6 max-w-2xl space-y-4 text-fd-muted-foreground">
             <p>
-              We're building an observability platform for developers and AI
-              agents, because understanding what your code is doing is still
-              harder than it should be, whether you're a person staring at a
-              failed run or an agent trying to validate the code it just
-              shipped.
-            </p>
-            <p>
               With Everr we want to bring AI into the software development
               lifecycle, making observability a natural part of your stack
               instead of a separate discipline, and guiding your team toward the

--- a/packages/docs/src/routes/devlog/index.tsx
+++ b/packages/docs/src/routes/devlog/index.tsx
@@ -69,15 +69,18 @@ function DevlogIndex() {
               shipped.
             </p>
             <p>
-              A growing share of code is written by AI. But when that code
-              breaks in CI, the feedback loop is slow and lossy. Agents don't
-              have good access to pipeline data, log structure, or test history.
-              Everr gives both humans and agents a fast, structured way to
-              understand what happened, why it failed, and what to do about it.
+              A growing share of code is written by AI, but the tools we use to
+              understand running code weren't built for agents. Dashboards live
+              behind clicks in a web UI, the data sits behind query languages
+              and APIs an agent has to learn first, and the knowledge of how to
+              investigate something lives in someone's head. Everr puts all of
+              that in your codebase, as code, so both humans and agents can read
+              it, write it, and improve it the same way they work on everything
+              else.
             </p>
             <p>
-              We use Everr on our own CI every day, and when something slows us
-              down, it becomes a fix the same week.
+              We use Everr on our own code every day, and when something slows
+              us down, it becomes a fix the same week.
             </p>
           </div>
         </section>

--- a/packages/docs/src/routes/devlog/index.tsx
+++ b/packages/docs/src/routes/devlog/index.tsx
@@ -69,18 +69,15 @@ function DevlogIndex() {
               shipped.
             </p>
             <p>
-              A growing share of code is written by AI, but the tools we use to
-              understand running code weren't built for agents. Dashboards live
-              behind clicks in a web UI, the data sits behind query languages
-              and APIs an agent has to learn first, and the knowledge of how to
-              investigate something lives in someone's head. Everr puts all of
-              that in your codebase, as code, so both humans and agents can read
-              it, write it, and improve it the same way they work on everything
-              else.
+              With Everr we want to bring AI into the software development
+              lifecycle, making observability a natural part of your stack
+              instead of a separate discipline, and guiding your team toward the
+              best practices that have always been too complicated to apply
+              everywhere.
             </p>
             <p>
-              We use Everr on our own code every day, and when something slows
-              us down, it becomes a fix the same week.
+              We use Everr on our own systems every day, and honestly we don't
+              know how we used to live without it.
             </p>
           </div>
         </section>


### PR DESCRIPTION
Updates the intro framing on the devlog home page (`/devlog`) to match where Everr has gone beyond CI.

- Broadens the second paragraph from the CI-only angle to the as-code story.
- Reframes around bringing AI into the software development lifecycle, making observability a natural part of your stack, and guiding teams toward best practices that used to be too complicated to apply everywhere.
- Updates the closing line ("our own systems every day…").

Single file: `packages/docs/src/routes/devlog/index.tsx`.