### PR TITLE
feat(workflows): cost-first workflow detail + easier nav from cost analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,27 @@
-## Unreleased
 
-### Breaking changes - CLI command groups
+### MCP server
 
-- Moved commands under grouped namespaces: `everr cloud login/logout`, `everr ci status/watch/runs/show/logs`, and `everr local start/status/query`.
-- Removed the retired CLI commands `everr test-history`, `everr slowest-tests`, `everr slowest-jobs`, `everr workflows`, and `everr ci grep`, along with their `/api/cli/*` backend routes.
+Introduced a new [MCP server](/docs/reference/mcp) at `/mcp` with a `query` tool that runs SQL against your telemetry from AI agents, plus a `whoami` introspection tool.
 
-### Breaking changes - `everr local`
+### Notebooks → Runbooks
 
-- Removed `everr local traces` and `everr local logs`, along with the filter flags `--service`, `--level`, `--trace-id`, `--from`, `--to`, `--attr`, `--name`, `--egrep`, and `--target`.
-- New `everr local query "<SQL>"` passes SQL to the collector's `/sql` endpoint.
-- Migration: previous invocations map to SQL queries. Example:
-  - `local logs --level ERROR --from now-1h` -> `local query "SELECT Timestamp, ServiceName, SeverityText, Body FROM otel_logs WHERE SeverityNumber >= 17 AND Timestamp > now() - INTERVAL 1 HOUR ORDER BY Timestamp DESC LIMIT 200"`
-  - `local traces --service X --trace-id abc` -> `local query "SELECT * FROM otel_traces WHERE ServiceName='X' AND TraceId='abc' LIMIT 50"`
-- Existing shell aliases and scripts must be updated. The local telemetry directory's on-disk format has changed; previous `otlp-*.json` files are ignored.
-- `--telemetry-dir` was removed. The CLI now targets its own build's collector sidecar by HTTP, so a path on disk is no longer meaningful.
-- Installer size increases by about 120 MB for the shipped universal macOS collector binary because of the bundled `libchdb`.
+- Renamed across the entire product — UI, docs, routes, navigation, and [alert definitions](/docs/alerts).
+- Backwards-compatible aliases: `notebook` field in legacy alert specs and the `Notebook` kind still work.
+
+### CI Runs Explorer
+
+- Runs page rebuilt as a filter-driven [explorer](/docs/ci-insights/debug-ci) with infinite scroll. Repository filter in the topbar with a "Your runs" toggle.
+- Runs explorer is now a shared component used in both the web app and desktop app.
+- Workflows list page removed; workflow names link directly to their detail views.
+
+### Dashboard Performance
+
+- [Dashboard](/docs/dashboards) panel queries are deferred until the panel scrolls into view.
+- In-flight panel queries are staggered so dashboards don't flood the database.
+
+### Desktop App
+
+- CI page with the shared runs explorer; auth required only on the CI page (rest of the app is freely accessible).
+- Unified top title bar with consistent fullscreen/windowed spacing.
+- Nav reordered to Logs / Traces / Errors / CI / Settings; default route is now `/logs`.
+- Skills install/status in Settings; Sign In available from the account menu.

--- a/packages/app/src/lib/auth.server.ts
+++ b/packages/app/src/lib/auth.server.ts
@@ -22,9 +22,9 @@ import {
   ownerAc,
 } from "better-auth/plugins/organization/access";
 import { tanstackStartCookies } from "better-auth/tanstack-start";
-import { and, eq } from "drizzle-orm";
+import { and, desc, eq, isNotNull } from "drizzle-orm";
 import { db } from "@/db/client";
-import { deviceCode, member, user } from "@/db/schema";
+import { deviceCode, member, session as sessionTable, user } from "@/db/schema";
 import { env } from "@/env";
 import {
   getDeviceApprovalUserCode,
@@ -91,6 +91,43 @@ async function getMarkedDeviceOrganizationId(
       and(
         eq(member.userId, session.userId),
         eq(member.organizationId, organizationId),
+      ),
+    )
+    .limit(1);
+
+  return membership[0]?.organizationId ?? null;
+}
+
+// The org the user most recently had active, read off their latest session.
+// A new login (notably CLI/device login) should land on the same org the user
+// was last using instead of an arbitrary membership. `session.updatedAt` bumps
+// whenever the active org changes, so the freshest session holds the current org.
+async function getLastUsedOrganizationId(session: { userId: string }) {
+  const recentSession = await db
+    .select({ organizationId: sessionTable.activeOrganizationId })
+    .from(sessionTable)
+    .where(
+      and(
+        eq(sessionTable.userId, session.userId),
+        isNotNull(sessionTable.activeOrganizationId),
+      ),
+    )
+    .orderBy(desc(sessionTable.updatedAt))
+    .limit(1);
+
+  const candidateOrgId = recentSession[0]?.organizationId ?? null;
+  if (!candidateOrgId) {
+    return null;
+  }
+
+  // Reuse it only if the user is still a member of that org.
+  const membership = await db
+    .select({ organizationId: member.organizationId })
+    .from(member)
+    .where(
+      and(
+        eq(member.userId, session.userId),
+        eq(member.organizationId, candidateOrgId),
       ),
     )
     .limit(1);
@@ -217,6 +254,12 @@ export const auth = betterAuth({
             session,
             context,
           );
+
+          // Prefer the org the user most recently had active (their "current"
+          // org) so a fresh login reuses it instead of picking the first one.
+          if (!activeOrganizationId) {
+            activeOrganizationId = await getLastUsedOrganizationId(session);
+          }
 
           // Look for an existing membership to set as active org.
           if (!activeOrganizationId) {


### PR DESCRIPTION
## Summary

Replaces the general-purpose workflow detail page with a cost-focused view and makes it easier to drill into from the Cost Analysis page.

### Changes

**Cost-first workflow detail**
- KPI row showing estimated cost, avg $/run, billed minutes, and avg wall-clock/run
- Job timeline Gantt chart with prev/next run stepping and parallelism via bar overlap
- "Cost by job" and "Recent runs" (with per-run cost) breakdown tables
- Breadcrumb + back button to return to Cost Analysis

**Navigational improvements**
- Cost-by-Workflow rows in Cost Analysis are now clickable drill-ins (whole-row navigation, time range retained) via a new optional `DataTable` `onRowClick`

**Refactoring**
- Paired `ResourceAttributes` filters with `mapContains` for bloom skip index pruning
- Shared resource attribute filter helpers via `run-query-helpers` (drops duplicated copies in cost-analysis)
- Dropped dead `WorkflowCostSummary` fields and related queries
- Collapsed `timelines` aggregation to a single pass; collapsed `RunsTable` to its one caller
- Removed unused run-level `endMs`/`computeMs` from `WorkflowRunGantt`

**Auth fix**
- New logins (CLI/device login) now land on the org the user was last using instead of an arbitrary membership