### PR TITLE
fix(auth): land CLI device login on the org active at approval

### DIFF
--- a/packages/app/src/lib/auth.server.ts
+++ b/packages/app/src/lib/auth.server.ts
@@ -40,6 +40,8 @@ import {
 import {
   getActiveOrganizationIdFromAuthSession,
   getDeviceOrgIdFromScope,
+  getMarkedDeviceOrgIdFromContext,
+  markDeviceOrgContext,
   withDeviceOrgScope,
 } from "@/lib/device-org-scope";
 import {
@@ -68,18 +70,10 @@ async function getMarkedDeviceOrganizationId(
   session: { userId: string },
   context: unknown,
 ) {
-  const deviceCodeValue = getDeviceTokenCode(context);
-  if (!deviceCodeValue) {
-    return null;
-  }
-
-  const deviceCodeRecord = await db
-    .select({ scope: deviceCode.scope })
-    .from(deviceCode)
-    .where(eq(deviceCode.deviceCode, deviceCodeValue))
-    .limit(1);
-
-  const organizationId = getDeviceOrgIdFromScope(deviceCodeRecord[0]?.scope);
+  // The org is read off the device code in the `/device/token` before-hook and
+  // stashed on the context, because better-auth consumes (deletes) the device
+  // code before this session hook runs (see the cli-device-organization plugin).
+  const organizationId = getMarkedDeviceOrgIdFromContext(context);
   if (!organizationId) {
     return null;
   }
@@ -378,6 +372,43 @@ export const auth = betterAuth({
               }
 
               return { context };
+            }),
+          },
+          {
+            // better-auth consumes (deletes) the device code while exchanging
+            // the token, before the session.create hook runs. Capture the
+            // marked org here — while the row still exists — and stash it on the
+            // context so getMarkedDeviceOrganizationId can read it back.
+            matcher: (context) => context.path === "/device/token",
+            handler: createAuthMiddleware(async (context) => {
+              const deviceCodeValue = getDeviceTokenCode(context);
+              if (!deviceCodeValue) {
+                return;
+              }
+
+              try {
+                const deviceCodeRecord = await db
+                  .select({ scope: deviceCode.scope })
+                  .from(deviceCode)
+                  .where(eq(deviceCode.deviceCode, deviceCodeValue))
+                  .limit(1);
+
+                const organizationId = getDeviceOrgIdFromScope(
+                  deviceCodeRecord[0]?.scope,
+                );
+                if (organizationId) {
+                  return { context: markDeviceOrgContext(organizationId) };
+                }
+              } catch (error) {
+                // Carrying the org across is an enhancement; never let a DB
+                // failure break the token exchange.
+                serverLogger.error(
+                  "cli_device_organization.capture.failed",
+                  exceptionAttributes(error),
+                );
+              }
+
+              return;
             }),
           },
         ],

--- a/packages/app/src/lib/auth.server.ts
+++ b/packages/app/src/lib/auth.server.ts
@@ -70,9 +70,7 @@ async function getMarkedDeviceOrganizationId(
   session: { userId: string },
   context: unknown,
 ) {
-  // The org is read off the device code in the `/device/token` before-hook and
-  // stashed on the context, because better-auth consumes (deletes) the device
-  // code before this session hook runs (see the cli-device-organization plugin).
+  // Stashed by the /device/token before-hook (see cli-device-organization).
   const organizationId = getMarkedDeviceOrgIdFromContext(context);
   if (!organizationId) {
     return null;
@@ -407,8 +405,6 @@ export const auth = betterAuth({
                   exceptionAttributes(error),
                 );
               }
-
-              return;
             }),
           },
         ],

--- a/packages/app/src/lib/device-org-scope.test.ts
+++ b/packages/app/src/lib/device-org-scope.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   getActiveOrganizationIdFromAuthSession,
   getDeviceOrgIdFromScope,
+  getMarkedDeviceOrgIdFromContext,
+  markDeviceOrgContext,
   withDeviceOrgScope,
 } from "@/lib/device-org-scope";
 
