### PR TITLE
perf(app): defer dashboard panel queries to visible panels

### DIFF
--- a/packages/app/src/components/dashboards/dashboard-panel.tsx
+++ b/packages/app/src/components/dashboards/dashboard-panel.tsx
@@ -6,10 +6,11 @@ import {
 import { useNavigate } from "@tanstack/react-router";
 import { TriangleAlert } from "lucide-react";
 import type { ReactNode } from "react";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import type { Panel } from "@/data/dashboards/schema";
 import { PanelShell } from "../panel-shell";
 import { useDashboardPanelData } from "./use-dashboard-panel-data";
+import { useInView } from "./use-in-view";
 import {
   getVisualizationInset,
   getVisualizationSpecWarnings,
@@ -59,8 +60,13 @@ export function DashboardPanel({
   const { display, plugin } = panel.spec;
   const navigate = useNavigate();
 
-  const { data, status, errorMessage, timeRange } =
-    useDashboardPanelData(panel);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inView = useInView(containerRef);
+
+  const { data, status, errorMessage, timeRange } = useDashboardPanelData(
+    panel,
+    { enabled: inView },
+  );
 
   const specWarnings = useMemo(
     () => getVisualizationSpecWarnings(plugin),
@@ -83,7 +89,7 @@ export function DashboardPanel({
   );
 
   return (
-    <div className="group/panel relative h-full">
+    <div ref={containerRef} className="group/panel relative h-full">
       <PanelShell
         title={display?.name ?? panelKey}
         description={display?.description}

--- a/packages/app/src/components/dashboards/use-dashboard-panel-data.ts
+++ b/packages/app/src/components/dashboards/use-dashboard-panel-data.ts
@@ -142,7 +142,11 @@ export interface DashboardPanelData extends CombinedPanelResult {
  * intermediate hooks to coordinate. The variable bar still uses
  * `useDashboardVariables` directly for its pickers.
  */
-export function useDashboardPanelData(panel: Panel): DashboardPanelData {
+export function useDashboardPanelData(
+  panel: Panel,
+  options?: { enabled?: boolean },
+): DashboardPanelData {
+  const active = options?.enabled ?? true;
   // Effective range: explicit URL params, else the dashboard's route defaults,
   // else the global default — resolved before first render (no flash). The
   // variable-options queries read the same range internally.
@@ -177,6 +181,7 @@ export function useDashboardPanelData(panel: Panel): DashboardPanelData {
         r.variableMeta,
       ),
       enabled:
+        active &&
         sourceIsActive(r.source) &&
         r.missingName === undefined &&
         r.optionsError === undefined &&

--- a/packages/app/src/components/dashboards/use-in-view.ts
+++ b/packages/app/src/components/dashboards/use-in-view.ts
@@ -1,0 +1,32 @@
+import { type RefObject, useEffect, useState } from "react";
+
+/**
+ * Tracks whether the referenced element is currently near the viewport. Used to
+ * gate expensive work — panel queries, preview embeds — to what's on screen:
+ * `enabled: inView` defers it until visible and, with `staleTime: Infinity` on
+ * the gated query, an off-screen element goes idle (keeping its cached data)
+ * without ever refetching on scroll-back. A refresh (`invalidateQueries`) then
+ * only re-runs what's currently visible; off-screen content revalidates when it
+ * scrolls back in. The effect only sets up the observer on mount; it does not
+ * react to a prop to set state.
+ */
+export function useInView(
+  ref: RefObject<Element | null>,
+  rootMargin = "200px",
+): boolean {
+  const [inView, setInView] = useState(false);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (entry) setInView(entry.isIntersecting);
+      },
+      { rootMargin },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [ref, rootMargin]);
+  return inView;
+}

--- a/packages/app/src/data/dashboards/options.ts
+++ b/packages/app/src/data/dashboards/options.ts
@@ -15,6 +15,10 @@ export const dashboardOptions = (project: string, slug: string) =>
   queryOptions({
     queryKey: [...dashboardsQueryKey, project, slug],
     queryFn: () => getDashboard({ data: { project, slug } }),
+    // The dashboard document is immutable (gitops); never auto-refetch it (e.g.
+    // when a card preview re-enters the viewport). A manual refresh still
+    // invalidates it.
+    staleTime: Number.POSITIVE_INFINITY,
   });
 
 export const dashboardListOptions = () =>
@@ -50,6 +54,11 @@ export const panelQueryOptions = (
       source.kind === "ClickHouseSQL"
         ? source.sql.trim().length > 0
         : source.kind === "TestData",
+    // Data for a given (source, range, variables) key never goes stale on its
+    // own: a panel that scrolls out of view and back must not refetch. Only an
+    // explicit refresh (invalidateQueries, which overrides staleTime) or a key
+    // change (range/variables) triggers a new fetch.
+    staleTime: Number.POSITIVE_INFINITY,
   });
 
 export const variableOptionsQueryOptions = (


### PR DESCRIPTION
## What

Dashboard panels now run their queries only while in the viewport, and panel/document queries are pinned with `staleTime: Infinity`.

Today a dashboard fires **every** panel's query on load (and on every refresh), regardless of what's on screen. On a tall dashboard that's a lot of wasted queries.

## How

- **`useInView`** — a small shared `IntersectionObserver` hook tracking current viewport visibility (with a 200px pre-load margin).
- **`useDashboardPanelData(panel, { enabled })`** — the panel query is gated by an `enabled` flag (defaults to `true`, so existing callers are unchanged).
- **`DashboardPanel`** observes its own shell and passes `enabled: inView`.
- **`panelQueryOptions` / `dashboardOptions`** get `staleTime: Infinity` — data for a given `(source, range, variables)` key is immutable, so it never auto-refetches on scroll-back. An explicit refresh (`invalidateQueries`, which overrides `staleTime`) or a key change (range/variables) still fetches.

## Behavior

- **Load**: only on-screen panels query; below-fold panels stay idle.
- **Scroll**: panels query as they enter view; scrolling back is free (no refetch).
- **Refresh**: re-runs only the panels currently visible; off-screen panels revalidate when scrolled back into view.

## Verification

Measured panel-query requests on an 18-panel dashboard (1280×800):

| Action | Panel queries |
| --- | --- |
| Initial load | 4 of 18 (only visible) |
| Scroll to bottom | 18 (below-fold load on the way) |
| Scroll back to top | +0 (no refetch) |
| Refresh at top | +4 (only the visible panels) |

`tsc --noEmit` clean.