### PR TITLE
collector: skip large log archives to prevent OOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,26 @@
 
+## 2026-07-04
+
+### `everr upgrade`
+
+New `everr upgrade` command to upgrade both the CLI and the Desktop App
+
+### Resource empty states
+
+Alerts, dashboards, and runbooks pages now show an empty state that provide instructions on how to create them.
+
+### Learning path
+
+Improved the getting started docs, to provide a full learning path.
+
+### Desktop app
+
+Local collector tables renamed to match directly the cloud tables, and removed the views we used as prev workaround.
+
+This should fix the issue that some users are facing due to a missing TimestampTime column
+
+## 2026-07-01
+
 ### MCP server
 
 Introduced a new [MCP server](/docs/reference/mcp) at `/mcp` with a `query` tool that runs SQL against your telemetry from AI agents, plus a `whoami` introspection tool.

--- a/collector/receiver/githubactionsreceiver/log_event_handling.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling.go
@@ -27,174 +27,108 @@ import (
 	conventions "go.opentelemetry.io/otel/semconv/v1.38.0"
 )
 
-const maxLogArchiveSize = 256 * 1024 * 1024 // 256 MB
+// Runs whose log archive exceeds this are ingested without logs (traces and
+// metrics still flow). The archive decompresses to roughly 7x its size and
+// materializes as one in-memory plog.Logs payload an order of magnitude
+// bigger than that, so a couple hundred MB of zip is a multi-GiB allocation
+// that OOM-kills the collector and loses in-flight data from every tenant.
+const maxLogArchiveSize = 15 * 1024 * 1024 // 15 MiB
 
