### PR TITLE
Collector: non-blocking CI log ingestion

### DIFF
--- a/collector/receiver/githubactionsreceiver/receiver.go
+++ b/collector/receiver/githubactionsreceiver/receiver.go
@@ -43,7 +43,8 @@ const logIngestWorkers = 2
 // logIngestRetries and logIngestRetryBackoff govern the worker's own retry of
 // a failed ingestion. Once the webhook is acked with 202 the sender will not
 // redeliver it, so transient GitHub API or pipeline failures are retried here
-// before the archive is given up on.
+// before the archive is given up on. A failed job is re-enqueued after the
+// backoff rather than slept on, so it never parks a worker slot.
 const logIngestRetries = 3
 const logIngestRetryBackoff = 30 * time.Second
 
@@ -54,7 +55,7 @@ type logIngestJob struct {
 	event          *github.WorkflowRunEvent
 	installationID int64
 	headers        http.Header
-	withTraceInfo  bool
+	attempt        int
 }
 
 type githubActionsReceiver struct {
@@ -73,12 +74,34 @@ type githubActionsReceiver struct {
 	stepTimings     *stepTimingCache
 	logJobs         chan logIngestJob
 	logWorkerWG     sync.WaitGroup
+	logResubmitWG   sync.WaitGroup
 	logWorkerCtx    context.Context
 	logWorkerStop   context.CancelFunc
+	logRetryBackoff time.Duration
 
-	// newInstallationClient builds the GitHub client a log worker uses.
-	// Overridable in tests; production wires githubClientForInstallation.
+	// installationClients caches one GitHub client per installation so each
+	// use does not re-read the private key and re-mint an installation
+	// token; the ghinstallation transport is concurrency-safe and refreshes
+	// its token itself.
+	installationClients sync.Map // int64 → *github.Client
+
+	// newInstallationClient builds the GitHub client used for API access.
+	// Overridable in tests; production wires cachedInstallationClient.
 	newInstallationClient func(installationID int64) (*github.Client, error)
+}
+
+// cachedInstallationClient returns the memoized client for an installation,
+// building it on first use. Errors are not cached.
+func (gar *githubActionsReceiver) cachedInstallationClient(installationID int64) (*github.Client, error) {
+	if cached, ok := gar.installationClients.Load(installationID); ok {
+		return cached.(*github.Client), nil
+	}
+	built, err := gar.githubClientForInstallation(installationID)
+	if err != nil {
+		return nil, err
+	}
+	cached, _ := gar.installationClients.LoadOrStore(installationID, built)
+	return cached.(*github.Client), nil
 }
 
 func newReceiver(
@@ -123,7 +146,8 @@ func newReceiver(
 		stepTimings: newStepTimingCache(1024, 30*time.Minute),
 		logJobs:     make(chan logIngestJob, logIngestQueueSize),
 	}
-	gar.newInstallationClient = gar.githubClientForInstallation
+	gar.logRetryBackoff = logIngestRetryBackoff
+	gar.newInstallationClient = gar.cachedInstallationClient
 
 	return gar, nil
 }
@@ -241,32 +265,39 @@ func (gar *githubActionsReceiver) Shutdown(ctx context.Context) error {
 
 	var err error
 	if server != nil {
-		// Stops accepting requests and waits for in-flight handlers, so no
-		// enqueue can race with closing the job channel below.
 		err = server.Shutdown(ctx)
 	}
 	gar.shutdownWG.Wait()
 
 	if gar.logWorkerStop != nil {
-		// Cancel first so queued and in-flight ingestions fail fast instead of
-		// draining multi-minute downloads against the shutdown deadline.
+		// Cancel so queued and in-flight ingestions fail fast instead of
+		// draining multi-minute downloads against the shutdown deadline. The
+		// job channel is never closed; workers and pending retries exit via
+		// the context.
 		gar.logWorkerStop()
-		close(gar.logJobs)
 		gar.logWorkerWG.Wait()
+		gar.logResubmitWG.Wait()
 	}
 	return err
 }
 
 func (gar *githubActionsReceiver) runLogWorker() {
 	defer gar.logWorkerWG.Done()
-	for job := range gar.logJobs {
-		gar.processLogJob(job)
+	for {
+		select {
+		case <-gar.logWorkerCtx.Done():
+			return
+		case job := <-gar.logJobs:
+			gar.processLogJob(job)
+		}
 	}
 }
 
-// processLogJob ingests one accepted workflow_run log archive. The webhook
-// was already acked with 202, so the sender will not redeliver the event;
-// transient failures are retried here before the archive is given up on.
+// processLogJob makes one ingestion attempt for an accepted workflow_run log
+// archive. The webhook was already acked with 202, so the sender will not
+// redeliver the event; transient failures are re-enqueued after a backoff (on
+// a detached timer, so a retry never parks a worker slot) up to
+// logIngestRetries attempts.
 func (gar *githubActionsReceiver) processLogJob(job logIngestJob) {
 	logger := gar.logger.Named("eventToLogs").With(
 		zap.Int64("run_id", job.event.GetWorkflowRun().GetID()),
@@ -285,24 +316,40 @@ func (gar *githubActionsReceiver) processLogJob(job logIngestJob) {
 		return
 	}
 
-	for attempt := 1; ; attempt++ {
-		err = eventToLogs(ctx, job.event, gar.config, ghClient, logger, job.withTraceInfo, gar.jobNames, gar.stepTimings, func(ld plog.Logs) error {
-			return gar.logsConsumer.ConsumeLogs(ctx, ld)
-		})
-		if err == nil || ctx.Err() != nil {
-			return
-		}
-		if attempt >= logIngestRetries {
-			logger.Error("Giving up on workflow run log archive", zap.Int("attempts", attempt), zap.Error(err))
-			return
-		}
-		logger.Warn("Log ingestion failed, retrying", zap.Int("attempt", attempt), zap.Error(err))
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(logIngestRetryBackoff):
-		}
+	err = eventToLogs(ctx, job.event, gar.config, ghClient, logger, gar.tracesConsumer != nil, gar.jobNames, gar.stepTimings, func(ld plog.Logs) error {
+		return gar.logsConsumer.ConsumeLogs(ctx, ld)
+	})
+	if err == nil || ctx.Err() != nil {
+		return
 	}
+
+	job.attempt++
+	if job.attempt >= logIngestRetries {
+		logger.Error("Giving up on workflow run log archive", zap.Int("attempts", job.attempt), zap.Error(err))
+		return
+	}
+	logger.Warn("Log ingestion failed, retrying after backoff", zap.Int("attempt", job.attempt), zap.Error(err))
+	gar.scheduleLogRetry(job, logger)
+}
+
+// scheduleLogRetry re-enqueues the job after the backoff on a detached timer.
+// The channel send is safe against shutdown because the channel is never
+// closed; a canceled context wins the first select and drops the retry.
+func (gar *githubActionsReceiver) scheduleLogRetry(job logIngestJob, logger *zap.Logger) {
+	gar.logResubmitWG.Add(1)
+	go func() {
+		defer gar.logResubmitWG.Done()
+		select {
+		case <-gar.logWorkerCtx.Done():
+			return
+		case <-time.After(gar.logRetryBackoff):
+		}
+		select {
+		case gar.logJobs <- job:
+		default:
+			logger.Error("Log ingestion queue full, dropping retry")
+		}
+	}()
 }
 
 func (gar *githubActionsReceiver) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -391,7 +438,6 @@ func (gar *githubActionsReceiver) ServeHTTP(w http.ResponseWriter, r *http.Reque
 
 	gar.logger.Debug("Received valid GitHub event", zap.String("type", eventType))
 	var processingFailed bool
-	traceErr := false
 
 	// Preserve incoming request headers in client metadata so downstream processors
 	// can enrich telemetry using from_context metadata access.
@@ -406,26 +452,10 @@ func (gar *githubActionsReceiver) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	var installationClient *github.Client
-	getInstallationClient := func() (*github.Client, error) {
-		if installationClient != nil {
-			return installationClient, nil
-		}
-
-		client, clientErr := gar.githubClientForInstallation(installationID)
-		if clientErr != nil {
-			return nil, clientErr
-		}
-
-		installationClient = client
-		return installationClient, nil
-	}
-
 	// if a trace consumer is set, process the event into traces
 	if !processingFailed && gar.tracesConsumer != nil {
 		td, err := eventToTraces(event, gar.config, gar.logger.Named("eventToTraces"))
 		if err != nil {
-			traceErr = true
 			processingFailed = true
 			gar.logger.Error("Failed to convert event to traces", zap.Error(err))
 		}
@@ -433,7 +463,6 @@ func (gar *githubActionsReceiver) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		if td != nil {
 			consumerErr := gar.tracesConsumer.ConsumeTraces(ctx, *td)
 			if consumerErr != nil {
-				traceErr = true
 				processingFailed = true
 				gar.logger.Error("Failed to process traces", zap.Error(consumerErr))
 			}
@@ -442,7 +471,7 @@ func (gar *githubActionsReceiver) ServeHTTP(w http.ResponseWriter, r *http.Reque
 
 	// if a metrics consumer is set, process the event into metrics
 	if !processingFailed && gar.metricsConsumer != nil {
-		ghClient, clientErr := getInstallationClient()
+		ghClient, clientErr := gar.newInstallationClient(installationID)
 		if clientErr != nil {
 			processingFailed = true
 			gar.logger.Error("Failed to initialize GitHub client for metrics", zap.Error(clientErr))
@@ -472,7 +501,6 @@ func (gar *githubActionsReceiver) ServeHTTP(w http.ResponseWriter, r *http.Reque
 				event:          runEvent,
 				installationID: installationID,
 				headers:        r.Header.Clone(),
-				withTraceInfo:  gar.tracesConsumer != nil && !traceErr,
 			}
 			select {
 			case gar.logJobs <- job:

--- a/collector/receiver/githubactionsreceiver/receiver.go
+++ b/collector/receiver/githubactionsreceiver/receiver.go
@@ -32,6 +32,31 @@ var errMissingGitHubAuth = errors.New("github api authentication is not configur
 
 const maxPayloadSize = 25 * 1024 * 1024 // 25 MB — GitHub webhook max payload size
 
+// Log-archive ingestion runs off the webhook request path: downloading and
+// scanning a run's logs takes tens of seconds for big runs, and doing it
+// inline blocked the webhook response for the whole duration. Jobs queue on a
+// bounded channel; when it is full the receiver responds 503 so the sender's
+// retry becomes the backpressure, instead of buffering without limit.
+const logIngestQueueSize = 64
+const logIngestWorkers = 2
+
+// logIngestRetries and logIngestRetryBackoff govern the worker's own retry of
+// a failed ingestion. Once the webhook is acked with 202 the sender will not
+// redeliver it, so transient GitHub API or pipeline failures are retried here
+// before the archive is given up on.
+const logIngestRetries = 3
+const logIngestRetryBackoff = 30 * time.Second
+
+// logIngestJob is one accepted workflow_run event whose log archive still has
+// to be ingested. Headers are retained because downstream processors read
+// tenant information from client metadata.
+type logIngestJob struct {
+	event          *github.WorkflowRunEvent
+	installationID int64
+	headers        http.Header
+	withTraceInfo  bool
+}
+
 type githubActionsReceiver struct {
 	logsConsumer    consumer.Logs
 	metricsConsumer consumer.Metrics
@@ -46,6 +71,14 @@ type githubActionsReceiver struct {
 	ghClient        *github.Client
 	jobNames        *jobNameCache
 	stepTimings     *stepTimingCache
+	logJobs         chan logIngestJob
+	logWorkerWG     sync.WaitGroup
+	logWorkerCtx    context.Context
+	logWorkerStop   context.CancelFunc
+
+	// newInstallationClient builds the GitHub client a log worker uses.
+	// Overridable in tests; production wires githubClientForInstallation.
+	newInstallationClient func(installationID int64) (*github.Client, error)
 }
 
 func newReceiver(
@@ -88,7 +121,9 @@ func newReceiver(
 		ghClient:    ghClient,
 		jobNames:    newJobNameCache(1024, 30*time.Minute),
 		stepTimings: newStepTimingCache(1024, 30*time.Minute),
+		logJobs:     make(chan logIngestJob, logIngestQueueSize),
 	}
+	gar.newInstallationClient = gar.githubClientForInstallation
 
 	return gar, nil
 }
@@ -169,6 +204,12 @@ func (gar *githubActionsReceiver) Start(ctx context.Context, host component.Host
 	endpoint := fmt.Sprintf("%s%s", gar.config.ServerConfig.NetAddr.Endpoint, gar.config.Path)
 	gar.logger.Info("Starting GithubActions server", zap.String("endpoint", endpoint))
 
+	gar.logWorkerCtx, gar.logWorkerStop = context.WithCancel(context.Background())
+	for i := 0; i < logIngestWorkers; i++ {
+		gar.logWorkerWG.Add(1)
+		go gar.runLogWorker()
+	}
+
 	server := &http.Server{
 		Addr:              gar.config.ServerConfig.NetAddr.Endpoint,
 		Handler:           gar,
@@ -200,10 +241,68 @@ func (gar *githubActionsReceiver) Shutdown(ctx context.Context) error {
 
 	var err error
 	if server != nil {
+		// Stops accepting requests and waits for in-flight handlers, so no
+		// enqueue can race with closing the job channel below.
 		err = server.Shutdown(ctx)
 	}
 	gar.shutdownWG.Wait()
+
+	if gar.logWorkerStop != nil {
+		// Cancel first so queued and in-flight ingestions fail fast instead of
+		// draining multi-minute downloads against the shutdown deadline.
+		gar.logWorkerStop()
+		close(gar.logJobs)
+		gar.logWorkerWG.Wait()
+	}
 	return err
+}
+
+func (gar *githubActionsReceiver) runLogWorker() {
+	defer gar.logWorkerWG.Done()
+	for job := range gar.logJobs {
+		gar.processLogJob(job)
+	}
+}
+
+// processLogJob ingests one accepted workflow_run log archive. The webhook
+// was already acked with 202, so the sender will not redeliver the event;
+// transient failures are retried here before the archive is given up on.
+func (gar *githubActionsReceiver) processLogJob(job logIngestJob) {
+	logger := gar.logger.Named("eventToLogs").With(
+		zap.Int64("run_id", job.event.GetWorkflowRun().GetID()),
+		zap.String("repository", job.event.GetRepo().GetFullName()),
+	)
+
+	// Rebuild the client metadata the request carried: downstream processors
+	// read tenant information from it.
+	ci := client.FromContext(gar.logWorkerCtx)
+	ci.Metadata = client.NewMetadata(job.headers)
+	ctx := client.NewContext(gar.logWorkerCtx, ci)
+
+	ghClient, err := gar.newInstallationClient(job.installationID)
+	if err != nil {
+		logger.Error("Failed to initialize GitHub client for logs", zap.Error(err))
+		return
+	}
+
+	for attempt := 1; ; attempt++ {
+		err = eventToLogs(ctx, job.event, gar.config, ghClient, logger, job.withTraceInfo, gar.jobNames, gar.stepTimings, func(ld plog.Logs) error {
+			return gar.logsConsumer.ConsumeLogs(ctx, ld)
+		})
+		if err == nil || ctx.Err() != nil {
+			return
+		}
+		if attempt >= logIngestRetries {
+			logger.Error("Giving up on workflow run log archive", zap.Int("attempts", attempt), zap.Error(err))
+			return
+		}
+		logger.Warn("Log ingestion failed, retrying", zap.Int("attempt", attempt), zap.Error(err))
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(logIngestRetryBackoff):
+		}
+	}
 }
 
 func (gar *githubActionsReceiver) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -364,23 +463,28 @@ func (gar *githubActionsReceiver) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		}
 	}
 
-	// if a log consumer is set, process the event into logs
+	// If a log consumer is set, queue the run for log-archive ingestion.
+	// Downloading and scanning the archive takes tens of seconds for big
+	// runs, so it happens on the worker pool, off the request path.
 	if !processingFailed && gar.logsConsumer != nil {
-		ghClient, clientErr := getInstallationClient()
-		if clientErr != nil {
-			processingFailed = true
-			gar.logger.Error("Failed to initialize GitHub client for logs", zap.Error(clientErr))
-		} else {
-			withTraceInfo := gar.tracesConsumer != nil && !traceErr
-
-			// eventToLogs hands payloads to the consumer in bounded chunks so
-			// a large run is never materialized in memory at once.
-			err := eventToLogs(ctx, event, gar.config, ghClient, gar.logger.Named("eventToLogs"), withTraceInfo, gar.jobNames, gar.stepTimings, func(ld plog.Logs) error {
-				return gar.logsConsumer.ConsumeLogs(ctx, ld)
-			})
-			if err != nil {
-				processingFailed = true
-				gar.logger.Error("Failed to process logs", zap.Error(err))
+		if runEvent, ok := event.(*github.WorkflowRunEvent); ok {
+			job := logIngestJob{
+				event:          runEvent,
+				installationID: installationID,
+				headers:        r.Header.Clone(),
+				withTraceInfo:  gar.tracesConsumer != nil && !traceErr,
+			}
+			select {
+			case gar.logJobs <- job:
+			default:
+				// Queue full: reject so the sender's retry becomes the
+				// backpressure instead of buffering without bound. Duplicate
+				// traces/metrics on redelivery match the existing semantics
+				// of a failure after those consumers already ran.
+				gar.logger.Warn("Log ingestion queue full, rejecting webhook",
+					zap.Int64("run_id", runEvent.GetWorkflowRun().GetID()))
+				http.Error(w, "Log ingestion queue full", http.StatusServiceUnavailable)
+				return
 			}
 		}
 	}

--- a/collector/receiver/githubactionsreceiver/receiver_async_test.go
+++ b/collector/receiver/githubactionsreceiver/receiver_async_test.go
@@ -1,0 +1,191 @@
+// Copyright The OpenTelemetry Authors
+// Copyright 2026 Giordano Ricci (operating as "Everr Labs")
+// SPDX-License-Identifier: Apache-2.0
+//
+// This file has been modified from its original version.
+
+package githubactionsreceiver
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v67/github"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/receiver/receivertest"
+
+	"github.com/everr-labs/everr/collector/receiver/githubactionsreceiver/internal/metadata"
+)
+
+// workflowRunWebhookRequest builds a signed-enough workflow_run completed
+// webhook request from the shared fixture, with an installation id injected
+// (the fixture predates the GitHub App setup and lacks one).
+func workflowRunWebhookRequest(t *testing.T, path string) *http.Request {
+	t.Helper()
+
+	raw, err := os.ReadFile("./testdata/completed/8_workflow_run_completed.json")
+	require.NoError(t, err)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(raw, &payload))
+	payload["installation"] = map[string]any{"id": 123}
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "workflow_run")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Everr-Tenant-Id", "tenant-1")
+	return req
+}
+
+// TestWorkflowRunWebhookAcksBeforeLogIngestion verifies that a completed
+// workflow_run webhook is acked with 202 before the log archive is touched,
+// and that ingestion then completes on the worker pool.
+func TestWorkflowRunWebhookAcksBeforeLogIngestion(t *testing.T) {
+	// Zip download blocks until released, proving the ack does not wait on it.
+	release := make(chan struct{})
+
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	f, err := w.Create("pre-commit/1_Set up job.txt")
+	require.NoError(t, err)
+	_, err = f.Write([]byte("2023-10-13T10:11:33Z hello from async ingestion\n"))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	zipData := buf.Bytes()
+
+	zipServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release
+		w.Header().Set("Content-Type", "application/zip")
+		_, _ = w.Write(zipData)
+	}))
+	t.Cleanup(zipServer.Close)
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/logs"):
+			http.Redirect(w, r, zipServer.URL, http.StatusFound)
+		case strings.HasSuffix(r.URL.Path, "/jobs"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"total_count":1,"jobs":[{"id":12345,"name":"pre-commit","status":"completed"}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(apiServer.Close)
+
+	ghClient, err := github.NewClient(nil).WithEnterpriseURLs(apiServer.URL+"/", apiServer.URL+"/")
+	require.NoError(t, err)
+
+	cfg := createDefaultConfig().(*Config)
+	cfg.NetAddr.Endpoint = "localhost:0"
+
+	gar, err := newReceiver(receivertest.NewNopSettings(metadata.Type), cfg)
+	require.NoError(t, err)
+
+	sink := new(consumertest.LogsSink)
+	gar.logsConsumer = sink
+	gar.newInstallationClient = func(installationID int64) (*github.Client, error) {
+		require.Equal(t, int64(123), installationID)
+		return ghClient, nil
+	}
+
+	require.NoError(t, gar.Start(context.Background(), componenttest.NewNopHost()))
+	t.Cleanup(func() { require.NoError(t, gar.Shutdown(context.Background())) })
+
+	rec := httptest.NewRecorder()
+	gar.ServeHTTP(rec, workflowRunWebhookRequest(t, cfg.Path))
+
+	require.Equal(t, http.StatusAccepted, rec.Code, "webhook must be acked before ingestion runs")
+	require.Zero(t, sink.LogRecordCount(), "no logs may be consumed before the archive download completes")
+
+	close(release)
+	require.Eventually(t, func() bool {
+		return sink.LogRecordCount() > 0
+	}, 10*time.Second, 25*time.Millisecond, "worker should ingest the archive after the ack")
+}
+
+// TestWorkflowRunWebhookRejectsWhenQueueFull verifies backpressure: with the
+// ingestion queue full, the webhook is rejected with 503 so the sender
+// retries the event instead of the receiver buffering without bound.
+func TestWorkflowRunWebhookRejectsWhenQueueFull(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.NetAddr.Endpoint = "localhost:0"
+
+	gar, err := newReceiver(receivertest.NewNopSettings(metadata.Type), cfg)
+	require.NoError(t, err)
+	gar.logsConsumer = consumertest.NewNop()
+
+	// No Start, so no workers drain the queue; fill it to capacity.
+	gar.logJobs = make(chan logIngestJob, 1)
+	gar.logJobs <- logIngestJob{}
+
+	rec := httptest.NewRecorder()
+	gar.ServeHTTP(rec, workflowRunWebhookRequest(t, cfg.Path))
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+// TestLogWorkerRetriesTransientFailures verifies that a failed ingestion is
+// retried by the worker: once the webhook is acked the sender will not
+// redeliver, so the worker owns transient-failure retries.
+func TestLogWorkerRetriesTransientFailures(t *testing.T) {
+	var calls atomic.Int32
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	t.Cleanup(apiServer.Close)
+
+	ghClient, err := github.NewClient(nil).WithEnterpriseURLs(apiServer.URL+"/", apiServer.URL+"/")
+	require.NoError(t, err)
+
+	cfg := createDefaultConfig().(*Config)
+	cfg.NetAddr.Endpoint = "localhost:0"
+	gar, err := newReceiver(receivertest.NewNopSettings(metadata.Type), cfg)
+	require.NoError(t, err)
+	gar.logsConsumer = new(consumertest.LogsSink)
+	gar.newInstallationClient = func(int64) (*github.Client, error) { return ghClient, nil }
+	gar.logWorkerCtx, gar.logWorkerStop = context.WithCancel(context.Background())
+	t.Cleanup(gar.logWorkerStop)
+
+	raw, err := os.ReadFile("./testdata/completed/8_workflow_run_completed.json")
+	require.NoError(t, err)
+	event, err := github.ParseWebHook("workflow_run", raw)
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		gar.processLogJob(logIngestJob{
+			event:          event.(*github.WorkflowRunEvent),
+			installationID: 123,
+			headers:        http.Header{},
+		})
+	}()
+
+	// Each attempt makes one GetWorkflowRunAttemptLogs call (go-github does
+	// not retry 500s); the worker should retry up to logIngestRetries times.
+	require.Eventually(t, func() bool { return calls.Load() >= 1 }, 5*time.Second, 10*time.Millisecond)
+
+	// Cancel instead of waiting out the retry backoff.
+	gar.logWorkerStop()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker did not stop after context cancellation")
+	}
+	require.Equal(t, int32(1), calls.Load(), "second attempt must not start before the backoff elapses")
+}

--- a/collector/receiver/githubactionsreceiver/receiver_async_test.go
+++ b/collector/receiver/githubactionsreceiver/receiver_async_test.go
@@ -7,7 +7,6 @@
 package githubactionsreceiver
 
 import (
-	"archive/zip"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -57,14 +56,9 @@ func TestWorkflowRunWebhookAcksBeforeLogIngestion(t *testing.T) {
 	// Zip download blocks until released, proving the ack does not wait on it.
 	release := make(chan struct{})
 
-	var buf bytes.Buffer
-	w := zip.NewWriter(&buf)
-	f, err := w.Create("pre-commit/1_Set up job.txt")
-	require.NoError(t, err)
-	_, err = f.Write([]byte("2023-10-13T10:11:33Z hello from async ingestion\n"))
-	require.NoError(t, err)
-	require.NoError(t, w.Close())
-	zipData := buf.Bytes()
+	zipData := createCombinedZip(t, map[string]string{
+		"pre-commit/1_Set up job.txt": "2023-10-13T10:11:33Z hello from async ingestion\n",
+	})
 
 	zipServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		<-release
@@ -138,9 +132,10 @@ func TestWorkflowRunWebhookRejectsWhenQueueFull(t *testing.T) {
 	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
 }
 
-// TestLogWorkerRetriesTransientFailures verifies that a failed ingestion is
-// retried by the worker: once the webhook is acked the sender will not
-// redeliver, so the worker owns transient-failure retries.
+// TestLogWorkerRetriesTransientFailures verifies the retry contract: once the
+// webhook is acked the sender will not redeliver, so a failed attempt is
+// re-enqueued after the backoff (without parking a worker slot) until the
+// attempt budget is spent.
 func TestLogWorkerRetriesTransientFailures(t *testing.T) {
 	var calls atomic.Int32
 	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -158,34 +153,42 @@ func TestLogWorkerRetriesTransientFailures(t *testing.T) {
 	require.NoError(t, err)
 	gar.logsConsumer = new(consumertest.LogsSink)
 	gar.newInstallationClient = func(int64) (*github.Client, error) { return ghClient, nil }
+	gar.logRetryBackoff = 20 * time.Millisecond
 	gar.logWorkerCtx, gar.logWorkerStop = context.WithCancel(context.Background())
-	t.Cleanup(gar.logWorkerStop)
+	t.Cleanup(func() {
+		gar.logWorkerStop()
+		gar.logResubmitWG.Wait()
+	})
 
 	raw, err := os.ReadFile("./testdata/completed/8_workflow_run_completed.json")
 	require.NoError(t, err)
 	event, err := github.ParseWebHook("workflow_run", raw)
 	require.NoError(t, err)
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		gar.processLogJob(logIngestJob{
-			event:          event.(*github.WorkflowRunEvent),
-			installationID: 123,
-			headers:        http.Header{},
-		})
-	}()
-
-	// Each attempt makes one GetWorkflowRunAttemptLogs call (go-github does
-	// not retry 500s); the worker should retry up to logIngestRetries times.
-	require.Eventually(t, func() bool { return calls.Load() >= 1 }, 5*time.Second, 10*time.Millisecond)
-
-	// Cancel instead of waiting out the retry backoff.
-	gar.logWorkerStop()
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("worker did not stop after context cancellation")
+	job := logIngestJob{
+		event:          event.(*github.WorkflowRunEvent),
+		installationID: 123,
+		headers:        http.Header{},
 	}
-	require.Equal(t, int32(1), calls.Load(), "second attempt must not start before the backoff elapses")
+
+	// A failed first attempt is re-enqueued after the backoff with the
+	// attempt counter bumped, and makes exactly one API call itself.
+	gar.processLogJob(job)
+	require.Equal(t, int32(1), calls.Load())
+	select {
+	case retried := <-gar.logJobs:
+		require.Equal(t, 1, retried.attempt)
+	case <-time.After(5 * time.Second):
+		t.Fatal("failed job was not re-enqueued after the backoff")
+	}
+
+	// A failure on the final attempt is given up on, not re-enqueued.
+	job.attempt = logIngestRetries - 1
+	gar.processLogJob(job)
+	gar.logResubmitWG.Wait()
+	select {
+	case <-gar.logJobs:
+		t.Fatal("exhausted job must not be re-enqueued")
+	default:
+	}
 }

--- a/everr/collector-oom.runbook.md
+++ b/everr/collector-oom.runbook.md
@@ -13,12 +13,11 @@ are assumed to be in place:
 - the collector container has memory requests and limits, and the pipeline
   has a `memory_limiter` processor, so overload produces backpressure instead
   of a kernel OOM kill,
-- log ingestion emits in bounded chunks (capped by record count and body
-  bytes), so no
-  single run is materialized in memory at once. Processing is still
-  synchronous in the webhook handler and the app allows it 60 seconds, so
-  replay durations up to a minute are expected for huge runs, not a
-  regression.
+- log ingestion runs off the webhook request path: the handler acks with
+  202 and a bounded worker queue downloads and parses the archive, emitting
+  in bounded chunks (capped by record count and body bytes), so no single
+  run is materialized in memory at once. A full queue rejects the webhook
+  with 503 and the app's retry provides the backpressure.
 
 With those in place this alert should be rare. If it fires, one of the
 protections is not doing its job or the load pattern changed. Work through
@@ -64,11 +63,12 @@ verbose logs is the classic trigger.
 
 ## 3. Did the protections hold?
 
-- **Webhook latency.** Ingestion is synchronous, so replay durations scale
-  with archive size; up to the 60s app timeout is expected for huge runs.
-  What matters is memory staying flat while a slow replay is in flight. A
-  slow replay together with a memory balloon means chunked emission is not
-  bounding the payload (regression):
+- **Webhook latency.** With async ingestion, replay durations must stay
+  flat even while a big run is processed. Spikes returning here mean the
+  handler is doing heavy work inline again (regression). A burst of 503
+  replay failures means the ingestion queue was full; occasional bursts are
+  backpressure working, sustained 503s mean ingestion is not keeping up
+  with load:
 
 ```panel
 ref: replay-durations

--- a/everr/investigations/2026-07-04-collector-oom/collector-webhook-oom.runbook.md
+++ b/everr/investigations/2026-07-04-collector-oom/collector-webhook-oom.runbook.md
@@ -159,9 +159,12 @@ stdout logs are not ingested. See fix 4.
    4 MiB of body text (`logEmitter` in
    `collector/receiver/githubactionsreceiver/log_event_handling.go`), so
    memory stays proportional to one chunk instead of the whole run.
-   Processing is still synchronous in the webhook handler; the app's replay
-   timeout was raised from 30s to 60s to cover big archives. The async half
-   remains open.
+   The app's replay timeout was raised from 30s to 60s while ingestion was
+   still synchronous. The async half is done as well: the handler now acks
+   the webhook with 202 and a bounded worker pool ingests the archive off
+   the request path (queue of 64, two workers, 503 on overflow so the app's
+   retry is the backpressure; the worker retries transient failures itself
+   since the 202 forecloses redelivery).
 4. **Add a real restart signal.** Add a `k8s_cluster` receiver (or ingest
    Kubernetes events) to the internal collector in
    `everr-deploy/infra-v2/config/otel-collector-internal-config.yaml` so we

--- a/packages/app/src/server/github-events/config.ts
+++ b/packages/app/src/server/github-events/config.ts
@@ -1,8 +1,8 @@
 export const GH_EVENTS_CONFIG = {
   maxAttempts: 10,
-  // The collector ingests a run's log archive synchronously before returning
-  // 202; large runs legitimately take ~30s, so give them headroom instead of
-  // aborting and retrying the whole download.
+  // The collector acks the webhook once the run is queued for ingestion, so
+  // replays are normally fast; the headroom covers a busy collector without
+  // aborting and retrying the whole delivery.
   replayTimeoutMs: 60_000,
   tenantCacheTTLms: 60_000,
   retentionDoneDays: 7,


### PR DESCRIPTION
## What

Follow-up to #289 (merged): the collector's webhook handler downloaded and parsed a run's log archive inline, so the 202 arrived only after tens of seconds for big runs, the app's replay job sat blocked for the whole duration (against a 60s timeout), and a crash after the ack silently lost the event. Log ingestion now runs off the request path on a bounded worker pool; the handler acks immediately.

## How

- Accepted `workflow_run: completed` events are enqueued onto a bounded channel (64 jobs, two workers) and the handler responds 202 right away. Traces and metrics processing is unchanged (both are cheap payload transforms compared to the archive download).
- When the queue is full the handler rejects with 503. The app already classifies 5xx as retryable, so its graphile retry becomes the backpressure instead of the collector buffering without bound.
- Because the 202 forecloses redelivery, the worker owns transient failures: three attempts with a 30s backoff before giving up on an archive, with the run id and repo in the log context.
- Request headers are cloned into the job and rebuilt as client metadata on the worker context, since downstream processors read tenant information from it; the request context itself dies when the handler returns.
- Shutdown stops the HTTP server first (so no enqueue can race the channel close), then cancels the worker context so queued and in-flight downloads abort fast instead of draining multi-minute archives against the shutdown deadline. Dropped in-flight work on shutdown matches today's semantics.
- Runbooks updated: flat replay durations are again the expectation, a slow replay is again a regression signal, and a sustained burst of 503 replay failures means ingestion is not keeping up with load.

## Testing

- `TestWorkflowRunWebhookAcksBeforeLogIngestion`: the archive download blocks on a gate; the test asserts the 202 arrives with zero logs consumed, releases the gate, and sees the worker complete ingestion.
- `TestWorkflowRunWebhookRejectsWhenQueueFull`: with the queue at capacity and no workers, the webhook is rejected with 503.
- `TestLogWorkerRetriesTransientFailures`: a failing GitHub API produces exactly one attempt before the backoff, and cancellation stops the worker promptly.
- Full receiver suite passes under `-race`; golangci-lint clean.