@@ -38,5 +40,20 @@ describe("device org scope helpers", () => {
   it("returns null when the browser auth session has no active org", () => {
     expect(getActiveOrganizationIdFromAuthSession({ session: {} })).toBeNull();
     expect(getActiveOrganizationIdFromAuthSession(null)).toBeNull();
+  });
+
+  it("round-trips the marked org through the request context", () => {
+    const context = {
+      path: "/device/token",
+      ...markDeviceOrgContext("org_99"),
+    };
+    expect(getMarkedDeviceOrgIdFromContext(context)).toBe("org_99");
+  });
+
+  it("returns null when the context has no marked org", () => {
+    expect(
+      getMarkedDeviceOrgIdFromContext({ path: "/device/token" }),
+    ).toBeNull();
+    expect(getMarkedDeviceOrgIdFromContext(null)).toBeNull();
   });
 });

--- a/packages/app/src/lib/device-org-scope.ts
+++ b/packages/app/src/lib/device-org-scope.ts
@@ -34,11 +34,8 @@ export function getDeviceOrgIdFromScope(scope: string | null | undefined) {
   }
 }
 
-// Key under which the device-login org is carried across the better-auth
-// request. better-auth consumes (deletes) the device code while exchanging the
-// token, before the `session.create.before` hook runs — so a `/device/token`
-// before-hook reads the marked org off the still-present device code and stashes
-// it on the endpoint context, where the session hook can still read it.
+// Context key for the device-login org, stashed by the /device/token
+// before-hook (see the cli-device-organization plugin in auth.server.ts).
 const DEVICE_ORG_CONTEXT_KEY = "everrDeviceOrgId";
 
 export function markDeviceOrgContext(organizationId: string) {

--- a/packages/app/src/lib/device-org-scope.ts
+++ b/packages/app/src/lib/device-org-scope.ts
@@ -34,6 +34,25 @@ export function getDeviceOrgIdFromScope(scope: string | null | undefined) {
   }
 }
 
+// Key under which the device-login org is carried across the better-auth
+// request. better-auth consumes (deletes) the device code while exchanging the
+// token, before the `session.create.before` hook runs — so a `/device/token`
+// before-hook reads the marked org off the still-present device code and stashes
+// it on the endpoint context, where the session hook can still read it.
+const DEVICE_ORG_CONTEXT_KEY = "everrDeviceOrgId";
+
+export function markDeviceOrgContext(organizationId: string) {
+  return { [DEVICE_ORG_CONTEXT_KEY]: organizationId };
+}
+
+export function getMarkedDeviceOrgIdFromContext(context: unknown) {
+  const value = (context as Record<string, unknown> | null | undefined)?.[
+    DEVICE_ORG_CONTEXT_KEY
+  ];
+
+  return typeof value === "string" && value ? value : null;
+}
+
 export function getActiveOrganizationIdFromAuthSession(session: unknown) {
   const activeOrganizationId = (
     session as {


### PR DESCRIPTION
## Problem

`everr cloud login` always landed on an arbitrary org instead of the one the user was actually using.

The browser's active org is correctly stamped onto the device code's `scope` at `/device/approve`. But the `session.create.before` hook recovered it by **re-reading the device-code row** — and better-auth's `/device/token` exchange calls `consumeOne`, which **deletes-and-commits that row before the session is created**. So the read always missed and the code fell through to an arbitrary `member … LIMIT 1` membership.

(The recently merged "prefer last-used org" change mitigates this for most logins, but the device-login path still couldn't honor the exact org chosen at approval time.)

## Fix

Capture the marked org in a `/device/token` **before-hook** — which runs before `consumeOne` deletes the row — and stash it on the request context. The `session.create.before` hook now reads it back from the context instead of re-querying the (already-consumed) device code, then verifies the user is still a member of that org.

## Changes

- `auth.server.ts`: new `/device/token` before-hook in the `cli-device-organization` plugin captures the marked org; `getMarkedDeviceOrganizationId` reads from the context stash.
- `device-org-scope.ts`: `markDeviceOrgContext` / `getMarkedDeviceOrgIdFromContext` helpers (keyed on `everrDeviceOrgId`).
- Unit tests for the context round-trip.

## Resulting org-selection precedence

1. Marked device org (org active at approval) — now works.
2. Last-used org (from the user's most recent session).
3. First membership.
4. Auto-created personal org.

## Verification

- `tsc --noEmit` clean; `device-org-scope` + `auth-context-body` unit tests pass.
- Root cause traced through better-auth 1.6.20's dispatch/consume internals (the device code is consumed at `routes.mjs:248`, before `createSession` at `:266`).

Not yet exercised live end-to-end (CLI → browser approval → CLI); happy to walk through an actual `everr cloud login` with a non-default org active if desired.