### PR TITLE
feat(desktop): instrument release builds with phase spans in the CI trace

### DIFF
--- a/.github/workflows/deploy-desktop-app.yml
+++ b/.github/workflows/deploy-desktop-app.yml
@@ -159,6 +159,8 @@ jobs:
       - name: Build signed desktop release
         env:
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          # Job display name; used to parent build-phase spans under this job in the CI trace.
+          EVERR_CI_JOB_NAME: Build, Sign, Notarize Desktop
           EVERR_INGEST_KEY: ${{ secrets.EVERR_INGEST_KEY }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
@@ -267,6 +269,8 @@ jobs:
 
       - name: Build release binary
         env:
+          # Job display name; used to parent build-phase spans under this job in the CI trace.
+          EVERR_CI_JOB_NAME: Build Linux CLI ${{ matrix.name }}
           EVERR_INGEST_KEY: ${{ secrets.EVERR_INGEST_KEY }}
         run: pnpm --dir packages/desktop-app build:cli:release
 

--- a/collector/receiver/githubactionsreceiver/build_telemetry_vectors_test.go
+++ b/collector/receiver/githubactionsreceiver/build_telemetry_vectors_test.go
@@ -1,0 +1,29 @@
+// Copyright 2026 Giordano Ricci (operating as "Everr Labs")
+// SPDX-License-Identifier: Apache-2.0
+
+package githubactionsreceiver
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These vectors are shared with the desktop build scripts, which derive the
+// same ids to attach build-phase spans to workflow traces. Keep them in sync
+// with packages/desktop-app/scripts/build-telemetry.test.ts; a change to the
+// derivation on either side must fail that side's suite.
+func TestBuildTelemetrySharedVectors(t *testing.T) {
+	traceID, err := generateTraceID(123456, 9876543210, 1)
+	require.NoError(t, err)
+	require.Equal(t, "ce3e4cc4a1ed6e03e580b6b9174acdbf", hex.EncodeToString(traceID[:]))
+
+	rootSpanID, err := generateParentSpanID(9876543210, 1)
+	require.NoError(t, err)
+	require.Equal(t, "00e6b232dd4f2fd7", hex.EncodeToString(rootSpanID[:]))
+
+	jobSpanID, err := generateJobSpanID(9876543210, 1, "Build, Sign, Notarize Desktop")
+	require.NoError(t, err)
+	require.Equal(t, "fb1a2fcb5d794586", hex.EncodeToString(jobSpanID[:]))
+}

--- a/packages/desktop-app/scripts/build-cli.ts
+++ b/packages/desktop-app/scripts/build-cli.ts
@@ -5,6 +5,7 @@ import {
   publishCliArtifact,
   resolveCliBuild,
 } from "./build-support.ts";
+import { withBuildTelemetry } from "./build-telemetry.ts";
 
 const args = process.argv.slice(2);
 
@@ -23,28 +24,38 @@ if (flag === "--install") {
   process.exit(1);
 }
 
-const { buildArgs, builtBin } = resolveCliBuild(mode);
-const assets = await prepareCliEmbeddedAssets(mode);
+await withBuildTelemetry("cli build", async (telemetry) => {
+  telemetry.setRootAttribute("everr.build.mode", mode);
 
-console.log(`Building everr CLI (${mode})...`);
-await $({
-  env: {
-    ...process.env,
-    EVERR_EMBEDDED_COLLECTOR_GZ: assets.collectorGz,
-    EVERR_EMBEDDED_CHDB_GZ: assets.chdbGz,
-    EVERR_REQUIRE_EMBEDDED_COLLECTOR: "1",
-  },
-})`cargo build ${buildArgs}`;
+  const { buildArgs, builtBin } = resolveCliBuild(mode);
+  const assets = await prepareCliEmbeddedAssets(mode, telemetry);
 
-let installSource = builtBin;
+  console.log(`Building everr CLI (${mode})...`);
+  await telemetry.phase(
+    "build cli",
+    () =>
+      $({
+        env: {
+          ...process.env,
+          EVERR_EMBEDDED_COLLECTOR_GZ: assets.collectorGz,
+          EVERR_EMBEDDED_CHDB_GZ: assets.chdbGz,
+          EVERR_REQUIRE_EMBEDDED_COLLECTOR: "1",
+        },
+      })`cargo build ${buildArgs}`,
+  );
 
-if (mode === "release") {
-  const { outputBin } = await publishCliArtifact(builtBin);
-  installSource = outputBin;
-}
+  let installSource = builtBin;
 
-if (installBin || mode === "debug") {
-  await installCliBinary(installSource, mode === "debug" ? "everr-dev" : "everr");
-}
+  if (mode === "release") {
+    const { outputBin } = await telemetry.phase("publish cli artifact", () =>
+      publishCliArtifact(builtBin),
+    );
+    installSource = outputBin;
+  }
 
-console.log(`Run '${mode === "debug" ? "everr-dev" : "everr"} --help' to get started.`);
+  if (installBin || mode === "debug") {
+    await installCliBinary(installSource, mode === "debug" ? "everr-dev" : "everr");
+  }
+
+  console.log(`Run '${mode === "debug" ? "everr-dev" : "everr"} --help' to get started.`);
+});

--- a/packages/desktop-app/scripts/build-desktop.ts
+++ b/packages/desktop-app/scripts/build-desktop.ts
@@ -12,6 +12,7 @@ import {
   resolveDesktopReleaseIdentity,
   writeDesktopReleaseTauriConfigOverride,
 } from "./build-support.ts";
+import { withBuildTelemetry } from "./build-telemetry.ts";
 import {
   notarizeReleaseDmgIfConfigured,
   stageReleaseArtifacts,
@@ -84,21 +85,31 @@ export async function buildDesktop(args = process.argv.slice(2)) {
     tauriArgs.push("--config", overridePath);
   }
 
-  // DMG packaging is more reliable in CI mode because Tauri skips Finder AppleScript setup.
-  await $({
-    env: {
-      ...process.env,
-      CI: process.env.CI || "true",
-      EVERR_RELEASE_SHA: identity.releaseSha,
-      EVERR_RELEASE_SHORT_SHA: identity.releaseShortSha,
-    },
-  })`pnpm tauri build --bundles app,dmg ${tauriArgs}`;
-  await notarizeReleaseDmgIfConfigured();
-  await stageReleaseArtifacts();
+  await withBuildTelemetry("desktop release build", async (telemetry) => {
+    telemetry.setRootAttribute("everr.build.version", identity.desktopVersion);
+    telemetry.setRootAttribute("everr.build.release_sha", identity.releaseSha);
 
-  if (installCli) {
-    await installCliBinary(path.join(desktopReleaseDir, "everr"));
-  }
+    // DMG packaging is more reliable in CI mode because Tauri skips Finder AppleScript setup.
+    await telemetry.phase(
+      "build tauri app",
+      (span) =>
+        $({
+          env: {
+            ...process.env,
+            ...span.childEnv(),
+            CI: process.env.CI || "true",
+            EVERR_RELEASE_SHA: identity.releaseSha,
+            EVERR_RELEASE_SHORT_SHA: identity.releaseShortSha,
+          },
+        })`pnpm tauri build --bundles app,dmg ${tauriArgs}`,
+    );
+    await notarizeReleaseDmgIfConfigured(telemetry);
+    await telemetry.phase("stage release artifacts", () => stageReleaseArtifacts());
+
+    if (installCli) {
+      await installCliBinary(path.join(desktopReleaseDir, "everr"));
+    }
+  });
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/packages/desktop-app/scripts/build-support.ts
+++ b/packages/desktop-app/scripts/build-support.ts
@@ -17,6 +17,7 @@ import { fileURLToPath } from "node:url";
 import { createGzip } from "node:zlib";
 import { valid as validVersion } from "semver";
 import { $ } from "zx";
+import { type BuildPhases, noopBuildPhases } from "./build-telemetry.ts";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -221,7 +222,10 @@ export type CliEmbeddedAssets = {
   chdbGz: string;
 };
 
-export async function prepareCliEmbeddedAssets(mode: string): Promise<CliEmbeddedAssets> {
+export async function prepareCliEmbeddedAssets(
+  mode: string,
+  telemetry: BuildPhases = noopBuildPhases,
+): Promise<CliEmbeddedAssets> {
   if (mode !== "debug" && mode !== "release") {
     throw new Error(`Unsupported mode: ${mode}`);
   }
@@ -235,7 +239,10 @@ export async function prepareCliEmbeddedAssets(mode: string): Promise<CliEmbedde
   const chdbGz = `${chdbPrepared}.gz`;
 
   console.log(`Building local OTel collector for CLI embedding (${mode})...`);
-  await $`make -C ${path.join(repoDir, "collector")} build-local`;
+  await telemetry.phase(
+    "build embedded collector",
+    () => $`make -C ${path.join(repoDir, "collector")} build-local`,
+  );
 
   await copyFile(collectorSource, collectorPrepared);
   await chmod(collectorPrepared, 0o755);
@@ -243,9 +250,13 @@ export async function prepareCliEmbeddedAssets(mode: string): Promise<CliEmbedde
     await signBinaryIfNeeded(collectorPrepared);
   }
 
-  await prepareChdbLibAt(mode, chdbPrepared);
-  await gzipFile(collectorPrepared, collectorGz);
-  await gzipFile(chdbPrepared, chdbGz);
+  await telemetry.phase("prepare chdb library", () => prepareChdbLibAt(mode, chdbPrepared));
+  await telemetry.phase("compress embedded assets", async () => {
+    await Promise.all([
+      gzipFile(collectorPrepared, collectorGz),
+      gzipFile(chdbPrepared, chdbGz),
+    ]);
+  });
 
   return { collectorGz, chdbGz };
 }

--- a/packages/desktop-app/scripts/build-telemetry.test.ts
+++ b/packages/desktop-app/scripts/build-telemetry.test.ts
@@ -122,7 +122,8 @@ describe("buildTelemetryResourceAttributes", () => {
       GITHUB_RUN_ID: "9876543210",
       EVERR_CI_JOB_NAME: "Build, Sign, Notarize Desktop",
     });
-    expect(attributes["service.name"]).toBe("everr-desktop-build");
+    expect(attributes["service.name"]).toBe("github-actions");
+    expect(attributes["service.namespace"]).toBe("cicd");
     expect(attributes["deployment.environment.name"]).toBe("ci");
     expect(attributes["service.version"]).toBe(
       "0123456789abcdef0123456789abcdef01234567",
@@ -132,8 +133,10 @@ describe("buildTelemetryResourceAttributes", () => {
     expect(attributes["cicd.pipeline.task.name"]).toBe("Build, Sign, Notarize Desktop");
   });
 
-  it("marks local builds as development", () => {
+  it("marks local builds as development under their own service name", () => {
     const attributes = buildTelemetryResourceAttributes({});
+    expect(attributes["service.name"]).toBe("everr-desktop-build");
+    expect(attributes["service.namespace"]).toBe("everr");
     expect(attributes["deployment.environment.name"]).toBe("development");
     expect(attributes["service.version"]).toBe("local-dev");
   });

--- a/packages/desktop-app/scripts/build-telemetry.test.ts
+++ b/packages/desktop-app/scripts/build-telemetry.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildOtlpTracePayload,
+  buildTelemetryResourceAttributes,
+  createBuildTelemetry,
+  deriveCiJobSpanId,
+  deriveCiRunRootSpanId,
+  deriveCiTraceId,
+  resolveBuildTelemetryExport,
+  resolveBuildTraceContext,
+} from "./build-telemetry";
+
+// Fixed vectors generated from the Go derivations in
+// collector/receiver/githubactionsreceiver/trace_event_handling.go; the
+// receiver's build_telemetry_vectors_test.go pins the same values so drift on
+// either side fails its own suite.
+describe("CI trace id derivation", () => {
+  it("matches the collector receiver's generateTraceID", () => {
+    expect(deriveCiTraceId("123456", "9876543210", "1")).toBe(
+      "ce3e4cc4a1ed6e03e580b6b9174acdbf",
+    );
+  });
+
+  it("matches the collector receiver's generateParentSpanID", () => {
+    expect(deriveCiRunRootSpanId("9876543210", "1")).toBe("00e6b232dd4f2fd7");
+  });
+
+  it("matches the collector receiver's generateJobSpanID", () => {
+    expect(deriveCiJobSpanId("9876543210", "1", "Build, Sign, Notarize Desktop")).toBe(
+      "fb1a2fcb5d794586",
+    );
+  });
+});
+
+describe("resolveBuildTraceContext", () => {
+  const ciEnv = {
+    GITHUB_REPOSITORY_ID: "123456",
+    GITHUB_RUN_ID: "9876543210",
+    GITHUB_RUN_ATTEMPT: "1",
+  };
+
+  it("prefers explicit child-script trace context", () => {
+    const context = resolveBuildTraceContext({
+      ...ciEnv,
+      EVERR_BUILD_TRACE_ID: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      EVERR_BUILD_PARENT_SPAN_ID: "bbbbbbbbbbbbbbbb",
+    });
+    expect(context).toEqual({
+      traceId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      parentSpanId: "bbbbbbbbbbbbbbbb",
+      source: "child-script",
+    });
+  });
+
+  it("parents under the job span when the job name is known", () => {
+    const context = resolveBuildTraceContext({
+      ...ciEnv,
+      EVERR_CI_JOB_NAME: "Build, Sign, Notarize Desktop",
+    });
+    expect(context.traceId).toBe("ce3e4cc4a1ed6e03e580b6b9174acdbf");
+    expect(context.parentSpanId).toBe("fb1a2fcb5d794586");
+    expect(context.source).toBe("github-actions");
+  });
+
+  it("falls back to the workflow run root span without a job name", () => {
+    const context = resolveBuildTraceContext(ciEnv);
+    expect(context.parentSpanId).toBe("00e6b232dd4f2fd7");
+  });
+
+  it("uses a random root trace outside CI", () => {
+    const context = resolveBuildTraceContext({});
+    expect(context.traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(context.parentSpanId).toBeUndefined();
+    expect(context.source).toBe("local");
+  });
+});
+
+describe("resolveBuildTelemetryExport", () => {
+  it("uses hosted ingest with a bearer header in CI when EVERR_INGEST_KEY is set", () => {
+    const target = resolveBuildTelemetryExport({
+      EVERR_INGEST_KEY: "test-key",
+      GITHUB_ACTIONS: "true",
+    });
+    expect(target?.url).toBe("https://ingest.everr.dev/v1/traces");
+    expect(target?.headers.authorization).toBe("Bearer test-key");
+  });
+
+  it("skips export entirely in CI without an ingest key", () => {
+    expect(resolveBuildTelemetryExport({ GITHUB_ACTIONS: "true" })).toBeNull();
+  });
+
+  it("keeps local builds on the local collector even with an ingest key", () => {
+    const target = resolveBuildTelemetryExport({ EVERR_INGEST_KEY: "test-key" });
+    expect(target?.url).toBe("http://127.0.0.1:54318/v1/traces");
+    expect(target?.headers.authorization).toBeUndefined();
+  });
+
+  it("uses an explicit endpoint verbatim without auth", () => {
+    const target = resolveBuildTelemetryExport({
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://127.0.0.1:4318/",
+      EVERR_INGEST_KEY: "test-key",
+      GITHUB_ACTIONS: "true",
+    });
+    expect(target?.url).toBe("http://127.0.0.1:4318/v1/traces");
+    expect(target?.headers.authorization).toBeUndefined();
+  });
+
+  it("falls back to the local collector", () => {
+    const target = resolveBuildTelemetryExport({});
+    expect(target?.url).toBe("http://127.0.0.1:54318/v1/traces");
+    expect(target?.headers.authorization).toBeUndefined();
+  });
+});
+
+describe("buildTelemetryResourceAttributes", () => {
+  it("identifies CI builds with vcs and pipeline attributes", () => {
+    const attributes = buildTelemetryResourceAttributes({
+      GITHUB_ACTIONS: "true",
+      GITHUB_SHA: "0123456789abcdef0123456789abcdef01234567",
+      GITHUB_REPOSITORY: "everr-labs/everr",
+      GITHUB_REF_NAME: "@everr/desktop-app@1.2.3",
+      GITHUB_RUN_ID: "9876543210",
+      EVERR_CI_JOB_NAME: "Build, Sign, Notarize Desktop",
+    });
+    expect(attributes["service.name"]).toBe("everr-desktop-build");
+    expect(attributes["deployment.environment.name"]).toBe("ci");
+    expect(attributes["service.version"]).toBe(
+      "0123456789abcdef0123456789abcdef01234567",
+    );
+    expect(attributes["vcs.repository.name"]).toBe("everr-labs/everr");
+    expect(attributes["cicd.pipeline.run.id"]).toBe("9876543210");
+    expect(attributes["cicd.pipeline.task.name"]).toBe("Build, Sign, Notarize Desktop");
+  });
+
+  it("marks local builds as development", () => {
+    const attributes = buildTelemetryResourceAttributes({});
+    expect(attributes["deployment.environment.name"]).toBe("development");
+    expect(attributes["service.version"]).toBe("local-dev");
+  });
+});
+
+describe("createBuildTelemetry", () => {
+  it("records phases as children of the root span and exposes child env", async () => {
+    const env = {
+      GITHUB_REPOSITORY_ID: "123456",
+      GITHUB_RUN_ID: "9876543210",
+      GITHUB_RUN_ATTEMPT: "1",
+      EVERR_CI_JOB_NAME: "Build, Sign, Notarize Desktop",
+    };
+    const telemetry = createBuildTelemetry({ buildName: "desktop release build", env });
+
+    let phaseChildEnv: Record<string, string> | undefined;
+    await expect(
+      telemetry.phase("build tauri app", async (span) => {
+        phaseChildEnv = span.childEnv();
+        return "ok";
+      }),
+    ).resolves.toBe("ok");
+    expect(phaseChildEnv?.EVERR_BUILD_TRACE_ID).toBe("ce3e4cc4a1ed6e03e580b6b9174acdbf");
+    expect(phaseChildEnv?.EVERR_BUILD_PARENT_SPAN_ID).toMatch(/^[0-9a-f]{16}$/);
+    await expect(
+      telemetry.phase("notarize dmg", async () => {
+        throw new Error("notarytool exploded");
+      }),
+    ).rejects.toThrow("notarytool exploded");
+  });
+
+  it("marks the phase span as errored in the OTLP payload", async () => {
+    const telemetry = createBuildTelemetry({ buildName: "cli release build", env: {} });
+    await telemetry
+      .phase("build cli", async () => {
+        throw new Error("cargo failed");
+      })
+      .catch(() => {});
+
+    const payload = capturePayload(telemetry);
+    const spans = (await payload).resourceSpans[0].scopeSpans[0].spans;
+    const failed = spans.find((span) => span.name === "build cli");
+    expect(failed?.status).toEqual({ code: 2, message: "cargo failed" });
+    const root = spans.find((span) => span.name === "cli release build");
+    expect(root?.status.code).toBe(1);
+    expect(root?.parentSpanId).toBeUndefined();
+  });
+});
+
+async function capturePayload(telemetry: {
+  flush(error?: unknown): Promise<void>;
+}): Promise<ReturnType<typeof buildOtlpTracePayload>> {
+  const originalFetch = globalThis.fetch;
+  let captured: ReturnType<typeof buildOtlpTracePayload> | undefined;
+  globalThis.fetch = (async (_url: unknown, init?: { body?: unknown }) => {
+    captured = JSON.parse(String(init?.body));
+    return new Response(null, { status: 200 });
+  }) as typeof fetch;
+  try {
+    await telemetry.flush();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+  if (!captured) {
+    throw new Error("flush did not export a payload");
+  }
+  return captured;
+}

--- a/packages/desktop-app/scripts/build-telemetry.ts
+++ b/packages/desktop-app/scripts/build-telemetry.ts
@@ -12,8 +12,15 @@ import { createHash, randomBytes, randomUUID } from "node:crypto";
  * build-telemetry.test.ts so drift on either side fails its own suite.
  */
 
-const BUILD_TELEMETRY_SERVICE_NAME = "everr-desktop-build";
-const BUILD_TELEMETRY_SERVICE_NAMESPACE = "everr";
+// In CI, spans join the workflow trace, so they carry the same service
+// identity the receiver stamps on it (attributes.go: githubActionsServiceName
+// and githubActionsServiceNamespace); the everr-build-telemetry scope and the
+// cicd.pipeline.* attributes still distinguish build-script spans. Local dev
+// builds keep their own service name so they never masquerade as CI.
+const CI_SERVICE_NAME = "github-actions";
+const CI_SERVICE_NAMESPACE = "cicd";
+const LOCAL_SERVICE_NAME = "everr-desktop-build";
+const LOCAL_SERVICE_NAMESPACE = "everr";
 const BUILD_TELEMETRY_SCOPE_NAME = "everr-build-telemetry";
 const DEFAULT_LOCAL_OTLP_ENDPOINT = "http://127.0.0.1:54318";
 const EVERR_HOSTED_OTLP_ENDPOINT = "https://ingest.everr.dev";
@@ -152,11 +159,12 @@ export function resolveBuildTelemetryExport(env: BuildTelemetryEnv): BuildTeleme
 }
 
 export function buildTelemetryResourceAttributes(env: BuildTelemetryEnv) {
+  const inCi = env.GITHUB_ACTIONS === "true";
   const attributes: Record<string, SpanAttributeValue> = {
-    "service.name": BUILD_TELEMETRY_SERVICE_NAME,
-    "service.namespace": BUILD_TELEMETRY_SERVICE_NAMESPACE,
+    "service.name": inCi ? CI_SERVICE_NAME : LOCAL_SERVICE_NAME,
+    "service.namespace": inCi ? CI_SERVICE_NAMESPACE : LOCAL_SERVICE_NAMESPACE,
     "service.instance.id": randomUUID(),
-    "deployment.environment.name": env.GITHUB_ACTIONS === "true" ? "ci" : "development",
+    "deployment.environment.name": inCi ? "ci" : "development",
   };
 
   const sha = cleanEnvValue(env.GITHUB_SHA);

--- a/packages/desktop-app/scripts/build-telemetry.ts
+++ b/packages/desktop-app/scripts/build-telemetry.ts
@@ -1,0 +1,379 @@
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+
+/**
+ * Build-phase telemetry for the desktop/CLI release scripts.
+ *
+ * Spans join the GitHub Actions workflow trace that Everr's collector
+ * receiver creates from webhooks. The trace and parent span ids must stay
+ * bit-identical to the derivations in
+ * collector/receiver/githubactionsreceiver/trace_event_handling.go
+ * (generateTraceID, generateParentSpanID, generateJobSpanID); the receiver's
+ * build_telemetry_vectors_test.go pins the same fixed vectors as
+ * build-telemetry.test.ts so drift on either side fails its own suite.
+ */
+
+const BUILD_TELEMETRY_SERVICE_NAME = "everr-desktop-build";
+const BUILD_TELEMETRY_SERVICE_NAMESPACE = "everr";
+const BUILD_TELEMETRY_SCOPE_NAME = "everr-build-telemetry";
+const DEFAULT_LOCAL_OTLP_ENDPOINT = "http://127.0.0.1:54318";
+const EVERR_HOSTED_OTLP_ENDPOINT = "https://ingest.everr.dev";
+const EXPORT_TIMEOUT_MS = 10_000;
+
+const TRACE_ID_ENV = "EVERR_BUILD_TRACE_ID";
+const PARENT_SPAN_ID_ENV = "EVERR_BUILD_PARENT_SPAN_ID";
+
+const SPAN_KIND_INTERNAL = 1;
+const STATUS_CODE_OK = 1;
+const STATUS_CODE_ERROR = 2;
+
+export type BuildTelemetryEnv = Partial<
+  Record<
+    | "EVERR_BUILD_PARENT_SPAN_ID"
+    | "EVERR_BUILD_TRACE_ID"
+    | "EVERR_CI_JOB_NAME"
+    | "EVERR_INGEST_KEY"
+    | "GITHUB_ACTIONS"
+    | "GITHUB_REF_NAME"
+    | "GITHUB_REPOSITORY"
+    | "GITHUB_REPOSITORY_ID"
+    | "GITHUB_RUN_ATTEMPT"
+    | "GITHUB_RUN_ID"
+    | "GITHUB_SHA"
+    | "OTEL_EXPORTER_OTLP_ENDPOINT",
+    string
+  >
+>;
+
+type SpanAttributeValue = string | number | boolean;
+
+type RecordedSpan = {
+  spanId: string;
+  parentSpanId: string | undefined;
+  name: string;
+  startTimeUnixNano: bigint;
+  endTimeUnixNano: bigint;
+  statusCode: number;
+  statusMessage: string | undefined;
+  attributes: Record<string, SpanAttributeValue>;
+};
+
+export type BuildTraceContext = {
+  traceId: string;
+  parentSpanId: string | undefined;
+  source: "child-script" | "github-actions" | "local";
+};
+
+function sha256Hex(input: string) {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+/** Mirrors generateTraceID: sha256("<repoId>@<runId>#<attempt>") hex chars [0, 32). */
+export function deriveCiTraceId(repositoryId: string, runId: string, runAttempt: string) {
+  return sha256Hex(`${repositoryId}@${runId}#${runAttempt}`).slice(0, 32);
+}
+
+/** Mirrors generateParentSpanID: sha256("<runId><attempt>s") hex chars [16, 32). */
+export function deriveCiRunRootSpanId(runId: string, runAttempt: string) {
+  return sha256Hex(`${runId}${runAttempt}s`).slice(16, 32);
+}
+
+/** Mirrors generateJobSpanID: sha256("<runId><attempt><jobName>") hex chars [16, 32). */
+export function deriveCiJobSpanId(runId: string, runAttempt: string, jobName: string) {
+  return sha256Hex(`${runId}${runAttempt}${jobName}`).slice(16, 32);
+}
+
+function cleanEnvValue(value: string | undefined) {
+  const cleaned = value?.trim();
+  return cleaned ? cleaned : undefined;
+}
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function resolveBuildTraceContext(env: BuildTelemetryEnv): BuildTraceContext {
+  const envTraceId = cleanEnvValue(env.EVERR_BUILD_TRACE_ID);
+  const envParentSpanId = cleanEnvValue(env.EVERR_BUILD_PARENT_SPAN_ID);
+  if (envTraceId && envParentSpanId) {
+    return { traceId: envTraceId, parentSpanId: envParentSpanId, source: "child-script" };
+  }
+
+  const repositoryId = cleanEnvValue(env.GITHUB_REPOSITORY_ID);
+  const runId = cleanEnvValue(env.GITHUB_RUN_ID);
+  const runAttempt = cleanEnvValue(env.GITHUB_RUN_ATTEMPT);
+  if (repositoryId && runId && runAttempt) {
+    const jobName = cleanEnvValue(env.EVERR_CI_JOB_NAME);
+    return {
+      traceId: deriveCiTraceId(repositoryId, runId, runAttempt),
+      parentSpanId: jobName
+        ? deriveCiJobSpanId(runId, runAttempt, jobName)
+        : deriveCiRunRootSpanId(runId, runAttempt),
+      source: "github-actions",
+    };
+  }
+
+  return {
+    traceId: randomBytes(16).toString("hex"),
+    parentSpanId: undefined,
+    source: "local",
+  };
+}
+
+export type BuildTelemetryExport = {
+  url: string;
+  headers: Record<string, string>;
+};
+
+export function resolveBuildTelemetryExport(env: BuildTelemetryEnv): BuildTelemetryExport | null {
+  const explicitEndpoint = cleanEnvValue(env.OTEL_EXPORTER_OTLP_ENDPOINT);
+  // Hosted ingest only in CI: local desktop builds can have EVERR_INGEST_KEY in
+  // .env for bundling into the app, and their build spans must stay local.
+  const ingestKey =
+    env.GITHUB_ACTIONS === "true" ? cleanEnvValue(env.EVERR_INGEST_KEY) : undefined;
+
+  // In CI without an ingest key or explicit endpoint there is nothing to export
+  // to; skip instead of warning about an unreachable local collector.
+  if (env.GITHUB_ACTIONS === "true" && !explicitEndpoint && !ingestKey) {
+    return null;
+  }
+
+  const endpoint = (
+    explicitEndpoint ?? (ingestKey ? EVERR_HOSTED_OTLP_ENDPOINT : DEFAULT_LOCAL_OTLP_ENDPOINT)
+  ).replace(/\/+$/, "");
+  const usesHostedIngest = !explicitEndpoint && Boolean(ingestKey);
+
+  return {
+    url: `${endpoint}/v1/traces`,
+    headers: {
+      "content-type": "application/json",
+      ...(usesHostedIngest && ingestKey ? { authorization: `Bearer ${ingestKey}` } : {}),
+    },
+  };
+}
+
+export function buildTelemetryResourceAttributes(env: BuildTelemetryEnv) {
+  const attributes: Record<string, SpanAttributeValue> = {
+    "service.name": BUILD_TELEMETRY_SERVICE_NAME,
+    "service.namespace": BUILD_TELEMETRY_SERVICE_NAMESPACE,
+    "service.instance.id": randomUUID(),
+    "deployment.environment.name": env.GITHUB_ACTIONS === "true" ? "ci" : "development",
+  };
+
+  const sha = cleanEnvValue(env.GITHUB_SHA);
+  attributes["service.version"] = sha ?? "local-dev";
+
+  const repository = cleanEnvValue(env.GITHUB_REPOSITORY);
+  if (repository) {
+    attributes["vcs.repository.name"] = repository;
+  }
+  if (sha) {
+    attributes["vcs.ref.head.revision"] = sha;
+  }
+  const refName = cleanEnvValue(env.GITHUB_REF_NAME);
+  if (refName) {
+    attributes["vcs.ref.head.name"] = refName;
+  }
+  const runId = cleanEnvValue(env.GITHUB_RUN_ID);
+  if (runId) {
+    attributes["cicd.pipeline.run.id"] = runId;
+  }
+  const jobName = cleanEnvValue(env.EVERR_CI_JOB_NAME);
+  if (jobName) {
+    attributes["cicd.pipeline.task.name"] = jobName;
+  }
+
+  return attributes;
+}
+
+function toOtlpAttributes(attributes: Record<string, SpanAttributeValue>) {
+  return Object.entries(attributes).map(([key, value]) => {
+    switch (typeof value) {
+      case "boolean":
+        return { key, value: { boolValue: value } };
+      case "number":
+        return {
+          key,
+          value: Number.isInteger(value) ? { intValue: String(value) } : { doubleValue: value },
+        };
+      default:
+        return { key, value: { stringValue: value } };
+    }
+  });
+}
+
+function nowUnixNano() {
+  return BigInt(Date.now()) * 1_000_000n;
+}
+
+export type PhaseHandle = {
+  /** Trace context env vars for nested build scripts, so their spans attach under this phase span. */
+  childEnv(): Record<string, string>;
+};
+
+export type BuildTelemetry = {
+  /** Runs fn inside a span that is a child of the root build span. */
+  phase<T>(
+    name: string,
+    fn: (span: PhaseHandle) => Promise<T>,
+    attributes?: Record<string, SpanAttributeValue>,
+  ): Promise<T>;
+  setRootAttribute(key: string, value: SpanAttributeValue): void;
+  /** Ends the root span and exports all spans. Never throws. */
+  flush(error?: unknown): Promise<void>;
+};
+
+/** The phase-recording surface build helpers accept. */
+export type BuildPhases = Pick<BuildTelemetry, "phase">;
+
+/** Default for helpers whose callers do not record build telemetry. */
+export const noopBuildPhases: BuildPhases = {
+  phase: (_name, fn) => fn({ childEnv: () => ({}) }),
+};
+
+export function createBuildTelemetry({
+  buildName,
+  env = process.env as BuildTelemetryEnv,
+}: {
+  buildName: string;
+  env?: BuildTelemetryEnv;
+}): BuildTelemetry {
+  const context = resolveBuildTraceContext(env);
+  const rootSpanId = randomBytes(8).toString("hex");
+  const rootStart = nowUnixNano();
+  const rootAttributes: Record<string, SpanAttributeValue> = {};
+  const spans: RecordedSpan[] = [];
+  let flushed = false;
+
+  const childEnvFor = (spanId: string) => ({
+    [TRACE_ID_ENV]: context.traceId,
+    [PARENT_SPAN_ID_ENV]: spanId,
+  });
+
+  return {
+    async phase(name, fn, attributes = {}) {
+      const spanId = randomBytes(8).toString("hex");
+      const startTimeUnixNano = nowUnixNano();
+      let statusCode = STATUS_CODE_OK;
+      let statusMessage: string | undefined;
+      try {
+        return await fn({ childEnv: () => childEnvFor(spanId) });
+      } catch (error) {
+        statusCode = STATUS_CODE_ERROR;
+        statusMessage = errorMessage(error);
+        throw error;
+      } finally {
+        spans.push({
+          spanId,
+          parentSpanId: rootSpanId,
+          name,
+          startTimeUnixNano,
+          endTimeUnixNano: nowUnixNano(),
+          statusCode,
+          statusMessage,
+          attributes,
+        });
+      }
+    },
+
+    setRootAttribute(key, value) {
+      rootAttributes[key] = value;
+    },
+
+    async flush(error) {
+      if (flushed) {
+        return;
+      }
+      flushed = true;
+
+      spans.push({
+        spanId: rootSpanId,
+        parentSpanId: context.parentSpanId,
+        name: buildName,
+        startTimeUnixNano: rootStart,
+        endTimeUnixNano: nowUnixNano(),
+        statusCode: error === undefined ? STATUS_CODE_OK : STATUS_CODE_ERROR,
+        statusMessage: error === undefined ? undefined : errorMessage(error),
+        attributes: rootAttributes,
+      });
+
+      const exportTarget = resolveBuildTelemetryExport(env);
+      if (!exportTarget) {
+        return;
+      }
+      const payload = buildOtlpTracePayload({ env, traceId: context.traceId, spans });
+
+      try {
+        const response = await fetch(exportTarget.url, {
+          method: "POST",
+          headers: exportTarget.headers,
+          body: JSON.stringify(payload),
+          signal: AbortSignal.timeout(EXPORT_TIMEOUT_MS),
+        });
+        if (!response.ok) {
+          console.error(
+            `Build telemetry export to ${exportTarget.url} failed with HTTP ${response.status}.`,
+          );
+        }
+      } catch (exportError) {
+        console.error(
+          `Build telemetry export to ${exportTarget.url} failed: ${errorMessage(exportError)}`,
+        );
+      }
+    },
+  };
+}
+
+/** Creates telemetry for a build script, runs it, and always flushes (with error status on failure). */
+export async function withBuildTelemetry<T>(
+  buildName: string,
+  fn: (telemetry: BuildTelemetry) => Promise<T>,
+): Promise<T> {
+  const telemetry = createBuildTelemetry({ buildName });
+  try {
+    const result = await fn(telemetry);
+    await telemetry.flush();
+    return result;
+  } catch (error) {
+    await telemetry.flush(error);
+    throw error;
+  }
+}
+
+export function buildOtlpTracePayload({
+  env,
+  traceId,
+  spans,
+}: {
+  env: BuildTelemetryEnv;
+  traceId: string;
+  spans: RecordedSpan[];
+}) {
+  return {
+    resourceSpans: [
+      {
+        resource: {
+          attributes: toOtlpAttributes(buildTelemetryResourceAttributes(env)),
+        },
+        scopeSpans: [
+          {
+            scope: { name: BUILD_TELEMETRY_SCOPE_NAME },
+            spans: spans.map((span) => ({
+              traceId,
+              spanId: span.spanId,
+              ...(span.parentSpanId ? { parentSpanId: span.parentSpanId } : {}),
+              name: span.name,
+              kind: SPAN_KIND_INTERNAL,
+              startTimeUnixNano: span.startTimeUnixNano.toString(),
+              endTimeUnixNano: span.endTimeUnixNano.toString(),
+              attributes: toOtlpAttributes(span.attributes),
+              status: {
+                code: span.statusCode,
+                ...(span.statusMessage ? { message: span.statusMessage } : {}),
+              },
+            })),
+          },
+        ],
+      },
+    ],
+  };
+}

--- a/packages/desktop-app/scripts/copy-release-artifact.ts
+++ b/packages/desktop-app/scripts/copy-release-artifact.ts
@@ -18,6 +18,7 @@ import {
   loadBuildEnvFile,
   resolveDesktopReleaseIdentity,
 } from "./build-support.ts";
+import { type BuildPhases, noopBuildPhases } from "./build-telemetry.ts";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const packageDir = path.resolve(scriptDir, "..");
@@ -236,7 +237,7 @@ export function resolveDmgNotarizationRequest({
   };
 }
 
-async function notarizeDmgIfConfigured(dmgPath: string) {
+async function notarizeDmgIfConfigured(dmgPath: string, telemetry: BuildPhases) {
   loadBuildEnvFile();
 
   const request = resolveDmgNotarizationRequest({ dmgPath });
@@ -248,14 +249,18 @@ async function notarizeDmgIfConfigured(dmgPath: string) {
   }
 
   console.log(`Submitting ${dmgPath} for Apple notarization...`);
-  await $`xcrun notarytool submit ${request.dmgPath} --key ${request.keyPath} --key-id ${request.keyId} --issuer ${request.issuer} --wait`;
-  await $`xcrun stapler staple ${request.dmgPath}`;
+  await telemetry.phase(
+    "notarize dmg",
+    () =>
+      $`xcrun notarytool submit ${request.dmgPath} --key ${request.keyPath} --key-id ${request.keyId} --issuer ${request.issuer} --wait`,
+  );
+  await telemetry.phase("staple dmg", () => $`xcrun stapler staple ${request.dmgPath}`);
 }
 
-export async function notarizeReleaseDmgIfConfigured() {
+export async function notarizeReleaseDmgIfConfigured(telemetry: BuildPhases = noopBuildPhases) {
   const bundleDir = await findBundleDir();
   const artifacts = await findReleaseArtifacts(bundleDir);
-  await notarizeDmgIfConfigured(artifacts.dmg);
+  await notarizeDmgIfConfigured(artifacts.dmg, telemetry);
 }
 
 async function findNewestFileWithSuffix(dir: string, suffix: string) {

--- a/packages/desktop-app/scripts/prepare-tauri-cli-sidecar.ts
+++ b/packages/desktop-app/scripts/prepare-tauri-cli-sidecar.ts
@@ -9,6 +9,7 @@ import {
   repoDir,
   signBinaryIfNeeded,
 } from "./build-support.ts";
+import { withBuildTelemetry } from "./build-telemetry.ts";
 
 const args = process.argv.slice(2);
 
@@ -18,30 +19,41 @@ if (args.length !== 1) {
 }
 
 const [mode] = args;
-const { buildArgs, builtBin } = resolveCliBuild(mode);
-const assets = await prepareCliEmbeddedAssets(mode);
-const sourceBin = builtBin;
-const resourceDir = path.join(repoDir, "target", "desktop-resources");
-const destBin = path.join(resourceDir, "everr");
 
-console.log(`Building bundled Everr CLI (${mode})...`);
-await $({
-  env: {
-    ...process.env,
-    EVERR_EMBEDDED_COLLECTOR_GZ: assets.collectorGz,
-    EVERR_EMBEDDED_CHDB_GZ: assets.chdbGz,
-    EVERR_REQUIRE_EMBEDDED_COLLECTOR: "1",
-  },
-})`cargo build ${buildArgs}`;
+await withBuildTelemetry("cli sidecar build", async (telemetry) => {
+  telemetry.setRootAttribute("everr.build.mode", mode);
 
-await mkdir(resourceDir, { recursive: true });
-await rm(path.join(resourceDir, "libchdb.so"), { force: true });
-await copyFile(sourceBin, destBin);
-await chmod(destBin, 0o755);
+  const { buildArgs, builtBin } = resolveCliBuild(mode);
+  const assets = await prepareCliEmbeddedAssets(mode, telemetry);
+  const sourceBin = builtBin;
+  const resourceDir = path.join(repoDir, "target", "desktop-resources");
+  const destBin = path.join(resourceDir, "everr");
 
-if (mode === "release") {
-  await signBinaryIfNeeded(destBin);
-  await publishCliArtifact(sourceBin, { outputDir: desktopReleaseDir });
-}
+  console.log(`Building bundled Everr CLI (${mode})...`);
+  await telemetry.phase(
+    "build cli",
+    () =>
+      $({
+        env: {
+          ...process.env,
+          EVERR_EMBEDDED_COLLECTOR_GZ: assets.collectorGz,
+          EVERR_EMBEDDED_CHDB_GZ: assets.chdbGz,
+          EVERR_REQUIRE_EMBEDDED_COLLECTOR: "1",
+        },
+      })`cargo build ${buildArgs}`,
+  );
 
-console.log(`Prepared bundled CLI resource at ${destBin}`);
+  await mkdir(resourceDir, { recursive: true });
+  await rm(path.join(resourceDir, "libchdb.so"), { force: true });
+  await copyFile(sourceBin, destBin);
+  await chmod(destBin, 0o755);
+
+  if (mode === "release") {
+    await telemetry.phase("sign cli binary", () => signBinaryIfNeeded(destBin));
+    await telemetry.phase("publish cli artifact", () =>
+      publishCliArtifact(sourceBin, { outputDir: desktopReleaseDir }),
+    );
+  }
+
+  console.log(`Prepared bundled CLI resource at ${destBin}`);
+});


### PR DESCRIPTION
## Why

The desktop release workflow's two long steps are opaque in Everr's CI traces: `Build signed desktop release` averages 192s (max 267s over the last 30 days) and `Build release binary` averages 180s (max 306s), while every other step is under 30s. Failed runs die at ~101s with no way to tell which phase failed (frontend build, cargo, bundling, signing, notarization, staging) without opening raw logs.

## What

The build scripts now emit one OTLP span per phase, and the spans join the **same trace** the collector's `githubactionsreceiver` already creates for the workflow run:

- **`scripts/build-telemetry.ts`** (new): dependency-free OTLP/HTTP JSON exporter for build scripts. It derives the trace id and parent span id with the same sha256 derivations as the receiver, parenting under the job span (via the new `EVERR_CI_JOB_NAME` env var) or the run root span as fallback. Nested scripts (the CLI sidecar prepare runs inside `tauri build`) attach under their parent phase through `EVERR_BUILD_TRACE_ID`/`EVERR_BUILD_PARENT_SPAN_ID`.
- **Phases instrumented**: `build tauri app`, `notarize dmg` (the variable-latency Apple wait gets its own span), `staple dmg`, `stage release artifacts`, `build embedded collector`, `prepare chdb library`, `compress embedded assets`, `build cli`, `sign cli binary`, `publish cli artifact`.
- **Export selection**: hosted ingest (`EVERR_INGEST_KEY`, already present in both steps) only when running in CI; local collector for dev builds; silent skip in CI without a key. Export failures warn and never fail the build.
- **Cross-language drift guard**: `build_telemetry_vectors_test.go` pins the id derivation vectors against the real receiver functions, and `build-telemetry.test.ts` pins the same values on the TS side, so a change to either implementation fails that side's suite.

Known coupling: `EVERR_CI_JOB_NAME` in `deploy-desktop-app.yml` must match the job's `name:` byte-for-byte (GitHub exposes no expression for the rendered display name). If it drifts, spans degrade gracefully to the run root span instead of the job span.

## Validation

- 85 desktop-app tests pass (`tsc --noEmit` clean); receiver Go tests and `golangci-lint` pass.
- Verified end to end against a local collector: ran the instrumented sidecar build and queried the exported trace back with `everr local query` (root `cli sidecar build` span with correctly parented `build cli`, `compress embedded assets`, `prepare chdb library`, `build embedded collector` children).
- The trace join with a real workflow run can only be confirmed on the next release tag: query the run's trace id: build-phase spans appear under `ServiceName = 'github-actions'` with scope `everr-build-telemetry` (local dev builds keep `everr-desktop-build`).
