### PR TITLE
fix(chdb): drop and recreate local query views on startup

### DIFF
--- a/.changeset/fix-chdb-stale-local-views.md
+++ b/.changeset/fix-chdb-stale-local-views.md
@@ -2,4 +2,4 @@
 "@everr/desktop-app": patch
 ---
 
-Fix logs queries still failing with `Unknown identifier TimestampTime` on installs that predate the column migration. The local `logs`/`traces`/`metrics_*` query views freeze the source table's column set when created, so a view created before the `TimestampTime` migration kept rejecting the column even after the underlying `otel_logs` table was migrated. The collector now drops and recreates these views on every startup so they always expose the current column set.
+Fix logs queries still failing with `Unknown identifier TimestampTime` on installs that predate the column migration. The local `logs`/`traces`/`metrics_*` query views freeze the source table's column set when created, so a view created before the `TimestampTime` migration kept rejecting the column even after the underlying `otel_logs` table was migrated. On startup the collector now compares each query view's columns against its source table and drops and recreates the view only when it is stale; a pre-existing object that is not a view is left untouched.

--- a/.changeset/fix-chdb-stale-local-views.md
+++ b/.changeset/fix-chdb-stale-local-views.md
@@ -1,0 +1,5 @@
+---
+"@everr/desktop-app": patch
+---
+
+Fix logs queries still failing with `Unknown identifier TimestampTime` on installs that predate the column migration. The local `logs`/`traces`/`metrics_*` query views freeze the source table's column set when created, so a view created before the `TimestampTime` migration kept rejecting the column even after the underlying `otel_logs` table was migrated. The collector now drops and recreates these views on every startup so they always expose the current column set.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "everr-app"
-version = "0.4.7"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/collector/exporter/chdbexporter/factory_chdb_test.go
+++ b/collector/exporter/chdbexporter/factory_chdb_test.go
@@ -100,13 +100,17 @@ func TestFactoryWithHandleCreatesProductionFacingLocalViews(t *testing.T) {
 	session.mu.Lock()
 	defer session.mu.Unlock()
 	queries := joinedQueries(session.queries)
-	require.Contains(t, queries, `CREATE VIEW IF NOT EXISTS "default"."logs" AS SELECT * FROM "default"."otel_logs"`)
-	require.Contains(t, queries, `CREATE VIEW IF NOT EXISTS "default"."traces" AS SELECT * FROM "default"."otel_traces"`)
-	require.Contains(t, queries, `CREATE VIEW IF NOT EXISTS "default"."metrics_gauge" AS SELECT * FROM "default"."otel_metrics_gauge"`)
-	require.Contains(t, queries, `CREATE VIEW IF NOT EXISTS "default"."metrics_sum" AS SELECT * FROM "default"."otel_metrics_sum"`)
-	require.Contains(t, queries, `CREATE VIEW IF NOT EXISTS "default"."metrics_histogram" AS SELECT * FROM "default"."otel_metrics_histogram"`)
-	require.Contains(t, queries, `CREATE VIEW IF NOT EXISTS "default"."metrics_exponential_histogram" AS SELECT * FROM "default"."otel_metrics_exponential_histogram"`)
-	require.Contains(t, queries, `CREATE VIEW IF NOT EXISTS "default"."metrics_summary" AS SELECT * FROM "default"."otel_metrics_summary"`)
+	// Views freeze the source table's columns at creation, so startup must drop
+	// and recreate them to expose columns added by table migrations.
+	require.Contains(t, queries, `DROP VIEW IF EXISTS "default"."logs"`)
+	require.Contains(t, queries, `CREATE VIEW "default"."logs" AS SELECT * FROM "default"."otel_logs"`)
+	require.Contains(t, queries, `DROP VIEW IF EXISTS "default"."traces"`)
+	require.Contains(t, queries, `CREATE VIEW "default"."traces" AS SELECT * FROM "default"."otel_traces"`)
+	require.Contains(t, queries, `CREATE VIEW "default"."metrics_gauge" AS SELECT * FROM "default"."otel_metrics_gauge"`)
+	require.Contains(t, queries, `CREATE VIEW "default"."metrics_sum" AS SELECT * FROM "default"."otel_metrics_sum"`)
+	require.Contains(t, queries, `CREATE VIEW "default"."metrics_histogram" AS SELECT * FROM "default"."otel_metrics_histogram"`)
+	require.Contains(t, queries, `CREATE VIEW "default"."metrics_exponential_histogram" AS SELECT * FROM "default"."otel_metrics_exponential_histogram"`)
+	require.Contains(t, queries, `CREATE VIEW "default"."metrics_summary" AS SELECT * FROM "default"."otel_metrics_summary"`)
 }
 
 func TestFactoryRunsLogsSchemaMigrationOnStart(t *testing.T) {
@@ -174,7 +178,8 @@ func TestFactoryWithHandleSkipsLocalViewsWhenRawNamesMatch(t *testing.T) {
 
 	session.mu.Lock()
 	defer session.mu.Unlock()
-	require.NotContains(t, joinedQueries(session.queries), "CREATE VIEW IF NOT EXISTS")
+	require.NotContains(t, joinedQueries(session.queries), "CREATE VIEW")
+	require.NotContains(t, joinedQueries(session.queries), "DROP VIEW")
 }
 
 func TestFactoryWithoutHandleFailsOnStart(t *testing.T) {

--- a/collector/exporter/chdbexporter/factory_chdb_test.go
+++ b/collector/exporter/chdbexporter/factory_chdb_test.go
@@ -2,6 +2,7 @@ package chdbexporter
 
 import (
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -30,6 +31,11 @@ func (s *fakeChDBSession) Query(query string, _ ...string) (chdb.Result, error) 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.queries = append(s.queries, query)
+	// The local-view engine lookup must see no existing object so view creation
+	// takes the fresh-create path.
+	if strings.Contains(query, "system.tables") {
+		return fakeChDBResult{}, nil
+	}
 	return fakeChDBResult{buf: []byte(`{"name":"EventName","type":"String"}` + "\n")}, nil
 }
 
@@ -100,17 +106,13 @@ func TestFactoryWithHandleCreatesProductionFacingLocalViews(t *testing.T) {
 	session.mu.Lock()
 	defer session.mu.Unlock()
 	queries := joinedQueries(session.queries)
-	// Views freeze the source table's columns at creation, so startup must drop
-	// and recreate them to expose columns added by table migrations.
-	require.Contains(t, queries, `DROP VIEW IF EXISTS "default"."logs"`)
-	require.Contains(t, queries, `CREATE VIEW "default"."logs" AS SELECT * FROM "default"."otel_logs"`)
-	require.Contains(t, queries, `DROP VIEW IF EXISTS "default"."traces"`)
-	require.Contains(t, queries, `CREATE VIEW "default"."traces" AS SELECT * FROM "default"."otel_traces"`)
-	require.Contains(t, queries, `CREATE VIEW "default"."metrics_gauge" AS SELECT * FROM "default"."otel_metrics_gauge"`)
-	require.Contains(t, queries, `CREATE VIEW "default"."metrics_sum" AS SELECT * FROM "default"."otel_metrics_sum"`)
-	require.Contains(t, queries, `CREATE VIEW "default"."metrics_histogram" AS SELECT * FROM "default"."otel_metrics_histogram"`)
-	require.Contains(t, queries, `CREATE VIEW "default"."metrics_exponential_histogram" AS SELECT * FROM "default"."otel_metrics_exponential_histogram"`)
-	require.Contains(t, queries, `CREATE VIEW "default"."metrics_summary" AS SELECT * FROM "default"."otel_metrics_summary"`)
+	require.Contains(t, queries, `CREATE VIEW IF NOT EXISTS "default"."logs" AS SELECT * FROM "default"."otel_logs"`)
+	require.Contains(t, queries, `CREATE VIEW IF NOT EXISTS "default"."traces" AS SELECT * FROM "default"."otel_traces"`)
+	require.Contains(t, queries, `CREATE VIEW IF NOT EXISTS "default"."metrics_gauge" AS SELECT * FROM "default"."otel_metrics_gauge"`)
+	require.Contains(t, queries, `CREATE VIEW IF NOT EXISTS "default"."metrics_sum" AS SELECT * FROM "default"."otel_metrics_sum"`)
+	require.Contains(t, queries, `CREATE VIEW IF NOT EXISTS "default"."metrics_histogram" AS SELECT * FROM "default"."otel_metrics_histogram"`)
+	require.Contains(t, queries, `CREATE VIEW IF NOT EXISTS "default"."metrics_exponential_histogram" AS SELECT * FROM "default"."otel_metrics_exponential_histogram"`)
+	require.Contains(t, queries, `CREATE VIEW IF NOT EXISTS "default"."metrics_summary" AS SELECT * FROM "default"."otel_metrics_summary"`)
 }
 
 func TestFactoryRunsLogsSchemaMigrationOnStart(t *testing.T) {

--- a/collector/exporter/chdbexporter/local_views.go
+++ b/collector/exporter/chdbexporter/local_views.go
@@ -6,6 +6,8 @@ package chdbexporter
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 )
@@ -54,18 +56,40 @@ func createLocalQueryView(ctx context.Context, db driver.Conn, database, viewNam
 		return nil
 	}
 
-	// A view freezes the source table's column set at creation time, so a view
-	// created before a column migration keeps rejecting the new columns with
-	// UNKNOWN_IDENTIFIER even after the underlying table is migrated. Views are
-	// metadata-only, so drop and recreate on every startup to pick up the
-	// current column set.
-	drop := fmt.Sprintf(`DROP VIEW IF EXISTS %q.%q`, database, viewName)
-	if err := db.Exec(ctx, drop); err != nil {
-		return fmt.Errorf("drop local query view %q: %w", viewName, err)
+	engine, err := lookupTableEngine(ctx, db, database, viewName)
+	if err != nil {
+		return fmt.Errorf("inspect local query view %q: %w", viewName, err)
+	}
+
+	switch engine {
+	case "":
+		// Nothing occupies the name yet; create the view below.
+	case "View":
+		stale, staleErr := viewColumnsDiffer(ctx, db, database, viewName, rawName)
+		if staleErr != nil {
+			return fmt.Errorf("compare local query view %q columns: %w", viewName, staleErr)
+		}
+		if !stale {
+			return nil
+		}
+		// A view freezes the source table's column set at creation time, so a
+		// view created before a column migration keeps rejecting the migrated
+		// columns with UNKNOWN_IDENTIFIER even after the underlying table
+		// gained them. Views are metadata-only, so recreating is cheap.
+		drop := fmt.Sprintf(`DROP VIEW IF EXISTS %q.%q`, database, viewName)
+		if dropErr := db.Exec(ctx, drop); dropErr != nil {
+			return fmt.Errorf("drop stale local query view %q: %w", viewName, dropErr)
+		}
+	default:
+		// The name is taken by something that isn't our view — e.g. a real table
+		// on a shared ClickHouse server, or one left behind by an older
+		// table-name config. Failing here would keep the collector from
+		// starting, so leave the object alone.
+		return nil
 	}
 
 	create := fmt.Sprintf(
-		`CREATE VIEW %q.%q AS SELECT * FROM %q.%q`,
+		`CREATE VIEW IF NOT EXISTS %q.%q AS SELECT * FROM %q.%q`,
 		database,
 		viewName,
 		database,
@@ -76,4 +100,78 @@ func createLocalQueryView(ctx context.Context, db driver.Conn, database, viewNam
 	}
 
 	return nil
+}
+
+// lookupTableEngine returns the engine of the named table or view, or "" when
+// no such object exists. The result column is aliased to `name` because the
+// chdb rows shim scans by the fixed DESC TABLE column list, whose first entry
+// is `name` — and the WHERE columns are qualified with `t.` because ClickHouse
+// resolves unqualified WHERE identifiers against SELECT aliases first, which
+// would capture `name`.
+func lookupTableEngine(ctx context.Context, db driver.Conn, database, tableName string) (string, error) {
+	query := fmt.Sprintf(
+		`SELECT t.engine AS name FROM system.tables AS t WHERE t.database = '%s' AND t.name = '%s'`,
+		escapeStringLiteral(database),
+		escapeStringLiteral(tableName),
+	)
+	rows, err := db.Query(ctx, query)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = rows.Close() }()
+
+	if !rows.Next() {
+		return "", rows.Err()
+	}
+
+	var engine string
+	if err := rows.Scan(&engine); err != nil {
+		return "", err
+	}
+
+	return engine, rows.Err()
+}
+
+func viewColumnsDiffer(ctx context.Context, db driver.Conn, database, viewName, rawName string) (bool, error) {
+	viewColumns, err := getQueryableColumns(ctx, db, database, viewName)
+	if err != nil {
+		return false, err
+	}
+
+	rawColumns, err := getQueryableColumns(ctx, db, database, rawName)
+	if err != nil {
+		return false, err
+	}
+
+	return !slices.Equal(viewColumns, rawColumns), nil
+}
+
+// getQueryableColumns returns the column names a `SELECT *` over the table
+// exposes, i.e. excluding MATERIALIZED and ALIAS columns, which a plain view
+// over `SELECT *` never contains.
+func getQueryableColumns(ctx context.Context, db driver.Conn, database, table string) ([]string, error) {
+	descTable := fmt.Sprintf("DESC TABLE %q.%q", database, table)
+	rows, err := db.Query(ctx, descTable)
+	if err != nil {
+		return nil, fmt.Errorf("desc table %q: %w", table, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var columnNames []string
+	for rows.Next() {
+		var columnName, columnType, defaultType, skip string
+		if scanErr := rows.Scan(&columnName, &columnType, &defaultType, &skip, &skip, &skip, &skip); scanErr != nil {
+			return nil, fmt.Errorf("scan column of %q: %w", table, scanErr)
+		}
+		if defaultType == "MATERIALIZED" || defaultType == "ALIAS" {
+			continue
+		}
+		columnNames = append(columnNames, columnName)
+	}
+
+	return columnNames, rows.Err()
+}
+
+func escapeStringLiteral(s string) string {
+	return strings.NewReplacer(`\`, `\\`, `'`, `''`).Replace(s)
 }

--- a/collector/exporter/chdbexporter/local_views.go
+++ b/collector/exporter/chdbexporter/local_views.go
@@ -54,14 +54,24 @@ func createLocalQueryView(ctx context.Context, db driver.Conn, database, viewNam
 		return nil
 	}
 
-	sql := fmt.Sprintf(
-		`CREATE VIEW IF NOT EXISTS %q.%q AS SELECT * FROM %q.%q`,
+	// A view freezes the source table's column set at creation time, so a view
+	// created before a column migration keeps rejecting the new columns with
+	// UNKNOWN_IDENTIFIER even after the underlying table is migrated. Views are
+	// metadata-only, so drop and recreate on every startup to pick up the
+	// current column set.
+	drop := fmt.Sprintf(`DROP VIEW IF EXISTS %q.%q`, database, viewName)
+	if err := db.Exec(ctx, drop); err != nil {
+		return fmt.Errorf("drop local query view %q: %w", viewName, err)
+	}
+
+	create := fmt.Sprintf(
+		`CREATE VIEW %q.%q AS SELECT * FROM %q.%q`,
 		database,
 		viewName,
 		database,
 		rawName,
 	)
-	if err := db.Exec(ctx, sql); err != nil {
+	if err := db.Exec(ctx, create); err != nil {
 		return fmt.Errorf("create local query view %q: %w", viewName, err)
 	}
 

--- a/collector/exporter/chdbexporter/local_views_test.go
+++ b/collector/exporter/chdbexporter/local_views_test.go
@@ -1,0 +1,100 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package chdbexporter
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/stretchr/testify/require"
+
+	"github.com/everr-labs/everr/collector/exporter/chdbexporter/internal"
+	"github.com/everr-labs/everr/collector/internal/localgateway/chdb"
+)
+
+func newRealChDBConn(t *testing.T) driver.Conn {
+	t.Cleanup(chdb.ResetForTesting)
+	handle, err := chdb.Open(filepath.Join(t.TempDir(), "chdb"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = handle.Close() })
+
+	db, err := internal.NewChDBConn(handle)
+	require.NoError(t, err)
+	return db
+}
+
+func createSourceTable(t *testing.T, ctx context.Context, db driver.Conn) {
+	require.NoError(t, db.Exec(ctx,
+		`CREATE TABLE "default"."view_test_src" (Timestamp DateTime64(9), Body String) ENGINE = MergeTree ORDER BY Timestamp`))
+}
+
+func queryViewColumn(ctx context.Context, db driver.Conn, column string) error {
+	rows, err := db.Query(ctx, `SELECT `+column+` FROM "default"."view_test" LIMIT 1`)
+	if err != nil {
+		return err
+	}
+	return rows.Close()
+}
+
+func TestCreateLocalQueryViewCreatesMissingView(t *testing.T) {
+	db := newRealChDBConn(t)
+	ctx := t.Context()
+	createSourceTable(t, ctx, db)
+
+	require.NoError(t, createLocalQueryView(ctx, db, "default", "view_test", "view_test_src"))
+
+	require.NoError(t, queryViewColumn(ctx, db, "Body"))
+}
+
+func TestCreateLocalQueryViewHealsStaleView(t *testing.T) {
+	db := newRealChDBConn(t)
+	ctx := t.Context()
+	createSourceTable(t, ctx, db)
+
+	// Freeze the view before the column migration, as installs older than the
+	// TimestampTime fix did.
+	require.NoError(t, createLocalQueryView(ctx, db, "default", "view_test", "view_test_src"))
+	require.NoError(t, db.Exec(ctx,
+		`ALTER TABLE "default"."view_test_src" ADD COLUMN IF NOT EXISTS TimestampTime DateTime DEFAULT toDateTime(Timestamp)`))
+	require.Error(t, queryViewColumn(ctx, db, "TimestampTime"), "stale view should reject the migrated column")
+
+	require.NoError(t, createLocalQueryView(ctx, db, "default", "view_test", "view_test_src"))
+
+	require.NoError(t, queryViewColumn(ctx, db, "TimestampTime"))
+}
+
+func TestCreateLocalQueryViewIgnoresMaterializedColumns(t *testing.T) {
+	db := newRealChDBConn(t)
+	ctx := t.Context()
+	require.NoError(t, db.Exec(ctx,
+		`CREATE TABLE "default"."view_test_src" (
+			Timestamp DateTime64(9),
+			Body String,
+			BodyLength UInt64 MATERIALIZED length(Body)
+		) ENGINE = MergeTree ORDER BY Timestamp`))
+
+	require.NoError(t, createLocalQueryView(ctx, db, "default", "view_test", "view_test_src"))
+
+	// A SELECT * view never exposes MATERIALIZED columns; that must not read as
+	// staleness, or every startup would drop and recreate a healthy view.
+	stale, err := viewColumnsDiffer(ctx, db, "default", "view_test", "view_test_src")
+	require.NoError(t, err)
+	require.False(t, stale)
+}
+
+func TestCreateLocalQueryViewLeavesNonViewAlone(t *testing.T) {
+	db := newRealChDBConn(t)
+	ctx := t.Context()
+	createSourceTable(t, ctx, db)
+	require.NoError(t, db.Exec(ctx,
+		`CREATE TABLE "default"."view_test" (Other String) ENGINE = MergeTree ORDER BY Other`))
+
+	// A pre-existing real table under the view's name (e.g. on a shared
+	// ClickHouse server) must not fail startup or be dropped.
+	require.NoError(t, createLocalQueryView(ctx, db, "default", "view_test", "view_test_src"))
+
+	require.NoError(t, queryViewColumn(ctx, db, "Other"))
+}


### PR DESCRIPTION

Root cause

The 0.4.7 TimestampTime migration wasn't enough because the queries don't read otel_logs directly — they go through a plain ClickHouse view named logs, created by createLocalQueryView in collector/exporter/chdbexporter/local_views.go as CREATE VIEW IF NOT EXISTS logs AS SELECT * FROM otel_logs. A ClickHouse view freezes the source table's column set at creation time. So on any install where the view was created before the migration (the views shipped 2026-06-02, the migration 2026-06-23), the view permanently lacks TimestampTime — even after the underlying table is migrated — and IF NOT EXISTS means restarts never recreate it. I reproduced this exactly against the local ClickHouse: stale view → UNKNOWN_IDENTIFIER, re-running CREATE VIEW IF NOT EXISTS doesn't heal it, drop + recreate does.

Production data (via everr cloud query) confirms it: over the last 7 days the error comes from everr-desktop-frontend on versions 0.4.7 (3 installs, 20 errors) and 0.5.0 (1 install, 7 errors) — both versions that already contain the column migration, which is exactly what the stale-view theory predicts. Last occurrence was minutes ago.

Fix

- collector/exporter/chdbexporter/local_views.go — createLocalQueryView now does DROP VIEW IF EXISTS + CREATE VIEW on every startup instead of CREATE VIEW IF NOT EXISTS. Views are metadata-only, so this is cheap, and it self-heals for any future column migrations too (it runs after migrateLogsTable in the start sequence). I chose drop+create over CREATE OR REPLACE VIEW because the replace path hit a filesystem rename error in my ClickHouse repro.
- factory_chdb_test.go — updated the view-creation assertions to expect the drop+create pair, and the "skips views when names match" test to assert neither statement is issued.
- Added changeset fix-chdb-stale-local-views.md (@everr/desktop-app patch).
