### PR TITLE
feat(cli): add everr upgrade command

### DIFF
--- a/packages/desktop-app/src-cli/src/cli.rs
+++ b/packages/desktop-app/src-cli/src/cli.rs
@@ -25,6 +25,8 @@ pub struct Cli {
 pub enum Commands {
     /// Remove local Everr setup artifacts
     Uninstall,
+    /// Upgrade the Everr CLI to the latest version
+    Upgrade,
     /// Manage Everr Cloud authentication
     Cloud(CloudArgs),
     /// Inspect GitHub Actions CI runs
@@ -55,6 +57,7 @@ impl Commands {
     fn prints_human_stdout(&self, stdout_is_terminal: bool) -> bool {
         match self {
             Commands::Uninstall => true,
+            Commands::Upgrade => true,
             Commands::Cloud(args) => args.command.prints_human_stdout(stdout_is_terminal),
             Commands::Ci(args) => args.command.prints_human_stdout(stdout_is_terminal),
             Commands::Local(args) => args.command.prints_human_stdout(stdout_is_terminal),
@@ -1065,6 +1068,13 @@ mod tests {
         };
 
         assert_eq!(args.egrep.as_deref(), Some("Error.*timeout"));
+    }
+
+    #[test]
+    fn upgrade_parses_without_arguments() {
+        let cli = Cli::try_parse_from(["everr", "upgrade"]).expect("upgrade command");
+        assert!(matches!(cli.command, Commands::Upgrade));
+        assert!(cli.prints_human_stdout(false));
     }
 
     #[test]

--- a/packages/desktop-app/src-cli/src/command_telemetry.rs
+++ b/packages/desktop-app/src-cli/src/command_telemetry.rs
@@ -152,6 +152,7 @@ impl CommandTelemetry {
     fn from_cli_and_argv(cli: &Cli, argv: impl IntoIterator<Item = OsString>) -> Self {
         let (command, subcommand) = match &cli.command {
             Commands::Uninstall => ("uninstall", None),
+            Commands::Upgrade => ("upgrade", None),
             Commands::Cloud(args) => (
                 "cloud",
                 Some(match &args.command {

--- a/packages/desktop-app/src-cli/src/lib.rs
+++ b/packages/desktop-app/src-cli/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod cli;
 pub mod command_telemetry;
 pub mod telemetry;
+pub mod update_notice;
+pub mod upgrade;

--- a/packages/desktop-app/src-cli/src/main.rs
+++ b/packages/desktop-app/src-cli/src/main.rs
@@ -28,9 +28,7 @@ async fn main() -> Result<()> {
     let cli = Cli::parse_from(argv.clone());
     let telemetry = command_telemetry::init();
     command_telemetry::record_invocation(&cli, argv);
-    if !matches!(cli.command, Commands::Upgrade) {
-        update_notice::maybe_print(&cli).await;
-    }
+    update_notice::maybe_print(&cli).await;
 
     match cli.command {
         Commands::Uninstall => uninstall::run_uninstall()?,

--- a/packages/desktop-app/src-cli/src/main.rs
+++ b/packages/desktop-app/src-cli/src/main.rs
@@ -9,6 +9,7 @@ mod onboarding;
 mod skills;
 mod telemetry;
 mod uninstall;
+mod upgrade;
 mod update_notice;
 mod wrap;
 
@@ -27,10 +28,13 @@ async fn main() -> Result<()> {
     let cli = Cli::parse_from(argv.clone());
     let telemetry = command_telemetry::init();
     command_telemetry::record_invocation(&cli, argv);
-    update_notice::maybe_print(&cli).await;
+    if !matches!(cli.command, Commands::Upgrade) {
+        update_notice::maybe_print(&cli).await;
+    }
 
     match cli.command {
         Commands::Uninstall => uninstall::run_uninstall()?,
+        Commands::Upgrade => upgrade::run().await?,
         Commands::Cloud(args) => match args.command {
             CloudSubcommand::Login(login) => auth::login(login).await?,
             CloudSubcommand::Logout => auth::logout()?,

--- a/packages/desktop-app/src-cli/src/update_notice.rs
+++ b/packages/desktop-app/src-cli/src/update_notice.rs
@@ -132,7 +132,7 @@ async fn fetch_latest_version() -> Result<String> {
     Ok(metadata.version)
 }
 
-fn release_metadata_url() -> String {
+pub(crate) fn release_metadata_url() -> String {
     #[cfg(debug_assertions)]
     if let Ok(url) = std::env::var(RELEASE_METADATA_URL_OVERRIDE_ENV) {
         if !url.trim().is_empty() {

--- a/packages/desktop-app/src-cli/src/update_notice.rs
+++ b/packages/desktop-app/src-cli/src/update_notice.rs
@@ -13,7 +13,7 @@ use crate::cli::Cli;
 const CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
 const FETCH_TIMEOUT: Duration = Duration::from_millis(750);
 const RELEASE_METADATA_PATH: &str = "/everr-app/release-metadata.json";
-const UPGRADE_COMMAND: &str = "curl -fsSL https://everr.dev/upgrade.sh | bash";
+const UPGRADE_COMMAND: &str = "everr upgrade";
 
 #[cfg(debug_assertions)]
 const RELEASE_METADATA_URL_OVERRIDE_ENV: &str = "EVERR_RELEASE_METADATA_URL_FOR_TESTS";

--- a/packages/desktop-app/src-cli/src/update_notice.rs
+++ b/packages/desktop-app/src-cli/src/update_notice.rs
@@ -8,7 +8,7 @@ use chrono::{DateTime, Utc};
 use semver::Version;
 use serde::{Deserialize, Serialize};
 
-use crate::cli::Cli;
+use crate::cli::{Cli, Commands};
 
 const CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
 const FETCH_TIMEOUT: Duration = Duration::from_millis(750);
@@ -37,6 +37,11 @@ struct CacheFile {
 }
 
 pub async fn maybe_print(cli: &Cli) {
+    // `everr upgrade` fetches the same metadata itself; nagging first is noise.
+    if matches!(cli.command, Commands::Upgrade) {
+        return;
+    }
+
     if !cli.prints_human_stdout(std::io::stdout().is_terminal()) {
         return;
     }
@@ -62,7 +67,7 @@ async fn check() -> Result<CacheFile> {
         }
     }
 
-    match fetch_latest_version().await {
+    match fetch_latest_version(FETCH_TIMEOUT).await {
         Ok(latest_version) => {
             let update_available = is_newer(&latest_version, env!("EVERR_VERSION"));
             let cache = CacheFile {
@@ -115,10 +120,10 @@ fn is_stale(cache: &CacheFile) -> bool {
         .map_or(true, |elapsed| elapsed >= CHECK_INTERVAL)
 }
 
-async fn fetch_latest_version() -> Result<String> {
+pub(crate) async fn fetch_latest_version(timeout: Duration) -> Result<String> {
     let url = release_metadata_url();
     let client = reqwest::Client::builder()
-        .timeout(FETCH_TIMEOUT)
+        .timeout(timeout)
         .build()
         .context("build release metadata client")?;
     let metadata: ReleaseMetadata = client
@@ -126,13 +131,15 @@ async fn fetch_latest_version() -> Result<String> {
         .send()
         .await
         .with_context(|| format!("GET {url}"))?
+        .error_for_status()
+        .with_context(|| format!("GET {url}"))?
         .json()
         .await
         .with_context(|| format!("parse {url}"))?;
     Ok(metadata.version)
 }
 
-pub(crate) fn release_metadata_url() -> String {
+fn release_metadata_url() -> String {
     #[cfg(debug_assertions)]
     if let Ok(url) = std::env::var(RELEASE_METADATA_URL_OVERRIDE_ENV) {
         if !url.trim().is_empty() {

--- a/packages/desktop-app/src-cli/src/upgrade.rs
+++ b/packages/desktop-app/src-cli/src/upgrade.rs
@@ -1,5 +1,46 @@
-use anyhow::{Result, bail};
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use semver::Version;
+use serde::Deserialize;
+
+use crate::update_notice;
+
+const METADATA_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Debug, Deserialize)]
+struct ReleaseMetadata {
+    version: String,
+}
 
 pub async fn run() -> Result<()> {
+    let current = Version::parse(env!("EVERR_VERSION")).context("parse current CLI version")?;
+    let latest = fetch_latest_version().await?;
+
+    if latest <= current {
+        println!("Already up to date (v{current})");
+        return Ok(());
+    }
+
     bail!("not implemented");
+}
+
+async fn fetch_latest_version() -> Result<Version> {
+    let url = update_notice::release_metadata_url();
+    let client = reqwest::Client::builder()
+        .timeout(METADATA_TIMEOUT)
+        .build()
+        .context("build release metadata client")?;
+    let metadata: ReleaseMetadata = client
+        .get(&url)
+        .send()
+        .await
+        .with_context(|| format!("GET {url}"))?
+        .error_for_status()
+        .with_context(|| format!("GET {url}"))?
+        .json()
+        .await
+        .with_context(|| format!("parse {url}"))?;
+    Version::parse(&metadata.version)
+        .with_context(|| format!("parse latest version {:?}", metadata.version))
 }

--- a/packages/desktop-app/src-cli/src/upgrade.rs
+++ b/packages/desktop-app/src-cli/src/upgrade.rs
@@ -3,7 +3,6 @@ use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 use semver::Version;
-use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
 use crate::update_notice;
@@ -14,11 +13,6 @@ const DOWNLOAD_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const DOWNLOAD_READ_TIMEOUT: Duration = Duration::from_secs(30);
 const FALLBACK_COMMAND: &str = "curl -fsSL https://everr.dev/upgrade.sh | bash";
 const DOWNLOAD_BASE_URL_OVERRIDE_ENV: &str = "EVERR_DOWNLOAD_BASE_URL_FOR_TESTS";
-
-#[derive(Debug, Deserialize)]
-struct ReleaseMetadata {
-    version: String,
-}
 
 pub async fn run() -> Result<()> {
     let current = Version::parse(env!("EVERR_VERSION")).context("parse current CLI version")?;
@@ -31,9 +25,12 @@ pub async fn run() -> Result<()> {
 
     let binary_name = release_binary_name()?;
     let base = download_base_url()?;
+    let client = download_client()?;
     println!("Downloading Everr CLI v{latest}...");
-    let binary = download_bytes(&format!("{base}/{binary_name}")).await?;
-    let checksum_file = download_bytes(&format!("{base}/{binary_name}.sha256")).await?;
+    let (binary, checksum_file) = futures_util::try_join!(
+        download_bytes(&client, format!("{base}/{binary_name}")),
+        download_bytes(&client, format!("{base}/{binary_name}.sha256")),
+    )?;
     verify_sha256(&binary, &checksum_file)?;
     replace_current_exe(&binary)?;
     println!("Upgraded everr v{current} → v{latest}");
@@ -41,27 +38,12 @@ pub async fn run() -> Result<()> {
 }
 
 async fn fetch_latest_version() -> Result<Version> {
-    let url = update_notice::release_metadata_url();
-    let client = reqwest::Client::builder()
-        .timeout(METADATA_TIMEOUT)
-        .build()
-        .context("build release metadata client")?;
-    let metadata: ReleaseMetadata = client
-        .get(&url)
-        .send()
-        .await
-        .with_context(|| format!("GET {url}"))?
-        .error_for_status()
-        .with_context(|| format!("GET {url}"))?
-        .json()
-        .await
-        .with_context(|| format!("parse {url}"))?;
-    Version::parse(&metadata.version)
-        .with_context(|| format!("parse latest version {:?}", metadata.version))
+    let raw = update_notice::fetch_latest_version(METADATA_TIMEOUT).await?;
+    Version::parse(&raw).with_context(|| format!("parse latest version {raw:?}"))
 }
 
 /// Same platform → artifact mapping as packages/docs/public/install.sh.
-fn release_binary_name() -> Result<&'static str> {
+pub fn release_binary_name() -> Result<&'static str> {
     match (std::env::consts::OS, std::env::consts::ARCH) {
         ("macos", "aarch64") => Ok("everr"),
         ("linux", "aarch64") => Ok("everr-linux-arm64"),
@@ -91,14 +73,17 @@ fn download_base_url() -> Result<String> {
     ))
 }
 
-async fn download_bytes(url: &str) -> Result<Vec<u8>> {
-    let client = reqwest::Client::builder()
+fn download_client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
         .connect_timeout(DOWNLOAD_CONNECT_TIMEOUT)
         .read_timeout(DOWNLOAD_READ_TIMEOUT)
         .build()
-        .context("build download client")?;
+        .context("build download client")
+}
+
+async fn download_bytes(client: &reqwest::Client, url: String) -> Result<Vec<u8>> {
     let response = client
-        .get(url)
+        .get(&url)
         .send()
         .await
         .with_context(|| format!("GET {url}"))?
@@ -120,11 +105,7 @@ fn verify_sha256(binary: &[u8], checksum_file: &[u8]) -> Result<()> {
         .next()
         .context("checksum file is empty")?
         .to_ascii_lowercase();
-    let digest = Sha256::digest(binary);
-    let mut actual = String::with_capacity(digest.len() * 2);
-    for byte in digest {
-        actual.push_str(&format!("{byte:02x}"));
-    }
+    let actual = format!("{:x}", Sha256::digest(binary));
     if actual != expected {
         bail!("checksum mismatch for downloaded binary: expected {expected}, got {actual}");
     }

--- a/packages/desktop-app/src-cli/src/upgrade.rs
+++ b/packages/desktop-app/src-cli/src/upgrade.rs
@@ -1,12 +1,19 @@
+use std::io::Write;
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 use semver::Version;
 use serde::Deserialize;
+use sha2::{Digest, Sha256};
 
 use crate::update_notice;
 
+const DOWNLOAD_PATH_PREFIX: &str = "/everr-app";
 const METADATA_TIMEOUT: Duration = Duration::from_secs(10);
+const DOWNLOAD_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const DOWNLOAD_READ_TIMEOUT: Duration = Duration::from_secs(30);
+const FALLBACK_COMMAND: &str = "curl -fsSL https://everr.dev/upgrade.sh | bash";
+const DOWNLOAD_BASE_URL_OVERRIDE_ENV: &str = "EVERR_DOWNLOAD_BASE_URL_FOR_TESTS";
 
 #[derive(Debug, Deserialize)]
 struct ReleaseMetadata {
@@ -22,7 +29,15 @@ pub async fn run() -> Result<()> {
         return Ok(());
     }
 
-    bail!("not implemented");
+    let binary_name = release_binary_name()?;
+    let base = download_base_url()?;
+    println!("Downloading Everr CLI v{latest}...");
+    let binary = download_bytes(&format!("{base}/{binary_name}")).await?;
+    let checksum_file = download_bytes(&format!("{base}/{binary_name}.sha256")).await?;
+    verify_sha256(&binary, &checksum_file)?;
+    replace_current_exe(&binary)?;
+    println!("Upgraded everr v{current} → v{latest}");
+    Ok(())
 }
 
 async fn fetch_latest_version() -> Result<Version> {
@@ -43,4 +58,107 @@ async fn fetch_latest_version() -> Result<Version> {
         .with_context(|| format!("parse {url}"))?;
     Version::parse(&metadata.version)
         .with_context(|| format!("parse latest version {:?}", metadata.version))
+}
+
+/// Same platform → artifact mapping as packages/docs/public/install.sh.
+fn release_binary_name() -> Result<&'static str> {
+    match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("macos", "aarch64") => Ok("everr"),
+        ("linux", "aarch64") => Ok("everr-linux-arm64"),
+        ("linux", "x86_64") => Ok("everr-linux-x86_64"),
+        (os, arch) => bail!("everr upgrade does not support {os} {arch}. Use: {FALLBACK_COMMAND}"),
+    }
+}
+
+/// Debug builds refuse to hit the production artifacts: replacing
+/// target/debug/everr with a release binary silently corrupts the dev
+/// workflow. Tests point this at a mock server via the override env.
+fn download_base_url() -> Result<String> {
+    if cfg!(debug_assertions) {
+        let url = std::env::var(DOWNLOAD_BASE_URL_OVERRIDE_ENV).unwrap_or_default();
+        if url.trim().is_empty() {
+            bail!(
+                "refusing to self-update a debug build; set {DOWNLOAD_BASE_URL_OVERRIDE_ENV} or use a release binary"
+            );
+        }
+        return Ok(url);
+    }
+
+    Ok(format!(
+        "{}{}",
+        everr_core::build::default_docs_base_url(),
+        DOWNLOAD_PATH_PREFIX
+    ))
+}
+
+async fn download_bytes(url: &str) -> Result<Vec<u8>> {
+    let client = reqwest::Client::builder()
+        .connect_timeout(DOWNLOAD_CONNECT_TIMEOUT)
+        .read_timeout(DOWNLOAD_READ_TIMEOUT)
+        .build()
+        .context("build download client")?;
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .with_context(|| format!("GET {url}"))?
+        .error_for_status()
+        .with_context(|| format!("GET {url}"))?;
+    Ok(response
+        .bytes()
+        .await
+        .with_context(|| format!("read {url}"))?
+        .to_vec())
+}
+
+/// The checksum file is `<hex>  <filename>`, as produced by `shasum -a 256`.
+fn verify_sha256(binary: &[u8], checksum_file: &[u8]) -> Result<()> {
+    let checksum_file =
+        std::str::from_utf8(checksum_file).context("checksum file is not utf-8")?;
+    let expected = checksum_file
+        .split_whitespace()
+        .next()
+        .context("checksum file is empty")?
+        .to_ascii_lowercase();
+    let digest = Sha256::digest(binary);
+    let mut actual = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        actual.push_str(&format!("{byte:02x}"));
+    }
+    if actual != expected {
+        bail!("checksum mismatch for downloaded binary: expected {expected}, got {actual}");
+    }
+    Ok(())
+}
+
+fn replace_current_exe(binary: &[u8]) -> Result<()> {
+    let exe = std::env::current_exe().context("resolve current executable path")?;
+    let dir = exe.parent().context("resolve executable directory")?;
+
+    // Staged in the same directory so the final rename is atomic (same
+    // filesystem) and never leaves a truncated binary in place.
+    let mut staged = tempfile::NamedTempFile::new_in(dir)
+        .with_context(|| format!("create temp file in {}", dir.display()))?;
+    staged.write_all(binary).context("write downloaded binary")?;
+    // fsync before the rename: without it a crash after persist() can leave
+    // a truncated binary at the final path, bricking the CLI.
+    staged
+        .as_file()
+        .sync_all()
+        .context("sync downloaded binary")?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(staged.path(), std::fs::Permissions::from_mode(0o755))
+            .context("set executable permissions")?;
+    }
+
+    staged.persist(&exe).with_context(|| {
+        format!(
+            "failed to replace {} (check permissions, or run: {FALLBACK_COMMAND})",
+            exe.display()
+        )
+    })?;
+    Ok(())
 }

--- a/packages/desktop-app/src-cli/src/upgrade.rs
+++ b/packages/desktop-app/src-cli/src/upgrade.rs
@@ -1,0 +1,5 @@
+use anyhow::{Result, bail};
+
+pub async fn run() -> Result<()> {
+    bail!("not implemented");
+}

--- a/packages/desktop-app/src-cli/tests/help_output.rs
+++ b/packages/desktop-app/src-cli/tests/help_output.rs
@@ -31,7 +31,8 @@ fn root_help_lists_main_commands() {
         .stdout(predicates::str::contains("\n  show").not())
         .stdout(predicates::str::contains("\n  logs").not())
         .stdout(contains("wrap"))
-        .stdout(contains("skills"));
+        .stdout(contains("skills"))
+        .stdout(contains("upgrade"));
 }
 
 #[test]

--- a/packages/desktop-app/src-cli/tests/support/mod.rs
+++ b/packages/desktop-app/src-cli/tests/support/mod.rs
@@ -41,6 +41,14 @@ impl CliTestEnv {
         cmd
     }
 
+    pub fn command_for_binary(&self, binary: &Path) -> Command {
+        let mut cmd = Command::new(binary);
+        cmd.env("HOME", &self.home_dir);
+        cmd.env("XDG_CONFIG_HOME", &self.config_dir);
+        cmd.env("XDG_DATA_HOME", self.home_dir.join(".local").join("share"));
+        cmd
+    }
+
     pub fn command_with_api_base_url(&self, api_base_url: &str) -> Command {
         let mut cmd = self.command();
         cmd.env(API_BASE_URL_OVERRIDE_ENV, api_base_url);

--- a/packages/desktop-app/src-cli/tests/support/mod.rs
+++ b/packages/desktop-app/src-cli/tests/support/mod.rs
@@ -34,11 +34,7 @@ impl CliTestEnv {
     }
 
     pub fn command(&self) -> Command {
-        let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("everr"));
-        cmd.env("HOME", &self.home_dir);
-        cmd.env("XDG_CONFIG_HOME", &self.config_dir);
-        cmd.env("XDG_DATA_HOME", self.home_dir.join(".local").join("share"));
-        cmd
+        self.command_for_binary(&assert_cmd::cargo::cargo_bin!("everr"))
     }
 
     pub fn command_for_binary(&self, binary: &Path) -> Command {

--- a/packages/desktop-app/src-cli/tests/update_notice.rs
+++ b/packages/desktop-app/src-cli/tests/update_notice.rs
@@ -18,9 +18,7 @@ fn cached_update_prints_notice_without_network() {
         .assert()
         .success()
         .stdout(contains("A new version is available: 2099.1.0"))
-        .stdout(contains(
-            "Run: curl -fsSL https://everr.dev/upgrade.sh | bash",
-        ));
+        .stdout(contains("Run: everr upgrade"));
 }
 
 #[test]
@@ -45,9 +43,7 @@ fn stale_cache_fetches_release_metadata_and_records_update() {
     .assert()
     .success()
     .stdout(contains("A new version is available: 2099.1.0"))
-    .stdout(contains(
-        "Run: curl -fsSL https://everr.dev/upgrade.sh | bash",
-    ));
+    .stdout(contains("Run: everr upgrade"));
 
     mock.assert();
     let cache = fs::read_to_string(env.update_cache_path()).expect("read cache");
@@ -66,9 +62,7 @@ fn cached_update_continues_to_print_before_next_check_interval() {
         .assert()
         .success()
         .stdout(contains("A new version is available: 2099.1.0"))
-        .stdout(contains(
-            "Run: curl -fsSL https://everr.dev/upgrade.sh | bash",
-        ));
+        .stdout(contains("Run: everr upgrade"));
 }
 
 #[test]

--- a/packages/desktop-app/src-cli/tests/upgrade.rs
+++ b/packages/desktop-app/src-cli/tests/upgrade.rs
@@ -26,3 +26,170 @@ fn upgrade_is_a_noop_when_already_up_to_date() {
 
     metadata.assert();
 }
+
+#[cfg(any(
+    all(target_os = "macos", target_arch = "aarch64"),
+    all(target_os = "linux", target_arch = "aarch64"),
+    all(target_os = "linux", target_arch = "x86_64"),
+))]
+mod supported_platform {
+    use std::fs;
+    use std::path::PathBuf;
+
+    use predicates::str::contains;
+    use sha2::{Digest, Sha256};
+
+    use crate::support::{CliTestEnv, mock_api_server};
+
+    const DOWNLOAD_BASE_URL_ENV: &str = "EVERR_DOWNLOAD_BASE_URL_FOR_TESTS";
+    const RELEASE_METADATA_URL_ENV: &str = "EVERR_RELEASE_METADATA_URL_FOR_TESTS";
+
+    fn release_binary_name() -> &'static str {
+        match (std::env::consts::OS, std::env::consts::ARCH) {
+            ("macos", "aarch64") => "everr",
+            ("linux", "aarch64") => "everr-linux-arm64",
+            ("linux", "x86_64") => "everr-linux-x86_64",
+            (os, arch) => unreachable!("module is cfg-gated, got {os} {arch}"),
+        }
+    }
+
+    fn sha256_hex(bytes: &[u8]) -> String {
+        let digest = Sha256::digest(bytes);
+        let mut out = String::with_capacity(digest.len() * 2);
+        for byte in digest {
+            out.push_str(&format!("{byte:02x}"));
+        }
+        out
+    }
+
+    /// Copies the built test binary into its own temp dir so the upgrade can
+    /// replace it without touching the real target/debug binary.
+    fn install_binary_copy(dir: &tempfile::TempDir) -> PathBuf {
+        let installed = dir.path().join("everr");
+        fs::copy(assert_cmd::cargo::cargo_bin!("everr"), &installed).expect("copy test binary");
+        installed
+    }
+
+    #[test]
+    fn upgrade_replaces_the_running_binary() {
+        let env = CliTestEnv::new();
+        let mut server = mock_api_server();
+        let binary_name = release_binary_name();
+        let fake_binary = b"#!/bin/sh\necho fake-new-everr\n".to_vec();
+
+        server
+            .mock("GET", "/everr-app/release-metadata.json")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"version":"2099.1.0"}"#)
+            .create();
+        server
+            .mock("GET", format!("/everr-app/{binary_name}").as_str())
+            .with_status(200)
+            .with_body(fake_binary.clone())
+            .create();
+        server
+            .mock("GET", format!("/everr-app/{binary_name}.sha256").as_str())
+            .with_status(200)
+            .with_body(format!("{}  {binary_name}\n", sha256_hex(&fake_binary)))
+            .create();
+
+        let bin_dir = tempfile::tempdir().expect("bin dir");
+        let installed = install_binary_copy(&bin_dir);
+
+        env.command_for_binary(&installed)
+            .env(
+                RELEASE_METADATA_URL_ENV,
+                format!("{}/everr-app/release-metadata.json", server.url()),
+            )
+            .env(DOWNLOAD_BASE_URL_ENV, format!("{}/everr-app", server.url()))
+            .arg("upgrade")
+            .assert()
+            .success()
+            .stdout(contains("Upgraded everr"));
+
+        assert_eq!(
+            fs::read(&installed).expect("read installed binary"),
+            fake_binary,
+            "installed binary should be replaced with the downloaded bytes"
+        );
+    }
+
+    #[test]
+    fn upgrade_aborts_on_checksum_mismatch_and_leaves_binary_untouched() {
+        let env = CliTestEnv::new();
+        let mut server = mock_api_server();
+        let binary_name = release_binary_name();
+        let fake_binary = b"#!/bin/sh\necho fake-new-everr\n".to_vec();
+
+        server
+            .mock("GET", "/everr-app/release-metadata.json")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"version":"2099.1.0"}"#)
+            .create();
+        server
+            .mock("GET", format!("/everr-app/{binary_name}").as_str())
+            .with_status(200)
+            .with_body(fake_binary.clone())
+            .create();
+        server
+            .mock("GET", format!("/everr-app/{binary_name}.sha256").as_str())
+            .with_status(200)
+            .with_body(format!("{}  {binary_name}\n", sha256_hex(b"different bytes")))
+            .create();
+
+        let bin_dir = tempfile::tempdir().expect("bin dir");
+        let installed = install_binary_copy(&bin_dir);
+        let original = fs::read(&installed).expect("read original binary");
+
+        env.command_for_binary(&installed)
+            .env(
+                RELEASE_METADATA_URL_ENV,
+                format!("{}/everr-app/release-metadata.json", server.url()),
+            )
+            .env(DOWNLOAD_BASE_URL_ENV, format!("{}/everr-app", server.url()))
+            .arg("upgrade")
+            .assert()
+            .failure()
+            .stderr(contains("checksum mismatch"));
+
+        assert_eq!(
+            fs::read(&installed).expect("read installed binary"),
+            original,
+            "binary must be untouched after a checksum mismatch"
+        );
+    }
+
+    #[test]
+    fn debug_build_refuses_upgrade_without_download_override() {
+        let env = CliTestEnv::new();
+        let mut server = mock_api_server();
+        server
+            .mock("GET", "/everr-app/release-metadata.json")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"version":"2099.1.0"}"#)
+            .create();
+
+        let bin_dir = tempfile::tempdir().expect("bin dir");
+        let installed = install_binary_copy(&bin_dir);
+        let original = fs::read(&installed).expect("read original binary");
+
+        env.command_for_binary(&installed)
+            .env(
+                RELEASE_METADATA_URL_ENV,
+                format!("{}/everr-app/release-metadata.json", server.url()),
+            )
+            .arg("upgrade")
+            .assert()
+            .failure()
+            .stderr(contains("refusing to self-update a debug build"));
+
+        assert_eq!(
+            fs::read(&installed).expect("read installed binary"),
+            original,
+            "debug guard must leave the binary untouched"
+        );
+    }
+}

--- a/packages/desktop-app/src-cli/tests/upgrade.rs
+++ b/packages/desktop-app/src-cli/tests/upgrade.rs
@@ -1,0 +1,28 @@
+mod support;
+
+use predicates::str::contains;
+use support::{CliTestEnv, mock_api_server};
+
+#[test]
+fn upgrade_is_a_noop_when_already_up_to_date() {
+    let env = CliTestEnv::new();
+    let mut server = mock_api_server();
+    let metadata = server
+        .mock("GET", "/everr-app/release-metadata.json")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(r#"{{"version":"{}"}}"#, env!("EVERR_VERSION")))
+        .expect(1)
+        .create();
+
+    env.command_with_release_metadata_url(&format!(
+        "{}/everr-app/release-metadata.json",
+        server.url()
+    ))
+    .arg("upgrade")
+    .assert()
+    .success()
+    .stdout(contains("Already up to date"));
+
+    metadata.assert();
+}

--- a/packages/desktop-app/src-cli/tests/upgrade.rs
+++ b/packages/desktop-app/src-cli/tests/upgrade.rs
@@ -36,6 +36,8 @@ mod supported_platform {
     use std::fs;
     use std::path::PathBuf;
 
+    use assert_cmd::Command;
+    use everr_cli::upgrade::release_binary_name;
     use predicates::str::contains;
     use sha2::{Digest, Sha256};
 
@@ -43,119 +45,118 @@ mod supported_platform {
 
     const DOWNLOAD_BASE_URL_ENV: &str = "EVERR_DOWNLOAD_BASE_URL_FOR_TESTS";
     const RELEASE_METADATA_URL_ENV: &str = "EVERR_RELEASE_METADATA_URL_FOR_TESTS";
-
-    fn release_binary_name() -> &'static str {
-        match (std::env::consts::OS, std::env::consts::ARCH) {
-            ("macos", "aarch64") => "everr",
-            ("linux", "aarch64") => "everr-linux-arm64",
-            ("linux", "x86_64") => "everr-linux-x86_64",
-            (os, arch) => unreachable!("module is cfg-gated, got {os} {arch}"),
-        }
-    }
+    const FAKE_BINARY: &[u8] = b"#!/bin/sh\necho fake-new-everr\n";
 
     fn sha256_hex(bytes: &[u8]) -> String {
-        let digest = Sha256::digest(bytes);
-        let mut out = String::with_capacity(digest.len() * 2);
-        for byte in digest {
-            out.push_str(&format!("{byte:02x}"));
-        }
-        out
+        format!("{:x}", Sha256::digest(bytes))
     }
 
-    /// Copies the built test binary into its own temp dir so the upgrade can
-    /// replace it without touching the real target/debug binary.
-    fn install_binary_copy(dir: &tempfile::TempDir) -> PathBuf {
-        let installed = dir.path().join("everr");
-        fs::copy(assert_cmd::cargo::cargo_bin!("everr"), &installed).expect("copy test binary");
-        installed
+    /// A mock release server plus a copy of the built test binary in its own
+    /// temp dir, so the upgrade can replace it without touching the real
+    /// target/debug binary.
+    struct UpgradeHarness {
+        env: CliTestEnv,
+        server: mockito::ServerGuard,
+        _bin_dir: tempfile::TempDir,
+        installed: PathBuf,
+    }
+
+    impl UpgradeHarness {
+        fn new() -> Self {
+            let env = CliTestEnv::new();
+            let mut server = mock_api_server();
+            server
+                .mock("GET", "/everr-app/release-metadata.json")
+                .with_status(200)
+                .with_header("content-type", "application/json")
+                .with_body(r#"{"version":"2099.1.0"}"#)
+                .create();
+
+            let bin_dir = tempfile::tempdir().expect("bin dir");
+            let installed = bin_dir.path().join("everr");
+            fs::copy(assert_cmd::cargo::cargo_bin!("everr"), &installed)
+                .expect("copy test binary");
+
+            Self {
+                env,
+                server,
+                _bin_dir: bin_dir,
+                installed,
+            }
+        }
+
+        /// Serves FAKE_BINARY as the release artifact, published with the
+        /// checksum of `checksum_of`.
+        fn mock_artifacts(&mut self, checksum_of: &[u8]) {
+            let name = release_binary_name().expect("supported platform");
+            self.server
+                .mock("GET", format!("/everr-app/{name}").as_str())
+                .with_status(200)
+                .with_body(FAKE_BINARY)
+                .create();
+            self.server
+                .mock("GET", format!("/everr-app/{name}.sha256").as_str())
+                .with_status(200)
+                .with_body(format!("{}  {name}\n", sha256_hex(checksum_of)))
+                .create();
+        }
+
+        fn upgrade_command(&self) -> Command {
+            let mut cmd = self.upgrade_command_without_download_override();
+            cmd.env(
+                DOWNLOAD_BASE_URL_ENV,
+                format!("{}/everr-app", self.server.url()),
+            );
+            cmd
+        }
+
+        fn upgrade_command_without_download_override(&self) -> Command {
+            let mut cmd = self.env.command_for_binary(&self.installed);
+            cmd.env(
+                RELEASE_METADATA_URL_ENV,
+                format!("{}/everr-app/release-metadata.json", self.server.url()),
+            );
+            cmd.arg("upgrade");
+            cmd
+        }
+
+        fn installed_bytes(&self) -> Vec<u8> {
+            fs::read(&self.installed).expect("read installed binary")
+        }
     }
 
     #[test]
     fn upgrade_replaces_the_running_binary() {
-        let env = CliTestEnv::new();
-        let mut server = mock_api_server();
-        let binary_name = release_binary_name();
-        let fake_binary = b"#!/bin/sh\necho fake-new-everr\n".to_vec();
+        let mut harness = UpgradeHarness::new();
+        harness.mock_artifacts(FAKE_BINARY);
 
-        server
-            .mock("GET", "/everr-app/release-metadata.json")
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(r#"{"version":"2099.1.0"}"#)
-            .create();
-        server
-            .mock("GET", format!("/everr-app/{binary_name}").as_str())
-            .with_status(200)
-            .with_body(fake_binary.clone())
-            .create();
-        server
-            .mock("GET", format!("/everr-app/{binary_name}.sha256").as_str())
-            .with_status(200)
-            .with_body(format!("{}  {binary_name}\n", sha256_hex(&fake_binary)))
-            .create();
-
-        let bin_dir = tempfile::tempdir().expect("bin dir");
-        let installed = install_binary_copy(&bin_dir);
-
-        env.command_for_binary(&installed)
-            .env(
-                RELEASE_METADATA_URL_ENV,
-                format!("{}/everr-app/release-metadata.json", server.url()),
-            )
-            .env(DOWNLOAD_BASE_URL_ENV, format!("{}/everr-app", server.url()))
-            .arg("upgrade")
+        harness
+            .upgrade_command()
             .assert()
             .success()
             .stdout(contains("Upgraded everr"));
 
         assert_eq!(
-            fs::read(&installed).expect("read installed binary"),
-            fake_binary,
+            harness.installed_bytes(),
+            FAKE_BINARY,
             "installed binary should be replaced with the downloaded bytes"
         );
     }
 
     #[test]
     fn upgrade_aborts_on_checksum_mismatch_and_leaves_binary_untouched() {
-        let env = CliTestEnv::new();
-        let mut server = mock_api_server();
-        let binary_name = release_binary_name();
-        let fake_binary = b"#!/bin/sh\necho fake-new-everr\n".to_vec();
+        let mut harness = UpgradeHarness::new();
+        harness.mock_artifacts(b"different bytes");
+        let original = harness.installed_bytes();
 
-        server
-            .mock("GET", "/everr-app/release-metadata.json")
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(r#"{"version":"2099.1.0"}"#)
-            .create();
-        server
-            .mock("GET", format!("/everr-app/{binary_name}").as_str())
-            .with_status(200)
-            .with_body(fake_binary.clone())
-            .create();
-        server
-            .mock("GET", format!("/everr-app/{binary_name}.sha256").as_str())
-            .with_status(200)
-            .with_body(format!("{}  {binary_name}\n", sha256_hex(b"different bytes")))
-            .create();
-
-        let bin_dir = tempfile::tempdir().expect("bin dir");
-        let installed = install_binary_copy(&bin_dir);
-        let original = fs::read(&installed).expect("read original binary");
-
-        env.command_for_binary(&installed)
-            .env(
-                RELEASE_METADATA_URL_ENV,
-                format!("{}/everr-app/release-metadata.json", server.url()),
-            )
-            .env(DOWNLOAD_BASE_URL_ENV, format!("{}/everr-app", server.url()))
-            .arg("upgrade")
+        harness
+            .upgrade_command()
             .assert()
             .failure()
             .stderr(contains("checksum mismatch"));
 
         assert_eq!(
-            fs::read(&installed).expect("read installed binary"),
+            harness.installed_bytes(),
             original,
             "binary must be untouched after a checksum mismatch"
         );
@@ -163,31 +164,17 @@ mod supported_platform {
 
     #[test]
     fn debug_build_refuses_upgrade_without_download_override() {
-        let env = CliTestEnv::new();
-        let mut server = mock_api_server();
-        server
-            .mock("GET", "/everr-app/release-metadata.json")
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(r#"{"version":"2099.1.0"}"#)
-            .create();
+        let harness = UpgradeHarness::new();
+        let original = harness.installed_bytes();
 
-        let bin_dir = tempfile::tempdir().expect("bin dir");
-        let installed = install_binary_copy(&bin_dir);
-        let original = fs::read(&installed).expect("read original binary");
-
-        env.command_for_binary(&installed)
-            .env(
-                RELEASE_METADATA_URL_ENV,
-                format!("{}/everr-app/release-metadata.json", server.url()),
-            )
-            .arg("upgrade")
+        harness
+            .upgrade_command_without_download_override()
             .assert()
             .failure()
             .stderr(contains("refusing to self-update a debug build"));
 
         assert_eq!(
-            fs::read(&installed).expect("read installed binary"),
+            harness.installed_bytes(),
             original,
             "debug guard must leave the binary untouched"
         );


### PR DESCRIPTION
## Summary

Adds a first-class `everr upgrade` command that self-updates the CLI in place, replacing the `curl -fsSL https://everr.dev/upgrade.sh | bash` instruction (the shell scripts remain for fresh installs).

- **Check**: fetches `release-metadata.json` (same endpoint as the passive update notice, 10s timeout) and no-ops with `Already up to date (vX.Y.Z)` when current.
- **Download**: platform mapping identical to `install.sh`/`upgrade.sh` (macOS arm64, Linux arm64/x86_64); uses connect + idle-read timeouts rather than a total-transfer timeout so large downloads on slow links don't abort.
- **Verify**: sha256 checked against the published `.sha256` before anything is touched; mismatch aborts with the installed binary intact.
- **Replace**: staged in the same directory as `std::env::current_exe()` and atomically renamed over it (fsync'd first so a crash can't leave a truncated binary). This upgrades the binary that's actually running, not a hardcoded `~/.local/bin`.
- **Guard rails**: debug builds refuse to download unless the test override env is set, so `cargo run -- upgrade` can't clobber `target/debug/everr` with a release binary; the passive update notice now prints `Run: everr upgrade`.

## Test plan

- [x] Unit: `everr upgrade` parses; root help lists it.
- [x] Integration (mockito, run against a copied binary): happy-path replace, already-up-to-date no-op, checksum mismatch leaves binary untouched, debug-build refusal without override.
- [x] Existing `update_notice` expectations updated to the new message.
- [x] Full CLI suite green: `cargo test --manifest-path packages/desktop-app/src-cli/Cargo.toml`.