-// A payload is handed to the consumer once it reaches either bound. Emitting
-// in chunks keeps memory proportional to one chunk instead of the whole run:
-// a large build matrix with verbose output decodes to multiple GiB of pdata
-// when materialized at once, which is what OOM-killed the collector. The
-// record bound caps per-record pdata overhead for runs with many tiny lines;
-// the byte bound caps payloads whose lines are individually huge (multi-line
-// step output folds continuation lines into single records).
-const logFlushRecordCount = 10_000
-const logFlushBodyBytes = 4 * 1024 * 1024
-
-// logEmitter incrementally builds plog.Logs payloads and hands each one to
-// consume when it reaches a flush bound. Every payload carries the full run
-// resource attributes and the current job's scope attributes, so chunked
-// output is indistinguishable from the previous whole-run payload downstream.
-// After a consume failure the emitter drops further records at flush time and
-// keeps the first error sticky so the whole event fails and the sender
-// retries it.
-type logEmitter struct {
-	consume     func(plog.Logs) error
-	setResource func(pcommon.Map)
-
-	logs      plog.Logs
-	resource  plog.ResourceLogs
-	scope     plog.ScopeLogs
-	hasScope  bool
-	jobName   string
-	jobID     int64
-	count     int
-	bodyBytes int
-	err       error
-}
-
-func newLogEmitter(consume func(plog.Logs) error, setResource func(pcommon.Map)) *logEmitter {
-	return &logEmitter{consume: consume, setResource: setResource}
-}
-
-// startJob sets the job whose scope attributes subsequent records belong to.
-func (le *logEmitter) startJob(jobName string, jobID int64) {
-	le.jobName = jobName
-	le.jobID = jobID
-	le.hasScope = false
-}
-
-// failed reports whether a consume error occurred. Once it has, flush drops
-// further records, so callers should stop scanning instead of decoding work
-// that will be thrown away.
-func (le *logEmitter) failed() bool {
-	return le.err != nil
-}
-
-// appendRecord returns a fresh record in the current job's scope, flushing
-// first if the pending payload reached a bound. bodyBytes is the record body
-// size the caller is about to set.
-func (le *logEmitter) appendRecord(bodyBytes int) plog.LogRecord {
-	if le.count >= logFlushRecordCount || le.bodyBytes >= logFlushBodyBytes {
-		le.flush()
-	}
-	if le.count == 0 {
-		le.logs = plog.NewLogs()
-		le.resource = le.logs.ResourceLogs().AppendEmpty()
-		le.setResource(le.resource.Resource().Attributes())
-	}
-	if !le.hasScope {
-		le.scope = le.resource.ScopeLogs().AppendEmpty()
-		setJobScopeAttributes(le.scope, le.jobName, le.jobID)
-		le.hasScope = true
-	}
-	le.count++
-	le.bodyBytes += bodyBytes
-	return le.scope.LogRecords().AppendEmpty()
-}
-
-// flush hands the accumulated payload to the consumer and resets the buffer.
-// It returns the first consume error seen so far, if any.
-func (le *logEmitter) flush() error {
-	if le.count > 0 && le.err == nil {
-		if err := le.consume(le.logs); err != nil {
-			le.err = err
-		}
-	}
-	le.hasScope = false
-	le.count = 0
-	le.bodyBytes = 0
-	return le.err
-}
-
-func eventToLogs(ctx context.Context, event interface{}, config *Config, ghClient *github.Client, logger *zap.Logger, withTraceInfo bool, jobNamesCache *jobNameCache, stepTimingsCache *stepTimingCache, consumeLogs func(plog.Logs) error) error {
+func eventToLogs(ctx context.Context, event interface{}, config *Config, ghClient *github.Client, logger *zap.Logger, withTraceInfo bool, jobNamesCache *jobNameCache, stepTimingsCache *stepTimingCache) (*plog.Logs, error) {
 	e, ok := event.(*github.WorkflowRunEvent)
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
 	if e.GetWorkflowRun().GetStatus() != "completed" {
 		logger.Debug("Run not completed, skipping")
-		return nil
+		return nil, nil
 	}
 
 	repositoryID, err := requireRepositoryID(e.GetRepo().GetID())
 	if err != nil {
 		logger.Error("Failed to determine repository ID", zap.Error(err))
-		return err
+		return nil, err
 	}
 
 	traceID, err := generateTraceID(repositoryID, e.GetWorkflowRun().GetID(), e.GetWorkflowRun().GetRunAttempt())
 	if err != nil {
 		logger.Error("Failed to generate trace ID", zap.Error(err))
-		return err
+		return nil, err
 	}
 
-	emitter := newLogEmitter(consumeLogs, func(attrs pcommon.Map) {
-		setWorkflowRunEventAttributes(attrs, e, config)
-	})
+	logs := plog.NewLogs()
+	allLogs := logs.ResourceLogs().AppendEmpty()
+	attrs := allLogs.Resource().Attributes()
+
+	setWorkflowRunEventAttributes(attrs, e, config)
 
 	url, ghResp, err := ghClient.Actions.GetWorkflowRunAttemptLogs(ctx, e.GetRepo().GetOwner().GetLogin(), e.GetRepo().GetName(), e.GetWorkflowRun().GetID(), e.GetWorkflowRun().GetRunAttempt(), 10)
 
 	if err != nil {
 		// Runs without a downloadable log archive (e.g. skipped or cancelled
 		// before any job produced output) return 404. That's not a processing
-		// failure — otherwise the caller turns this into a 500 and the sender
-		// retries the event.
+		// failure — return the logs built so far so the caller doesn't turn
+		// this into a 500 and the sender doesn't retry the event.
 		if ghResp != nil && ghResp.StatusCode == http.StatusNotFound {
 			logger.Warn("No log archive available for workflow run", zap.Error(err))
-			return nil
+			return &logs, nil
 		}
 		logger.Error("Failed to get logs", zap.Error(err))
-		return err
+		return nil, err
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
 	if err != nil {
 		logger.Error("Failed to create log download request", zap.Error(err))
-		return err
+		return nil, err
 	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		logger.Error("Failed to get logs", zap.Error(err))
-		return err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	tmpFile, err := os.CreateTemp("", "tmpfile-")
 	if err != nil {
 		logger.Error("Failed to create temp file", zap.Error(err))
-		return err
+		return nil, err
 	}
 	defer os.Remove(tmpFile.Name())
 	defer tmpFile.Close()
 
-	// Copy the response into the temp file with a size limit
-	_, err = io.Copy(tmpFile, io.LimitReader(resp.Body, maxLogArchiveSize))
+	// GitHub streams the archive without a Content-Length, so the size can
+	// only be checked by downloading up to the cap. Read one byte past it to
+	// distinguish "exactly at the cap" from "over it".
+	written, err := io.Copy(tmpFile, io.LimitReader(resp.Body, maxLogArchiveSize+1))
 	if err != nil {
 		logger.Error("Failed to copy response to temp file", zap.Error(err))
-		return err
+		return nil, err
+	}
+	if written > maxLogArchiveSize {
+		// Not a processing failure: retrying would download the same
+		// oversized archive again. Return the logs built so far (resource
+		// attributes only) so the event still succeeds without log records.
+		logger.Warn("Log archive exceeds size cap, skipping log ingestion for run",
+			zap.Int64("cap_bytes", maxLogArchiveSize),
+			zap.Int64("repository_id", e.GetRepo().GetID()),
+			zap.Int64("run_id", e.GetWorkflowRun().GetID()),
+			zap.Int("run_attempt", e.GetWorkflowRun().GetRunAttempt()))
+		return &logs, nil
 	}
 
 	archive, err := zip.OpenReader(tmpFile.Name())
 	if err != nil {
 		logger.Error("Failed to open zip file", zap.Error(err))
-		return fmt.Errorf("failed to open zip file: %w", err)
+		return nil, fmt.Errorf("failed to open zip file: %w", err)
 	}
 	defer archive.Close()
 
 	if archive.File == nil {
 		logger.Error("Archive is empty")
-		return fmt.Errorf("archive is empty")
+		return nil, fmt.Errorf("archive is empty")
 	}
 
 	// Classify zip entries: subdirectory files are per-step logs (normal format),
@@ -245,12 +179,12 @@ func eventToLogs(ctx context.Context, event interface{}, config *Config, ghClien
 		}
 		if cachedJobs == nil {
 			logger.Warn("No step timing data available, cannot split combined logs")
-			return nil
+			return &logs, nil
 		}
 		stepTimingsCache.Delete(key)
 
-		processCombinedLogs(combinedFiles, e, emitter, traceID, withTraceInfo, cachedJobs, logger)
-		return emitter.flush()
+		processCombinedLogs(combinedFiles, e, allLogs, traceID, withTraceInfo, cachedJobs, logger)
+		return &logs, nil
 	}
 
 	// Normal format: per-step log files in subdirectories
@@ -269,11 +203,6 @@ func eventToLogs(ctx context.Context, event interface{}, config *Config, ghClien
 	resolvedNames := resolveJobNames(ctx, jobs, jobNamesCache, ghClient, e, logger)
 
 	for _, zipJobName := range jobs {
-		// A consume failure is sticky; stop scanning the remaining jobs.
-		if emitter.failed() {
-			break
-		}
-
 		// Use the original (unsanitized) name for scope attributes and span IDs.
 		// The ZIP directory name is kept for file path matching.
 		jobName := zipJobName
@@ -288,7 +217,8 @@ func eventToLogs(ctx context.Context, event interface{}, config *Config, ghClien
 			jobID = metadata.jobID
 		}
 
-		emitter.startJob(jobName, jobID)
+		jobLogsScope := allLogs.ScopeLogs().AppendEmpty()
+		setJobScopeAttributes(jobLogsScope, jobName, jobID)
 
 		for _, logFile := range stepFiles {
 			// File matching uses the ZIP directory name
@@ -311,11 +241,11 @@ func eventToLogs(ctx context.Context, event interface{}, config *Config, ghClien
 				continue
 			}
 
-			emitLogRecords(logFile, emitter, traceID, spanID, stepNumber, withTraceInfo, logger)
+			emitLogRecords(logFile, jobLogsScope, traceID, spanID, stepNumber, withTraceInfo, logger)
 		}
 	}
 
-	return emitter.flush()
+	return &logs, nil
 }
 
 // parsedLine is a single log line with its parsed timestamp.
@@ -325,8 +255,7 @@ type parsedLine struct {
 }
 
 // scanLogFile reads a zip log file and calls emit for each parsed line.
-// Scanning stops early when emit returns false.
-func scanLogFile(f *zip.File, logger *zap.Logger, emit func(parsedLine) bool) {
+func scanLogFile(f *zip.File, logger *zap.Logger, emit func(parsedLine)) {
 	ff, err := f.Open()
 	if err != nil {
 		logger.Error("Failed to open file", zap.Error(err))
@@ -350,9 +279,7 @@ func scanLogFile(f *zip.File, logger *zap.Logger, emit func(parsedLine) bool) {
 		if ts, line, ok := strings.Cut(lineText, " "); ok {
 			if parsedTime, err := time.Parse(time.RFC3339, ts); err == nil {
 				lastTime = parsedTime
-				if !emit(parsedLine{time: parsedTime, body: line}) {
-					return
-				}
+				emit(parsedLine{time: parsedTime, body: line})
 				continue
 			}
 		}
@@ -360,9 +287,7 @@ func scanLogFile(f *zip.File, logger *zap.Logger, emit func(parsedLine) bool) {
 		// No leading timestamp — this is a continuation of multi-line step
 		// output, not an error. Keep the full text and attribute it to the
 		// previous line's timestamp (zero if it's the very first line).
-		if !emit(parsedLine{time: lastTime, body: lineText}) {
-			return
-		}
+		emit(parsedLine{time: lastTime, body: lineText})
 	}
 
 	if err := scanner.Err(); err != nil {
@@ -371,12 +296,9 @@ func scanLogFile(f *zip.File, logger *zap.Logger, emit func(parsedLine) bool) {
 }
 
 // emitLogRecords reads a zip log file and emits one log record per line.
-func emitLogRecords(logFile *zip.File, emitter *logEmitter, traceID pcommon.TraceID, spanID pcommon.SpanID, stepNumber int, withTraceInfo bool, logger *zap.Logger) {
-	scanLogFile(logFile, logger, func(pl parsedLine) bool {
-		if emitter.failed() {
-			return false
-		}
-		record := emitter.appendRecord(len(pl.body))
+func emitLogRecords(logFile *zip.File, scope plog.ScopeLogs, traceID pcommon.TraceID, spanID pcommon.SpanID, stepNumber int, withTraceInfo bool, logger *zap.Logger) {
+	scanLogFile(logFile, logger, func(pl parsedLine) {
+		record := scope.LogRecords().AppendEmpty()
 		if withTraceInfo {
 			record.SetSpanID(spanID)
 			record.SetTraceID(traceID)
@@ -385,7 +307,6 @@ func emitLogRecords(logFile *zip.File, emitter *logEmitter, traceID pcommon.Trac
 		record.SetTimestamp(pcommon.NewTimestampFromTime(pl.time))
 		record.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 		record.Body().SetStr(pl.body)
-		return true
 	})
 }
 
@@ -396,7 +317,7 @@ func emitLogRecords(logFile *zip.File, emitter *logEmitter, traceID pcommon.Trac
 func processCombinedLogs(
 	combinedFiles []*zip.File,
 	e *github.WorkflowRunEvent,
-	emitter *logEmitter,
+	allLogs plog.ResourceLogs,
 	traceID pcommon.TraceID,
 	withTraceInfo bool,
 	cachedJobs []jobStepTimings,
@@ -417,11 +338,6 @@ func processCombinedLogs(
 	}
 
 	for _, cf := range combinedFiles {
-		// A consume failure is sticky; stop scanning the remaining files.
-		if emitter.failed() {
-			break
-		}
-
 		// Parse "0_<jobName>.txt" → jobName
 		jobZipName := parseCombinedFileName(cf.Name)
 		if jobZipName == "" {
@@ -438,7 +354,8 @@ func processCombinedLogs(
 		// Use the original (unsanitized) job name for scope attributes and span IDs
 		jobName := jst.jobName
 
-		emitter.startJob(jobName, jst.jobID)
+		jobLogsScope := allLogs.ScopeLogs().AppendEmpty()
+		setJobScopeAttributes(jobLogsScope, jobName, jst.jobID)
 
 		// Pre-generate span IDs for each step
 		steps := make([]stepInfo, 0, len(jst.steps))
@@ -456,11 +373,7 @@ func processCombinedLogs(
 			})
 		}
 
-		scanLogFile(cf, logger, func(pl parsedLine) bool {
-			if emitter.failed() {
-				return false
-			}
-
+		scanLogFile(cf, logger, func(pl parsedLine) {
 			// Find which step this line belongs to based on timestamp
 			step := assignLineToStep(pl.time, steps)
 			if step == nil {
@@ -468,10 +381,10 @@ func processCombinedLogs(
 				step = nearestStep(pl.time, steps)
 			}
 			if step == nil {
-				return true
+				return
 			}
 
-			record := emitter.appendRecord(len(pl.body))
+			record := jobLogsScope.LogRecords().AppendEmpty()
 			if withTraceInfo {
 				record.SetSpanID(step.spanID)
 				record.SetTraceID(traceID)
@@ -480,7 +393,6 @@ func processCombinedLogs(
 			record.SetTimestamp(pcommon.NewTimestampFromTime(pl.time))
 			record.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 			record.Body().SetStr(pl.body)
-			return true
 		})
 	}
 

--- a/collector/receiver/githubactionsreceiver/log_event_handling_test.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -348,8 +347,7 @@ func TestProcessCombinedLogsWithRealWebhook(t *testing.T) {
 
 	jnCache := newJobNameCache(100, 30*time.Minute)
 
-	var consumed []plog.Logs
-	err = eventToLogs(
+	logs, err := eventToLogs(
 		context.Background(),
 		wre,
 		&Config{},
@@ -358,14 +356,9 @@ func TestProcessCombinedLogsWithRealWebhook(t *testing.T) {
 		true, // withTraceInfo
 		jnCache,
 		stCache,
-		func(ld plog.Logs) error {
-			consumed = append(consumed, ld)
-			return nil
-		},
 	)
 	require.NoError(t, err)
-	require.Len(t, consumed, 1)
-	logs := consumed[0]
+	require.NotNil(t, logs)
 
 	// Verify we got log records split across the correct steps
 	rl := logs.ResourceLogs()
@@ -491,8 +484,7 @@ func TestEventToLogsNormalFormatUnchanged(t *testing.T) {
 	jnCache := newJobNameCache(100, 30*time.Minute)
 	stCache := newStepTimingCache(100, 30*time.Minute)
 
-	var consumed []plog.Logs
-	err = eventToLogs(
+	logs, err := eventToLogs(
 		context.Background(),
 		wre,
 		&Config{},
@@ -501,14 +493,9 @@ func TestEventToLogsNormalFormatUnchanged(t *testing.T) {
 		true,
 		jnCache,
 		stCache,
-		func(ld plog.Logs) error {
-			consumed = append(consumed, ld)
-			return nil
-		},
 	)
 	require.NoError(t, err)
-	require.Len(t, consumed, 1)
-	logs := consumed[0]
+	require.NotNil(t, logs)
 
 	// Should have used the normal path (subdirectory step files)
 	rl := logs.ResourceLogs()
@@ -541,7 +528,7 @@ func TestEventToLogsNoLogArchive(t *testing.T) {
 	require.NoError(t, err)
 	wre := runEvent.(*github.WorkflowRunEvent)
 
-	newEventToLogs := func(t *testing.T, statusCode int) ([]plog.Logs, error) {
+	newEventToLogs := func(t *testing.T, statusCode int) (*plog.Logs, error) {
 		t.Helper()
 		apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, http.StatusText(statusCode), statusCode)
@@ -551,8 +538,7 @@ func TestEventToLogsNoLogArchive(t *testing.T) {
 		ghClient, err := github.NewClient(nil).WithEnterpriseURLs(apiServer.URL+"/", apiServer.URL+"/")
 		require.NoError(t, err)
 
-		var consumed []plog.Logs
-		err = eventToLogs(
+		return eventToLogs(
 			context.Background(),
 			wre,
 			&Config{},
@@ -561,164 +547,24 @@ func TestEventToLogsNoLogArchive(t *testing.T) {
 			true,
 			newJobNameCache(100, 30*time.Minute),
 			newStepTimingCache(100, 30*time.Minute),
-			func(ld plog.Logs) error {
-				consumed = append(consumed, ld)
-				return nil
-			},
 		)
-		return consumed, err
 	}
 
 	t.Run("404 means no logs, not a failure", func(t *testing.T) {
-		consumed, err := newEventToLogs(t, http.StatusNotFound)
+		logs, err := newEventToLogs(t, http.StatusNotFound)
 		require.NoError(t, err)
-		require.Empty(t, consumed)
+		require.NotNil(t, logs)
+
+		// Resource attributes are set, but no log records were produced.
+		require.Equal(t, 1, logs.ResourceLogs().Len())
+		require.Equal(t, 0, logs.ResourceLogs().At(0).ScopeLogs().Len())
 	})
 
 	t.Run("server errors still fail", func(t *testing.T) {
-		consumed, err := newEventToLogs(t, http.StatusServiceUnavailable)
+		logs, err := newEventToLogs(t, http.StatusServiceUnavailable)
 		require.Error(t, err)
-		require.Empty(t, consumed)
+		require.Nil(t, logs)
 	})
-}
-
-// TestEventToLogsChunksLargePayloads verifies that a run whose logs exceed
-// logFlushRecordCount is delivered to the consumer in multiple bounded
-// payloads, each carrying the run resource attributes and the job scope, so
-// no single plog.Logs materializes the whole run in memory.
-func TestEventToLogsChunksLargePayloads(t *testing.T) {
-	logger := zaptest.NewLogger(t)
-
-	runPayload, err := os.ReadFile("./testdata/completed/8_workflow_run_completed.json")
-	require.NoError(t, err)
-	runEvent, err := github.ParseWebHook("workflow_run", runPayload)
-	require.NoError(t, err)
-	wre := runEvent.(*github.WorkflowRunEvent)
-
-	totalLines := logFlushRecordCount*2 + logFlushRecordCount/2
-
-	var logText bytes.Buffer
-	for i := 0; i < totalLines; i++ {
-		fmt.Fprintf(&logText, "2023-10-13T10:11:33Z line %d\n", i)
-	}
-
-	var buf bytes.Buffer
-	w := zip.NewWriter(&buf)
-	f, err := w.Create("pre-commit/1_Set up job.txt")
-	require.NoError(t, err)
-	_, err = f.Write(logText.Bytes())
-	require.NoError(t, err)
-	require.NoError(t, w.Close())
-	zipData := buf.Bytes()
-
-	zipServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/zip")
-		_, _ = w.Write(zipData)
-	}))
-	defer zipServer.Close()
-
-	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasSuffix(r.URL.Path, "/logs") {
-			http.Redirect(w, r, zipServer.URL, http.StatusFound)
-			return
-		}
-		if strings.HasSuffix(r.URL.Path, "/jobs") {
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"total_count":1,"jobs":[{"id":12345,"name":"pre-commit","status":"completed"}]}`))
-			return
-		}
-		http.NotFound(w, r)
-	}))
-	defer apiServer.Close()
-
-	ghClient, err := github.NewClient(nil).WithEnterpriseURLs(apiServer.URL+"/", apiServer.URL+"/")
-	require.NoError(t, err)
-
-	var consumed []plog.Logs
-	err = eventToLogs(
-		context.Background(),
-		wre,
-		&Config{},
-		ghClient,
-		logger,
-		true,
-		newJobNameCache(100, 30*time.Minute),
-		newStepTimingCache(100, 30*time.Minute),
-		func(ld plog.Logs) error {
-			consumed = append(consumed, ld)
-			return nil
-		},
-	)
-	require.NoError(t, err)
-	require.Len(t, consumed, 3, "expected the run split into 3 bounded payloads")
-
-	total := 0
-	for i, ld := range consumed {
-		require.Equal(t, 1, ld.ResourceLogs().Len())
-		rl := ld.ResourceLogs().At(0)
-
-		// Every chunk must be self-contained: run resource attributes and
-		// job scope attributes present.
-		_, ok := rl.Resource().Attributes().Get(string(conventions.ServiceNameKey))
-		require.True(t, ok, "payload %d missing resource attributes", i)
-
-		require.Equal(t, 1, rl.ScopeLogs().Len())
-		scope := rl.ScopeLogs().At(0)
-		jobName, ok := scope.Scope().Attributes().Get("cicd.pipeline.task.name")
-		require.True(t, ok, "payload %d missing job scope attributes", i)
-		require.Equal(t, "pre-commit", jobName.Str())
-
-		count := scope.LogRecords().Len()
-		require.LessOrEqual(t, count, logFlushRecordCount, "payload %d exceeds the chunk bound", i)
-		total += count
-	}
-	require.Equal(t, totalLines, total, "no records lost or duplicated across chunks")
-
-	// A consume failure must fail the event so the sender retries it.
-	consumeErr := fmt.Errorf("pipeline refused data")
-	err = eventToLogs(
-		context.Background(),
-		wre,
-		&Config{},
-		ghClient,
-		logger,
-		true,
-		newJobNameCache(100, 30*time.Minute),
-		newStepTimingCache(100, 30*time.Minute),
-		func(ld plog.Logs) error { return consumeErr },
-	)
-	require.ErrorIs(t, err, consumeErr)
-}
-
-// TestLogEmitterFlushesOnByteBound verifies that a payload flushes once its
-// accumulated record bodies reach logFlushBodyBytes even when far below the
-// record-count bound, so few-huge-lines jobs cannot balloon a single chunk.
-func TestLogEmitterFlushesOnByteBound(t *testing.T) {
-	var consumed []plog.Logs
-	emitter := newLogEmitter(
-		func(ld plog.Logs) error {
-			consumed = append(consumed, ld)
-			return nil
-		},
-		func(attrs pcommon.Map) { attrs.PutStr("run", "r1") },
-	)
-	emitter.startJob("job", 1)
-
-	// Three records just over half the byte bound each: the third append
-	// crosses the bound and flushes the first two.
-	overHalf := logFlushBodyBytes/2 + 1
-	for i := 0; i < 3; i++ {
-		emitter.appendRecord(overHalf).Body().SetStr("x")
-	}
-	require.NoError(t, emitter.flush())
-
-	require.Len(t, consumed, 2)
-	require.Equal(t, 2, consumed[0].LogRecordCount())
-	require.Equal(t, 1, consumed[1].LogRecordCount())
-	for i, ld := range consumed {
-		_, ok := ld.ResourceLogs().At(0).Resource().Attributes().Get("run")
-		require.True(t, ok, "payload %d missing resource attributes", i)
-	}
 }
 
 // TestScanLogFileContinuationLines verifies that multi-line step output —
@@ -738,9 +584,8 @@ func TestScanLogFileContinuationLines(t *testing.T) {
 		t.Helper()
 		core, observed := observer.New(zap.ErrorLevel)
 		var lines []parsedLine
-		scanLogFile(newZipFile(t, content), zap.New(core), func(pl parsedLine) bool {
+		scanLogFile(newZipFile(t, content), zap.New(core), func(pl parsedLine) {
 			lines = append(lines, pl)
-			return true
 		})
 		return lines, observed
 	}
@@ -788,4 +633,57 @@ func makeTestWorkflowRunEvent(repoID, runID int64, runAttempt int) *github.Workf
 			Status:     getPtr("completed"),
 		},
 	}
+}
+
+func TestEventToLogsSkipsOversizedArchive(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	runPayload, err := os.ReadFile("./testdata/completed/8_workflow_run_completed.json")
+	require.NoError(t, err)
+	runEvent, err := github.ParseWebHook("workflow_run", runPayload)
+	require.NoError(t, err)
+	wre := runEvent.(*github.WorkflowRunEvent)
+
+	// One byte past the cap. GitHub streams archives without a Content-Length,
+	// so the receiver can only detect the overflow while downloading.
+	oversized := bytes.Repeat([]byte("x"), maxLogArchiveSize+1)
+	zipServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		_, _ = w.Write(oversized)
+	}))
+	defer zipServer.Close()
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		expectedSuffix := fmt.Sprintf("/repos/%s/%s/actions/runs/%d/attempts/%d/logs",
+			wre.GetRepo().GetOwner().GetLogin(),
+			wre.GetRepo().GetName(),
+			wre.GetWorkflowRun().GetID(),
+			wre.GetWorkflowRun().GetRunAttempt())
+		if r.URL.Path == expectedSuffix || r.URL.Path == "/api/v3"+expectedSuffix {
+			http.Redirect(w, r, zipServer.URL, http.StatusFound)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer apiServer.Close()
+
+	ghClient, err := github.NewClient(nil).WithEnterpriseURLs(apiServer.URL+"/", apiServer.URL+"/")
+	require.NoError(t, err)
+
+	logs, err := eventToLogs(
+		context.Background(),
+		wre,
+		&Config{},
+		ghClient,
+		logger,
+		true,
+		newJobNameCache(100, 30*time.Minute),
+		newStepTimingCache(100, 30*time.Minute),
+	)
+
+	// The oversized archive is skipped, not failed: the event must succeed so
+	// the sender does not retry the same download.
+	require.NoError(t, err)
+	require.NotNil(t, logs)
+	require.Equal(t, 0, logs.LogRecordCount())
 }

--- a/collector/receiver/githubactionsreceiver/receiver.go
+++ b/collector/receiver/githubactionsreceiver/receiver.go
@@ -20,7 +20,6 @@ import (
 	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
-	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/receiverhelper"
 	"go.uber.org/zap"
@@ -373,14 +372,18 @@ func (gar *githubActionsReceiver) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		} else {
 			withTraceInfo := gar.tracesConsumer != nil && !traceErr
 
-			// eventToLogs hands payloads to the consumer in bounded chunks so
-			// a large run is never materialized in memory at once.
-			err := eventToLogs(ctx, event, gar.config, ghClient, gar.logger.Named("eventToLogs"), withTraceInfo, gar.jobNames, gar.stepTimings, func(ld plog.Logs) error {
-				return gar.logsConsumer.ConsumeLogs(ctx, ld)
-			})
+			ld, err := eventToLogs(ctx, event, gar.config, ghClient, gar.logger.Named("eventToLogs"), withTraceInfo, gar.jobNames, gar.stepTimings)
 			if err != nil {
 				processingFailed = true
 				gar.logger.Error("Failed to process logs", zap.Error(err))
+			}
+
+			if ld != nil {
+				consumerErr := gar.logsConsumer.ConsumeLogs(ctx, *ld)
+				if consumerErr != nil {
+					processingFailed = true
+					gar.logger.Error("Failed to consume logs", zap.Error(consumerErr))
+				}
 			}
 		}
 	}

--- a/crates/everr-core/src/skills.rs
+++ b/crates/everr-core/src/skills.rs
@@ -14,6 +14,7 @@ const LEGACY_SKILL_RENAMES: &[(&str, &str)] = &[
     ("everr-local-debugging", "everr-use-telemetry"),
     ("everr-write-dashboards", "everr-setup-resources"),
     ("everr-write-runbooks", "everr-setup-resources"),
+    ("everr-write-notebooks", "everr-setup-resources"),
 ];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize)]

--- a/crates/everr-core/tests/skills.rs
+++ b/crates/everr-core/tests/skills.rs
@@ -509,6 +509,60 @@ fn update_replaces_installed_legacy_skill_with_new_skill() {
 }
 
 #[test]
+fn update_replaces_installed_notebooks_skill_with_setup_resources() {
+    let repo = tempdir().expect("repo tempdir");
+    let home = tempdir().expect("home tempdir");
+    let legacy_canonical = repo.path().join(".agents/skills/everr-write-notebooks");
+    fs::create_dir_all(&legacy_canonical).expect("create legacy skill");
+    fs::write(
+        legacy_canonical.join("SKILL.md"),
+        "name: everr-write-notebooks",
+    )
+    .expect("write legacy skill");
+
+    #[cfg(unix)]
+    {
+        let legacy_provider = repo.path().join(".claude/skills/everr-write-notebooks");
+        fs::create_dir_all(legacy_provider.parent().expect("provider parent"))
+            .expect("create provider parent");
+        std::os::unix::fs::symlink(&legacy_canonical, &legacy_provider)
+            .expect("create legacy provider symlink");
+    }
+
+    let options = SkillOperationOptions {
+        scope: SkillScope::Project,
+        cwd: repo.path().to_path_buf(),
+        home_dir: home.path().to_path_buf(),
+        providers: vec![SkillProvider::ClaudeCode],
+        skill_names: Vec::new(),
+        all: false,
+        dry_run: false,
+    };
+
+    let summary = update_bundled_skills(&options).expect("update notebooks skill");
+
+    assert_eq!(summary.skills, vec!["everr-setup-resources"]);
+    assert!(!legacy_canonical.exists());
+    let new_canonical = repo.path().join(".agents/skills/everr-setup-resources");
+    assert!(new_canonical.join("SKILL.md").is_file());
+    let content = fs::read_to_string(new_canonical.join("SKILL.md")).expect("read new skill");
+    assert!(content.contains("name: everr-setup-resources"));
+    #[cfg(unix)]
+    {
+        assert!(
+            !repo
+                .path()
+                .join(".claude/skills/everr-write-notebooks")
+                .exists()
+        );
+        assert_symlink_to(
+            &repo.path().join(".claude/skills/everr-setup-resources"),
+            &new_canonical,
+        );
+    }
+}
+
+#[test]
 fn install_overwrites_modified_skill() {
     let repo = tempdir().expect("repo tempdir");
     let home = tempdir().expect("home tempdir");

--- a/everr/collector-oom.runbook.md
+++ b/everr/collector-oom.runbook.md
@@ -7,18 +7,17 @@ peaks above **1024 MiB** working set over the last 5 minutes. Baseline is
 The known driver is GitHub Actions log ingestion: a `workflow_run: completed`
 webhook makes the collector download and parse the run's full log archive.
 The protections added after the
-[2026-07-04 investigation](./investigations/collector-webhook-oom.runbook.md)
+[2026-07-04 investigation](./investigations/2026-07-04-collector-oom/collector-webhook-oom.runbook.md)
 are assumed to be in place:
 
 - the collector container has memory requests and limits, and the pipeline
   has a `memory_limiter` processor, so overload produces backpressure instead
   of a kernel OOM kill,
-- log ingestion emits in bounded chunks (capped by record count and body
-  bytes), so no
-  single run is materialized in memory at once. Processing is still
-  synchronous in the webhook handler and the app allows it 60 seconds, so
-  replay durations up to a minute are expected for huge runs, not a
-  regression.
+- log ingestion skips any run whose log archive exceeds **15 MiB**
+  compressed. The run keeps its pipeline trace spans and metrics, it just
+  gets no log lines, and the collector logs a "Log archive exceeds size cap"
+  warning with the repo and run id. Runs under the cap are small enough that
+  the whole-run payload stays far from the danger zone.
 
 With those in place this alert should be rare. If it fires, one of the
 protections is not doing its job or the load pattern changed. Work through
@@ -64,11 +63,10 @@ verbose logs is the classic trigger.
 
 ## 3. Did the protections hold?
 
-- **Webhook latency.** Ingestion is synchronous, so replay durations scale
-  with archive size; up to the 60s app timeout is expected for huge runs.
-  What matters is memory staying flat while a slow replay is in flight. A
-  slow replay together with a memory balloon means chunked emission is not
-  bounding the payload (regression):
+- **Webhook latency.** Ingestion is synchronous, but the 15 MiB archive cap
+  bounds the work per run, so replays should stay well under the app's 30s
+  timeout. A replay near the timeout together with a memory balloon means
+  the size cap is not being enforced (regression):
 
 ```panel
 ref: replay-durations
@@ -92,14 +90,14 @@ height: 240
 
 | Finding | Action |
 | --- | --- |
-| One pathological workflow run, protections held, no restart | Nothing urgent. Note the repo/run; consider a per-run size guard if it repeats. |
-| Replay durations spiky again, or whole runs buffered in memory | Regression in the receiver. Compare the deployed collector image against main and roll back or fix. |
+| One pathological workflow run, protections held, no restart | Nothing urgent. Note the repo/run; if its archive was over the 15 MiB cap its logs were skipped by design. |
+| Replay durations spiky again, or whole runs buffered in memory | Regression in the receiver's archive size cap. Compare the deployed collector image against main and roll back or fix. |
 | OOMKilled at the container limit, memory_limiter never engaged | Fix the `memory_limiter` soft/hard limits so they sit safely below the container limit. |
 | No container limits present | Restore memory requests/limits in the collector deployment (everr-deploy). |
 | Sustained high memory with steady refusals | Load outgrew the sizing. Raise the container limit and the memory_limiter thresholds together, then raise the alert threshold in `collector-oom.alert.yaml` to keep headroom. |
 
 ## Related
 
-- [Investigation (2026-07-04)](./investigations/collector-webhook-oom.runbook.md):
+- [Investigation (2026-07-04)](./investigations/2026-07-04-collector-oom/collector-webhook-oom.runbook.md):
   the original incident analysis, root cause in the
   `githubactionsreceiver`, and the fixes this runbook assumes are deployed.

--- a/everr/collector-oom.runbook.yaml
+++ b/everr/collector-oom.runbook.yaml
@@ -72,7 +72,7 @@ spec:
       spec:
         display:
           name: Webhook replay duration (worst per interval)
-          description: Max duration of github_events.jobs.replay_webhook_to_collector spans. With async ingestion deployed this should stay flat in the low milliseconds; a return of 20-30s spikes means the webhook handler is doing heavy work inline again.
+          description: Max duration of github_events.jobs.replay_webhook_to_collector spans. With the 15 MiB archive cap, ingestion is bounded and replays should stay in the low seconds; spikes toward the 30s timeout mean the cap is not being enforced.
         plugin:
           kind: TimeSeriesChart
           spec:
@@ -259,6 +259,62 @@ spec:
                       AND ResourceAttributes['k8s.namespace.name'] = 'collector'
                     ORDER BY mem_mib DESC
                     LIMIT 10
+    post-release-memory-scrapes:
+      kind: Panel
+      spec:
+        display:
+          name: Highest collector memory scrapes after the chunked-emitter release (pinned)
+          description: Top kubelet scrapes of collector pod working set between the b78b1fc3 rollout (2026-07-04 13:15 UTC) and 15:00 UTC. The multi-GiB rows show the exporter queue absorbing the run despite chunked emission. Does not follow the time picker.
+        plugin:
+          kind: Table
+          spec:
+            stickyHeader: true
+        queries:
+          - kind: ClickHouseSQL
+            spec:
+              plugin:
+                kind: ClickHouseSQL
+                spec:
+                  query: |
+                    SELECT
+                      formatDateTime(TimeUnix, '%m-%d %H:%i:%S') AS scraped,
+                      ResourceAttributes['k8s.pod.name'] AS pod,
+                      round(Value / 1048576, 1) AS mem_mib
+                    FROM metrics_gauge
+                    WHERE TimeUnix >= '2026-07-04 13:15:00' AND TimeUnix <= '2026-07-04 15:00:00'
+                      AND MetricName = 'k8s.pod.memory.working_set'
+                      AND ResourceAttributes['k8s.namespace.name'] = 'collector'
+                    ORDER BY mem_mib DESC
+                    LIMIT 10
+    post-release-slow-replays:
+      kind: Panel
+      spec:
+        display:
+          name: Replay retry storm after the chunked-emitter release (pinned)
+          description: Replays over 5s between the b78b1fc3 rollout (2026-07-04 13:15 UTC) and 15:00 UTC. Every attempt fails at exactly 30s (the app replay timeout), and each retry started another overlapping ingestion of the same run. Does not follow the time picker.
+        plugin:
+          kind: Table
+          spec:
+            stickyHeader: true
+        queries:
+          - kind: ClickHouseSQL
+            spec:
+              plugin:
+                kind: ClickHouseSQL
+                spec:
+                  query: |
+                    SELECT
+                      formatDateTime(Timestamp, '%m-%d %H:%i:%S') AS started,
+                      SpanAttributes['github.event.type'] AS event_type,
+                      round(Duration / 1e6, 1) AS duration_ms,
+                      StatusCode AS status,
+                      TraceId AS trace_id
+                    FROM traces
+                    WHERE Timestamp >= '2026-07-04 13:15:00' AND Timestamp <= '2026-07-04 15:00:00'
+                      AND SpanName = 'github_events.jobs.replay_webhook_to_collector'
+                      AND Duration > 5e9
+                    ORDER BY Timestamp ASC
+                    LIMIT 20
   markdown:
     file: ./collector-oom.runbook.md
   pages:

--- a/everr/investigations/2026-07-04-collector-oom/collector-webhook-oom.runbook.md
+++ b/everr/investigations/2026-07-04-collector-oom/collector-webhook-oom.runbook.md
@@ -34,6 +34,25 @@ The app-side replay span now records
 (`packages/app/src/server/github-events/tasks.ts`), so the next slow
 replay names its run directly.
 
+**Update, 2026-07-04 (post-release recurrence):** the chunked emitter
+(fix 3's emit half, image `b78b1fc3`, deployed 13:15 UTC) did not stop the
+ballooning. The new pod spiked to 6.7 GiB at 14:05 UTC and 4.3 GiB at
+14:35 UTC while ingesting the same cross-compilation workflow. The
+analysis of this recurrence found two remaining drivers, recorded in
+[Where the memory actually lives](#where-the-memory-actually-lives) and
+[The retry storm multiplier](#the-retry-storm-multiplier) below. In short:
+the chunks now pile up in the ClickHouse exporter's sending queue instead
+of the receiver, and the app's 30-second replay timeout plus job retries
+run several full ingestions of the same run concurrently.
+
+**Update, 2026-07-04 (resolution):** rather than keep hardening the
+streaming path, chunked emission was reverted entirely in favor of a
+simple **15 MiB cap on the compressed log archive** (fix 7). Runs over the
+cap skip log ingestion (traces and metrics still flow); runs under it are
+small enough that the original whole-run payload is harmless. The 60s app
+replay timeout was also reverted to 30s: it never had an effect, since the
+collector server's own `WriteTimeout` is 30s.
+
 ## Status at the time vs now
 
 The left tile of each pair is pinned to the incident window (2026-07-03 17:00
@@ -112,6 +131,74 @@ The collector returns 202 for the event and then dies. Anything batched but
 not yet exported to ClickHouse at kill time is silently lost, including
 telemetry from unrelated tenants that happened to be in flight.
 
+## Where the memory actually lives
+
+Analysis of the post-release recurrence (14:05 UTC spike on the pod running
+`b78b1fc3`). Measured on a representative run of the offending workflow: the
+log archive is 85 MiB compressed, decoding to 572 MB of text across 367
+files and 11.2 million lines. The chunked emitter turns that into roughly
+1,120 payloads of 10k records each, so the receiver itself now holds only
+one chunk at a time. The fix bounded the receiver, not the process:
+
+- The logs pipeline is `resource, batch -> clickhouse`. The `batch`
+  processor is asynchronous: it accepts a chunk, returns immediately, and
+  passes batches on later. Any error it hits downstream is logged and the
+  batch is dropped; no backpressure ever reaches the receiver.
+- The ClickHouse exporter (clickhouseexporter v0.152.0) defaults to a
+  sending queue of **1,000 requests, sized by request count, not bytes**,
+  with `block_on_overflow: false` and 10 insert consumers. A 10k-record
+  chunk is about 4 MB of pdata, so the queue alone can absorb about 4 GiB,
+  nearly the entire run.
+- The scan reads a local temp file and produces chunks far faster than the
+  insert consumers drain them, so for a large run the queue simply fills to
+  capacity. The whole-run materialization moved from the receiver into the
+  exporter queue.
+
+Two visible consequences confirm this. The memory spikes match the queue
+math (6.7 GiB with overlapping attempts, see below). And once the queue is
+full, the batch processor drops what it cannot enqueue: in the 14:05 to
+14:30 window, only about 16k of the run's 11.2 million log lines landed in
+ClickHouse.
+
+```panel
+ref: post-release-memory-scrapes
+height: 300
+```
+
+## The retry storm multiplier
+
+The replay spans changed shape after the release. Before it, `workflow_run`
+replays completed in 22 to 29 seconds with status Unset. After it, every
+replay of the large run fails at exactly 30.0 seconds with status Error,
+repeatedly, in a backoff pattern: 8 attempts between 14:04 and 14:37 UTC.
+
+```panel
+ref: post-release-slow-replays
+height: 280
+```
+
+The mechanics:
+
+1. The deployed app still aborts replays at 30 seconds
+   (`replayTimeoutMs: 30_000`; the raise to 60s exists on main but was not
+   deployed, and the collector's own HTTP server has `WriteTimeout: 30s`,
+   which caps the response window regardless of the app's timeout).
+2. When the app aborts, the collector does not stop: after the archive
+   download nothing in the scan-and-emit path checks the request context,
+   so each aborted attempt keeps scanning and queueing for minutes.
+3. The app marks the job failed and graphile-worker retries it with
+   backoff (up to `maxAttempts: 10`), starting a **new full ingestion
+   while the previous ones are still running**. Overlapping attempts stack
+   their queue usage, which is how a run whose queue footprint is about
+   4 GiB produced 6.7 GiB and later 4.3 GiB spikes.
+
+The archive size cap (fix 7) removes the storm's precondition: an
+oversized run's log ingestion is skipped after at most a 15 MiB download,
+and runs under the cap finish well inside the 30s response window, so
+replays succeed on the first attempt and there is nothing to retry. A
+single-flight guard in the receiver (fix 6) was prototyped as an
+alternative but dropped in favor of the cap's simplicity.
+
 ## The alert that came out of this
 
 The **collector-oom** alert (`everr/collector-oom.alert.yaml`) fires when any
@@ -162,11 +249,43 @@ stdout logs are not ingested. See fix 4.
    Processing is still synchronous in the webhook handler; the app's replay
    timeout was raised from 30s to 60s to cover big archives. The async half
    remains open.
+   **Update, 2026-07-04 (post-release):** released as `b78b1fc3` and
+   confirmed insufficient on its own; the chunks pile up in the exporter's
+   sending queue instead (see
+   [Where the memory actually lives](#where-the-memory-actually-lives)).
+   Note the 60s app timeout is also capped by the collector server's own
+   `WriteTimeout: 30s`, so raising it never had any effect.
+   **Update, 2026-07-04 (resolution):** chunked emission reverted and the
+   app timeout restored to 30s; superseded by the archive size cap (fix 7).
+   The async half is no longer needed for memory safety, though it remains
+   the right long-term shape for webhook handling.
 4. **Add a real restart signal.** Add a `k8s_cluster` receiver (or ingest
    Kubernetes events) to the internal collector in
    `everr-deploy/infra-v2/config/otel-collector-internal-config.yaml` so we
    get `k8s.container.restarts`, then alert on restart increases directly
    instead of on the memory precursor.
+5. **Make the pipeline backpressure the receiver.** From the post-release
+   recurrence. Configure the ClickHouse exporter's `sending_queue` with a
+   small size and `block_on_overflow: true`, and drop the `batch` processor
+   from the logs pipeline so `ConsumeLogs` blocks when the queue is full
+   and the scan self-paces at insert speed. Not pursued: superseded by the
+   archive size cap (fix 7), which keeps whole-run payloads small enough
+   that queue buffering is harmless.
+6. **Deduplicate run ingestion (single-flight).** From the post-release
+   recurrence. Claim each `(repository, run id, run attempt)` before
+   processing so a sender retry cannot start an overlapping ingestion of
+   the same run. Prototyped and dropped: with fix 7 in place replays finish
+   inside the response window, so the retry storm has no trigger.
+7. **Cap the log archive size.** The applied resolution. The receiver
+   downloads at most 15 MiB (+1 byte) of the compressed archive; if the
+   archive is bigger, it skips log ingestion for that run with a "Log
+   archive exceeds size cap" warning naming the repo and run, and the event
+   still succeeds so the sender does not retry (the run keeps its trace
+   spans and metrics). GitHub streams the archive without a Content-Length
+   and rejects HEAD and range requests, so the check happens during the
+   download, bounding the wasted transfer at 15 MiB. Chunked emission
+   (fix 3's emit half) was reverted at the same time: under the cap the
+   original whole-run payload stays comfortably small.
 
 ## Minor findings from the same investigation
 

--- a/packages/app/src/server/github-events/config.ts
+++ b/packages/app/src/server/github-events/config.ts
@@ -1,9 +1,9 @@
 export const GH_EVENTS_CONFIG = {
   maxAttempts: 10,
-  // The collector ingests a run's log archive synchronously before returning
-  // 202; large runs legitimately take ~30s, so give them headroom instead of
-  // aborting and retrying the whole download.
-  replayTimeoutMs: 60_000,
+  // Keep in step with the collector server's WriteTimeout: responses can't
+  // take longer than that anyway, and with the log archive size cap the
+  // collector answers well within it.
+  replayTimeoutMs: 30_000,
   tenantCacheTTLms: 60_000,
   retentionDoneDays: 7,
   retentionDeadDays: 30,


### PR DESCRIPTION
## Summary

- Reduces `maxLogArchiveSize` from 256MB to 15MB and gracefully skips oversized archives instead of failing the event (retrying wouldn't help since the archive size doesn't change)
- Refactors `eventToLogs` to return `*plog.Logs` directly instead of streaming via `consumeLogs` callback, removing the `logEmitter` chunking mechanism
- Adds `everr-write-notebooks` to legacy skill renames
- Updates CHANGELOG and collector OOM runbooks

## Why

Large log archives were OOM-killing the collector. The archive decompresses to ~7x its size and materializes as one in-memory `plog.Logs` payload, so a couple hundred MB of zip becomes a multi-GiB allocation. By capping at 15MB and skipping oversized archives gracefully, the event still succeeds (traces/metrics flow, just without logs) and the sender doesn't retry a download that will always fail.