### PR TITLE
Report web app browser errors to Everr

### DIFF
--- a/packages/app/src/components/root-error.tsx
+++ b/packages/app/src/components/root-error.tsx
@@ -1,0 +1,24 @@
+import { captureReactError } from "@everr/auto-otel-errors/react";
+import { RetryError } from "@everr/ui/components/retry-error";
+import type { ErrorComponentProps } from "@tanstack/react-router";
+import { useEffect } from "react";
+
+// The router's default error component: it catches any route render error in
+// its own per-route boundary (below <Outlet />), so the browser `error`
+// handlers never see these. Report them explicitly, and show a recovery UI
+// instead of the router's bare stock fallback.
+export function RootErrorComponent({ error }: ErrorComponentProps) {
+  useEffect(() => {
+    captureReactError(error);
+  }, [error]);
+
+  return (
+    <div className="flex h-screen items-center justify-center p-6">
+      <RetryError
+        title="Something went wrong"
+        message="An unexpected error occurred. Reloading the page usually fixes it."
+        onRetry={() => window.location.reload()}
+      />
+    </div>
+  );
+}

--- a/packages/app/src/router.tsx
+++ b/packages/app/src/router.tsx
@@ -1,6 +1,7 @@
 import { QueryClient } from "@tanstack/react-query";
 import { createRouteMask, createRouter } from "@tanstack/react-router";
 import { Loader2 } from "lucide-react";
