### PR TITLE
fix(docs): keep hero full-width on wide viewports

### DIFF
--- a/packages/docs/src/components/hero.tsx
+++ b/packages/docs/src/components/hero.tsx
@@ -6,7 +6,7 @@ import { InstallCommand } from "./ui/install-command";
 
 export function Hero() {
   return (
-    <div className="relative overflow-x-clip md:aspect-video md:max-h-svh md:overflow-hidden">
+    <div className="relative overflow-x-clip md:h-[min(56.25vw,100svh)] md:overflow-hidden">
       <div className="@container-size absolute inset-0 overflow-hidden">
         <HoleBackground className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 aspect-video h-auto w-[max(100cqw,177.78cqh)]" />
       </div>


### PR DESCRIPTION
## Problem

On viewports wider than 16:9 (ultrawide monitors, or any wide-but-short window), the landing hero and its background didn't fill the full width — a black band appeared on the right that grew wider as the screen widened.

## Cause

The hero root used `md:aspect-video md:max-h-svh`. `aspect-video` sets `aspect-ratio: 16/9`, which couples width and height. When `max-h-svh` clamped the height on a wide viewport, the browser shrank the **width** to preserve 16:9 (e.g. `577 × 16/9 = 1026px` instead of the full `1280px`), so the background stopped short of the viewport edge.

## Fix

Drive the height directly instead of via aspect-ratio:

```diff
- md:aspect-video md:max-h-svh md:overflow-hidden
+ md:h-[min(56.25vw,100svh)] md:overflow-hidden
```

`56.25vw` is the 16:9 height (`100vw × 9/16`), capped at `100svh`. Sizing is identical to before on normal screens, but with no aspect-ratio the width stays 100% at every aspect ratio.

## Verification

Measured the hero element width against the viewport at a wide ratio:

| | before | after |
|---|---|---|
| hero width @ 1280px viewport | 1026px | 1280px |

Also confirmed visually the background renders edge-to-edge with no black band, and normal (≤16:9) screens are unchanged.