### PR TITLE
fix(collector): don't 500 the github webhook when a run has no logs

### DIFF
--- a/collector/receiver/githubactionsreceiver/attributes.go
+++ b/collector/receiver/githubactionsreceiver/attributes.go
@@ -56,7 +56,7 @@ func setWorkflowRunEventAttributes(attrs pcommon.Map, e *github.WorkflowRunEvent
 	}
 
 	attrs.PutInt(semconv.EverrGitHubWorkflowRunRunAttempt, int64(e.GetWorkflowRun().GetRunAttempt()))
-	attrs.PutStr(semconv.EverrGitHubWorkflowRunStartedAt, e.GetWorkflowRun().RunStartedAt.Format(time.RFC3339))
+	attrs.PutStr(semconv.EverrGitHubWorkflowRunStartedAt, e.GetWorkflowRun().GetRunStartedAt().Format(time.RFC3339))
 	attrs.PutStr(semconv.EverrGitHubWorkflowRunStatus, e.GetWorkflowRun().GetStatus())
 	attrs.PutStr(semconv.CICDPipelineRunSenderLogin, e.GetSender().GetLogin())
 	attrs.PutStr(semconv.EverrGitHubWorkflowRunTriggeringActorLogin, e.GetWorkflowRun().GetTriggeringActor().GetLogin())

