### PR TITLE
perf(app): stagger panel queries with a concurrency limiter

### DIFF
--- a/packages/app/src/data/dashboards/options.ts
+++ b/packages/app/src/data/dashboards/options.ts
@@ -1,6 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 import type { PanelQuerySource } from "@/components/dashboards/query-array";
 import type { QueryResultRow } from "@/components/dashboards/visualizations";
+import { createLimiter } from "@/lib/limiter";
 import type { VariableMeta, VariableValues } from "./interpolate";
 import {
   getDashboard,
@@ -10,6 +11,12 @@ import {
 } from "./server";
 
 const dashboardsQueryKey = ["dashboards"] as const;
+
+// Cap how many panel queries run at once so a dashboard (or a grid of card
+// previews) doesn't fire every panel's query simultaneously. Shared across all
+// panels on the page; the rest queue and start in waves as slots free.
+const MAX_CONCURRENT_PANEL_QUERIES = 4;
+const panelLimiter = createLimiter(MAX_CONCURRENT_PANEL_QUERIES);
 
 export const dashboardOptions = (project: string, slug: string) =>
   queryOptions({
@@ -43,12 +50,14 @@ export const panelQueryOptions = (
       variables ?? null,
       variableMeta ?? null,
     ],
-    queryFn: async (): Promise<{ rows: QueryResultRow[] }> => {
+    queryFn: async ({ signal }): Promise<{ rows: QueryResultRow[] }> => {
       // `none` is never enabled, but the queryFn must still type-check.
       if (source.kind === "none") return { rows: [] };
-      return runPanelQuery({
-        data: { source, from, to, variables, variableMeta },
-      });
+      return panelLimiter(signal, () =>
+        runPanelQuery({
+          data: { source, from, to, variables, variableMeta },
+        }),
+      );
     },
     enabled:
       source.kind === "ClickHouseSQL"

--- a/packages/app/src/lib/limiter.test.ts
+++ b/packages/app/src/lib/limiter.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { createLimiter } from "./limiter";
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe("createLimiter", () => {
+  it("never runs more than maxConcurrent tasks at once, and runs them all", async () => {
+    const run = createLimiter(2);
+    let active = 0;
+    let maxActive = 0;
+    const gates = [
+      deferred<void>(),
+      deferred<void>(),
+      deferred<void>(),
+      deferred<void>(),
+    ];
+    const results = gates.map((gate, i) =>
+      run(undefined, async () => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        await gate.promise;
+        active--;
+        return i;
+      }),
+    );
+
+    await tick();
+    expect(active).toBe(2); // only the first two started; the rest queued
+
+    gates[0].resolve();
+    await tick();
+    expect(active).toBe(2); // a queued task took the freed slot
+
+    gates[1].resolve();
+    gates[2].resolve();
+    gates[3].resolve();
+    expect(await Promise.all(results)).toEqual([0, 1, 2, 3]);
+    expect(maxActive).toBe(2);
+  });
+
+  it("skips an already-aborted task without running its work", async () => {
+    const run = createLimiter(2);
+    let ran = false;
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      run(controller.signal, async () => {
+        ran = true;
+      }),
+    ).rejects.toBeDefined();
+    expect(ran).toBe(false);
+  });
+
+  it("a queued task still runs after earlier tasks finish", async () => {
+    const run = createLimiter(1);
+    const order: number[] = [];
+    const first = deferred<void>();
+    const p1 = run(undefined, async () => {
+      order.push(1);
+      await first.promise;
+    });
+    const p2 = run(undefined, async () => {
+      order.push(2);
+    });
+
+    await tick();
+    expect(order).toEqual([1]); // second is queued behind the single slot
+
+    first.resolve();
+    await Promise.all([p1, p2]);
+    expect(order).toEqual([1, 2]);
+  });
+});

--- a/packages/app/src/lib/limiter.ts
+++ b/packages/app/src/lib/limiter.ts
@@ -1,0 +1,39 @@
+/**
+ * Bounds how many async tasks run concurrently. Calls beyond `maxConcurrent`
+ * queue (FIFO) and start as running tasks finish — so a burst of work (e.g. a
+ * dashboard's panels all becoming visible at once) is spread into waves instead
+ * of hitting the backend simultaneously.
+ *
+ * Each call may pass an `AbortSignal`; a task already aborted by the time its
+ * turn comes is skipped (it rejects without running its work), which lets
+ * react-query treat it as a cancellation rather than firing a useless request.
+ */
+export function createLimiter(maxConcurrent: number) {
+  let active = 0;
+  const waiters: Array<() => void> = [];
+
+  function release() {
+    const next = waiters.shift();
+    // Hand the freed slot straight to the next waiter (active stays at the cap);
+    // only drop the count when nobody is waiting.
+    if (next) next();
+    else active--;
+  }
+
+  return async function run<T>(
+    signal: AbortSignal | undefined,
+    task: () => Promise<T>,
+  ): Promise<T> {
+    if (active >= maxConcurrent) {
+      await new Promise<void>((resolve) => waiters.push(resolve));
+    } else {
+      active++;
+    }
+    try {
+      if (signal?.aborted) throw signal.reason ?? new Error("aborted");
+      return await task();
+    } finally {
+      release();
+    }
+  };
+}


### PR DESCRIPTION
## What

A dashboard with many panels — or a grid of live card previews — fires **every** visible panel's query at the same moment, hammering the backend with a burst. This caps how many panel queries run concurrently and queues the rest, so they start in waves.

Builds on the panel viewport-gating from #271: off-screen panels don't enqueue at all, and the ones that do are now throttled.

## How

- **`createLimiter(maxConcurrent)`** — a small shared async concurrency limiter (semaphore). Calls beyond the cap queue FIFO and start as running tasks finish. Abort-aware: a task already aborted by the time its turn comes (panel scrolled away / unmounted) is skipped without running, so react-query treats it as a cancellation instead of firing a useless request.
- **`panelQueryOptions`** routes `runPanelQuery` through a module-level `panelLimiter` (`MAX_CONCURRENT_PANEL_QUERIES = 4`). One limiter shared across every panel on the page, so even a grid of preview cards can't burst the backend.

## Verification

- Unit tests (`limiter.test.ts`): never exceeds the cap, runs all tasks, queues correctly, skips aborted tasks. 3/3 pass.
- Browser, 18-panel dashboard: all 18 queries fire, but **never more than 4 in flight at once**.
- `tsc --noEmit` clean.

## Tuning

`MAX_CONCURRENT_PANEL_QUERIES` in `data/dashboards/options.ts` — one line to raise (snappier) or lower (gentler on the backend).