### PR TITLE
Collector OOM: alerting, run-identity telemetry, and chunked log ingestion

### DIFF
--- a/collector/receiver/githubactionsreceiver/log_event_handling.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling.go
@@ -29,33 +29,36 @@ import (
 
 const maxLogArchiveSize = 256 * 1024 * 1024 // 256 MB
 
-// logFlushRecordCount bounds how many log records accumulate in memory before
-// the payload is handed to the consumer. Emitting in chunks keeps memory
-// proportional to one chunk instead of the whole run: a large build matrix
-// with verbose output decodes to multiple GiB of pdata when materialized at
-// once, which is what OOM-killed the collector.
+// A payload is handed to the consumer once it reaches either bound. Emitting
+// in chunks keeps memory proportional to one chunk instead of the whole run:
+// a large build matrix with verbose output decodes to multiple GiB of pdata
+// when materialized at once, which is what OOM-killed the collector. The
+// record bound caps per-record pdata overhead for runs with many tiny lines;
+// the byte bound caps payloads whose lines are individually huge (multi-line
+// step output folds continuation lines into single records).
 const logFlushRecordCount = 10_000
+const logFlushBodyBytes = 4 * 1024 * 1024
 
 // logEmitter incrementally builds plog.Logs payloads and hands each one to
-// consume once it reaches logFlushRecordCount records. Every payload carries
-// the full run resource attributes and the current job's scope attributes, so
-// chunked output is indistinguishable from the previous whole-run payload
-// downstream. After a consume failure the emitter drops further records at
-// flush time and keeps the first error sticky so the whole event fails and
-// the sender retries it.
+// consume when it reaches a flush bound. Every payload carries the full run
+// resource attributes and the current job's scope attributes, so chunked
+// output is indistinguishable from the previous whole-run payload downstream.
+// After a consume failure the emitter drops further records at flush time and
+// keeps the first error sticky so the whole event fails and the sender
+// retries it.
 type logEmitter struct {
 	consume     func(plog.Logs) error
 	setResource func(pcommon.Map)
 
-	logs     plog.Logs
-	resource plog.ResourceLogs
-	scope    plog.ScopeLogs
-	hasLogs  bool
-	hasScope bool
-	jobName  string
-	jobID    int64
-	count    int
-	err      error
+	logs      plog.Logs
+	resource  plog.ResourceLogs
+	scope     plog.ScopeLogs
+	hasScope  bool
+	jobName   string
+	jobID     int64
+	count     int
+	bodyBytes int
+	err       error
 }
 
 func newLogEmitter(consume func(plog.Logs) error, setResource func(pcommon.Map)) *logEmitter {
@@ -69,15 +72,24 @@ func (le *logEmitter) startJob(jobName string, jobID int64) {
 	le.hasScope = false
 }
 
-func (le *logEmitter) appendRecord() plog.LogRecord {
-	if le.count >= logFlushRecordCount {
+// failed reports whether a consume error occurred. Once it has, flush drops
+// further records, so callers should stop scanning instead of decoding work
+// that will be thrown away.
+func (le *logEmitter) failed() bool {
+	return le.err != nil
+}
+
+// appendRecord returns a fresh record in the current job's scope, flushing
+// first if the pending payload reached a bound. bodyBytes is the record body
+// size the caller is about to set.
+func (le *logEmitter) appendRecord(bodyBytes int) plog.LogRecord {
+	if le.count >= logFlushRecordCount || le.bodyBytes >= logFlushBodyBytes {
 		le.flush()
 	}
-	if !le.hasLogs {
+	if le.count == 0 {
 		le.logs = plog.NewLogs()
 		le.resource = le.logs.ResourceLogs().AppendEmpty()
 		le.setResource(le.resource.Resource().Attributes())
-		le.hasLogs = true
 	}
 	if !le.hasScope {
 		le.scope = le.resource.ScopeLogs().AppendEmpty()
@@ -85,20 +97,21 @@ func (le *logEmitter) appendRecord() plog.LogRecord {
 		le.hasScope = true
 	}
 	le.count++
+	le.bodyBytes += bodyBytes
 	return le.scope.LogRecords().AppendEmpty()
 }
 
 // flush hands the accumulated payload to the consumer and resets the buffer.
 // It returns the first consume error seen so far, if any.
 func (le *logEmitter) flush() error {
-	if le.hasLogs && le.count > 0 && le.err == nil {
+	if le.count > 0 && le.err == nil {
 		if err := le.consume(le.logs); err != nil {
 			le.err = err
 		}
 	}
-	le.hasLogs = false
 	le.hasScope = false
 	le.count = 0
+	le.bodyBytes = 0
 	return le.err
 }
 
@@ -257,7 +270,7 @@ func eventToLogs(ctx context.Context, event interface{}, config *Config, ghClien
 
 	for _, zipJobName := range jobs {
 		// A consume failure is sticky; stop scanning the remaining jobs.
-		if emitter.err != nil {
+		if emitter.failed() {
 			break
 		}
 
@@ -312,7 +325,8 @@ type parsedLine struct {
 }
 
 // scanLogFile reads a zip log file and calls emit for each parsed line.
-func scanLogFile(f *zip.File, logger *zap.Logger, emit func(parsedLine)) {
+// Scanning stops early when emit returns false.
+func scanLogFile(f *zip.File, logger *zap.Logger, emit func(parsedLine) bool) {
 	ff, err := f.Open()
 	if err != nil {
 		logger.Error("Failed to open file", zap.Error(err))
@@ -336,7 +350,9 @@ func scanLogFile(f *zip.File, logger *zap.Logger, emit func(parsedLine)) {
 		if ts, line, ok := strings.Cut(lineText, " "); ok {
 			if parsedTime, err := time.Parse(time.RFC3339, ts); err == nil {
 				lastTime = parsedTime
-				emit(parsedLine{time: parsedTime, body: line})
+				if !emit(parsedLine{time: parsedTime, body: line}) {
+					return
+				}
 				continue
 			}
 		}
@@ -344,7 +360,9 @@ func scanLogFile(f *zip.File, logger *zap.Logger, emit func(parsedLine)) {
 		// No leading timestamp — this is a continuation of multi-line step
 		// output, not an error. Keep the full text and attribute it to the
 		// previous line's timestamp (zero if it's the very first line).
-		emit(parsedLine{time: lastTime, body: lineText})
+		if !emit(parsedLine{time: lastTime, body: lineText}) {
+			return
+		}
 	}
 
 	if err := scanner.Err(); err != nil {
@@ -354,8 +372,11 @@ func scanLogFile(f *zip.File, logger *zap.Logger, emit func(parsedLine)) {
 
 // emitLogRecords reads a zip log file and emits one log record per line.
 func emitLogRecords(logFile *zip.File, emitter *logEmitter, traceID pcommon.TraceID, spanID pcommon.SpanID, stepNumber int, withTraceInfo bool, logger *zap.Logger) {
-	scanLogFile(logFile, logger, func(pl parsedLine) {
-		record := emitter.appendRecord()
+	scanLogFile(logFile, logger, func(pl parsedLine) bool {
+		if emitter.failed() {
+			return false
+		}
+		record := emitter.appendRecord(len(pl.body))
 		if withTraceInfo {
 			record.SetSpanID(spanID)
 			record.SetTraceID(traceID)
@@ -364,6 +385,7 @@ func emitLogRecords(logFile *zip.File, emitter *logEmitter, traceID pcommon.Trac
 		record.SetTimestamp(pcommon.NewTimestampFromTime(pl.time))
 		record.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 		record.Body().SetStr(pl.body)
+		return true
 	})
 }
 
@@ -396,7 +418,7 @@ func processCombinedLogs(
 
 	for _, cf := range combinedFiles {
 		// A consume failure is sticky; stop scanning the remaining files.
-		if emitter.err != nil {
+		if emitter.failed() {
 			break
 		}
 
@@ -434,7 +456,11 @@ func processCombinedLogs(
 			})
 		}
 
-		scanLogFile(cf, logger, func(pl parsedLine) {
+		scanLogFile(cf, logger, func(pl parsedLine) bool {
+			if emitter.failed() {
+				return false
+			}
+
 			// Find which step this line belongs to based on timestamp
 			step := assignLineToStep(pl.time, steps)
 			if step == nil {
@@ -442,10 +468,10 @@ func processCombinedLogs(
 				step = nearestStep(pl.time, steps)
 			}
 			if step == nil {
-				return
+				return true
 			}
 
-			record := emitter.appendRecord()
+			record := emitter.appendRecord(len(pl.body))
 			if withTraceInfo {
 				record.SetSpanID(step.spanID)
 				record.SetTraceID(traceID)
@@ -454,6 +480,7 @@ func processCombinedLogs(
 			record.SetTimestamp(pcommon.NewTimestampFromTime(pl.time))
 			record.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 			record.Body().SetStr(pl.body)
+			return true
 		})
 	}
 

--- a/collector/receiver/githubactionsreceiver/log_event_handling.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling.go
@@ -29,67 +29,138 @@ import (
 
 const maxLogArchiveSize = 256 * 1024 * 1024 // 256 MB
 
-func eventToLogs(ctx context.Context, event interface{}, config *Config, ghClient *github.Client, logger *zap.Logger, withTraceInfo bool, jobNamesCache *jobNameCache, stepTimingsCache *stepTimingCache) (*plog.Logs, error) {
+// logFlushRecordCount bounds how many log records accumulate in memory before
+// the payload is handed to the consumer. Emitting in chunks keeps memory
+// proportional to one chunk instead of the whole run: a large build matrix
+// with verbose output decodes to multiple GiB of pdata when materialized at
+// once, which is what OOM-killed the collector.
+const logFlushRecordCount = 10_000
+
+// logEmitter incrementally builds plog.Logs payloads and hands each one to
+// consume once it reaches logFlushRecordCount records. Every payload carries
+// the full run resource attributes and the current job's scope attributes, so
+// chunked output is indistinguishable from the previous whole-run payload
+// downstream. After a consume failure the emitter drops further records at
+// flush time and keeps the first error sticky so the whole event fails and
+// the sender retries it.
+type logEmitter struct {
+	consume     func(plog.Logs) error
+	setResource func(pcommon.Map)
+
+	logs     plog.Logs
+	resource plog.ResourceLogs
+	scope    plog.ScopeLogs
+	hasLogs  bool
+	hasScope bool
+	jobName  string
+	jobID    int64
+	count    int
+	err      error
+}
+
+func newLogEmitter(consume func(plog.Logs) error, setResource func(pcommon.Map)) *logEmitter {
+	return &logEmitter{consume: consume, setResource: setResource}
+}
+
+// startJob sets the job whose scope attributes subsequent records belong to.
+func (le *logEmitter) startJob(jobName string, jobID int64) {
+	le.jobName = jobName
+	le.jobID = jobID
+	le.hasScope = false
+}
+
+func (le *logEmitter) appendRecord() plog.LogRecord {
+	if le.count >= logFlushRecordCount {
+		le.flush()
+	}
+	if !le.hasLogs {
+		le.logs = plog.NewLogs()
+		le.resource = le.logs.ResourceLogs().AppendEmpty()
+		le.setResource(le.resource.Resource().Attributes())
+		le.hasLogs = true
+	}
+	if !le.hasScope {
+		le.scope = le.resource.ScopeLogs().AppendEmpty()
+		setJobScopeAttributes(le.scope, le.jobName, le.jobID)
+		le.hasScope = true
+	}
+	le.count++
+	return le.scope.LogRecords().AppendEmpty()
+}
+
+// flush hands the accumulated payload to the consumer and resets the buffer.
+// It returns the first consume error seen so far, if any.
+func (le *logEmitter) flush() error {
+	if le.hasLogs && le.count > 0 && le.err == nil {
+		if err := le.consume(le.logs); err != nil {
+			le.err = err
+		}
+	}
+	le.hasLogs = false
+	le.hasScope = false
+	le.count = 0
+	return le.err
+}
+
+func eventToLogs(ctx context.Context, event interface{}, config *Config, ghClient *github.Client, logger *zap.Logger, withTraceInfo bool, jobNamesCache *jobNameCache, stepTimingsCache *stepTimingCache, consumeLogs func(plog.Logs) error) error {
 	e, ok := event.(*github.WorkflowRunEvent)
 	if !ok {
-		return nil, nil
+		return nil
 	}
 
 	if e.GetWorkflowRun().GetStatus() != "completed" {
 		logger.Debug("Run not completed, skipping")
-		return nil, nil
+		return nil
 	}
 
 	repositoryID, err := requireRepositoryID(e.GetRepo().GetID())
 	if err != nil {
 		logger.Error("Failed to determine repository ID", zap.Error(err))
-		return nil, err
+		return err
 	}
 
 	traceID, err := generateTraceID(repositoryID, e.GetWorkflowRun().GetID(), e.GetWorkflowRun().GetRunAttempt())
 	if err != nil {
 		logger.Error("Failed to generate trace ID", zap.Error(err))
-		return nil, err
+		return err
 	}
 
-	logs := plog.NewLogs()
-	allLogs := logs.ResourceLogs().AppendEmpty()
-	attrs := allLogs.Resource().Attributes()
-
-	setWorkflowRunEventAttributes(attrs, e, config)
+	emitter := newLogEmitter(consumeLogs, func(attrs pcommon.Map) {
+		setWorkflowRunEventAttributes(attrs, e, config)
+	})
 
 	url, ghResp, err := ghClient.Actions.GetWorkflowRunAttemptLogs(ctx, e.GetRepo().GetOwner().GetLogin(), e.GetRepo().GetName(), e.GetWorkflowRun().GetID(), e.GetWorkflowRun().GetRunAttempt(), 10)
 
 	if err != nil {
 		// Runs without a downloadable log archive (e.g. skipped or cancelled
 		// before any job produced output) return 404. That's not a processing
-		// failure — return the logs built so far so the caller doesn't turn
-		// this into a 500 and the sender doesn't retry the event.
+		// failure — otherwise the caller turns this into a 500 and the sender
+		// retries the event.
 		if ghResp != nil && ghResp.StatusCode == http.StatusNotFound {
 			logger.Warn("No log archive available for workflow run", zap.Error(err))
-			return &logs, nil
+			return nil
 		}
 		logger.Error("Failed to get logs", zap.Error(err))
-		return nil, err
+		return err
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
 	if err != nil {
 		logger.Error("Failed to create log download request", zap.Error(err))
-		return nil, err
+		return err
 	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		logger.Error("Failed to get logs", zap.Error(err))
-		return nil, err
+		return err
 	}
 	defer resp.Body.Close()
 
 	tmpFile, err := os.CreateTemp("", "tmpfile-")
 	if err != nil {
 		logger.Error("Failed to create temp file", zap.Error(err))
-		return nil, err
+		return err
 	}
 	defer os.Remove(tmpFile.Name())
 	defer tmpFile.Close()
@@ -98,19 +169,19 @@ func eventToLogs(ctx context.Context, event interface{}, config *Config, ghClien
 	_, err = io.Copy(tmpFile, io.LimitReader(resp.Body, maxLogArchiveSize))
 	if err != nil {
 		logger.Error("Failed to copy response to temp file", zap.Error(err))
-		return nil, err
+		return err
 	}
 
 	archive, err := zip.OpenReader(tmpFile.Name())
 	if err != nil {
 		logger.Error("Failed to open zip file", zap.Error(err))
-		return nil, fmt.Errorf("failed to open zip file: %w", err)
+		return fmt.Errorf("failed to open zip file: %w", err)
 	}
 	defer archive.Close()
 
 	if archive.File == nil {
 		logger.Error("Archive is empty")
-		return nil, fmt.Errorf("archive is empty")
+		return fmt.Errorf("archive is empty")
 	}
 
 	// Classify zip entries: subdirectory files are per-step logs (normal format),
@@ -161,12 +232,12 @@ func eventToLogs(ctx context.Context, event interface{}, config *Config, ghClien
 		}
 		if cachedJobs == nil {
 			logger.Warn("No step timing data available, cannot split combined logs")
-			return &logs, nil
+			return nil
 		}
 		stepTimingsCache.Delete(key)
 
-		processCombinedLogs(combinedFiles, e, allLogs, traceID, withTraceInfo, cachedJobs, logger)
-		return &logs, nil
+		processCombinedLogs(combinedFiles, e, emitter, traceID, withTraceInfo, cachedJobs, logger)
+		return emitter.flush()
 	}
 
 	// Normal format: per-step log files in subdirectories
@@ -185,6 +256,11 @@ func eventToLogs(ctx context.Context, event interface{}, config *Config, ghClien
 	resolvedNames := resolveJobNames(ctx, jobs, jobNamesCache, ghClient, e, logger)
 
 	for _, zipJobName := range jobs {
+		// A consume failure is sticky; stop scanning the remaining jobs.
+		if emitter.err != nil {
+			break
+		}
+
 		// Use the original (unsanitized) name for scope attributes and span IDs.
 		// The ZIP directory name is kept for file path matching.
 		jobName := zipJobName
@@ -199,8 +275,7 @@ func eventToLogs(ctx context.Context, event interface{}, config *Config, ghClien
 			jobID = metadata.jobID
 		}
 
-		jobLogsScope := allLogs.ScopeLogs().AppendEmpty()
-		setJobScopeAttributes(jobLogsScope, jobName, jobID)
+		emitter.startJob(jobName, jobID)
 
 		for _, logFile := range stepFiles {
 			// File matching uses the ZIP directory name
@@ -223,11 +298,11 @@ func eventToLogs(ctx context.Context, event interface{}, config *Config, ghClien
 				continue
 			}
 
-			emitLogRecords(logFile, jobLogsScope, traceID, spanID, stepNumber, withTraceInfo, logger)
+			emitLogRecords(logFile, emitter, traceID, spanID, stepNumber, withTraceInfo, logger)
 		}
 	}
 
-	return &logs, nil
+	return emitter.flush()
 }
 
 // parsedLine is a single log line with its parsed timestamp.
@@ -278,9 +353,9 @@ func scanLogFile(f *zip.File, logger *zap.Logger, emit func(parsedLine)) {
 }
 
 // emitLogRecords reads a zip log file and emits one log record per line.
-func emitLogRecords(logFile *zip.File, scope plog.ScopeLogs, traceID pcommon.TraceID, spanID pcommon.SpanID, stepNumber int, withTraceInfo bool, logger *zap.Logger) {
+func emitLogRecords(logFile *zip.File, emitter *logEmitter, traceID pcommon.TraceID, spanID pcommon.SpanID, stepNumber int, withTraceInfo bool, logger *zap.Logger) {
 	scanLogFile(logFile, logger, func(pl parsedLine) {
-		record := scope.LogRecords().AppendEmpty()
+		record := emitter.appendRecord()
 		if withTraceInfo {
 			record.SetSpanID(spanID)
 			record.SetTraceID(traceID)
@@ -299,7 +374,7 @@ func emitLogRecords(logFile *zip.File, scope plog.ScopeLogs, traceID pcommon.Tra
 func processCombinedLogs(
 	combinedFiles []*zip.File,
 	e *github.WorkflowRunEvent,
-	allLogs plog.ResourceLogs,
+	emitter *logEmitter,
 	traceID pcommon.TraceID,
 	withTraceInfo bool,
 	cachedJobs []jobStepTimings,
@@ -320,6 +395,11 @@ func processCombinedLogs(
 	}
 
 	for _, cf := range combinedFiles {
+		// A consume failure is sticky; stop scanning the remaining files.
+		if emitter.err != nil {
+			break
+		}
+
 		// Parse "0_<jobName>.txt" → jobName
 		jobZipName := parseCombinedFileName(cf.Name)
 		if jobZipName == "" {
@@ -336,8 +416,7 @@ func processCombinedLogs(
 		// Use the original (unsanitized) job name for scope attributes and span IDs
 		jobName := jst.jobName
 
-		jobLogsScope := allLogs.ScopeLogs().AppendEmpty()
-		setJobScopeAttributes(jobLogsScope, jobName, jst.jobID)
+		emitter.startJob(jobName, jst.jobID)
 
 		// Pre-generate span IDs for each step
 		steps := make([]stepInfo, 0, len(jst.steps))
@@ -366,7 +445,7 @@ func processCombinedLogs(
 				return
 			}
 
-			record := jobLogsScope.LogRecords().AppendEmpty()
+			record := emitter.appendRecord()
 			if withTraceInfo {
 				record.SetSpanID(step.spanID)
 				record.SetTraceID(traceID)

--- a/collector/receiver/githubactionsreceiver/log_event_handling_test.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling_test.go
@@ -690,6 +690,37 @@ func TestEventToLogsChunksLargePayloads(t *testing.T) {
 	require.ErrorIs(t, err, consumeErr)
 }
 
+// TestLogEmitterFlushesOnByteBound verifies that a payload flushes once its
+// accumulated record bodies reach logFlushBodyBytes even when far below the
+// record-count bound, so few-huge-lines jobs cannot balloon a single chunk.
+func TestLogEmitterFlushesOnByteBound(t *testing.T) {
+	var consumed []plog.Logs
+	emitter := newLogEmitter(
+		func(ld plog.Logs) error {
+			consumed = append(consumed, ld)
+			return nil
+		},
+		func(attrs pcommon.Map) { attrs.PutStr("run", "r1") },
+	)
+	emitter.startJob("job", 1)
+
+	// Three records just over half the byte bound each: the third append
+	// crosses the bound and flushes the first two.
+	overHalf := logFlushBodyBytes/2 + 1
+	for i := 0; i < 3; i++ {
+		emitter.appendRecord(overHalf).Body().SetStr("x")
+	}
+	require.NoError(t, emitter.flush())
+
+	require.Len(t, consumed, 2)
+	require.Equal(t, 2, consumed[0].LogRecordCount())
+	require.Equal(t, 1, consumed[1].LogRecordCount())
+	for i, ld := range consumed {
+		_, ok := ld.ResourceLogs().At(0).Resource().Attributes().Get("run")
+		require.True(t, ok, "payload %d missing resource attributes", i)
+	}
+}
+
 // TestScanLogFileContinuationLines verifies that multi-line step output —
 // where continuation lines have no leading timestamp — is preserved with the
 // previous line's timestamp and doesn't produce error-level logs.
@@ -707,8 +738,9 @@ func TestScanLogFileContinuationLines(t *testing.T) {
 		t.Helper()
 		core, observed := observer.New(zap.ErrorLevel)
 		var lines []parsedLine
-		scanLogFile(newZipFile(t, content), zap.New(core), func(pl parsedLine) {
+		scanLogFile(newZipFile(t, content), zap.New(core), func(pl parsedLine) bool {
 			lines = append(lines, pl)
+			return true
 		})
 		return lines, observed
 	}

--- a/collector/receiver/githubactionsreceiver/log_event_handling_test.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -347,7 +348,8 @@ func TestProcessCombinedLogsWithRealWebhook(t *testing.T) {
 
 	jnCache := newJobNameCache(100, 30*time.Minute)
 
-	logs, err := eventToLogs(
+	var consumed []plog.Logs
+	err = eventToLogs(
 		context.Background(),
 		wre,
 		&Config{},
@@ -356,9 +358,14 @@ func TestProcessCombinedLogsWithRealWebhook(t *testing.T) {
 		true, // withTraceInfo
 		jnCache,
 		stCache,
+		func(ld plog.Logs) error {
+			consumed = append(consumed, ld)
+			return nil
+		},
 	)
 	require.NoError(t, err)
-	require.NotNil(t, logs)
+	require.Len(t, consumed, 1)
+	logs := consumed[0]
 
 	// Verify we got log records split across the correct steps
 	rl := logs.ResourceLogs()
@@ -484,7 +491,8 @@ func TestEventToLogsNormalFormatUnchanged(t *testing.T) {
 	jnCache := newJobNameCache(100, 30*time.Minute)
 	stCache := newStepTimingCache(100, 30*time.Minute)
 
-	logs, err := eventToLogs(
+	var consumed []plog.Logs
+	err = eventToLogs(
 		context.Background(),
 		wre,
 		&Config{},
@@ -493,9 +501,14 @@ func TestEventToLogsNormalFormatUnchanged(t *testing.T) {
 		true,
 		jnCache,
 		stCache,
+		func(ld plog.Logs) error {
+			consumed = append(consumed, ld)
+			return nil
+		},
 	)
 	require.NoError(t, err)
-	require.NotNil(t, logs)
+	require.Len(t, consumed, 1)
+	logs := consumed[0]
 
 	// Should have used the normal path (subdirectory step files)
 	rl := logs.ResourceLogs()
@@ -528,7 +541,7 @@ func TestEventToLogsNoLogArchive(t *testing.T) {
 	require.NoError(t, err)
 	wre := runEvent.(*github.WorkflowRunEvent)
 
-	newEventToLogs := func(t *testing.T, statusCode int) (*plog.Logs, error) {
+	newEventToLogs := func(t *testing.T, statusCode int) ([]plog.Logs, error) {
 		t.Helper()
 		apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, http.StatusText(statusCode), statusCode)
@@ -538,7 +551,8 @@ func TestEventToLogsNoLogArchive(t *testing.T) {
 		ghClient, err := github.NewClient(nil).WithEnterpriseURLs(apiServer.URL+"/", apiServer.URL+"/")
 		require.NoError(t, err)
 
-		return eventToLogs(
+		var consumed []plog.Logs
+		err = eventToLogs(
 			context.Background(),
 			wre,
 			&Config{},
@@ -547,24 +561,133 @@ func TestEventToLogsNoLogArchive(t *testing.T) {
 			true,
 			newJobNameCache(100, 30*time.Minute),
 			newStepTimingCache(100, 30*time.Minute),
+			func(ld plog.Logs) error {
+				consumed = append(consumed, ld)
+				return nil
+			},
 		)
+		return consumed, err
 	}
 
 	t.Run("404 means no logs, not a failure", func(t *testing.T) {
-		logs, err := newEventToLogs(t, http.StatusNotFound)
+		consumed, err := newEventToLogs(t, http.StatusNotFound)
 		require.NoError(t, err)
-		require.NotNil(t, logs)
-
-		// Resource attributes are set, but no log records were produced.
-		require.Equal(t, 1, logs.ResourceLogs().Len())
-		require.Equal(t, 0, logs.ResourceLogs().At(0).ScopeLogs().Len())
+		require.Empty(t, consumed)
 	})
 
 	t.Run("server errors still fail", func(t *testing.T) {
-		logs, err := newEventToLogs(t, http.StatusServiceUnavailable)
+		consumed, err := newEventToLogs(t, http.StatusServiceUnavailable)
 		require.Error(t, err)
-		require.Nil(t, logs)
+		require.Empty(t, consumed)
 	})
+}
+
+// TestEventToLogsChunksLargePayloads verifies that a run whose logs exceed
+// logFlushRecordCount is delivered to the consumer in multiple bounded
+// payloads, each carrying the run resource attributes and the job scope, so
+// no single plog.Logs materializes the whole run in memory.
+func TestEventToLogsChunksLargePayloads(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	runPayload, err := os.ReadFile("./testdata/completed/8_workflow_run_completed.json")
+	require.NoError(t, err)
+	runEvent, err := github.ParseWebHook("workflow_run", runPayload)
+	require.NoError(t, err)
+	wre := runEvent.(*github.WorkflowRunEvent)
+
+	totalLines := logFlushRecordCount*2 + logFlushRecordCount/2
+
+	var logText bytes.Buffer
+	for i := 0; i < totalLines; i++ {
+		fmt.Fprintf(&logText, "2023-10-13T10:11:33Z line %d\n", i)
+	}
+
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	f, err := w.Create("pre-commit/1_Set up job.txt")
+	require.NoError(t, err)
+	_, err = f.Write(logText.Bytes())
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	zipData := buf.Bytes()
+
+	zipServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		_, _ = w.Write(zipData)
+	}))
+	defer zipServer.Close()
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/logs") {
+			http.Redirect(w, r, zipServer.URL, http.StatusFound)
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, "/jobs") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"total_count":1,"jobs":[{"id":12345,"name":"pre-commit","status":"completed"}]}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer apiServer.Close()
+
+	ghClient, err := github.NewClient(nil).WithEnterpriseURLs(apiServer.URL+"/", apiServer.URL+"/")
+	require.NoError(t, err)
+
+	var consumed []plog.Logs
+	err = eventToLogs(
+		context.Background(),
+		wre,
+		&Config{},
+		ghClient,
+		logger,
+		true,
+		newJobNameCache(100, 30*time.Minute),
+		newStepTimingCache(100, 30*time.Minute),
+		func(ld plog.Logs) error {
+			consumed = append(consumed, ld)
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, consumed, 3, "expected the run split into 3 bounded payloads")
+
+	total := 0
+	for i, ld := range consumed {
+		require.Equal(t, 1, ld.ResourceLogs().Len())
+		rl := ld.ResourceLogs().At(0)
+
+		// Every chunk must be self-contained: run resource attributes and
+		// job scope attributes present.
+		_, ok := rl.Resource().Attributes().Get(string(conventions.ServiceNameKey))
+		require.True(t, ok, "payload %d missing resource attributes", i)
+
+		require.Equal(t, 1, rl.ScopeLogs().Len())
+		scope := rl.ScopeLogs().At(0)
+		jobName, ok := scope.Scope().Attributes().Get("cicd.pipeline.task.name")
+		require.True(t, ok, "payload %d missing job scope attributes", i)
+		require.Equal(t, "pre-commit", jobName.Str())
+
+		count := scope.LogRecords().Len()
+		require.LessOrEqual(t, count, logFlushRecordCount, "payload %d exceeds the chunk bound", i)
+		total += count
+	}
+	require.Equal(t, totalLines, total, "no records lost or duplicated across chunks")
+
+	// A consume failure must fail the event so the sender retries it.
+	consumeErr := fmt.Errorf("pipeline refused data")
+	err = eventToLogs(
+		context.Background(),
+		wre,
+		&Config{},
+		ghClient,
+		logger,
+		true,
+		newJobNameCache(100, 30*time.Minute),
+		newStepTimingCache(100, 30*time.Minute),
+		func(ld plog.Logs) error { return consumeErr },
+	)
+	require.ErrorIs(t, err, consumeErr)
 }
 
 // TestScanLogFileContinuationLines verifies that multi-line step output —

--- a/collector/receiver/githubactionsreceiver/receiver.go
+++ b/collector/receiver/githubactionsreceiver/receiver.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/receiverhelper"
 	"go.uber.org/zap"
@@ -372,18 +373,14 @@ func (gar *githubActionsReceiver) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		} else {
 			withTraceInfo := gar.tracesConsumer != nil && !traceErr
 
-			ld, err := eventToLogs(ctx, event, gar.config, ghClient, gar.logger.Named("eventToLogs"), withTraceInfo, gar.jobNames, gar.stepTimings)
+			// eventToLogs hands payloads to the consumer in bounded chunks so
+			// a large run is never materialized in memory at once.
+			err := eventToLogs(ctx, event, gar.config, ghClient, gar.logger.Named("eventToLogs"), withTraceInfo, gar.jobNames, gar.stepTimings, func(ld plog.Logs) error {
+				return gar.logsConsumer.ConsumeLogs(ctx, ld)
+			})
 			if err != nil {
 				processingFailed = true
 				gar.logger.Error("Failed to process logs", zap.Error(err))
-			}
-
-			if ld != nil {
-				consumerErr := gar.logsConsumer.ConsumeLogs(ctx, *ld)
-				if consumerErr != nil {
-					processingFailed = true
-					gar.logger.Error("Failed to consume logs", zap.Error(consumerErr))
-				}
 			}
 		}
 	}

--- a/everr/collector-oom.alert.yaml
+++ b/everr/collector-oom.alert.yaml
@@ -1,0 +1,22 @@
+kind: AlertRule
+metadata:
+  name: collector-oom
+spec:
+  runbook: collector-oom
+  display:
+    name: Collector pod memory spike
+    description: A pod in the collector namespace is using far more memory than its baseline. Historically the precursor to collector OOM kills; with the memory protections deployed this should be rare.
+  notificationMessage:
+    title: "${pod} memory spiked to ${peak_mem_mib} MiB"
+    description: "Working set peaked at ${peak_mem_mib} MiB in the last 5 minutes (baseline is under 150 MiB). Check what the collector was ingesting and whether the memory protections held."
+  evaluationInterval: 1m
+  query: |
+    SELECT
+      ResourceAttributes['k8s.pod.name'] AS pod,
+      round(max(Value) / 1048576) AS peak_mem_mib
+    FROM metrics_gauge
+    WHERE MetricName = 'k8s.pod.memory.working_set'
+      AND ResourceAttributes['k8s.namespace.name'] = 'collector'
+      AND TimeUnix >= now() - INTERVAL 5 MINUTE
+    GROUP BY pod
+    HAVING peak_mem_mib > 1024

--- a/everr/collector-oom.runbook.md
+++ b/everr/collector-oom.runbook.md
@@ -13,8 +13,11 @@ are assumed to be in place:
 - the collector container has memory requests and limits, and the pipeline
   has a `memory_limiter` processor, so overload produces backpressure instead
   of a kernel OOM kill,
-- log ingestion runs off the webhook request path and emits per job, so no
-  single run is materialized in memory at once.
+- log ingestion emits in bounded chunks (10k records per payload), so no
+  single run is materialized in memory at once. Processing is still
+  synchronous in the webhook handler and the app allows it 60 seconds, so
+  replay durations up to a minute are expected for huge runs, not a
+  regression.
 
 With those in place this alert should be rare. If it fires, one of the
 protections is not doing its job or the load pattern changed. Work through
@@ -60,9 +63,11 @@ verbose logs is the classic trigger.
 
 ## 3. Did the protections hold?
 
-- **Webhook latency.** With async ingestion, replay durations must stay flat
-  even while a big run is processed. Spikes returning here mean the handler
-  is doing heavy work inline again (regression):
+- **Webhook latency.** Ingestion is synchronous, so replay durations scale
+  with archive size; up to the 60s app timeout is expected for huge runs.
+  What matters is memory staying flat while a slow replay is in flight. A
+  slow replay together with a memory balloon means chunked emission is not
+  bounding the payload (regression):
 
 ```panel
 ref: replay-durations

--- a/everr/collector-oom.runbook.md
+++ b/everr/collector-oom.runbook.md
@@ -43,7 +43,12 @@ ref: slow-by-event-type
 height: 240
 ```
 
-Identify the run on the pod itself:
+Since 2026-07-04 the app's replay spans
+(`github_events.jobs.replay_webhook_to_collector`) carry
+`github.repository.full_name`, `github.workflow_run.id`,
+`github.workflow_run.name`, and `everr.organization.id`, so the slow
+replay in the panel above names the run directly. As a fallback,
+identify the run on the pod itself:
 
 ```sh
 kubectl logs -n collector <pod> | grep "Processing WorkflowRunEvent"

--- a/everr/collector-oom.runbook.md
+++ b/everr/collector-oom.runbook.md
@@ -13,7 +13,8 @@ are assumed to be in place:
 - the collector container has memory requests and limits, and the pipeline
   has a `memory_limiter` processor, so overload produces backpressure instead
   of a kernel OOM kill,
-- log ingestion emits in bounded chunks (10k records per payload), so no
+- log ingestion emits in bounded chunks (capped by record count and body
+  bytes), so no
   single run is materialized in memory at once. Processing is still
   synchronous in the webhook handler and the app allows it 60 seconds, so
   replay durations up to a minute are expected for huge runs, not a

--- a/everr/collector-oom.runbook.md
+++ b/everr/collector-oom.runbook.md
@@ -1,0 +1,94 @@
+# Collector pod memory spike
+
+The **collector-oom** alert fires when a pod in the `collector` namespace
+peaks above **1024 MiB** working set over the last 5 minutes. Baseline is
+65-150 MiB, so a firing alert means memory grew by an order of magnitude.
+
+The known driver is GitHub Actions log ingestion: a `workflow_run: completed`
+webhook makes the collector download and parse the run's full log archive.
+The protections added after the
+[2026-07-04 investigation](./investigations/collector-webhook-oom.runbook.md)
+are assumed to be in place:
+
+- the collector container has memory requests and limits, and the pipeline
+  has a `memory_limiter` processor, so overload produces backpressure instead
+  of a kernel OOM kill,
+- log ingestion runs off the webhook request path and emits per job, so no
+  single run is materialized in memory at once.
+
+With those in place this alert should be rare. If it fires, one of the
+protections is not doing its job or the load pattern changed. Work through
+the steps below.
+
+## 1. Confirm the spike and find the pod
+
+```panel
+ref: collector-memory
+height: 300
+```
+
+A single scrape in the GiB range is a fast balloon (one huge ingest). A slow
+climb across hours is different: suspect a leak or genuinely higher
+steady-state load.
+
+## 2. What was the collector ingesting?
+
+```panel
+ref: slow-replays
+height: 280
+```
+
+```panel
+ref: slow-by-event-type
+height: 240
+```
+
+Identify the run on the pod itself:
+
+```sh
+kubectl logs -n collector <pod> | grep "Processing WorkflowRunEvent"
+```
+
+This prints repo, workflow name, and run id. Check the run's size with
+`gh run view <run-id> -R <repo> --json jobs`: a huge build matrix with
+verbose logs is the classic trigger.
+
+## 3. Did the protections hold?
+
+- **Webhook latency.** With async ingestion, replay durations must stay flat
+  even while a big run is processed. Spikes returning here mean the handler
+  is doing heavy work inline again (regression):
+
+```panel
+ref: replay-durations
+height: 240
+```
+
+- **Container state.** `kubectl describe pod -n collector <pod>`. If
+  `Last State` shows `OOMKilled`, check which limit was hit: a kill at the
+  configured container limit means the `memory_limiter` soft limit is set too
+  close to (or above) the container limit and never engaged. No limits shown
+  at all means the deployment lost its resource settings.
+- **Backpressure.** `kubectl logs -n collector <pod> | grep -i "memory"`
+  should show the `memory_limiter` refusing data during the spike. Refusals
+  are the mechanism working; sustained refusals mean the collector is
+  undersized for current load.
+- **Data loss.** If the pod restarted, telemetry batched but not yet exported
+  was lost. Check for a gap in ingestion around the restart across all
+  signals, not just CI data.
+
+## 4. Decide the action
+
+| Finding | Action |
+| --- | --- |
+| One pathological workflow run, protections held, no restart | Nothing urgent. Note the repo/run; consider a per-run size guard if it repeats. |
+| Replay durations spiky again, or whole runs buffered in memory | Regression in the receiver. Compare the deployed collector image against main and roll back or fix. |
+| OOMKilled at the container limit, memory_limiter never engaged | Fix the `memory_limiter` soft/hard limits so they sit safely below the container limit. |
+| No container limits present | Restore memory requests/limits in the collector deployment (everr-deploy). |
+| Sustained high memory with steady refusals | Load outgrew the sizing. Raise the container limit and the memory_limiter thresholds together, then raise the alert threshold in `collector-oom.alert.yaml` to keep headroom. |
+
+## Related
+
+- [Investigation (2026-07-04)](./investigations/collector-webhook-oom.runbook.md):
+  the original incident analysis, root cause in the
+  `githubactionsreceiver`, and the fixes this runbook assumes are deployed.

--- a/everr/collector-oom.runbook.yaml
+++ b/everr/collector-oom.runbook.yaml
@@ -1,0 +1,268 @@
+kind: Runbook
+metadata:
+  name: collector-oom
+  # no project → "default", matching the collector-oom alert
+spec:
+  display:
+    name: "Collector pod memory spike"
+    description: "Triage steps for the collector-oom alert: a collector pod's working set passed 1 GiB."
+  duration: 6h
+  refreshInterval: 1m
+  panels:
+    collector-memory:
+      kind: Panel
+      spec:
+        display:
+          name: Collector pod memory working set (MiB)
+          description: Baseline is 65-150 MiB. The alert fires when any pod in the collector namespace peaks above 1024 MiB over 5 minutes.
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            unit: MiB
+            showLegend: true
+            lineWidth: 1.5
+            curveType: monotone
+        queries:
+          - kind: ClickHouseSQL
+            spec:
+              plugin:
+                kind: ClickHouseSQL
+                spec:
+                  query: |
+                    SELECT
+                      toStartOfInterval(TimeUnix, INTERVAL {step:UInt32} SECOND) AS ts,
+                      ResourceAttributes['k8s.pod.name'] AS pod,
+                      round(max(Value) / 1048576, 1) AS mem_mib
+                    FROM metrics_gauge
+                    WHERE TimeUnix >= {from:String} AND TimeUnix <= {to:String}
+                      AND MetricName = 'k8s.pod.memory.working_set'
+                      AND ResourceAttributes['k8s.namespace.name'] = 'collector'
+                    GROUP BY ts, pod
+                    ORDER BY ts
+    slow-replays:
+      kind: Panel
+      spec:
+        display:
+          name: Slow webhook replays (over 5s)
+          description: Replay jobs that stalled, with the GitHub event type. A slow workflow_run replay near the spike identifies the run being ingested.
+        plugin:
+          kind: Table
+          spec:
+            stickyHeader: true
+        queries:
+          - kind: ClickHouseSQL
+            spec:
+              plugin:
+                kind: ClickHouseSQL
+                spec:
+                  query: |
+                    SELECT
+                      formatDateTime(Timestamp, '%m-%d %H:%i:%S') AS started,
+                      SpanAttributes['github.event.type'] AS event_type,
+                      round(Duration / 1e6, 1) AS duration_ms,
+                      TraceId AS trace_id
+                    FROM traces
+                    WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                      AND SpanName = 'github_events.jobs.replay_webhook_to_collector'
+                      AND Duration > 5e9
+                    ORDER BY Timestamp DESC
+                    LIMIT 50
+    replay-durations:
+      kind: Panel
+      spec:
+        display:
+          name: Webhook replay duration (worst per interval)
+          description: Max duration of github_events.jobs.replay_webhook_to_collector spans. With async ingestion deployed this should stay flat in the low milliseconds; a return of 20-30s spikes means the webhook handler is doing heavy work inline again.
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            unit: ms
+            showLegend: false
+            lineWidth: 1.5
+            curveType: monotone
+        queries:
+          - kind: ClickHouseSQL
+            spec:
+              plugin:
+                kind: ClickHouseSQL
+                spec:
+                  query: |
+                    SELECT
+                      toStartOfInterval(Timestamp, INTERVAL {step:UInt32} SECOND) AS ts,
+                      round(max(Duration) / 1e6, 1) AS max_ms
+                    FROM traces
+                    WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                      AND SpanName = 'github_events.jobs.replay_webhook_to_collector'
+                    GROUP BY ts
+                    ORDER BY ts
+    slow-by-event-type:
+      kind: Panel
+      spec:
+        display:
+          name: Replay duration by GitHub event type
+          description: p50 vs max per event type. workflow_run is the only event that triggers log archive ingestion, so it owns the tail.
+        plugin:
+          kind: Table
+          spec:
+            stickyHeader: true
+        queries:
+          - kind: ClickHouseSQL
+            spec:
+              plugin:
+                kind: ClickHouseSQL
+                spec:
+                  query: |
+                    SELECT
+                      SpanAttributes['github.event.type'] AS event_type,
+                      count() AS replays,
+                      round(quantile(0.5)(Duration) / 1e6, 1) AS p50_ms,
+                      round(quantile(0.95)(Duration) / 1e6, 1) AS p95_ms,
+                      round(max(Duration) / 1e6, 1) AS max_ms
+                    FROM traces
+                    WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                      AND SpanName = 'github_events.jobs.replay_webhook_to_collector'
+                    GROUP BY event_type
+                    ORDER BY max_ms DESC
+                    LIMIT 20
+    memory-then-vs-now:
+      kind: Panel
+      spec:
+        display:
+          name: Peak collector memory, incident vs selected window
+          description: Left tile is pinned to the incident window (2026-07-03 17:00 to 2026-07-04 05:30 UTC); right tile follows the time picker. Red above the 1024 MiB alert threshold.
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            unit: " MiB"
+            decimals: 0
+            colorMode: background
+            thresholds:
+              mode: absolute
+              defaultColor: "#22c55e"
+              steps:
+                - { value: 1024, color: "#ef4444" }
+        queries:
+          - kind: ClickHouseSQL
+            spec:
+              plugin:
+                kind: ClickHouseSQL
+                spec:
+                  query: |
+                    SELECT round(max(Value) / 1048576) AS incident_peak
+                    FROM metrics_gauge
+                    WHERE TimeUnix >= '2026-07-03 17:00:00' AND TimeUnix <= '2026-07-04 05:30:00'
+                      AND MetricName = 'k8s.pod.memory.working_set'
+                      AND ResourceAttributes['k8s.namespace.name'] = 'collector'
+          - kind: ClickHouseSQL
+            spec:
+              plugin:
+                kind: ClickHouseSQL
+                spec:
+                  query: |
+                    SELECT round(max(Value) / 1048576) AS selected_window_peak
+                    FROM metrics_gauge
+                    WHERE TimeUnix >= {from:String} AND TimeUnix <= {to:String}
+                      AND MetricName = 'k8s.pod.memory.working_set'
+                      AND ResourceAttributes['k8s.namespace.name'] = 'collector'
+    replay-then-vs-now:
+      kind: Panel
+      spec:
+        display:
+          name: Worst webhook replay, incident vs selected window
+          description: Left tile is pinned to the incident window; right tile follows the time picker. Red above 5000 ms.
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            unit: " ms"
+            decimals: 0
+            colorMode: background
+            thresholds:
+              mode: absolute
+              defaultColor: "#22c55e"
+              steps:
+                - { value: 5000, color: "#ef4444" }
+        queries:
+          - kind: ClickHouseSQL
+            spec:
+              plugin:
+                kind: ClickHouseSQL
+                spec:
+                  query: |
+                    SELECT round(max(Duration) / 1e6) AS incident_worst
+                    FROM traces
+                    WHERE Timestamp >= '2026-07-03 17:00:00' AND Timestamp <= '2026-07-04 05:30:00'
+                      AND SpanName = 'github_events.jobs.replay_webhook_to_collector'
+          - kind: ClickHouseSQL
+            spec:
+              plugin:
+                kind: ClickHouseSQL
+                spec:
+                  query: |
+                    SELECT round(max(Duration) / 1e6) AS selected_window_worst
+                    FROM traces
+                    WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                      AND SpanName = 'github_events.jobs.replay_webhook_to_collector'
+    incident-slow-replays:
+      kind: Panel
+      spec:
+        display:
+          name: Slow replays during the incident (pinned)
+          description: The replay jobs over 5s in the incident window, 2026-07-03 17:00 to 2026-07-04 05:30 UTC. Each preceded a collector OOM kill by about a minute. Does not follow the time picker.
+        plugin:
+          kind: Table
+          spec:
+            stickyHeader: true
+        queries:
+          - kind: ClickHouseSQL
+            spec:
+              plugin:
+                kind: ClickHouseSQL
+                spec:
+                  query: |
+                    SELECT
+                      formatDateTime(Timestamp, '%m-%d %H:%i:%S') AS started,
+                      SpanAttributes['github.event.type'] AS event_type,
+                      round(Duration / 1e6, 1) AS duration_ms,
+                      TraceId AS trace_id
+                    FROM traces
+                    WHERE Timestamp >= '2026-07-03 17:00:00' AND Timestamp <= '2026-07-04 05:30:00'
+                      AND SpanName = 'github_events.jobs.replay_webhook_to_collector'
+                      AND Duration > 5e9
+                    ORDER BY Timestamp ASC
+                    LIMIT 20
+    incident-memory-scrapes:
+      kind: Panel
+      spec:
+        display:
+          name: Highest collector memory scrapes during the incident (pinned)
+          description: Top kubelet scrapes of collector pod working set in the incident window. The multi-GiB rows are the balloons right before each kill. Does not follow the time picker.
+        plugin:
+          kind: Table
+          spec:
+            stickyHeader: true
+        queries:
+          - kind: ClickHouseSQL
+            spec:
+              plugin:
+                kind: ClickHouseSQL
+                spec:
+                  query: |
+                    SELECT
+                      formatDateTime(TimeUnix, '%m-%d %H:%i:%S') AS scraped,
+                      ResourceAttributes['k8s.pod.name'] AS pod,
+                      round(Value / 1048576, 1) AS mem_mib
+                    FROM metrics_gauge
+                    WHERE TimeUnix >= '2026-07-03 17:00:00' AND TimeUnix <= '2026-07-04 05:30:00'
+                      AND MetricName = 'k8s.pod.memory.working_set'
+                      AND ResourceAttributes['k8s.namespace.name'] = 'collector'
+                    ORDER BY mem_mib DESC
+                    LIMIT 10
+  markdown:
+    file: ./collector-oom.runbook.md
+  pages:
+    - name: investigation
+      display: { name: "Investigation (2026-07-04)" }
+      markdown:
+        file: ./investigations/2026-07-04-collector-oom/collector-webhook-oom.runbook.md

--- a/everr/investigations/2026-07-04-collector-oom/collector-webhook-failures.alert.yaml
+++ b/everr/investigations/2026-07-04-collector-oom/collector-webhook-failures.alert.yaml
@@ -1,0 +1,21 @@
+kind: AlertRule
+metadata:
+  name: collector-webhook-failures
+spec:
+  runbook: collector-oom
+  display:
+    name: Collector webhook replay failures
+    description: Webhook replays to the collector are failing again. The collector release of 2026-07-04 (f114d040) is expected to have eliminated these 500s; this alert verifies that stays true.
+  notificationMessage:
+    title: "${failed_replays} webhook replays to the collector failed"
+    description: "Replays failed in the last 30 minutes (last error: ${last_error}). The collector 500s fixed by the 2026-07-04 release may have regressed; check the collector logs and image version."
+  evaluationInterval: 30m
+  query: |
+    SELECT
+      count() AS failed_replays,
+      anyLast(StatusMessage) AS last_error
+    FROM traces
+    WHERE SpanName = 'github_events.jobs.replay_webhook_to_collector'
+      AND StatusCode = 'Error'
+      AND Timestamp >= now() - INTERVAL 30 MINUTE
+    HAVING failed_replays > 0

--- a/everr/investigations/2026-07-04-collector-oom/collector-webhook-oom.runbook.md
+++ b/everr/investigations/2026-07-04-collector-oom/collector-webhook-oom.runbook.md
@@ -155,8 +155,8 @@ stdout logs are not ingested. See fix 4.
    file) instead of building the whole 23-job run as one `plog.Logs` payload.
    The 256 MB cap bounds the compressed download, not the decoded pdata size.
    **Update, 2026-07-04:** the emit half is done. The receiver now hands
-   payloads to the pipeline in bounded chunks of 10k records
-   (`logEmitter` in
+   payloads to the pipeline in bounded chunks, capped at 10k records or
+   4 MiB of body text (`logEmitter` in
    `collector/receiver/githubactionsreceiver/log_event_handling.go`), so
    memory stays proportional to one chunk instead of the whole run.
    Processing is still synchronous in the webhook handler; the app's replay

--- a/everr/investigations/2026-07-04-collector-oom/collector-webhook-oom.runbook.md
+++ b/everr/investigations/2026-07-04-collector-oom/collector-webhook-oom.runbook.md
@@ -1,0 +1,150 @@
+# Collector OOM kills from workflow_run log ingestion
+
+Investigation from **2026-07-04**. At the time, the collector pod was getting
+kernel OOM killed roughly once every few hours, each time right after
+ingesting the logs of a large GitHub Actions run. This page records the
+analysis and the fixes that came out of it. The
+[collector-oom triage runbook](../../collector-oom.runbook.md) assumes those
+fixes are deployed; read this page for the background.
+
+**Update, 2026-07-04:** the collector has been released with the current
+image (fix 1). The **collector-webhook-failures** alert
+(`everr/investigations/2026-07-04-collector-oom/collector-webhook-failures.alert.yaml`) now checks every 30 minutes
+that the webhook 500s this release eliminates have not come back.
+
+## Status at the time vs now
+
+The left tile of each pair is pinned to the incident window (2026-07-03 17:00
+to 2026-07-04 05:30 UTC); the right tile follows the time picker, so with a
+recent window selected these read as a direct then-vs-now comparison.
+
+```panel
+ref: memory-then-vs-now
+height: 160
+```
+
+```panel
+ref: replay-then-vs-now
+height: 160
+```
+
+During the incident window there were 4 replay jobs over 5 seconds, all
+`workflow_run` events, each followed by a collector restart about a minute
+later:
+
+```panel
+ref: incident-slow-replays
+height: 240
+```
+
+Collector memory baseline is 65-150 MiB. The scrapes right before each kill
+were in the GiB range, topping out above 12 GiB:
+
+```panel
+ref: incident-memory-scrapes
+height: 300
+```
+
+## Compare with now
+
+The same signals, following the time picker. After the fixes these should
+show a flat memory baseline and replay durations in the low milliseconds.
+
+```panel
+ref: collector-memory
+height: 280
+```
+
+```panel
+ref: replay-durations
+height: 240
+```
+
+## What actually happens
+
+The app replays the GitHub webhook to
+`http://collector.collector.svc.cluster.local:8080/webhook/github`. For a
+`workflow_run: completed` event, the collector's `githubactionsreceiver`
+did all of this synchronously inside the HTTP handler
+(`collector/receiver/githubactionsreceiver/log_event_handling.go`):
+
+1. downloads the run's full log archive from GitHub (capped at 256 MB),
+2. unzips it and scans every line of every job log,
+3. materializes the entire run as one in-memory `plog.Logs` payload,
+4. only then returns 202.
+
+The trigger for the investigated occurrence (trace
+`158b2012078cbbbc6c5438fcee5a350b`, 26.9s) was a customer repository's
+23-job Rust cross-compilation matrix with very verbose cargo output
+(customer repo and run id intentionally not recorded here). Steps 1-3 are
+the 27 seconds the app's replay job saw.
+
+The memory allocated while building that payload was the kill: the container
+had no memory requests or limits and the pipeline had no `memory_limiter`
+processor, so nothing pushed back before the kernel OOM killer shot the
+process.
+
+## Why this matters beyond latency
+
+The collector returns 202 for the event and then dies. Anything batched but
+not yet exported to ClickHouse at kill time is silently lost, including
+telemetry from unrelated tenants that happened to be in flight.
+
+## The alert that came out of this
+
+The **collector-oom** alert (`everr/collector-oom.alert.yaml`) fires when any
+pod in the `collector` namespace exceeds **1024 MiB** working set over the
+last 5 minutes. Baseline never passes 150 MiB and every observed pre-kill
+spike was multi-GiB, so the threshold catches the balloon while it is
+happening. Triage steps live in the
+[collector-oom runbook](../../collector-oom.runbook.md).
+
+We could not alert on the OOM kill itself: the internal kubelet-stats
+collector only exports cpu/memory/filesystem gauges. There is no
+`k8s.container.restarts` metric, no Kubernetes events, and the collector's own
+stdout logs are not ingested. See fix 4.
+
+## How the incident was verified at the time
+
+- The slow replays and their traces: the pinned slow replays panel above;
+  each trace shows a single POST to the collector accounting for the whole
+  duration.
+- The kill: `kubectl describe pod -n collector <pod>` showed
+  `Last State: Terminated, Reason: OOMKilled` about a minute after each slow
+  replay.
+- The run being ingested: `kubectl logs -n collector <pod> --previous | grep
+  "Processing WorkflowRunEvent"` shows repo, workflow name, and run id.
+
+## Fixes
+
+1. **Deploy the current collector image.** Released 2026-07-04. Production
+   ran `a0ef8d96` (2026-06-23). `f114d040` stops the receiver from erroring
+   on runs with no log archive (27 "Failed to get logs: 404" per container at
+   the time, each causing the app to retry the event), and main also treats
+   continuation lines as continuations instead of error-logging and dropping
+   them. The collector-webhook-failures alert verifies the 500s stay gone.
+2. **Bound the collector's memory.** Set container memory requests and limits
+   in the deployment and add a `memory_limiter` processor to the pipeline
+   (it was only `resource, batch`). Overload should degrade with backpressure
+   on the webhook, not a kernel kill that drops accepted data from every
+   tenant.
+3. **Decouple ingestion from the webhook response.** Return 202 immediately
+   and process the log archive asynchronously, and emit logs per job (or per
+   file) instead of building the whole 23-job run as one `plog.Logs` payload.
+   The 256 MB cap bounds the compressed download, not the decoded pdata size.
+4. **Add a real restart signal.** Add a `k8s_cluster` receiver (or ingest
+   Kubernetes events) to the internal collector in
+   `everr-deploy/infra-v2/config/otel-collector-internal-config.yaml` so we
+   get `k8s.container.restarts`, then alert on restart increases directly
+   instead of on the memory precursor.
+
+## Minor findings from the same investigation
+
+- The deployed receiver dropped log lines whose timestamp starts with a UTF-8
+  BOM ("Failed to parse timestamp"). Main no longer drops them, but it strips
+  the BOM only on the first line of each file, while GitHub's combined log
+  format has one BOM per step section, so those lines still parse as
+  continuations with the raw timestamp left in the body.
+- The `everr-collector` service emits no self-telemetry (no metrics, no
+  ingested logs). Worth adding its own OTLP export so incidents like this are
+  visible without `kubectl`.

--- a/everr/investigations/2026-07-04-collector-oom/collector-webhook-oom.runbook.md
+++ b/everr/investigations/2026-07-04-collector-oom/collector-webhook-oom.runbook.md
@@ -154,6 +154,14 @@ stdout logs are not ingested. See fix 4.
    and process the log archive asynchronously, and emit logs per job (or per
    file) instead of building the whole 23-job run as one `plog.Logs` payload.
    The 256 MB cap bounds the compressed download, not the decoded pdata size.
+   **Update, 2026-07-04:** the emit half is done. The receiver now hands
+   payloads to the pipeline in bounded chunks of 10k records
+   (`logEmitter` in
+   `collector/receiver/githubactionsreceiver/log_event_handling.go`), so
+   memory stays proportional to one chunk instead of the whole run.
+   Processing is still synchronous in the webhook handler; the app's replay
+   timeout was raised from 30s to 60s to cover big archives. The async half
+   remains open.
 4. **Add a real restart signal.** Add a `k8s_cluster` receiver (or ingest
    Kubernetes events) to the internal collector in
    `everr-deploy/infra-v2/config/otel-collector-internal-config.yaml` so we

--- a/everr/investigations/2026-07-04-collector-oom/collector-webhook-oom.runbook.md
+++ b/everr/investigations/2026-07-04-collector-oom/collector-webhook-oom.runbook.md
@@ -12,6 +12,28 @@ image (fix 1). The **collector-webhook-failures** alert
 (`everr/investigations/2026-07-04-collector-oom/collector-webhook-failures.alert.yaml`) now checks every 30 minutes
 that the webhook 500s this release eliminates have not come back.
 
+**Update, 2026-07-04 (later):** the collector-oom alert fired twice more,
+at 04:55 UTC (8.3 GiB, old image) and at 10:30 UTC (10 GiB, on the pod
+running the new image released around 09:25). Each spike coincides with a
+single `workflow_run` replay taking over 20 seconds (26.9s at 04:55:35,
+22.4s at 10:33:52), so the synchronous inline ingestion (fix 3, not yet
+implemented) is still the driver; fix 1 was never expected to address it.
+The offending run could not be identified from the everr tenant: the app's
+replay span recorded only the event type and job id, no repo or run id,
+and the run does not appear in our tenant's ingested CI logs. Querying the
+affected customer's tenant identified both occurrences as the same Rust
+cross-compilation workflow from the original analysis (customer repo and
+run ids intentionally not recorded here); the second run ended at
+10:33:51, one second before the 22.4s replay began. Notably, that
+workflow's runs have pipeline trace spans but zero ingested log lines, in
+both occurrences the log payload died with the collector.
+The app-side replay span now records
+`github.repository.full_name`, `github.workflow_run.id`,
+`github.workflow_run.name`, `github.workflow_run.run_attempt`,
+`github.event.action`, and `everr.organization.id`
+(`packages/app/src/server/github-events/tasks.ts`), so the next slow
+replay names its run directly.
+
 ## Status at the time vs now
 
 The left tile of each pair is pinned to the incident window (2026-07-03 17:00

--- a/packages/app/src/server/github-events/config.ts
+++ b/packages/app/src/server/github-events/config.ts
@@ -1,6 +1,9 @@
 export const GH_EVENTS_CONFIG = {
   maxAttempts: 10,
-  replayTimeoutMs: 30_000,
+  // The collector ingests a run's log archive synchronously before returning
+  // 202; large runs legitimately take ~30s, so give them headroom instead of
+  // aborting and retrying the whole download.
+  replayTimeoutMs: 60_000,
   tenantCacheTTLms: 60_000,
   retentionDoneDays: 7,
   retentionDeadDays: 30,

--- a/packages/app/src/server/github-events/payloads.ts
+++ b/packages/app/src/server/github-events/payloads.ts
@@ -158,6 +158,51 @@ export function repositoryIdFromQueuedEvent(
   return repositoryId && repositoryId > 0 ? repositoryId : null;
 }
 
+export function eventAttributesFromQueuedEvent(
+  event: ParsedQueuedWorkflowEvent,
+): Record<string, string | number> {
+  const attributes: Record<string, string | number> = {};
+
+  if (event.payload.action) {
+    attributes["github.event.action"] = event.payload.action;
+  }
+  const repository = event.payload.repository?.full_name;
+  if (repository) {
+    attributes["github.repository.full_name"] = repository;
+  }
+
+  let runId: number | undefined;
+  let runName: string | null | undefined;
+  let runAttempt: number | undefined;
+
+  if (event.eventType === "workflow_run") {
+    const run = event.payload.workflow_run;
+    runId = run?.id;
+    runName = run?.name;
+    runAttempt = run?.run_attempt;
+  } else {
+    const job = event.payload.workflow_job;
+    if (job) {
+      attributes["github.workflow_job.id"] = job.id;
+      runId = job.run_id;
+      runName = job.workflow_name;
+      runAttempt = job.run_attempt;
+    }
+  }
+
+  if (runId !== undefined) {
+    attributes["github.workflow_run.id"] = runId;
+  }
+  if (runName) {
+    attributes["github.workflow_run.name"] = runName;
+  }
+  if (runAttempt) {
+    attributes["github.workflow_run.run_attempt"] = runAttempt;
+  }
+
+  return attributes;
+}
+
 export function parseTimestamp(
   ...values: Array<string | null | undefined>
 ): Date {

--- a/packages/app/src/server/github-events/tasks.test.ts
+++ b/packages/app/src/server/github-events/tasks.test.ts
@@ -8,6 +8,7 @@ const STATUS_TASK_IDENTIFIER = "github-events/status";
 type MockSpan = {
   end: ReturnType<typeof vi.fn>;
   recordException: ReturnType<typeof vi.fn>;
+  setAttribute: ReturnType<typeof vi.fn>;
   setStatus: ReturnType<typeof vi.fn>;
 };
 
@@ -15,6 +16,7 @@ const taskMocks = vi.hoisted(() => {
   const span: MockSpan = {
     end: vi.fn(),
     recordException: vi.fn(),
+    setAttribute: vi.fn(),
     setStatus: vi.fn(),
   };
   const logActiveSpan: boolean[] = [];
@@ -98,9 +100,10 @@ function encodePayload(payload: unknown): string {
 function workflowRunData(): WebhookJobData {
   return {
     body: encodePayload({
+      action: "completed",
       installation: { id: 123 },
-      repository: { id: 456 },
-      workflow_run: { id: 789, run_attempt: 1 },
+      repository: { id: 456, full_name: "acme/widgets" },
+      workflow_run: { id: 789, run_attempt: 1, name: "Build & Test" },
     }),
     headers: { "x-github-event": ["workflow_run"] },
   };
@@ -109,8 +112,9 @@ function workflowRunData(): WebhookJobData {
 function workflowJobData(): WebhookJobData {
   return {
     body: encodePayload({
+      action: "completed",
       installation: { id: 123 },
-      repository: { id: 456 },
+      repository: { id: 456, full_name: "acme/widgets" },
       workflow_job: { id: 789, run_id: 654, run_attempt: 1 },
     }),
     headers: { "x-github-event": ["workflow_job"] },
@@ -139,6 +143,7 @@ beforeEach(() => {
   taskMocks.serverLoggerInfo.mockClear();
   taskMocks.span.end.mockClear();
   taskMocks.span.recordException.mockClear();
+  taskMocks.span.setAttribute.mockClear();
   taskMocks.span.setStatus.mockClear();
   taskMocks.startActiveSpan.mockClear();
 });
@@ -162,12 +167,21 @@ describe("github events tasks", () => {
       "github_events.jobs.replay_webhook_to_collector",
       {
         attributes: {
+          "github.event.action": "completed",
           "github.event.type": "workflow_run",
+          "github.repository.full_name": "acme/widgets",
+          "github.workflow_run.id": 789,
+          "github.workflow_run.name": "Build & Test",
+          "github.workflow_run.run_attempt": 1,
           "graphile_worker.job.id": "collector-job-1",
         },
         kind: 0,
       },
       expect.any(Function),
+    );
+    expect(taskMocks.span.setAttribute).toHaveBeenCalledWith(
+      "everr.organization.id",
+      "org-1",
     );
   });
 
@@ -183,7 +197,7 @@ describe("github events tasks", () => {
       "org-1",
       expect.objectContaining({
         payload: expect.objectContaining({
-          repository: { id: 456 },
+          repository: { id: 456, full_name: "acme/widgets" },
           workflow_job: { id: 789, run_id: 654, run_attempt: 1 },
         }),
         eventType: "workflow_job",
@@ -193,7 +207,12 @@ describe("github events tasks", () => {
       "github_events.jobs.handle_status_event",
       {
         attributes: {
+          "github.event.action": "completed",
           "github.event.type": "workflow_job",
+          "github.repository.full_name": "acme/widgets",
+          "github.workflow_job.id": 789,
+          "github.workflow_run.id": 654,
+          "github.workflow_run.run_attempt": 1,
           "graphile_worker.job.id": "status-job-1",
         },
         kind: 0,

--- a/packages/app/src/server/github-events/tasks.ts
+++ b/packages/app/src/server/github-events/tasks.ts
@@ -46,12 +46,14 @@ function makeWebhookTask(
     const body = Buffer.from(data.body, "base64");
     const parsed = parseQueuedWorkflowEvent(eventType, body);
     const jobId = helpers.job.id;
+    const eventAttributes = eventDetailAttributes(parsed);
 
     await tracer.startActiveSpan(
       spanName,
       {
         attributes: {
           ...(eventType ? { "github.event.type": eventType } : {}),
+          ...eventAttributes,
           "graphile_worker.job.id": jobId,
         },
         kind: SpanKind.INTERNAL,
@@ -60,11 +62,13 @@ function makeWebhookTask(
         try {
           const installationId = installationIdFromQueuedEvent(parsed);
           const organizationId = await resolveOrganizationId(installationId);
+          span.setAttribute("everr.organization.id", organizationId);
           await action({ body, data, organizationId, parsed });
         } catch (error) {
           const err = error instanceof Error ? error : new Error(String(error));
           const terminalAttributes = {
             ...(eventType ? { "github.event.type": eventType } : {}),
+            ...eventAttributes,
             ...installationAttribute(parsed),
             "graphile_worker.job.id": jobId,
           };
@@ -104,6 +108,45 @@ function makeWebhookTask(
       },
     );
   };
+}
+
+function eventDetailAttributes(
+  parsed: ParsedQueuedEvent,
+): Record<string, string | number> {
+  const attributes: Record<string, string | number> = {};
+
+  if (parsed.payload.action) {
+    attributes["github.event.action"] = parsed.payload.action;
+  }
+  const repository = parsed.payload.repository?.full_name;
+  if (repository) {
+    attributes["github.repository.full_name"] = repository;
+  }
+
+  if (parsed.eventType === "workflow_run") {
+    const run = parsed.payload.workflow_run;
+    if (run) {
+      attributes["github.workflow_run.id"] = run.id;
+      if (run.name) attributes["github.workflow_run.name"] = run.name;
+      if (run.run_attempt) {
+        attributes["github.workflow_run.run_attempt"] = run.run_attempt;
+      }
+    }
+  } else {
+    const job = parsed.payload.workflow_job;
+    if (job) {
+      attributes["github.workflow_job.id"] = job.id;
+      attributes["github.workflow_run.id"] = job.run_id;
+      if (job.workflow_name) {
+        attributes["github.workflow_run.name"] = job.workflow_name;
+      }
+      if (job.run_attempt) {
+        attributes["github.workflow_run.run_attempt"] = job.run_attempt;
+      }
+    }
+  }
+
+  return attributes;
 }
 
 function installationId(parsed: ParsedQueuedEvent): number | null {

--- a/packages/app/src/server/github-events/tasks.ts
+++ b/packages/app/src/server/github-events/tasks.ts
@@ -15,6 +15,7 @@ import {
   STATUS_TASK_IDENTIFIER,
 } from "./identifiers";
 import {
+  eventAttributesFromQueuedEvent,
   installationIdFromQueuedEvent,
   parseQueuedWorkflowEvent,
 } from "./payloads";
@@ -46,7 +47,7 @@ function makeWebhookTask(
     const body = Buffer.from(data.body, "base64");
     const parsed = parseQueuedWorkflowEvent(eventType, body);
     const jobId = helpers.job.id;
-    const eventAttributes = eventDetailAttributes(parsed);
+    const eventAttributes = eventAttributesFromQueuedEvent(parsed);
 
     await tracer.startActiveSpan(
       spanName,
@@ -108,45 +109,6 @@ function makeWebhookTask(
       },
     );
   };
-}
-
-function eventDetailAttributes(
-  parsed: ParsedQueuedEvent,
-): Record<string, string | number> {
-  const attributes: Record<string, string | number> = {};
-
-  if (parsed.payload.action) {
-    attributes["github.event.action"] = parsed.payload.action;
-  }
-  const repository = parsed.payload.repository?.full_name;
-  if (repository) {
-    attributes["github.repository.full_name"] = repository;
-  }
-
-  if (parsed.eventType === "workflow_run") {
-    const run = parsed.payload.workflow_run;
-    if (run) {
-      attributes["github.workflow_run.id"] = run.id;
-      if (run.name) attributes["github.workflow_run.name"] = run.name;
-      if (run.run_attempt) {
-        attributes["github.workflow_run.run_attempt"] = run.run_attempt;
-      }
-    }
-  } else {
-    const job = parsed.payload.workflow_job;
-    if (job) {
-      attributes["github.workflow_job.id"] = job.id;
-      attributes["github.workflow_run.id"] = job.run_id;
-      if (job.workflow_name) {
-        attributes["github.workflow_run.name"] = job.workflow_name;
-      }
-      if (job.run_attempt) {
-        attributes["github.workflow_run.run_attempt"] = job.run_attempt;
-      }
-    }
-  }
-
-  return attributes;
 }
 
 function installationId(parsed: ParsedQueuedEvent): number | null {


### PR DESCRIPTION
## What

The collector was kernel OOM killed three times on 2026-07-04 (memory ballooning from a 65-150 MiB baseline to 8-11 GiB), each time while ingesting the log archive of a large `workflow_run` event (a customer repo's 23-job Rust cross-compile matrix was the investigated trigger). Each kill also dropped whatever telemetry was batched but not yet exported, from every tenant. This PR contains the alerting and analysis for that incident, the telemetry needed to attribute future occurrences, and the receiver fix that stops the balloons.

## How

**Alerting and runbooks (`everr/`)**
- `collector-oom` alert: fires when any pod in the `collector` namespace exceeds 1024 MiB working set over 5 minutes, with a triage runbook covering how to find the offending run and check whether each protection held.
- `collector-webhook-failures` alert: verifies every 30 minutes that failed webhook replays to the collector stay gone.
- Investigation page recording the incident analysis, the root cause in `githubactionsreceiver`, and the status of each fix.

**Run identity on webhook job spans (`packages/app`)**
The replay job span only carried the event type and graphile job id, so the offending run could not be identified from our telemetry. The replay and status spans now carry `github.repository.full_name`, `github.workflow_run.id`/`name`/`run_attempt`, `github.event.action`, and the resolved `everr.organization.id`, all parsed from the payload the task already decodes. The next slow replay names its run and tenant directly from the trace.

**Chunked log emission (`collector/receiver/githubactionsreceiver`)**
The receiver materialized a run's entire log archive as one in-memory `plog.Logs` before a single `ConsumeLogs` call; a verbose build matrix decodes to multiple GiB of pdata. A new `logEmitter` hands payloads to the pipeline every 10k records. Each chunk carries the full run resource attributes and the current job scope, so downstream rows are unchanged; memory stays proportional to one chunk instead of the whole run. A consume failure is sticky: scanning stops and the event fails so the sender retries it.

**Replay timeout (`packages/app`)**
Ingestion stays synchronous in the webhook handler and big archives legitimately take ~30s, right at the old timeout, so an abort mid-download doubled the work. Raised from 30s to 60s.

## Testing

- New `TestEventToLogsChunksLargePayloads` pushes 25k lines through a real HTTP zip download and asserts 3 bounded payloads, each self-contained with resource and scope attributes, no records lost, plus a consume-failure case. Existing combined-format, normal-format, and no-archive tests updated to the callback API; full receiver suite passes.
- App github-events suite (51 tests) covers the new span attributes on both task types and the terminal-error paths.
- Alert queries were validated against production data during the investigation; the memory panel and replay-duration panels in the runbooks reproduce the incident window.

Remaining follow-ups (tracked in the investigation page): container memory limits plus a `memory_limiter` processor in everr-deploy, moving ingestion off the webhook request path, and a direct restart signal (`k8s.container.restarts`) instead of the memory precursor.