--- a/collector/receiver/githubactionsreceiver/log_event_handling.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling.go
@@ -58,9 +58,17 @@ func eventToLogs(ctx context.Context, event interface{}, config *Config, ghClien
 
 	setWorkflowRunEventAttributes(attrs, e, config)
 
-	url, _, err := ghClient.Actions.GetWorkflowRunAttemptLogs(ctx, e.GetRepo().GetOwner().GetLogin(), e.GetRepo().GetName(), e.GetWorkflowRun().GetID(), e.GetWorkflowRun().GetRunAttempt(), 10)
+	url, ghResp, err := ghClient.Actions.GetWorkflowRunAttemptLogs(ctx, e.GetRepo().GetOwner().GetLogin(), e.GetRepo().GetName(), e.GetWorkflowRun().GetID(), e.GetWorkflowRun().GetRunAttempt(), 10)
 
 	if err != nil {
+		// Runs without a downloadable log archive (e.g. skipped or cancelled
+		// before any job produced output) return 404. That's not a processing
+		// failure — return the logs built so far so the caller doesn't turn
+		// this into a 500 and the sender doesn't retry the event.
+		if ghResp != nil && ghResp.StatusCode == http.StatusNotFound {
+			logger.Warn("No log archive available for workflow run", zap.Error(err))
+			return &logs, nil
+		}
 		logger.Error("Failed to get logs", zap.Error(err))
 		return nil, err
 	}
@@ -239,6 +247,7 @@ func scanLogFile(f *zip.File, logger *zap.Logger, emit func(parsedLine)) {
 
 	scanner := bufio.NewScanner(ff)
 	firstLine := true
+	var lastTime time.Time
 	for scanner.Scan() {
 		lineText := scanner.Text()
 		if firstLine {
@@ -249,19 +258,18 @@ func scanLogFile(f *zip.File, logger *zap.Logger, emit func(parsedLine)) {
 			continue
 		}
 
-		ts, line, ok := strings.Cut(lineText, " ")
-		if !ok {
-			logger.Error("Failed to cut log line", zap.String("body", lineText))
-			continue
+		if ts, line, ok := strings.Cut(lineText, " "); ok {
+			if parsedTime, err := time.Parse(time.RFC3339, ts); err == nil {
+				lastTime = parsedTime
+				emit(parsedLine{time: parsedTime, body: line})
+				continue
+			}
 		}
 
-		parsedTime, err := time.Parse(time.RFC3339, ts)
-		if err != nil {
-			logger.Error("Failed to parse timestamp", zap.String("timestamp", ts), zap.Error(err))
-			continue
-		}
-
-		emit(parsedLine{time: parsedTime, body: line})
+		// No leading timestamp — this is a continuation of multi-line step
+		// output, not an error. Keep the full text and attribute it to the
+		// previous line's timestamp (zero if it's the very first line).
+		emit(parsedLine{time: lastTime, body: lineText})
 	}
 
 	if err := scanner.Err(); err != nil {

--- a/collector/receiver/githubactionsreceiver/log_event_handling_test.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling_test.go
@@ -15,8 +15,11 @@ import (
 	"github.com/google/go-github/v67/github"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
 	conventions "go.opentelemetry.io/otel/semconv/v1.38.0"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/everr-labs/everr/collector/semconv"
 )
@@ -510,6 +513,111 @@ func TestEventToLogsNormalFormatUnchanged(t *testing.T) {
 	sn, ok := records.At(0).Attributes().Get(semconv.EverrGitHubWorkflowJobStepNumber)
 	require.True(t, ok)
 	require.Equal(t, int64(1), sn.Int())
+}
+
+// TestEventToLogsNoLogArchive verifies that a completed run whose log archive
+// doesn't exist (GitHub returns 404, e.g. for runs skipped or cancelled before
+// producing output) is not treated as a processing failure — otherwise the
+// receiver responds 500 and the sender keeps redelivering the event.
+func TestEventToLogsNoLogArchive(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	runPayload, err := os.ReadFile("./testdata/completed/8_workflow_run_completed.json")
+	require.NoError(t, err)
+	runEvent, err := github.ParseWebHook("workflow_run", runPayload)
+	require.NoError(t, err)
+	wre := runEvent.(*github.WorkflowRunEvent)
+
+	newEventToLogs := func(t *testing.T, statusCode int) (*plog.Logs, error) {
+		t.Helper()
+		apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, http.StatusText(statusCode), statusCode)
+		}))
+		t.Cleanup(apiServer.Close)
+
+		ghClient, err := github.NewClient(nil).WithEnterpriseURLs(apiServer.URL+"/", apiServer.URL+"/")
+		require.NoError(t, err)
+
+		return eventToLogs(
+			context.Background(),
+			wre,
+			&Config{},
+			ghClient,
+			logger,
+			true,
+			newJobNameCache(100, 30*time.Minute),
+			newStepTimingCache(100, 30*time.Minute),
+		)
+	}
+
+	t.Run("404 means no logs, not a failure", func(t *testing.T) {
+		logs, err := newEventToLogs(t, http.StatusNotFound)
+		require.NoError(t, err)
+		require.NotNil(t, logs)
+
+		// Resource attributes are set, but no log records were produced.
+		require.Equal(t, 1, logs.ResourceLogs().Len())
+		require.Equal(t, 0, logs.ResourceLogs().At(0).ScopeLogs().Len())
+	})
+
+	t.Run("server errors still fail", func(t *testing.T) {
+		logs, err := newEventToLogs(t, http.StatusServiceUnavailable)
+		require.Error(t, err)
+		require.Nil(t, logs)
+	})
+}
+
+// TestScanLogFileContinuationLines verifies that multi-line step output —
+// where continuation lines have no leading timestamp — is preserved with the
+// previous line's timestamp and doesn't produce error-level logs.
+func TestScanLogFileContinuationLines(t *testing.T) {
+	newZipFile := func(t *testing.T, content string) *zip.File {
+		t.Helper()
+		zipData := createCombinedZip(t, map[string]string{"job/1_step.txt": content})
+		reader, err := zip.NewReader(bytes.NewReader(zipData), int64(len(zipData)))
+		require.NoError(t, err)
+		require.Len(t, reader.File, 1)
+		return reader.File[0]
+	}
+
+	scan := func(t *testing.T, content string) ([]parsedLine, *observer.ObservedLogs) {
+		t.Helper()
+		core, observed := observer.New(zap.ErrorLevel)
+		var lines []parsedLine
+		scanLogFile(newZipFile(t, content), zap.New(core), func(pl parsedLine) {
+			lines = append(lines, pl)
+		})
+		return lines, observed
+	}
+
+	t.Run("continuation inherits previous timestamp", func(t *testing.T) {
+		lines, observed := scan(t, ""+
+			"2023-10-13T10:11:33Z line one\n"+
+			"core.setOutput(\"reason\", continuation without timestamp)\n"+
+			"2023-10-13T10:11:35Z line two\n")
+
+		require.Len(t, lines, 3)
+		require.Equal(t, "line one", lines[0].body)
+		require.Equal(t, "core.setOutput(\"reason\", continuation without timestamp)", lines[1].body)
+		require.Equal(t, lines[0].time, lines[1].time, "continuation line should inherit previous timestamp")
+		require.Equal(t, "line two", lines[2].body)
+		require.True(t, lines[2].time.After(lines[0].time))
+
+		require.Equal(t, 0, observed.Len(), "continuation lines must not log at error level")
+	})
+
+	t.Run("leading line without timestamp", func(t *testing.T) {
+		lines, observed := scan(t, ""+
+			"no timestamp at all\n"+
+			"2023-10-13T10:11:33Z line one\n")
+
+		require.Len(t, lines, 2)
+		require.Equal(t, "no timestamp at all", lines[0].body)
+		require.True(t, lines[0].time.IsZero(), "line before any timestamp should have zero time")
+		require.Equal(t, "line one", lines[1].body)
+
+		require.Equal(t, 0, observed.Len(), "lines without timestamps must not log at error level")
+	})
 }
 
 func makeTestWorkflowRunEvent(repoID, runID int64, runAttempt int) *github.WorkflowRunEvent {

--- a/collector/receiver/githubactionsreceiver/receiver_test.go
+++ b/collector/receiver/githubactionsreceiver/receiver_test.go
@@ -329,6 +329,29 @@ func TestGitHubActionsServiceResourceAttributes(t *testing.T) {
 	})
 }
 
