### PR TITLE
Add Run test to the simplified alert detail page

### DIFF
--- a/packages/app/src/data/alerts/history.server.test.ts
+++ b/packages/app/src/data/alerts/history.server.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { queryAlertHistory } from "./history.server";
+import { queryAlertEventLog, queryAlertHistory } from "./history.server";
 
 describe("queryAlertHistory", () => {
   it("filters app.logs by scope, slug, event type, and time range", async () => {
@@ -90,6 +90,140 @@ describe("queryAlertHistory", () => {
     const row = await runWithRawRow({
       evidenceJson: '{"count":1}',
     });
+    expect(row).not.toHaveProperty("evidenceJson");
+  });
+});
+
+describe("queryAlertEventLog", () => {
+  it("filters app.logs by service, scope, and time range only (rule-agnostic)", async () => {
+    const ch = vi.fn().mockResolvedValue([]);
+    await queryAlertEventLog(ch, {
+      limit: 200,
+      fromISO: "2026-06-01T00:00:00Z",
+      toISO: "2026-06-16T00:00:00Z",
+    });
+    const [sql, params] = ch.mock.calls[0];
+    expect(sql).toContain("FROM app.logs");
+    expect(sql).toContain("ServiceName = 'alert'");
+    expect(sql).toContain("ScopeName = 'everr.alerting'");
+    // No per-rule or per-event-type narrowing: the monitor shows everything.
+    expect(sql).not.toContain("alert.slug'] =");
+    expect(sql).not.toContain("IN ('instance_fired'");
+    // Tenancy comes from the row-level policy, never a SQL org filter.
+    expect(sql).not.toMatch(/organization|tenant_id/);
+    // DateTime64 params: resolveTimeRange emits fractional seconds, which a
+    // String -> DateTime coercion rejects (TYPE_MISMATCH).
+    expect(sql).toContain("TimestampTime >= {fromTime:DateTime64(3)}");
+    expect(sql).toContain("TimestampTime <= {toTime:DateTime64(3)}");
+    expect(sql).toContain("LIMIT {limit:UInt32}");
+    expect(params).toMatchObject({
+      limit: 200,
+      fromTime: "2026-06-01T00:00:00Z",
+      toTime: "2026-06-16T00:00:00Z",
+    });
+  });
+
+  const baseRawRow = {
+    timestamp: "2026-06-10T00:00:00Z",
+    eventType: "instance_fired",
+    slug: "high-5xx",
+    instanceFingerprint: "fp1",
+    instanceLabelsJson: '{"host":"web-1"}',
+    severity: "",
+    suppressed: "false",
+    silenced: "",
+    deliveryTargetsRaw: "",
+    evidenceJson: "",
+  };
+
+  async function runWithRawRow(overrides: Record<string, string>) {
+    const ch = vi.fn().mockResolvedValue([{ ...baseRawRow, ...overrides }]);
+    const [row] = await queryAlertEventLog(ch, {
+      limit: 200,
+      fromISO: "2026-06-01T00:00:00Z",
+      toISO: "2026-06-16T00:00:00Z",
+    });
+    return row;
+  }
+
+  it("maps attributes onto the row shape", async () => {
+    const row = await runWithRawRow({});
+    expect(row).toMatchObject({
+      timestamp: "2026-06-10T00:00:00Z",
+      eventType: "instance_fired",
+      slug: "high-5xx",
+      instanceFingerprint: "fp1",
+      labels: { host: "web-1" },
+      severity: "",
+      suppressed: false,
+      silenced: false,
+      deliveryTargets: [],
+      evidence: null,
+    });
+  });
+
+  it("collapses malformed or non-object instance labels to {}", async () => {
+    expect(
+      (await runWithRawRow({ instanceLabelsJson: "{oops" })).labels,
+    ).toEqual({});
+    expect(
+      (await runWithRawRow({ instanceLabelsJson: "[1,2]" })).labels,
+    ).toEqual({});
+    expect((await runWithRawRow({ instanceLabelsJson: "" })).labels).toEqual(
+      {},
+    );
+  });
+
+  it("stringifies non-string label values instead of dropping them", async () => {
+    const row = await runWithRawRow({
+      instanceLabelsJson: '{"host":"web-1","code":500}',
+    });
+    expect(row.labels).toEqual({ host: "web-1", code: "500" });
+  });
+
+  it("maps suppressed and silenced flags to booleans (literal 'true' only)", async () => {
+    expect((await runWithRawRow({ suppressed: "true" })).suppressed).toBe(true);
+    expect((await runWithRawRow({ suppressed: "" })).suppressed).toBe(false);
+    expect((await runWithRawRow({ silenced: "true" })).silenced).toBe(true);
+    expect((await runWithRawRow({ silenced: "false" })).silenced).toBe(false);
+  });
+
+  it("parses comma-joined delivery targets (CC's current shape)", async () => {
+    const row = await runWithRawRow({
+      deliveryTargetsRaw: "ops-slack, pagerduty-primary",
+    });
+    expect(row.deliveryTargets).toEqual(["ops-slack", "pagerduty-primary"]);
+  });
+
+  it("parses JSON-array and JSON-object delivery targets (older shapes)", async () => {
+    expect(
+      (await runWithRawRow({ deliveryTargetsRaw: '["a","b"]' }))
+        .deliveryTargets,
+    ).toEqual(["a", "b"]);
+    expect(
+      (await runWithRawRow({ deliveryTargetsRaw: '{"slack":["ops"]}' }))
+        .deliveryTargets,
+    ).toEqual(["slack:ops"]);
+  });
+
+  it("treats malformed delivery targets as a comma-joined string", async () => {
+    const row = await runWithRawRow({ deliveryTargetsRaw: "{not json" });
+    expect(row.deliveryTargets).toEqual(["{not json"]);
+  });
+
+  it("parses evidence with the same defensive rules as the per-slug reader", async () => {
+    expect(
+      (await runWithRawRow({ evidenceJson: '{"count":42}' })).evidence,
+    ).toEqual({ count: 42 });
+    expect(
+      (await runWithRawRow({ evidenceJson: "{oops" })).evidence,
+    ).toBeNull();
+  });
+
+  it("does not leak raw projection fields onto the mapped row", async () => {
+    const row = await runWithRawRow({});
+    expect(row).not.toHaveProperty("instanceLabelsJson");
+    expect(row).not.toHaveProperty("deliveryTargetsRaw");
     expect(row).not.toHaveProperty("evidenceJson");
   });
 });

--- a/packages/app/src/data/alerts/history.server.ts
+++ b/packages/app/src/data/alerts/history.server.ts
@@ -52,6 +52,53 @@ function parseEvidence(json: string): AlertEvidence | null {
   return null;
 }
 
+// Parse a JSON object of instance labels into a string->string record. CC writes
+// alert.instance_labels as a JSON object of strings; anything else collapses to {}.
+function parseStringMap(json: string): Record<string, string> {
+  if (!json) return {};
+  try {
+    const parsed: unknown = JSON.parse(json);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return Object.fromEntries(
+        Object.entries(parsed).map(([k, v]) => [
+          k,
+          typeof v === "string" ? v : JSON.stringify(v),
+        ]),
+      );
+    }
+  } catch {
+    // malformed labels -> {}
+  }
+  return {};
+}
+
+// alert.delivery_targets: CC currently emits a comma-joined list of target names,
+// but earlier shapes were JSON (array, or object of channel -> names). Accept all
+// three so the reader survives records from any CC version.
+function parseDeliveryTargets(raw: string): string[] {
+  if (!raw) return [];
+  const t = raw.trim();
+  if (t.startsWith("[") || t.startsWith("{")) {
+    try {
+      const parsed: unknown = JSON.parse(t);
+      if (Array.isArray(parsed)) return parsed.map((v) => String(v));
+      if (parsed && typeof parsed === "object") {
+        return Object.entries(parsed).flatMap(([channel, names]) =>
+          Array.isArray(names)
+            ? names.map((n) => `${channel}:${String(n)}`)
+            : [`${channel}:${String(names)}`],
+        );
+      }
+    } catch {
+      // fall through to the comma-joined form
+    }
+  }
+  return t
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
 /**
  * Per-alert event history from app.logs. The collector lands CC's alert events here
  * (ScopeName='everr.alerting'), keyed by alert.slug. Row-level security pins the tenant
@@ -81,8 +128,8 @@ export async function queryAlertHistory(
       WHERE ScopeName = 'everr.alerting'
         AND LogAttributes['alert.slug'] = {slug:String}
         AND LogAttributes['alert.event_type'] IN ('instance_fired', 'instance_resolved')
-        AND TimestampTime >= {fromTime:String}
-        AND TimestampTime <= {toTime:String}
+        AND TimestampTime >= {fromTime:DateTime64(3)}
+        AND TimestampTime <= {toTime:DateTime64(3)}
       ORDER BY Timestamp DESC
       LIMIT {limit:UInt32}
     `,
@@ -98,4 +145,101 @@ export async function queryAlertHistory(
     evidence: parseEvidence(evidenceJson),
     evidenceTruncated: evidenceTruncated === "true",
   }));
+}
+
+// One row of the rule-agnostic alerting event log (all slugs, all event types).
+export type AlertEventLogRow = {
+  timestamp: string;
+  // alert.event_type: instance_fired | instance_resolved | rule_health | delivery | silenced
+  eventType: string;
+  slug: string; // alert.slug (everr.name annotation, falling back to the rule id)
+  instanceFingerprint: string;
+  labels: Record<string, string>; // alert.instance_labels decoded
+  // alert.severity when CC stamps it; empty today (records carry no severity attribute),
+  // selected defensively so it flows through once CC adds it.
+  severity: string;
+  suppressed: boolean; // alert.suppressed === "true"
+  silenced: boolean; // alert.silenced === "true" (only on dispatcher records)
+  deliveryTargets: string[]; // alert.delivery_targets decoded (only on delivery records)
+  evidence: AlertEvidence | null;
+};
+
+type AlertEventLogRawRow = {
+  timestamp: string;
+  eventType: string;
+  slug: string;
+  instanceFingerprint: string;
+  instanceLabelsJson: string;
+  severity: string;
+  suppressed: string;
+  silenced: string;
+  deliveryTargetsRaw: string;
+  evidenceJson: string;
+};
+
+/**
+ * Rule-agnostic alerting event log from app.logs: every CC event the collector landed
+ * (ScopeName='everr.alerting'), regardless of slug or event type. Backs the monitor
+ * stream's historical page under the live SSE tail. Row-level security pins the tenant
+ * via SQL_everr_tenant_id, so this never filters by organization_id in SQL.
+ *
+ * ServiceName='alert' is CC's stable resource attribute (src/otel/exporter.rs; the
+ * trusted collector pipeline passes it through). Filtering on it lets this scan use
+ * the app.logs ORDER BY prefix (tenant_id, ServiceName, TimestampTime) instead of
+ * skipping ServiceName. It also skips legacy 'alert-preview' rows from the retired
+ * in-process evaluator; CC previews arrive as ServiceName='alert' with
+ * alert.suppressed='true'.
+ *
+ * The time params are DateTime64(3) (not String) because resolveTimeRange emits
+ * 'YYYY-MM-DD HH:mm:ss.SSS' and ClickHouse cannot coerce a fractional-seconds
+ * string to the column's plain DateTime.
+ */
+export async function queryAlertEventLog(
+  clickhouse: ClickhouseQuery,
+  opts: { limit: number; fromISO: string; toISO: string },
+): Promise<AlertEventLogRow[]> {
+  const rows = await clickhouse<AlertEventLogRawRow>(
+    `
+      SELECT
+        concat(formatDateTime(TimestampTime, '%Y-%m-%dT%H:%i:%S', 'UTC'), 'Z') AS timestamp,
+        LogAttributes['alert.event_type']           AS eventType,
+        LogAttributes['alert.slug']                 AS slug,
+        LogAttributes['alert.instance_fingerprint'] AS instanceFingerprint,
+        LogAttributes['alert.instance_labels']      AS instanceLabelsJson,
+        LogAttributes['alert.severity']             AS severity,
+        LogAttributes['alert.suppressed']           AS suppressed,
+        LogAttributes['alert.silenced']             AS silenced,
+        LogAttributes['alert.delivery_targets']     AS deliveryTargetsRaw,
+        LogAttributes['alert.evidence_json']        AS evidenceJson
+      FROM app.logs
+      WHERE ServiceName = 'alert'
+        AND ScopeName = 'everr.alerting'
+        AND TimestampTime >= {fromTime:DateTime64(3)}
+        AND TimestampTime <= {toTime:DateTime64(3)}
+      ORDER BY Timestamp DESC
+      LIMIT {limit:UInt32}
+    `,
+    {
+      fromTime: opts.fromISO,
+      toTime: opts.toISO,
+      limit: opts.limit,
+    },
+  );
+  return rows.map(
+    ({
+      instanceLabelsJson,
+      suppressed,
+      silenced,
+      deliveryTargetsRaw,
+      evidenceJson,
+      ...row
+    }) => ({
+      ...row,
+      labels: parseStringMap(instanceLabelsJson),
+      suppressed: suppressed === "true",
+      silenced: silenced === "true",
+      deliveryTargets: parseDeliveryTargets(deliveryTargetsRaw),
+      evidence: parseEvidence(evidenceJson),
+    }),
+  );
 }

--- a/packages/app/src/data/alerts/preview-cleanup.server.test.ts
+++ b/packages/app/src/data/alerts/preview-cleanup.server.test.ts
@@ -5,9 +5,14 @@ vi.mock("@/data/cc/client", () => ({
   deleteRule: vi.fn(),
 }));
 
+// The sweep's production db path pulls in @/db/client, which reads server-only
+// env at import; the tests drive the sweep through an injected fake instead, so
+// a stub keeps the real client (and its env access) out of the jsdom runner.
+vi.mock("@/db/client", () => ({ db: {} }));
+
 // The logger emits via the OTel API; keep it inert and assertable.
 vi.mock("@/telemetry/logger", () => ({
-  serverLogger: { error: vi.fn() },
+  serverLogger: { error: vi.fn(), info: vi.fn() },
   errorMessage: (reason: unknown) =>
     reason instanceof Error ? reason.message : String(reason),
 }));
@@ -15,7 +20,11 @@ vi.mock("@/telemetry/logger", () => ({
 import * as cc from "@/data/cc/client";
 import { serverLogger } from "@/telemetry/logger";
 import { MANAGED_SIMPLE, OWN_MANAGED, OWN_PREVIEW, OWN_REPO } from "./mapping";
-import { deletePreviewCcRules } from "./preview-cleanup.server";
+import {
+  deletePreviewCcRules,
+  type OrphanSweepDb,
+  sweepOrphanCcRules,
+} from "./preview-cleanup.server";
 
 const mockedListRules = cc.listRules as ReturnType<typeof vi.fn>;
 const mockedDeleteRule = cc.deleteRule as ReturnType<typeof vi.fn>;
@@ -94,5 +103,122 @@ describe("deletePreviewCcRules", () => {
     );
     // The other org's cleanup still ran.
     expect(mockedDeleteRule).toHaveBeenCalledWith("org-b", "b1");
+  });
+});
+
+/**
+ * A fake registry: `orgs` are the orgs to sweep; `existing` is the set of
+ * preview ids that still have a registry row. `existingPreviewIds` records the
+ * order of its calls relative to `listRules` so a test can assert the race
+ * guard (list before snapshot).
+ */
+function fakeSweepDb(
+  orgs: string[],
+  existing: Set<string>,
+  onSnapshot?: (orgId: string) => void,
+): OrphanSweepDb {
+  return {
+    listPreviewOrgs: async () => orgs,
+    existingPreviewIds: async (orgId, ids) => {
+      onSnapshot?.(orgId);
+      return new Set([...ids].filter((id) => existing.has(id)));
+    },
+  };
+}
+
+describe("sweepOrphanCcRules", () => {
+  it("deletes preview rules whose annotation id is absent from the registry", async () => {
+    mockedListRules.mockResolvedValue([
+      ccRule("live"), // no preview annotation → never touched
+      ccRule("keep", "p-live"), // registry row still exists → kept
+      ccRule("orphan1", "p-gone"), // no registry row → orphan
+      ccRule("orphan2", "p-gone2"),
+    ]);
+    const db = fakeSweepDb(["org-a"], new Set(["p-live"]));
+
+    await sweepOrphanCcRules(db);
+
+    expect(mockedDeleteRule.mock.calls).toEqual([
+      ["org-a", "orphan1"],
+      ["org-a", "orphan2"],
+    ]);
+  });
+
+  it("keeps a preview created between the list and the registry snapshot (race guard)", async () => {
+    // The rule is listed while its preview looks gone, but the registry
+    // snapshot (read AFTER the list) shows the row present → retained.
+    const calls: string[] = [];
+    mockedListRules.mockImplementation(async (orgId: string) => {
+      calls.push(`list:${orgId}`);
+      return [ccRule("racy", "p-racy")];
+    });
+    const db = fakeSweepDb(["org-a"], new Set(["p-racy"]), (orgId) =>
+      calls.push(`snapshot:${orgId}`),
+    );
+
+    await sweepOrphanCcRules(db);
+
+    // Snapshot happened strictly after the list, and nothing was deleted.
+    expect(calls).toEqual(["list:org-a", "snapshot:org-a"]);
+    expect(mockedDeleteRule).not.toHaveBeenCalled();
+  });
+
+  it("caps deletions per org and flags the run as capped", async () => {
+    const rules = Array.from({ length: 150 }, (_, i) =>
+      ccRule(`orphan-${i}`, `p-${i}`),
+    );
+    mockedListRules.mockResolvedValue(rules);
+    const db = fakeSweepDb(["org-a"], new Set());
+
+    await sweepOrphanCcRules(db);
+
+    expect(mockedDeleteRule).toHaveBeenCalledTimes(100);
+    expect(serverLogger.info).toHaveBeenCalledWith(
+      "previews.cc_orphan_sweep.swept",
+      expect.objectContaining({
+        "organization.id": "org-a",
+        "previews.orphan_rules_deleted": 100,
+        "previews.orphan_sweep_capped": true,
+      }),
+    );
+  });
+
+  it("logs and continues to the next org when CC is unreachable for one", async () => {
+    mockedListRules.mockImplementation(async (orgId: string) => {
+      if (orgId === "org-a") throw new Error("cc down");
+      return [ccRule("orphan", "p-gone")];
+    });
+    const db = fakeSweepDb(["org-a", "org-b"], new Set());
+
+    let threw = false;
+    try {
+      await sweepOrphanCcRules(db);
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(false);
+
+    expect(serverLogger.error).toHaveBeenCalledWith(
+      "previews.cc_orphan_sweep.failed",
+      expect.objectContaining({
+        "organization.id": "org-a",
+        "error.message": "cc down",
+      }),
+    );
+    // The healthy org was still swept.
+    expect(mockedDeleteRule).toHaveBeenCalledWith("org-b", "orphan");
+  });
+
+  it("does not read the registry or delete when an org has no preview rules", async () => {
+    mockedListRules.mockResolvedValue([ccRule("live")]);
+    const snapshots: string[] = [];
+    const db = fakeSweepDb(["org-a"], new Set(), (orgId) =>
+      snapshots.push(orgId),
+    );
+
+    await sweepOrphanCcRules(db);
+
+    expect(snapshots).toEqual([]);
+    expect(mockedDeleteRule).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/data/alerts/preview-cleanup.server.ts
+++ b/packages/app/src/data/alerts/preview-cleanup.server.ts
@@ -1,6 +1,28 @@
+import { and, eq, inArray } from "drizzle-orm";
 import * as cc from "@/data/cc/client";
+import { db } from "@/db/client";
+import { previews } from "@/db/schema";
 import { errorMessage, serverLogger } from "@/telemetry/logger";
 import { previewIdOf } from "./mapping";
+
+/** At most this many orphan rules are deleted per org per sweep run. */
+const ORPHAN_SWEEP_CAP_PER_ORG = 100;
+
+/**
+ * Delete the given CC rule ids for one org, at most `cap` of them (0 = no cap).
+ * Shared by the on-delete fast path and the periodic sweep. Returns how many
+ * were deleted and whether the cap clipped the list.
+ */
+async function deleteCcRules(
+  orgId: string,
+  ruleIds: readonly string[],
+  cap = 0,
+): Promise<{ deleted: number; capped: boolean }> {
+  const capped = cap > 0 && ruleIds.length > cap;
+  const targets = capped ? ruleIds.slice(0, cap) : ruleIds;
+  for (const id of targets) await cc.deleteRule(orgId, id);
+  return { deleted: targets.length, capped };
+}
 
 /**
  * Best-effort removal of the suppressed CC rules left behind by deleted
@@ -13,8 +35,8 @@ import { previewIdOf } from "./mapping";
  * rules of a preview that just came back to life) and means a CC outage can
  * never block retention. The tradeoff: if CC is unreachable here, the
  * suppressed rules are orphaned (they keep evaluating but never notify) with
- * no automatic retry — we log the org and preview ids so they can be cleaned
- * up manually.
+ * no immediate retry — {@link sweepOrphanCcRules} is the periodic backstop
+ * that eventually reaps them.
  */
 export async function deletePreviewCcRules(
   deleted: readonly { id: string; organizationId: string }[],
@@ -28,16 +50,120 @@ export async function deletePreviewCcRules(
   for (const [orgId, previewIds] of byOrg) {
     try {
       const rules = await cc.listRules(orgId);
-      for (const rule of rules) {
-        const previewId = previewIdOf(rule.spec);
-        if (previewId !== null && previewIds.has(previewId)) {
-          await cc.deleteRule(orgId, rule.id);
-        }
-      }
+      const ruleIds = rules
+        .filter((rule) => {
+          const previewId = previewIdOf(rule.spec);
+          return previewId !== null && previewIds.has(previewId);
+        })
+        .map((rule) => rule.id);
+      await deleteCcRules(orgId, ruleIds);
     } catch (error) {
       serverLogger.error("previews.cc_cleanup.failed", {
         "organization.id": orgId,
         "previews.ids": [...previewIds].join(","),
+        "error.message": errorMessage(error),
+      });
+    }
+  }
+}
+
+/**
+ * The Postgres reads the orphan sweep needs, behind an interface so the
+ * decision logic can be unit-tested with a fake (the CC client is mocked at
+ * the module boundary, like the rest of this file's tests).
+ */
+export interface OrphanSweepDb {
+  /** Distinct orgs with at least one preview registry row. */
+  listPreviewOrgs(): Promise<string[]>;
+  /**
+   * Which of `ids` still exist as registry rows for `orgId`. Read AFTER the CC
+   * listing so it is the race-guard snapshot (see {@link sweepOrphanCcRules}).
+   */
+  existingPreviewIds(
+    orgId: string,
+    ids: readonly string[],
+  ): Promise<Set<string>>;
+}
+
+const productionDb: OrphanSweepDb = {
+  async listPreviewOrgs() {
+    const rows = await db
+      .selectDistinct({ organizationId: previews.organizationId })
+      .from(previews);
+    return rows.map((row) => row.organizationId);
+  },
+  async existingPreviewIds(orgId, ids) {
+    if (ids.length === 0) return new Set();
+    const rows = await db
+      .select({ id: previews.id })
+      .from(previews)
+      .where(
+        and(eq(previews.organizationId, orgId), inArray(previews.id, [...ids])),
+      );
+    return new Set(rows.map((row) => row.id));
+  },
+};
+
+/**
+ * Durable backstop for the on-delete fast path: reaps suppressed CC rules whose
+ * everr.preview annotation names a preview that no longer exists in the
+ * registry. These accumulate when {@link deletePreviewCcRules} could not reach
+ * CC at deletion time; left alone they evaluate forever and never notify.
+ *
+ * Scope: every org that still has at least one preview registry row — the orgs
+ * where preview churn (and therefore orphaning) realistically happens. An org
+ * that deleted its last preview while CC was down keeps its orphans until it
+ * next applies a preview; that is an accepted, rare gap, not worth listing CC
+ * for every tenant in the system.
+ *
+ * Race guard: for each org we list the CC rules FIRST, then snapshot the
+ * registry. A preview created between the two reads writes its registry row
+ * before its CC rules (see upsertPreview → reconcile ordering), so any rule we
+ * listed has its parent row present in the snapshot and is retained. We only
+ * ever delete a rule whose annotation id is absent from a registry snapshot
+ * taken strictly after the list.
+ *
+ * CC unavailability is tolerated per org: a failing org is logged and skipped,
+ * and the next hourly run retries it. Deletions are capped per org per run so a
+ * pathological backlog cannot monopolize a single run.
+ */
+export async function sweepOrphanCcRules(
+  sweepDb: OrphanSweepDb = productionDb,
+): Promise<void> {
+  const orgs = await sweepDb.listPreviewOrgs();
+  for (const orgId of orgs) {
+    try {
+      // List first — the registry snapshot below must be strictly newer.
+      const rules = await cc.listRules(orgId);
+      const referenced = new Set<string>();
+      for (const rule of rules) {
+        const previewId = previewIdOf(rule.spec);
+        if (previewId !== null) referenced.add(previewId);
+      }
+      if (referenced.size === 0) continue;
+
+      const live = await sweepDb.existingPreviewIds(orgId, [...referenced]);
+      const orphanRuleIds = rules
+        .filter((rule) => {
+          const previewId = previewIdOf(rule.spec);
+          return previewId !== null && !live.has(previewId);
+        })
+        .map((rule) => rule.id);
+      if (orphanRuleIds.length === 0) continue;
+
+      const { deleted, capped } = await deleteCcRules(
+        orgId,
+        orphanRuleIds,
+        ORPHAN_SWEEP_CAP_PER_ORG,
+      );
+      serverLogger.info("previews.cc_orphan_sweep.swept", {
+        "organization.id": orgId,
+        "previews.orphan_rules_deleted": deleted,
+        "previews.orphan_sweep_capped": capped,
+      });
+    } catch (error) {
+      serverLogger.error("previews.cc_orphan_sweep.failed", {
+        "organization.id": orgId,
         "error.message": errorMessage(error),
       });
     }

--- a/packages/app/src/data/alerts/server.test.ts
+++ b/packages/app/src/data/alerts/server.test.ts
@@ -13,6 +13,7 @@ vi.mock("@/data/cc/client", () => ({
   deleteSilence: vi.fn(),
   pauseRule: vi.fn(),
   resumeRule: vi.fn(),
+  testRule: vi.fn(),
   listReceivers: vi.fn(),
   upsertReceiver: vi.fn(),
   listRoutes: vi.fn(),
@@ -36,6 +37,7 @@ import {
   getAlertSettings,
   listAlertSilences,
   listAlerts,
+  testAlert,
   updateAlertSettings,
 } from "./server";
 
@@ -580,5 +582,55 @@ describe("activate/deactivate", () => {
     mock(cc.pauseRule).mockResolvedValue({ id: "rule-1" });
     await deactivateAlert({ data: { alertId: "rule-1" } });
     expect(cc.pauseRule).toHaveBeenCalledWith("test_org", "rule-1");
+  });
+});
+
+describe("testAlert", () => {
+  const testResult = {
+    matched: 2,
+    rows: [{ labels: { route: "/x" }, value: 5 }],
+  };
+
+  it("tests the CC rule with the loaded spec", async () => {
+    mock(cc.getRule).mockResolvedValue(ruleView());
+    mock(cc.testRule).mockResolvedValue(testResult);
+    const out = await testAlert({ data: { alertId: "rule-1" } });
+    expect(cc.testRule).toHaveBeenCalledWith(
+      "test_org",
+      "rule-1",
+      ruleView().spec,
+    );
+    expect(out).toEqual(testResult);
+  });
+
+  it("rejects non-managed rules without testing", async () => {
+    mock(cc.getRule).mockResolvedValue(
+      ruleView({ spec: { ...ruleView().spec, annotations: {} } }),
+    );
+    try {
+      await testAlert({ data: { alertId: "x" } });
+      expect.fail("expected testAlert to reject a non-managed rule");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe("Alert not found");
+    }
+    expect(cc.testRule).not.toHaveBeenCalled();
+  });
+
+  it("is gated to org admins, like pause/resume", async () => {
+    vi.mocked(auth.api.getActiveMemberRole).mockResolvedValue({
+      role: "member",
+    } as never);
+    mock(cc.getRule).mockResolvedValue(ruleView());
+    try {
+      await testAlert({ data: { alertId: "rule-1" } });
+      expect.fail("expected testAlert to reject a non-admin");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe(
+        "Only organization admins can manage alerts",
+      );
+    }
+    expect(cc.testRule).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/data/alerts/server.ts
+++ b/packages/app/src/data/alerts/server.ts
@@ -658,3 +658,18 @@ export const activateAlert = createAuthenticatedServerFn({ method: "POST" })
     await ensureOrgAdmin();
     return cc.resumeRule(session.session.activeOrganizationId, alertId);
   });
+
+// Ad-hoc evaluation of the alert's current spec against ClickHouse, changing no
+// state (no instances, events, or notifications). Gated like the pause/resume
+// mutations: the simplified page never exposes the raw CC spec, so — unlike the
+// power-user testCcRule — the spec is loaded here from the managed rule rather
+// than trusted from the client.
+export const testAlert = createAuthenticatedServerFn({ method: "POST" })
+  .inputValidator(alertIdInput)
+  .handler(async ({ data: { alertId }, context: { session } }) => {
+    const org = session.session.activeOrganizationId;
+    await ensureOrgAdmin();
+    const rule = await cc.getRule(org, alertId);
+    if (!isManagedSimple(rule.spec)) throw new Error("Alert not found");
+    return cc.testRule(org, alertId, rule.spec);
+  });

--- a/packages/app/src/data/cc/server.ts
+++ b/packages/app/src/data/cc/server.ts
@@ -1,4 +1,6 @@
+import { resolveTimeRange, TimeRangeSchema } from "@everr/ui/lib/time-range";
 import { z } from "zod";
+import { queryAlertEventLog } from "@/data/alerts/history.server";
 import { createAuthenticatedServerFn } from "@/lib/serverFn";
 import * as cc from "./client";
 import { CcMatcherSchema, CcRuleSpecSchema } from "./schema";
@@ -40,6 +42,21 @@ export const listCcSilences = createAuthenticatedServerFn({
 export const listCcSubscriptions = createAuthenticatedServerFn({
   method: "GET",
 }).handler(({ context: { session } }) => cc.listSubscriptions(orgId(session)));
+
+// Stored CC event history (all rules, all event types) from ClickHouse app.logs.
+// Tenancy rides on the org-scoped clickhouse context (row-level policy), not on a
+// SQL organization filter. Backs the monitor stream's historical page.
+export const listCcEventHistory = createAuthenticatedServerFn({ method: "GET" })
+  .inputValidator(
+    z.object({
+      limit: z.number().int().min(1).max(500).default(200),
+      timeRange: TimeRangeSchema,
+    }),
+  )
+  .handler(({ data: { limit, timeRange }, context: { clickhouse } }) => {
+    const { fromISO, toISO } = resolveTimeRange(timeRange);
+    return queryAlertEventLog(clickhouse.query, { limit, fromISO, toISO });
+  });
 
 // ---- Rule operations ----
 export const pauseCcRule = createAuthenticatedServerFn({ method: "POST" })

--- a/packages/app/src/data/cc/unified-events.test.ts
+++ b/packages/app/src/data/cc/unified-events.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+import type { AlertEventLogRow } from "@/data/alerts/history.server";
+import type { CcEvent } from "./types";
+import {
+  CC_UNIFIED_EVENTS_CAP,
+  ccEventDedupKey,
+  historyToUnified,
+  liveToUnified,
+  mergeCcEvents,
+} from "./unified-events";
+
+function liveEvent(overrides: Partial<CcEvent> = {}): CcEvent {
+  return {
+    tenant: "org1",
+    rule: "5a1e8d6a-0000-0000-0000-000000000000",
+    instance_key: "fp1",
+    status: "firing",
+    labels: { host: "web-1" },
+    value: 1,
+    severity: "critical",
+    annotations: {},
+    eval_ts: "2026-06-10T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function historyRow(
+  overrides: Partial<AlertEventLogRow> = {},
+): AlertEventLogRow {
+  return {
+    timestamp: "2026-06-10T12:00:00Z",
+    eventType: "instance_fired",
+    slug: "high-5xx",
+    instanceFingerprint: "fp1",
+    labels: { host: "web-1" },
+    severity: "",
+    suppressed: false,
+    silenced: false,
+    deliveryTargets: [],
+    evidence: null,
+    ...overrides,
+  };
+}
+
+describe("ccEventDedupKey", () => {
+  it("floors timestamps to whole seconds so SSE millis match stored seconds", () => {
+    expect(
+      ccEventDedupKey("fp1", "2026-06-10T12:00:00.734Z", "instance_fired"),
+    ).toBe(ccEventDedupKey("fp1", "2026-06-10T12:00:00Z", "instance_fired"));
+  });
+
+  it("separates different fingerprints, seconds, and event types", () => {
+    const base = ccEventDedupKey(
+      "fp1",
+      "2026-06-10T12:00:00Z",
+      "instance_fired",
+    );
+    expect(
+      ccEventDedupKey("fp2", "2026-06-10T12:00:00Z", "instance_fired"),
+    ).not.toBe(base);
+    expect(
+      ccEventDedupKey("fp1", "2026-06-10T12:00:01Z", "instance_fired"),
+    ).not.toBe(base);
+    expect(
+      ccEventDedupKey("fp1", "2026-06-10T12:00:00Z", "instance_resolved"),
+    ).not.toBe(base);
+  });
+
+  it("keeps an unparseable timestamp verbatim instead of collapsing to one bucket", () => {
+    expect(ccEventDedupKey("fp1", "garbage-a", "delivery")).not.toBe(
+      ccEventDedupKey("fp1", "garbage-b", "delivery"),
+    );
+  });
+});
+
+describe("liveToUnified", () => {
+  it("maps firing/resolved onto the stored event_type vocabulary", () => {
+    expect(liveToUnified(liveEvent()).eventType).toBe("instance_fired");
+    expect(liveToUnified(liveEvent({ status: "resolved" })).eventType).toBe(
+      "instance_resolved",
+    );
+  });
+
+  it("maps rule_health kind regardless of status and drops the status badge", () => {
+    const u = liveToUnified(liveEvent({ kind: "rule_health" }));
+    expect(u.eventType).toBe("rule_health");
+    expect(u.status).toBeNull();
+  });
+
+  it("prefers the everr.name annotation as the rule handle, falling back to the id", () => {
+    expect(
+      liveToUnified(liveEvent({ annotations: { "everr.name": "high-5xx" } }))
+        .rule,
+    ).toBe("high-5xx");
+    expect(liveToUnified(liveEvent()).rule).toBe(
+      "5a1e8d6a-0000-0000-0000-000000000000",
+    );
+  });
+
+  it("is marked live and carries severity", () => {
+    const u = liveToUnified(liveEvent());
+    expect(u.source).toBe("live");
+    expect(u.severity).toBe("critical");
+  });
+});
+
+describe("historyToUnified", () => {
+  it("derives the status badge only for instance transitions", () => {
+    expect(historyToUnified(historyRow()).status).toBe("firing");
+    expect(
+      historyToUnified(historyRow({ eventType: "instance_resolved" })).status,
+    ).toBe("resolved");
+    expect(
+      historyToUnified(historyRow({ eventType: "delivery" })).status,
+    ).toBeNull();
+    expect(
+      historyToUnified(historyRow({ eventType: "rule_health" })).status,
+    ).toBeNull();
+  });
+
+  it("maps empty severity to null and keeps a stamped one", () => {
+    expect(historyToUnified(historyRow()).severity).toBeNull();
+    expect(historyToUnified(historyRow({ severity: "warning" })).severity).toBe(
+      "warning",
+    );
+  });
+
+  it("is marked history and keyed on fingerprint/timestamp/event type", () => {
+    const u = historyToUnified(historyRow());
+    expect(u.source).toBe("history");
+    expect(u.key).toBe(
+      ccEventDedupKey("fp1", "2026-06-10T12:00:00Z", "instance_fired"),
+    );
+  });
+});
+
+describe("mergeCcEvents", () => {
+  it("drops a stored row whose identity also arrived over SSE (live wins)", () => {
+    const live = [
+      liveToUnified(liveEvent({ eval_ts: "2026-06-10T12:00:00.734Z" })),
+    ];
+    const hist = [historyToUnified(historyRow())]; // same fp/second/type
+    const merged = mergeCcEvents(live, hist);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].source).toBe("live");
+    expect(merged[0].severity).toBe("critical");
+  });
+
+  it("keeps stored rows with a different second, type, or fingerprint", () => {
+    const live = [liveToUnified(liveEvent())];
+    const hist = [
+      historyToUnified(historyRow({ timestamp: "2026-06-10T11:59:59Z" })),
+      historyToUnified(historyRow({ eventType: "instance_resolved" })),
+      historyToUnified(historyRow({ instanceFingerprint: "fp2" })),
+    ];
+    expect(mergeCcEvents(live, hist)).toHaveLength(4);
+  });
+
+  it("does not collapse same-key rows within one source (delivery fan-out)", () => {
+    const hist = [
+      historyToUnified(historyRow({ eventType: "delivery" })),
+      historyToUnified(historyRow({ eventType: "delivery" })),
+    ];
+    expect(mergeCcEvents([], hist)).toHaveLength(2);
+  });
+
+  it("sorts the merged list newest-first across sources", () => {
+    const live = [
+      liveToUnified(liveEvent({ eval_ts: "2026-06-10T12:00:05Z" })),
+    ];
+    const hist = [
+      historyToUnified(historyRow({ timestamp: "2026-06-10T12:00:10Z" })),
+      historyToUnified(historyRow({ timestamp: "2026-06-10T12:00:01Z" })),
+    ];
+    expect(mergeCcEvents(live, hist).map((e) => e.ts)).toEqual([
+      "2026-06-10T12:00:10Z",
+      "2026-06-10T12:00:05Z",
+      "2026-06-10T12:00:01Z",
+    ]);
+  });
+
+  it("caps the merged list at the newest rows (default 700)", () => {
+    const hist = Array.from({ length: 30 }, (_, i) =>
+      historyToUnified(
+        historyRow({
+          instanceFingerprint: `fp${i}`,
+          timestamp: `2026-06-10T12:00:${String(i % 60).padStart(2, "0")}Z`,
+        }),
+      ),
+    );
+    const merged = mergeCcEvents([], hist, 10);
+    expect(merged).toHaveLength(10);
+    // The newest 10 survive.
+    expect(merged[0].ts).toBe("2026-06-10T12:00:29Z");
+    expect(merged[9].ts).toBe("2026-06-10T12:00:20Z");
+    expect(CC_UNIFIED_EVENTS_CAP).toBe(700);
+  });
+});

--- a/packages/app/src/data/cc/unified-events.ts
+++ b/packages/app/src/data/cc/unified-events.ts
@@ -1,0 +1,118 @@
+// Pure merge/dedup logic for the monitor stream's unified event view: stored CC
+// history from ClickHouse layered under the live SSE tail. Client-safe (types only
+// from the server module).
+import type { AlertEventLogRow } from "@/data/alerts/history.server";
+import type { CcEvent } from "./types";
+
+/**
+ * Memory bound for the merged list. The live hook caps its buffer at 500 and the
+ * history fetch is capped at 500 by the server fn, so the merged view holds at
+ * most 700 rows (~a few hundred KB of labels/strings) regardless of session length.
+ */
+export const CC_UNIFIED_EVENTS_CAP = 700;
+
+export type CcUnifiedEvent = {
+  source: "live" | "history";
+  ts: string; // ISO timestamp (live eval_ts / stored TimestampTime)
+  // instance_fired | instance_resolved | rule_health | delivery | silenced
+  eventType: string;
+  // firing/resolved for instance transitions; null for the other event types.
+  status: "firing" | "resolved" | null;
+  severity: string | null; // live frames carry it; stored records do not (yet)
+  labels: Record<string, string>;
+  // Human handle for the rule: the slug (everr.name annotation) when known,
+  // otherwise the rule id.
+  rule: string;
+  fingerprint: string; // instance_key (live) === alert.instance_fingerprint (stored)
+  suppressed: boolean;
+  deliveryTargets: string[];
+  /** Identity for live/history dedup: see {@link ccEventDedupKey}. */
+  key: string;
+};
+
+/**
+ * Dedup identity across the SSE and ClickHouse representations of one event:
+ * (instance fingerprint, eval timestamp, event type). The stored record's
+ * timestamp is CC's eval_ts truncated to whole seconds by formatDateTime, so
+ * both sides floor to epoch seconds before comparing.
+ */
+export function ccEventDedupKey(
+  fingerprint: string,
+  ts: string,
+  eventType: string,
+): string {
+  const ms = Date.parse(ts);
+  const sec = Number.isNaN(ms) ? ts : Math.floor(ms / 1000);
+  return `${fingerprint}|${sec}|${eventType}`;
+}
+
+// Live frames carry (kind, status); stored records carry alert.event_type. Map the
+// live pair onto the stored vocabulary so one column renders both.
+function liveEventType(e: CcEvent): string {
+  if (e.kind === "rule_health") return "rule_health";
+  return e.status === "resolved" ? "instance_resolved" : "instance_fired";
+}
+
+export function liveToUnified(e: CcEvent): CcUnifiedEvent {
+  const eventType = liveEventType(e);
+  return {
+    source: "live",
+    ts: e.eval_ts,
+    eventType,
+    status: eventType === "rule_health" ? null : e.status,
+    severity: e.severity,
+    labels: e.labels,
+    rule: e.annotations["everr.name"] || e.rule,
+    fingerprint: e.instance_key,
+    suppressed: false, // the SSE payload has no suppression flag
+    deliveryTargets: [],
+    key: ccEventDedupKey(e.instance_key, e.eval_ts, eventType),
+  };
+}
+
+export function historyToUnified(r: AlertEventLogRow): CcUnifiedEvent {
+  const status =
+    r.eventType === "instance_fired"
+      ? "firing"
+      : r.eventType === "instance_resolved"
+        ? "resolved"
+        : null;
+  return {
+    source: "history",
+    ts: r.timestamp,
+    eventType: r.eventType,
+    status,
+    severity: r.severity || null,
+    labels: r.labels,
+    rule: r.slug,
+    fingerprint: r.instanceFingerprint,
+    suppressed: r.suppressed,
+    deliveryTargets: r.deliveryTargets,
+    key: ccEventDedupKey(r.instanceFingerprint, r.timestamp, r.eventType),
+  };
+}
+
+/**
+ * Merge the live buffer over the stored history, newest first, capped at `cap`.
+ *
+ * Dedup runs BETWEEN the two sources only: a stored row whose key also appears in
+ * the live buffer is dropped (the live frame wins: it carries severity and full
+ * annotations). Rows within one source are trusted as distinct, so two same-second
+ * records from ClickHouse (e.g. delivery fan-out) are never collapsed.
+ */
+export function mergeCcEvents(
+  live: CcUnifiedEvent[],
+  history: CcUnifiedEvent[],
+  cap: number = CC_UNIFIED_EVENTS_CAP,
+): CcUnifiedEvent[] {
+  const liveKeys = new Set(live.map((e) => e.key));
+  const merged = [...live, ...history.filter((h) => !liveKeys.has(h.key))];
+  // Stable sort: same-timestamp rows keep live-before-history order from above.
+  // Unparseable timestamps sink to the bottom instead of poisoning the comparator.
+  const epochMs = (ts: string) => {
+    const ms = Date.parse(ts);
+    return Number.isNaN(ms) ? 0 : ms;
+  };
+  merged.sort((a, b) => epochMs(b.ts) - epochMs(a.ts));
+  return merged.length > cap ? merged.slice(0, cap) : merged;
+}

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts_.$alertId.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts_.$alertId.tsx
@@ -39,6 +39,8 @@ import {
   CircleCheck,
   CirclePlay,
   CircleStop,
+  FlaskConical,
+  Loader2,
   NotebookText,
   Plus,
   X,
@@ -66,7 +68,9 @@ import {
   listAlertEvents,
   listAlertInstances,
   listAlertSilences,
+  testAlert,
 } from "@/data/alerts/server";
+import type { CcTestResult } from "@/data/cc/types";
 import { useCcInvalidation } from "@/hooks/use-cc-invalidation";
 import { useTimeRange } from "@/hooks/use-time-range";
 import {
@@ -170,6 +174,7 @@ function AlertDetailPage() {
     null,
   );
   const [newSilenceOpen, setNewSilenceOpen] = useState(false);
+  const [testResult, setTestResult] = useState<CcTestResult | null>(null);
 
   const setActive = useMutation({
     mutationFn: (active: boolean) =>
@@ -179,6 +184,13 @@ function AlertDetailPage() {
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ["alerts"] });
     },
+  });
+
+  // Ad-hoc evaluation of the alert's current spec: no state change, so the
+  // result is held in local state rather than the query cache.
+  const runTest = useMutation({
+    mutationFn: () => testAlert({ data: { alertId } }),
+    onSuccess: (result) => setTestResult(result),
   });
 
   if (alert.isPending) {
@@ -413,6 +425,15 @@ function AlertDetailPage() {
                   {detail.parsedQuery}
                 </pre>
               </div>
+
+              {!isPreviewRule && (
+                <RunTest
+                  isPending={runTest.isPending}
+                  error={runTest.error}
+                  onRun={() => runTest.mutate()}
+                  result={testResult}
+                />
+              )}
             </div>
 
             <div className="grid h-fit grid-cols-[auto_1fr] items-start gap-x-3 gap-y-2 text-xs">
@@ -534,6 +555,82 @@ function AlertDetailPage() {
           }}
         />
       )}
+    </div>
+  );
+}
+
+// Run an ad-hoc evaluation of the alert's spec against ClickHouse without
+// changing any state, mirroring the power-user rule page's "Run test": a button,
+// a matched-row count, and a compact result table. An empty match is a
+// first-class result (the alert would not fire), distinct from an error.
+function RunTest({
+  isPending,
+  error,
+  onRun,
+  result,
+}: {
+  isPending: boolean;
+  error: Error | null;
+  onRun: () => void;
+  result: CcTestResult | null;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <span className="text-muted-foreground text-xs">Test evaluation</span>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={isPending}
+          onClick={onRun}
+        >
+          {isPending ? (
+            <Loader2 data-icon="inline-start" className="animate-spin" />
+          ) : (
+            <FlaskConical data-icon="inline-start" />
+          )}
+          {isPending ? "Running…" : "Run test"}
+        </Button>
+      </div>
+      {error && (
+        <p className="text-sm text-destructive" role="alert">
+          {error.message}
+        </p>
+      )}
+      {result &&
+        (result.rows.length === 0 ? (
+          <p className="text-xs text-muted-foreground">
+            0 rows — the alert would not fire. No state changed.
+          </p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            <p className="text-xs text-muted-foreground">
+              Matched{" "}
+              <span className="font-medium text-foreground tabular-nums">
+                {result.matched}
+              </span>{" "}
+              row(s) — no state changed.
+            </p>
+            <DataTable
+              data={result.rows}
+              columns={[
+                {
+                  header: "Labels",
+                  cell: (row) => <KeyValueList values={row.labels} />,
+                },
+                {
+                  header: "Value",
+                  cell: (row) => (
+                    <span className="font-mono text-xs tabular-nums">
+                      {row.value ?? "-"}
+                    </span>
+                  ),
+                },
+              ]}
+              rowKey={(_, i) => String(i)}
+            />
+          </div>
+        ))}
     </div>
   );
 }

--- a/packages/app/src/routes/_authenticated/_dashboard/cc-alerting/monitor/stream.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/cc-alerting/monitor/stream.tsx
@@ -15,16 +15,28 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@everr/ui/components/select";
+import { type TimeRange, withTimeRange } from "@everr/ui/lib/time-range";
+import { queryOptions, useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { Pause, Play, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
-import type { CcEvent } from "@/data/cc/types";
+import { listCcEventHistory } from "@/data/cc/server";
+import {
+  type CcUnifiedEvent,
+  historyToUnified,
+  liveToUnified,
+  mergeCcEvents,
+} from "@/data/cc/unified-events";
 import { useCcEvents } from "@/hooks/use-cc-events";
+import { useTimeRange } from "@/hooks/use-time-range";
 import {
   CcConnectionBadge,
   CcEmptyState,
   CcEventStatusBadge,
   CcSeverityBadge,
+  CcStatusDot,
+  CcTableSkeleton,
+  ccErrorMessage,
   ccFormatTs,
   LabelSet,
 } from "../-cc-shared";
@@ -36,9 +48,24 @@ const SEVERITY_LABELS: Record<string, string> = {
   critical: "Critical",
 };
 
+const HISTORY_LIMIT = 200;
+
+const historyQuery = (timeRange: TimeRange) =>
+  queryOptions({
+    queryKey: ["cc", "event-history", timeRange],
+    queryFn: () =>
+      listCcEventHistory({ data: { limit: HISTORY_LIMIT, timeRange } }),
+  });
+
 export const Route = createFileRoute(
   "/_authenticated/_dashboard/cc-alerting/monitor/stream",
 )({
+  // The cc-alerting section hides the global time-range picker; this page reads
+  // stored history, so it opts back in (the deepest staticData value wins).
+  staticData: { hideTimeRangePicker: false },
+  loaderDeps: ({ search }) => ({ timeRange: withTimeRange(search).timeRange }),
+  loader: ({ context: { queryClient }, deps }) =>
+    queryClient.prefetchQuery(historyQuery(deps.timeRange)),
   component: CcMonitorStream,
 });
 
@@ -46,28 +73,82 @@ function CcMonitorStream() {
   const { events, connected, clear, setPaused } = useCcEvents();
   const [paused, setLocalPaused] = useState(false);
   const [severity, setSeverity] = useState<string>("all");
+  const { timeRange } = useTimeRange();
+  const history = useQuery(historyQuery(timeRange));
+
+  // Live SSE frames layered over stored history, deduped on (fingerprint,
+  // eval second, event type) with the live frame winning. Bounded memory: the
+  // live buffer caps at 500, the history page at 200, the merged list at 700.
+  const merged = useMemo(
+    () =>
+      mergeCcEvents(
+        events.map(liveToUnified),
+        (history.data ?? []).map(historyToUnified),
+      ),
+    [events, history.data],
+  );
 
   const filtered = useMemo(
     () =>
       severity === "all"
-        ? events
-        : events.filter((e) => e.severity === severity),
-    [events, severity],
+        ? merged
+        : merged.filter((e) => e.severity === severity),
+    [merged, severity],
   );
 
-  const columns: Column<CcEvent>[] = [
-    { header: "Time", cell: (e) => ccFormatTs(e.eval_ts) },
-    { header: "Status", cell: (e) => <CcEventStatusBadge status={e.status} /> },
+  const columns: Column<CcUnifiedEvent>[] = [
+    {
+      header: "Time",
+      cell: (e) => (
+        <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
+          {e.source === "live" ? (
+            <span title="arrived over the live stream">
+              <CcStatusDot tone="live" />
+            </span>
+          ) : (
+            // Keeps live and stored timestamps horizontally aligned.
+            <span className="inline-flex size-1.5 shrink-0" aria-hidden />
+          )}
+          {ccFormatTs(e.ts)}
+        </span>
+      ),
+    },
+    {
+      header: "Event",
+      cell: (e) => (
+        <span className="inline-flex items-center gap-1.5">
+          {e.status ? (
+            <CcEventStatusBadge status={e.status} />
+          ) : (
+            <span className="text-xs text-muted-foreground">{e.eventType}</span>
+          )}
+          {e.suppressed && (
+            <span className="text-[0.6875rem] text-muted-foreground/70">
+              suppressed
+            </span>
+          )}
+        </span>
+      ),
+    },
     {
       header: "Severity",
-      cell: (e) => <CcSeverityBadge severity={e.severity} />,
+      cell: (e) =>
+        e.severity ? (
+          <CcSeverityBadge severity={e.severity} />
+        ) : (
+          <span className="text-xs text-muted-foreground">—</span>
+        ),
     },
-    { header: "Kind", cell: (e) => e.kind ?? "alert" },
     { header: "Labels", cell: (e) => <LabelSet labels={e.labels} /> },
     {
       header: "Rule",
       cell: (e) => (
-        <span className="font-mono text-xs">{e.rule.slice(0, 8)}</span>
+        <span
+          className="inline-block max-w-44 truncate align-bottom font-mono text-xs"
+          title={e.rule}
+        >
+          {e.rule}
+        </span>
       ),
     },
   ];
@@ -76,12 +157,12 @@ function CcMonitorStream() {
     <Card inset="flush-content">
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
-          Live tail
+          Event stream
           <CcConnectionBadge connected={connected} />
         </CardTitle>
         <CardDescription>
-          Last 500 events. CC events are streamed, not stored — a queryable
-          history arrives once CC writes events to ClickHouse.
+          New events stream in live (dotted rows); earlier ones are read from
+          ClickHouse for the selected time range. Newest 700 kept.
         </CardDescription>
         <CardAction>
           <div className="flex items-center gap-1.5">
@@ -124,34 +205,46 @@ function CcMonitorStream() {
               disabled={events.length === 0}
             >
               <Trash2 data-icon="inline-start" />
-              Clear
+              Clear live
             </Button>
           </div>
         </CardAction>
       </CardHeader>
       <CardContent>
-        <DataTable
-          data={filtered}
-          columns={columns}
-          rowKey={(e, i) => `${e.instance_key}-${e.eval_ts}-${i}`}
-          emptyState={
-            <CcEmptyState
-              icon={paused ? Pause : undefined}
-              title={
-                paused
-                  ? "Stream paused"
-                  : severity === "all"
-                    ? "Waiting for events…"
-                    : `No ${severity} events yet`
-              }
-              hint={
-                paused
-                  ? "Resume to keep tailing live events."
-                  : "Events appear here in real time as rules evaluate."
-              }
-            />
-          }
-        />
+        {history.isError && (
+          <div className="px-3 pb-2 text-xs text-destructive">
+            Stored history unavailable ({ccErrorMessage(history.error)}); the
+            live tail is still running.
+          </div>
+        )}
+        {history.isPending && merged.length === 0 ? (
+          <CcTableSkeleton rows={6} />
+        ) : (
+          <DataTable
+            data={filtered}
+            columns={columns}
+            rowKey={(e, i) => `${e.source}-${e.key}-${i}`}
+            emptyState={
+              <CcEmptyState
+                icon={paused ? Pause : undefined}
+                title={
+                  paused
+                    ? "Stream paused"
+                    : severity === "all"
+                      ? "No events in range"
+                      : `No ${severity} events`
+                }
+                hint={
+                  paused
+                    ? "Resume to keep tailing live events. Stored history stays put."
+                    : severity === "all"
+                      ? "Live events appear in real time; stored events load for the selected time range."
+                      : "Stored events carry no severity yet, so this filter matches live frames only."
+                }
+              />
+            }
+          />
+        )}
       </CardContent>
     </Card>
   );

--- a/packages/app/src/server/previews/00-runtime.ts
+++ b/packages/app/src/server/previews/00-runtime.ts
@@ -4,11 +4,13 @@ import {
   parseCronItems,
   type TaskList,
 } from "graphile-worker";
+import { sweepOrphanCcRules } from "@/data/alerts/preview-cleanup.server";
 import { deleteStalePreviews } from "@/data/previews/apply.server";
 import { env } from "@/env";
 import { serverLogger } from "@/telemetry/logger";
 
 const PREVIEWS_RETENTION_TASK = "previews/retention";
+const PREVIEWS_CC_ORPHAN_SWEEP_TASK = "previews/cc-orphan-sweep";
 
 export const previewsTaskList: TaskList = {
   [PREVIEWS_RETENTION_TASK]: context.bind(ROOT_CONTEXT, async () => {
@@ -19,6 +21,11 @@ export const previewsTaskList: TaskList = {
       });
     }
   }),
+  // Backstop for deletePreviewCcRules: reaps suppressed CC rules orphaned when
+  // CC was unreachable at preview-deletion time.
+  [PREVIEWS_CC_ORPHAN_SWEEP_TASK]: context.bind(ROOT_CONTEXT, async () => {
+    await sweepOrphanCcRules();
+  }),
 };
 
 export const previewsCronItems: ParsedCronItem[] = parseCronItems([
@@ -27,6 +34,13 @@ export const previewsCronItems: ParsedCronItem[] = parseCronItems([
     // Daily, off the minute-boundary rush of the alerts scanner.
     match: "13 3 * * *",
     identifier: "previews-retention",
+    options: { backfillPeriod: 0 },
+  },
+  {
+    task: PREVIEWS_CC_ORPHAN_SWEEP_TASK,
+    // Hourly, off the minute-boundary rush of the alerts scanner.
+    match: "27 * * * *",
+    identifier: "previews-cc-orphan-sweep",
     options: { backfillPeriod: 0 },
   },
 ]);


### PR DESCRIPTION
Stacked on #300.

The power-user rule page has ad-hoc test evaluation; the simplified `/alerts` detail now gets it too.

- New `testAlert` server fn: admin-gated, loads the managed rule server-side (client never supplies the spec, unlike the power-user fn where the operator owns the spec), guards `isManagedSimple`, calls CC's no-state-change test endpoint.
- Definition card gains a "Run test" affordance with loading / error / "0 rows, would not fire" / matched-rows table states; hidden for preview rules like the other mutations.

Verified: scoped vitest 29 passed (3 new), `tsc --noEmit` clean, biome clean.