+import { RootErrorComponent } from "./components/root-error";
 import { routeTree } from "./routeTree.gen";
 
 export interface RouterContext {
@@ -39,6 +40,9 @@ export const getRouter = () => {
     routeTree,
     routeMasks: [traceDetailModalMask, errorDetailModalMask],
     context: { queryClient },
+    // Captures and renders any route render error the router catches in its
+    // per-route boundary (routes with their own errorComponent still win).
+    defaultErrorComponent: RootErrorComponent,
     // TODO: maybe preload?
     // defaultPreload: "intent",
     scrollRestoration: true,

--- a/packages/app/src/routes/__root.tsx
+++ b/packages/app/src/routes/__root.tsx
@@ -1,8 +1,6 @@
 // Side-effect import: starts browser error tracking as early as the client
 // bundle loads (no-op during SSR and when unconfigured). See telemetry/client.
 import "@/telemetry/client";
-import { ErrorBoundary } from "@everr/auto-otel-errors/react";
-import { Button } from "@everr/ui/components/button";
 import { Toaster } from "@everr/ui/components/sonner";
 import { TanStackDevtools } from "@tanstack/react-devtools";
 import { FormDevtoolsPanel } from "@tanstack/react-form-devtools";
@@ -83,27 +81,11 @@ export const Route = createRootRouteWithContext<RouterContext>()({
   component: Component,
 });
 
-function AppErrorFallback() {
-  return (
-    <div className="flex h-screen flex-col items-center justify-center gap-4 p-6 text-center">
-      <div className="space-y-1">
-        <h1 className="text-lg font-semibold">Something went wrong</h1>
-        <p className="text-muted-foreground max-w-sm text-sm/relaxed">
-          An unexpected error occurred. Reloading the page usually fixes it.
-        </p>
-      </div>
-      <Button onClick={() => window.location.reload()}>Reload</Button>
-    </div>
-  );
-}
-
 function Component() {
   const { queryClient } = Route.useRouteContext();
   return (
     <QueryClientProvider client={queryClient}>
-      <ErrorBoundary fallback={<AppErrorFallback />}>
-        <Outlet />
-      </ErrorBoundary>
+      <Outlet />
       <TanStackDevtools
         config={{ position: "bottom-right" }}
         plugins={[

--- a/packages/app/src/routes/__root.tsx
+++ b/packages/app/src/routes/__root.tsx
@@ -1,3 +1,8 @@
+// Side-effect import: starts browser error tracking as early as the client
+// bundle loads (no-op during SSR and when unconfigured). See telemetry/client.
+import "@/telemetry/client";
+import { ErrorBoundary } from "@everr/auto-otel-errors/react";
+import { Button } from "@everr/ui/components/button";
 import { Toaster } from "@everr/ui/components/sonner";
 import { TanStackDevtools } from "@tanstack/react-devtools";
 import { FormDevtoolsPanel } from "@tanstack/react-form-devtools";
@@ -78,11 +83,27 @@ export const Route = createRootRouteWithContext<RouterContext>()({
   component: Component,
 });
 
+function AppErrorFallback() {
+  return (
+    <div className="flex h-screen flex-col items-center justify-center gap-4 p-6 text-center">
+      <div className="space-y-1">
+        <h1 className="text-lg font-semibold">Something went wrong</h1>
+        <p className="text-muted-foreground max-w-sm text-sm/relaxed">
+          An unexpected error occurred. Reloading the page usually fixes it.
+        </p>
+      </div>
+      <Button onClick={() => window.location.reload()}>Reload</Button>
+    </div>
+  );
+}
+
 function Component() {
   const { queryClient } = Route.useRouteContext();
   return (
     <QueryClientProvider client={queryClient}>
-      <Outlet />
+      <ErrorBoundary fallback={<AppErrorFallback />}>
+        <Outlet />
+      </ErrorBoundary>
       <TanStackDevtools
         config={{ position: "bottom-right" }}
         plugins={[

--- a/packages/app/src/telemetry/client.ts
+++ b/packages/app/src/telemetry/client.ts
@@ -24,10 +24,10 @@ const BATCH_OPTIONS = {
   exportTimeoutMillis: 30_000,
 };
 
-let started = false;
-
 function initClientErrorTracking(): void {
-  if (started || typeof window === "undefined") return;
+  // Runs once at client bundle load (this is a side-effect module). No-op on
+  // the server.
+  if (typeof window === "undefined") return;
 
   const ingestKey = import.meta.env.VITE_EVERR_PUBLIC_INGEST_KEY?.trim();
   const endpointOverride = import.meta.env.VITE_EVERR_INGEST_ENDPOINT?.trim();
@@ -37,8 +37,6 @@ function initClientErrorTracking(): void {
   // there. In dev, fall back to the local collector so developers see their
   // own browser errors with no setup.
   if (!ingestKey && !endpointOverride && !import.meta.env.DEV) return;
-
-  started = true;
 
   const config = resolveTelemetryConfig(
     {

--- a/packages/app/src/telemetry/client.ts
+++ b/packages/app/src/telemetry/client.ts
@@ -1,0 +1,78 @@
+import { init as initErrorTracking } from "@everr/auto-otel-errors/browser";
+import { logs } from "@opentelemetry/api-logs";
+import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import {
+  BatchLogRecordProcessor,
+  LoggerProvider,
+} from "@opentelemetry/sdk-logs";
+import { resolveTelemetryConfig, signalUrl } from "./config";
+
+// Browser error tracking for the web app (dogfooding): captured errors become
+// OTel log records that ship to Everr over OTLP/HTTP. This mirrors the app's
+// server telemetry (`node.ts`) but for the browser, and reuses the same
+// endpoint/key resolution in `config.ts`.
+//
+// `@everr/auto-otel-errors` is transport-less: its `init()` is a no-op unless a
+// global `LoggerProvider` is registered first, which is exactly what this
+// module does before calling it.
+
+const BATCH_OPTIONS = {
+  maxQueueSize: 100,
+  maxExportBatchSize: 32,
+  scheduledDelayMillis: 5_000,
+  exportTimeoutMillis: 30_000,
+};
+
+let started = false;
+
+function initClientErrorTracking(): void {
+  if (started || typeof window === "undefined") return;
+
+  const ingestKey = import.meta.env.VITE_EVERR_PUBLIC_INGEST_KEY?.trim();
+  const endpointOverride = import.meta.env.VITE_EVERR_INGEST_ENDPOINT?.trim();
+
+  // In production, only send when a public key (or explicit endpoint) is
+  // configured, so a keyless deploy never POSTs to a collector that isn't
+  // there. In dev, fall back to the local collector so developers see their
+  // own browser errors with no setup.
+  if (!ingestKey && !endpointOverride && !import.meta.env.DEV) return;
+
+  started = true;
+
+  const config = resolveTelemetryConfig(
+    {
+      EVERR_INGEST_KEY: ingestKey,
+      OTEL_EXPORTER_OTLP_ENDPOINT: endpointOverride,
+      DEPLOYMENT_ENVIRONMENT: import.meta.env.MODE,
+    },
+    crypto.randomUUID(),
+  );
+  if (!config) return;
+
+  const loggerProvider = new LoggerProvider({
+    resource: resourceFromAttributes(config.resourceAttributes),
+    processors: [
+      new BatchLogRecordProcessor(
+        new OTLPLogExporter({
+          url: signalUrl(config.endpoint, "logs"),
+          headers: config.headers,
+        }),
+        BATCH_OPTIONS,
+      ),
+    ],
+  });
+  logs.setGlobalLoggerProvider(loggerProvider);
+
+  // Installs window `error` / `unhandledrejection` handlers and wires manual
+  // `captureError` / the React `ErrorBoundary`. Each capture emits one log
+  // record through the provider above.
+  initErrorTracking();
+
+  // Best-effort flush of anything still batched when the page goes away.
+  window.addEventListener("beforeunload", () => {
+    void loggerProvider.shutdown();
+  });
+}
+
+initClientErrorTracking();

--- a/packages/app/src/vite-env.d.ts
+++ b/packages/app/src/vite-env.d.ts
@@ -13,7 +13,3 @@ interface ImportMetaEnv {
    */
   readonly VITE_EVERR_INGEST_ENDPOINT?: string;
 }
-
-interface ImportMeta {
-  readonly env: ImportMetaEnv;
-}

--- a/packages/app/src/vite-env.d.ts
+++ b/packages/app/src/vite-env.d.ts
@@ -1,0 +1,19 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  /**
+   * Public (origin-bound, ingest-only) `ek_` key used to send browser error
+   * telemetry to Everr. Safe to ship in the client bundle. When unset in a
+   * production build, browser error tracking stays off.
+   */
+  readonly VITE_EVERR_PUBLIC_INGEST_KEY?: string;
+  /**
+   * Optional OTLP endpoint override for browser telemetry. Defaults to the
+   * hosted ingest endpoint when a key is set, or the local collector in dev.
+   */
+  readonly VITE_EVERR_INGEST_ENDPOINT?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
> Stacked on #296 (browser ingestion). Base branch: `gio/browser-ingestion`. Review/merge that one first.

## What

Dogfoods Everr: the web app now reports its own **browser** errors to Everr, using the public browser ingest keys added in the base PR.

Captured and sent as OTel log records:
- Uncaught errors (`window.onerror`)
- Unhandled promise rejections
- React render errors, via a new root `ErrorBoundary` (the app had none), which also gives users a "Something went wrong / Reload" fallback instead of a blank page.

## How

- **`telemetry/client.ts`** (new): builds a browser `LoggerProvider` + `OTLPLogExporter`, registers it globally, then calls `@everr/auto-otel-errors/browser`'s `init()`. The SDK is transport-less, so this provider wiring is what makes capture actually send. Reuses the existing `telemetry/config.ts` endpoint/key resolution. Flushes on `beforeunload`. Self-guards to the browser, so it's a no-op during SSR.
- **`__root.tsx`**: side-effect import of the telemetry module (earliest client init, no-op on the server) plus the root `ErrorBoundary`.
- **`vite-env.d.ts`** (new): types the client env var.

No new dependencies: `sdk-logs`, `exporter-logs-otlp-http`, and `api-logs` were already in `packages/app`.

## Configuration

A new client env var, `VITE_EVERR_PUBLIC_INGEST_KEY`, holds a **public** `ek_` key (origin-bound, ingest-only, safe to ship in the bundle). Behavior by environment:

- **Production**: sends to `https://ingest.everr.dev` with the public key. With no key set, error tracking stays off (no-op), so a keyless deploy never POSTs anywhere.
- **Local dev**: falls back to the local collector (`127.0.0.1:54318`, no auth) so developers see their own browser errors with no setup.

To activate in production: mint a public browser key from the API keys page (allowed origin = the app's domain) and set `VITE_EVERR_PUBLIC_INGEST_KEY` at build/deploy. The key value is not committed.

## Scope

Errors only (logs). Out of scope: browser traces/spans, console capture, network/fetch capture, session replay.

## Verification

Typecheck, biome, fallow, and the full app test suite (1228 passing) are green. The production build succeeds and the client bundle includes the capture code; the browser telemetry module is SSR-safe (window-guarded, no top-level DOM access). The live send path depends on the collector CORS + the public key's allowed origins from the base PR.