+// TestSetWorkflowRunEventAttributesNilRunStartedAt verifies that a payload
+// with a null run_started_at (e.g. a run cancelled before starting) doesn't
+// panic on the raw *Timestamp pointer.
+func TestSetWorkflowRunEventAttributesNilRunStartedAt(t *testing.T) {
+	payload, err := os.ReadFile("./testdata/completed/8_workflow_run_completed.json")
+	require.NoError(t, err)
+
+	event, err := github.ParseWebHook("workflow_run", payload)
+	require.NoError(t, err)
+
+	wre := event.(*github.WorkflowRunEvent)
+	wre.WorkflowRun.RunStartedAt = nil
+
+	attrs := pcommon.NewMap()
+	require.NotPanics(t, func() {
+		setWorkflowRunEventAttributes(attrs, wre, &Config{})
+	})
+
+	started, found := attrs.Get(semconv.EverrGitHubWorkflowRunStartedAt)
+	require.True(t, found)
+	require.Equal(t, time.Time{}.Format(time.RFC3339), started.Str())
+}
+
 // attributeValueToString converts an attribute value to a string regardless of its actual type
 func attributeValueToString(attr pcommon.Value) string {
 	switch attr.Type() {


### PR DESCRIPTION
## Problem

Production error tracking was flooded with `collector status=500 body=""` from the github-events collector-replay worker.

Confirmed from collector pod logs: `workflow_run` **completed** events whose runs have **no downloadable log archive** (skipped / concurrency-cancelled runs) make GitHub return **404** for `GetWorkflowRunAttemptLogs`. `eventToLogs` turned that 404 into an error → `ServeHTTP` responded with a **bodyless 500** → the sender treats 500 as retryable and retries each event **up to 10×**.

Evidence over 12h: `workflow_job` = 0 errors; `workflow_run` = 505 error spans, but only **54 distinct events** each retried the full 10 attempts (so ~6% of completed runs, permanently failing — not a transient race). Collector logged **0 panics**; the fatal path was `log_event_handling.go:64` → `unexpected status code: 404 Not Found` (507×).

## Fix

- **404 log archive is not a failure.** Capture the previously-discarded `*github.Response`; on `404`, log at Warn and return the logs built so far with no error, so the receiver answers **202** and the event isn't retried. Traces/metrics for the run are already emitted at that point. Other statuses (e.g. 503) still error → 500 → retry, as before.

Two latent bugs in the same path, fixed while here:

- **Dropped log lines / error-log noise.** `scanLogFile` split each line on the first space and required an RFC3339 timestamp; multi-line step output (continuation lines with no leading timestamp) was **silently dropped** and logged at Error with stack traces. Now continuation lines are preserved with the previous line's timestamp and no longer logged as errors.
- **Latent nil-pointer panic.** `setWorkflowRunEventAttributes` dereferenced the raw `RunStartedAt` pointer, which would panic into an empty 500 on a null `run_started_at`. Switched to the nil-safe `GetRunStartedAt()` getter (matching every other timestamp in that function).

## Tests

Added to the receiver package (all passing; `go build` / `go vet` / `gofmt` clean, lint green via pre-commit):

- `TestEventToLogsNoLogArchive` — 404 → no error (→ 202); 503 → still errors (→ 500/retry).
- `TestScanLogFileContinuationLines` — continuation lines preserved, no Error logs.
- `TestSetWorkflowRunEventAttributesNilRunStartedAt` — `NotPanics` on null `run_started_at`.

## Note

Requires a collector image build + deploy to take effect in production.