### PR TITLE
Unify stored and live alert events in the monitor stream

### DIFF
--- a/packages/app/src/data/alerts/history.server.test.ts
+++ b/packages/app/src/data/alerts/history.server.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { queryAlertHistory } from "./history.server";
+import { queryAlertEventLog, queryAlertHistory } from "./history.server";
 
 describe("queryAlertHistory", () => {
   it("filters app.logs by scope, slug, event type, and time range", async () => {
@@ -90,6 +90,140 @@ describe("queryAlertHistory", () => {
     const row = await runWithRawRow({
       evidenceJson: '{"count":1}',
     });
+    expect(row).not.toHaveProperty("evidenceJson");
+  });
+});
+
+describe("queryAlertEventLog", () => {
+  it("filters app.logs by service, scope, and time range only (rule-agnostic)", async () => {
+    const ch = vi.fn().mockResolvedValue([]);
+    await queryAlertEventLog(ch, {
+      limit: 200,
+      fromISO: "2026-06-01T00:00:00Z",
+      toISO: "2026-06-16T00:00:00Z",
+    });
+    const [sql, params] = ch.mock.calls[0];
+    expect(sql).toContain("FROM app.logs");
+    expect(sql).toContain("ServiceName = 'alert'");
+    expect(sql).toContain("ScopeName = 'everr.alerting'");
+    // No per-rule or per-event-type narrowing: the monitor shows everything.
+    expect(sql).not.toContain("alert.slug'] =");
+    expect(sql).not.toContain("IN ('instance_fired'");
+    // Tenancy comes from the row-level policy, never a SQL org filter.
+    expect(sql).not.toMatch(/organization|tenant_id/);
+    // DateTime64 params: resolveTimeRange emits fractional seconds, which a
+    // String -> DateTime coercion rejects (TYPE_MISMATCH).
+    expect(sql).toContain("TimestampTime >= {fromTime:DateTime64(3)}");
+    expect(sql).toContain("TimestampTime <= {toTime:DateTime64(3)}");
+    expect(sql).toContain("LIMIT {limit:UInt32}");
+    expect(params).toMatchObject({
+      limit: 200,
+      fromTime: "2026-06-01T00:00:00Z",
+      toTime: "2026-06-16T00:00:00Z",
+    });
+  });
+
+  const baseRawRow = {
+    timestamp: "2026-06-10T00:00:00Z",
+    eventType: "instance_fired",
+    slug: "high-5xx",
+    instanceFingerprint: "fp1",
+    instanceLabelsJson: '{"host":"web-1"}',
+    severity: "",
+    suppressed: "false",
+    silenced: "",
+    deliveryTargetsRaw: "",
+    evidenceJson: "",
+  };
+
+  async function runWithRawRow(overrides: Record<string, string>) {
+    const ch = vi.fn().mockResolvedValue([{ ...baseRawRow, ...overrides }]);
+    const [row] = await queryAlertEventLog(ch, {
+      limit: 200,
+      fromISO: "2026-06-01T00:00:00Z",
+      toISO: "2026-06-16T00:00:00Z",
+    });
+    return row;
+  }
+
+  it("maps attributes onto the row shape", async () => {
+    const row = await runWithRawRow({});
+    expect(row).toMatchObject({
+      timestamp: "2026-06-10T00:00:00Z",
+      eventType: "instance_fired",
+      slug: "high-5xx",
+      instanceFingerprint: "fp1",
+      labels: { host: "web-1" },
+      severity: "",
+      suppressed: false,
+      silenced: false,
+      deliveryTargets: [],
+      evidence: null,
+    });
+  });
+
+  it("collapses malformed or non-object instance labels to {}", async () => {
+    expect(
+      (await runWithRawRow({ instanceLabelsJson: "{oops" })).labels,
+    ).toEqual({});
+    expect(
+      (await runWithRawRow({ instanceLabelsJson: "[1,2]" })).labels,
+    ).toEqual({});
+    expect((await runWithRawRow({ instanceLabelsJson: "" })).labels).toEqual(
+      {},
+    );
+  });
+
+  it("stringifies non-string label values instead of dropping them", async () => {
+    const row = await runWithRawRow({
+      instanceLabelsJson: '{"host":"web-1","code":500}',
+    });
+    expect(row.labels).toEqual({ host: "web-1", code: "500" });
+  });
+
+  it("maps suppressed and silenced flags to booleans (literal 'true' only)", async () => {
+    expect((await runWithRawRow({ suppressed: "true" })).suppressed).toBe(true);
+    expect((await runWithRawRow({ suppressed: "" })).suppressed).toBe(false);
+    expect((await runWithRawRow({ silenced: "true" })).silenced).toBe(true);
+    expect((await runWithRawRow({ silenced: "false" })).silenced).toBe(false);
+  });
+
+  it("parses comma-joined delivery targets (CC's current shape)", async () => {
+    const row = await runWithRawRow({
+      deliveryTargetsRaw: "ops-slack, pagerduty-primary",
+    });
+    expect(row.deliveryTargets).toEqual(["ops-slack", "pagerduty-primary"]);
+  });
+
+  it("parses JSON-array and JSON-object delivery targets (older shapes)", async () => {
+    expect(
+      (await runWithRawRow({ deliveryTargetsRaw: '["a","b"]' }))
+        .deliveryTargets,
+    ).toEqual(["a", "b"]);
+    expect(
+      (await runWithRawRow({ deliveryTargetsRaw: '{"slack":["ops"]}' }))
+        .deliveryTargets,
+    ).toEqual(["slack:ops"]);
+  });
+
+  it("treats malformed delivery targets as a comma-joined string", async () => {
+    const row = await runWithRawRow({ deliveryTargetsRaw: "{not json" });
+    expect(row.deliveryTargets).toEqual(["{not json"]);
+  });
+
+  it("parses evidence with the same defensive rules as the per-slug reader", async () => {
+    expect(
+      (await runWithRawRow({ evidenceJson: '{"count":42}' })).evidence,
+    ).toEqual({ count: 42 });
+    expect(
+      (await runWithRawRow({ evidenceJson: "{oops" })).evidence,
+    ).toBeNull();
+  });
+
+  it("does not leak raw projection fields onto the mapped row", async () => {
+    const row = await runWithRawRow({});
+    expect(row).not.toHaveProperty("instanceLabelsJson");
+    expect(row).not.toHaveProperty("deliveryTargetsRaw");
     expect(row).not.toHaveProperty("evidenceJson");
   });
 });

--- a/packages/app/src/data/alerts/history.server.ts
+++ b/packages/app/src/data/alerts/history.server.ts
@@ -52,6 +52,53 @@ function parseEvidence(json: string): AlertEvidence | null {
   return null;
 }
 
+// Parse a JSON object of instance labels into a string->string record. CC writes
+// alert.instance_labels as a JSON object of strings; anything else collapses to {}.
+function parseStringMap(json: string): Record<string, string> {
+  if (!json) return {};
+  try {
+    const parsed: unknown = JSON.parse(json);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return Object.fromEntries(
+        Object.entries(parsed).map(([k, v]) => [
+          k,
+          typeof v === "string" ? v : JSON.stringify(v),
+        ]),
+      );
+    }
+  } catch {
+    // malformed labels -> {}
+  }
+  return {};
+}
+
+// alert.delivery_targets: CC currently emits a comma-joined list of target names,
+// but earlier shapes were JSON (array, or object of channel -> names). Accept all
+// three so the reader survives records from any CC version.
+function parseDeliveryTargets(raw: string): string[] {
+  if (!raw) return [];
+  const t = raw.trim();
+  if (t.startsWith("[") || t.startsWith("{")) {
+    try {
+      const parsed: unknown = JSON.parse(t);
+      if (Array.isArray(parsed)) return parsed.map((v) => String(v));
+      if (parsed && typeof parsed === "object") {
+        return Object.entries(parsed).flatMap(([channel, names]) =>
+          Array.isArray(names)
+            ? names.map((n) => `${channel}:${String(n)}`)
+            : [`${channel}:${String(names)}`],
+        );
+      }
+    } catch {
+      // fall through to the comma-joined form
+    }
+  }
+  return t
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
 /**
  * Per-alert event history from app.logs. The collector lands CC's alert events here
  * (ScopeName='everr.alerting'), keyed by alert.slug. Row-level security pins the tenant
@@ -81,8 +128,8 @@ export async function queryAlertHistory(
       WHERE ScopeName = 'everr.alerting'
         AND LogAttributes['alert.slug'] = {slug:String}
         AND LogAttributes['alert.event_type'] IN ('instance_fired', 'instance_resolved')
-        AND TimestampTime >= {fromTime:String}
-        AND TimestampTime <= {toTime:String}
+        AND TimestampTime >= {fromTime:DateTime64(3)}
+        AND TimestampTime <= {toTime:DateTime64(3)}
       ORDER BY Timestamp DESC
       LIMIT {limit:UInt32}
     `,
@@ -98,4 +145,101 @@ export async function queryAlertHistory(
     evidence: parseEvidence(evidenceJson),
     evidenceTruncated: evidenceTruncated === "true",
   }));
+}
+
+// One row of the rule-agnostic alerting event log (all slugs, all event types).
+export type AlertEventLogRow = {
+  timestamp: string;
+  // alert.event_type: instance_fired | instance_resolved | rule_health | delivery | silenced
+  eventType: string;
+  slug: string; // alert.slug (everr.name annotation, falling back to the rule id)
+  instanceFingerprint: string;
+  labels: Record<string, string>; // alert.instance_labels decoded
+  // alert.severity when CC stamps it; empty today (records carry no severity attribute),
+  // selected defensively so it flows through once CC adds it.
+  severity: string;
+  suppressed: boolean; // alert.suppressed === "true"
+  silenced: boolean; // alert.silenced === "true" (only on dispatcher records)
+  deliveryTargets: string[]; // alert.delivery_targets decoded (only on delivery records)
+  evidence: AlertEvidence | null;
+};
+
+type AlertEventLogRawRow = {
+  timestamp: string;
+  eventType: string;
+  slug: string;
+  instanceFingerprint: string;
+  instanceLabelsJson: string;
+  severity: string;
+  suppressed: string;
+  silenced: string;
+  deliveryTargetsRaw: string;
+  evidenceJson: string;
+};
+
+/**
+ * Rule-agnostic alerting event log from app.logs: every CC event the collector landed
+ * (ScopeName='everr.alerting'), regardless of slug or event type. Backs the monitor
+ * stream's historical page under the live SSE tail. Row-level security pins the tenant
+ * via SQL_everr_tenant_id, so this never filters by organization_id in SQL.
+ *
+ * ServiceName='alert' is CC's stable resource attribute (src/otel/exporter.rs; the
+ * trusted collector pipeline passes it through). Filtering on it lets this scan use
+ * the app.logs ORDER BY prefix (tenant_id, ServiceName, TimestampTime) instead of
+ * skipping ServiceName. It also skips legacy 'alert-preview' rows from the retired
+ * in-process evaluator; CC previews arrive as ServiceName='alert' with
+ * alert.suppressed='true'.
+ *
+ * The time params are DateTime64(3) (not String) because resolveTimeRange emits
+ * 'YYYY-MM-DD HH:mm:ss.SSS' and ClickHouse cannot coerce a fractional-seconds
+ * string to the column's plain DateTime.
+ */
+export async function queryAlertEventLog(
+  clickhouse: ClickhouseQuery,
+  opts: { limit: number; fromISO: string; toISO: string },
+): Promise<AlertEventLogRow[]> {
+  const rows = await clickhouse<AlertEventLogRawRow>(
+    `
+      SELECT
+        concat(formatDateTime(TimestampTime, '%Y-%m-%dT%H:%i:%S', 'UTC'), 'Z') AS timestamp,
+        LogAttributes['alert.event_type']           AS eventType,
+        LogAttributes['alert.slug']                 AS slug,
+        LogAttributes['alert.instance_fingerprint'] AS instanceFingerprint,
+        LogAttributes['alert.instance_labels']      AS instanceLabelsJson,
+        LogAttributes['alert.severity']             AS severity,
+        LogAttributes['alert.suppressed']           AS suppressed,
+        LogAttributes['alert.silenced']             AS silenced,
+        LogAttributes['alert.delivery_targets']     AS deliveryTargetsRaw,
+        LogAttributes['alert.evidence_json']        AS evidenceJson
+      FROM app.logs
+      WHERE ServiceName = 'alert'
+        AND ScopeName = 'everr.alerting'
+        AND TimestampTime >= {fromTime:DateTime64(3)}
+        AND TimestampTime <= {toTime:DateTime64(3)}
+      ORDER BY Timestamp DESC
+      LIMIT {limit:UInt32}
+    `,
+    {
+      fromTime: opts.fromISO,
+      toTime: opts.toISO,
+      limit: opts.limit,
+    },
+  );
+  return rows.map(
+    ({
+      instanceLabelsJson,
+      suppressed,
+      silenced,
+      deliveryTargetsRaw,
+      evidenceJson,
+      ...row
+    }) => ({
+      ...row,
+      labels: parseStringMap(instanceLabelsJson),
+      suppressed: suppressed === "true",
+      silenced: silenced === "true",
+      deliveryTargets: parseDeliveryTargets(deliveryTargetsRaw),
+      evidence: parseEvidence(evidenceJson),
+    }),
+  );
 }

--- a/packages/app/src/data/cc/server.ts
+++ b/packages/app/src/data/cc/server.ts
@@ -1,4 +1,6 @@
+import { resolveTimeRange, TimeRangeSchema } from "@everr/ui/lib/time-range";
 import { z } from "zod";
+import { queryAlertEventLog } from "@/data/alerts/history.server";
 import { createAuthenticatedServerFn } from "@/lib/serverFn";
 import * as cc from "./client";
 import { CcMatcherSchema, CcRuleSpecSchema } from "./schema";
@@ -40,6 +42,21 @@ export const listCcSilences = createAuthenticatedServerFn({
 export const listCcSubscriptions = createAuthenticatedServerFn({
   method: "GET",
 }).handler(({ context: { session } }) => cc.listSubscriptions(orgId(session)));
+
+// Stored CC event history (all rules, all event types) from ClickHouse app.logs.
+// Tenancy rides on the org-scoped clickhouse context (row-level policy), not on a
+// SQL organization filter. Backs the monitor stream's historical page.
+export const listCcEventHistory = createAuthenticatedServerFn({ method: "GET" })
+  .inputValidator(
+    z.object({
+      limit: z.number().int().min(1).max(500).default(200),
+      timeRange: TimeRangeSchema,
+    }),
+  )
+  .handler(({ data: { limit, timeRange }, context: { clickhouse } }) => {
+    const { fromISO, toISO } = resolveTimeRange(timeRange);
+    return queryAlertEventLog(clickhouse.query, { limit, fromISO, toISO });
+  });
 
 // ---- Rule operations ----
 export const pauseCcRule = createAuthenticatedServerFn({ method: "POST" })

--- a/packages/app/src/data/cc/unified-events.test.ts
+++ b/packages/app/src/data/cc/unified-events.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+import type { AlertEventLogRow } from "@/data/alerts/history.server";
+import type { CcEvent } from "./types";
+import {
+  CC_UNIFIED_EVENTS_CAP,
+  ccEventDedupKey,
+  historyToUnified,
+  liveToUnified,
+  mergeCcEvents,
+} from "./unified-events";
+
+function liveEvent(overrides: Partial<CcEvent> = {}): CcEvent {
+  return {
+    tenant: "org1",
+    rule: "5a1e8d6a-0000-0000-0000-000000000000",
+    instance_key: "fp1",
+    status: "firing",
+    labels: { host: "web-1" },
+    value: 1,
+    severity: "critical",
+    annotations: {},
+    eval_ts: "2026-06-10T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function historyRow(
+  overrides: Partial<AlertEventLogRow> = {},
+): AlertEventLogRow {
+  return {
+    timestamp: "2026-06-10T12:00:00Z",
+    eventType: "instance_fired",
+    slug: "high-5xx",
+    instanceFingerprint: "fp1",
+    labels: { host: "web-1" },
+    severity: "",
+    suppressed: false,
+    silenced: false,
+    deliveryTargets: [],
+    evidence: null,
+    ...overrides,
+  };
+}
+
+describe("ccEventDedupKey", () => {
+  it("floors timestamps to whole seconds so SSE millis match stored seconds", () => {
+    expect(
+      ccEventDedupKey("fp1", "2026-06-10T12:00:00.734Z", "instance_fired"),
+    ).toBe(ccEventDedupKey("fp1", "2026-06-10T12:00:00Z", "instance_fired"));
+  });
+
+  it("separates different fingerprints, seconds, and event types", () => {
+    const base = ccEventDedupKey(
+      "fp1",
+      "2026-06-10T12:00:00Z",
+      "instance_fired",
+    );
+    expect(
+      ccEventDedupKey("fp2", "2026-06-10T12:00:00Z", "instance_fired"),
+    ).not.toBe(base);
+    expect(
+      ccEventDedupKey("fp1", "2026-06-10T12:00:01Z", "instance_fired"),
+    ).not.toBe(base);
+    expect(
+      ccEventDedupKey("fp1", "2026-06-10T12:00:00Z", "instance_resolved"),
+    ).not.toBe(base);
+  });
+
+  it("keeps an unparseable timestamp verbatim instead of collapsing to one bucket", () => {
+    expect(ccEventDedupKey("fp1", "garbage-a", "delivery")).not.toBe(
+      ccEventDedupKey("fp1", "garbage-b", "delivery"),
+    );
+  });
+});
+
+describe("liveToUnified", () => {
+  it("maps firing/resolved onto the stored event_type vocabulary", () => {
+    expect(liveToUnified(liveEvent()).eventType).toBe("instance_fired");
+    expect(liveToUnified(liveEvent({ status: "resolved" })).eventType).toBe(
+      "instance_resolved",
+    );
+  });
+
+  it("maps rule_health kind regardless of status and drops the status badge", () => {
+    const u = liveToUnified(liveEvent({ kind: "rule_health" }));
+    expect(u.eventType).toBe("rule_health");
+    expect(u.status).toBeNull();
+  });
+
+  it("prefers the everr.name annotation as the rule handle, falling back to the id", () => {
+    expect(
+      liveToUnified(liveEvent({ annotations: { "everr.name": "high-5xx" } }))
+        .rule,
+    ).toBe("high-5xx");
+    expect(liveToUnified(liveEvent()).rule).toBe(
+      "5a1e8d6a-0000-0000-0000-000000000000",
+    );
+  });
+
+  it("is marked live and carries severity", () => {
+    const u = liveToUnified(liveEvent());
+    expect(u.source).toBe("live");
+    expect(u.severity).toBe("critical");
+  });
+});
+
+describe("historyToUnified", () => {
+  it("derives the status badge only for instance transitions", () => {
+    expect(historyToUnified(historyRow()).status).toBe("firing");
+    expect(
+      historyToUnified(historyRow({ eventType: "instance_resolved" })).status,
+    ).toBe("resolved");
+    expect(
+      historyToUnified(historyRow({ eventType: "delivery" })).status,
+    ).toBeNull();
+    expect(
+      historyToUnified(historyRow({ eventType: "rule_health" })).status,
+    ).toBeNull();
+  });
+
+  it("maps empty severity to null and keeps a stamped one", () => {
+    expect(historyToUnified(historyRow()).severity).toBeNull();
+    expect(historyToUnified(historyRow({ severity: "warning" })).severity).toBe(
+      "warning",
+    );
+  });
+
+  it("is marked history and keyed on fingerprint/timestamp/event type", () => {
+    const u = historyToUnified(historyRow());
+    expect(u.source).toBe("history");
+    expect(u.key).toBe(
+      ccEventDedupKey("fp1", "2026-06-10T12:00:00Z", "instance_fired"),
+    );
+  });
+});
+
+describe("mergeCcEvents", () => {
+  it("drops a stored row whose identity also arrived over SSE (live wins)", () => {
+    const live = [
+      liveToUnified(liveEvent({ eval_ts: "2026-06-10T12:00:00.734Z" })),
+    ];
+    const hist = [historyToUnified(historyRow())]; // same fp/second/type
+    const merged = mergeCcEvents(live, hist);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].source).toBe("live");
+    expect(merged[0].severity).toBe("critical");
+  });
+
+  it("keeps stored rows with a different second, type, or fingerprint", () => {
+    const live = [liveToUnified(liveEvent())];
+    const hist = [
+      historyToUnified(historyRow({ timestamp: "2026-06-10T11:59:59Z" })),
+      historyToUnified(historyRow({ eventType: "instance_resolved" })),
+      historyToUnified(historyRow({ instanceFingerprint: "fp2" })),
+    ];
+    expect(mergeCcEvents(live, hist)).toHaveLength(4);
+  });
+
+  it("does not collapse same-key rows within one source (delivery fan-out)", () => {
+    const hist = [
+      historyToUnified(historyRow({ eventType: "delivery" })),
+      historyToUnified(historyRow({ eventType: "delivery" })),
+    ];
+    expect(mergeCcEvents([], hist)).toHaveLength(2);
+  });
+
+  it("sorts the merged list newest-first across sources", () => {
+    const live = [
+      liveToUnified(liveEvent({ eval_ts: "2026-06-10T12:00:05Z" })),
+    ];
+    const hist = [
+      historyToUnified(historyRow({ timestamp: "2026-06-10T12:00:10Z" })),
+      historyToUnified(historyRow({ timestamp: "2026-06-10T12:00:01Z" })),
+    ];
+    expect(mergeCcEvents(live, hist).map((e) => e.ts)).toEqual([
+      "2026-06-10T12:00:10Z",
+      "2026-06-10T12:00:05Z",
+      "2026-06-10T12:00:01Z",
+    ]);
+  });
+
+  it("caps the merged list at the newest rows (default 700)", () => {
+    const hist = Array.from({ length: 30 }, (_, i) =>
+      historyToUnified(
+        historyRow({
+          instanceFingerprint: `fp${i}`,
+          timestamp: `2026-06-10T12:00:${String(i % 60).padStart(2, "0")}Z`,
+        }),
+      ),
+    );
+    const merged = mergeCcEvents([], hist, 10);
+    expect(merged).toHaveLength(10);
+    // The newest 10 survive.
+    expect(merged[0].ts).toBe("2026-06-10T12:00:29Z");
+    expect(merged[9].ts).toBe("2026-06-10T12:00:20Z");
+    expect(CC_UNIFIED_EVENTS_CAP).toBe(700);
+  });
+});

--- a/packages/app/src/data/cc/unified-events.ts
+++ b/packages/app/src/data/cc/unified-events.ts
@@ -1,0 +1,118 @@
+// Pure merge/dedup logic for the monitor stream's unified event view: stored CC
+// history from ClickHouse layered under the live SSE tail. Client-safe (types only
+// from the server module).
+import type { AlertEventLogRow } from "@/data/alerts/history.server";
+import type { CcEvent } from "./types";
+
+/**
+ * Memory bound for the merged list. The live hook caps its buffer at 500 and the
+ * history fetch is capped at 500 by the server fn, so the merged view holds at
+ * most 700 rows (~a few hundred KB of labels/strings) regardless of session length.
+ */
+export const CC_UNIFIED_EVENTS_CAP = 700;
+
+export type CcUnifiedEvent = {
+  source: "live" | "history";
+  ts: string; // ISO timestamp (live eval_ts / stored TimestampTime)
+  // instance_fired | instance_resolved | rule_health | delivery | silenced
+  eventType: string;
+  // firing/resolved for instance transitions; null for the other event types.
+  status: "firing" | "resolved" | null;
+  severity: string | null; // live frames carry it; stored records do not (yet)
+  labels: Record<string, string>;
+  // Human handle for the rule: the slug (everr.name annotation) when known,
+  // otherwise the rule id.
+  rule: string;
+  fingerprint: string; // instance_key (live) === alert.instance_fingerprint (stored)
+  suppressed: boolean;
+  deliveryTargets: string[];
+  /** Identity for live/history dedup: see {@link ccEventDedupKey}. */
+  key: string;
+};
+
+/**
+ * Dedup identity across the SSE and ClickHouse representations of one event:
+ * (instance fingerprint, eval timestamp, event type). The stored record's
+ * timestamp is CC's eval_ts truncated to whole seconds by formatDateTime, so
+ * both sides floor to epoch seconds before comparing.
+ */
+export function ccEventDedupKey(
+  fingerprint: string,
+  ts: string,
+  eventType: string,
+): string {
+  const ms = Date.parse(ts);
+  const sec = Number.isNaN(ms) ? ts : Math.floor(ms / 1000);
+  return `${fingerprint}|${sec}|${eventType}`;
+}
+
+// Live frames carry (kind, status); stored records carry alert.event_type. Map the
+// live pair onto the stored vocabulary so one column renders both.
+function liveEventType(e: CcEvent): string {
+  if (e.kind === "rule_health") return "rule_health";
+  return e.status === "resolved" ? "instance_resolved" : "instance_fired";
+}
+
+export function liveToUnified(e: CcEvent): CcUnifiedEvent {
+  const eventType = liveEventType(e);
+  return {
+    source: "live",
+    ts: e.eval_ts,
+    eventType,
+    status: eventType === "rule_health" ? null : e.status,
+    severity: e.severity,
+    labels: e.labels,
+    rule: e.annotations["everr.name"] || e.rule,
+    fingerprint: e.instance_key,
+    suppressed: false, // the SSE payload has no suppression flag
+    deliveryTargets: [],
+    key: ccEventDedupKey(e.instance_key, e.eval_ts, eventType),
+  };
+}
+
+export function historyToUnified(r: AlertEventLogRow): CcUnifiedEvent {
+  const status =
+    r.eventType === "instance_fired"
+      ? "firing"
+      : r.eventType === "instance_resolved"
+        ? "resolved"
+        : null;
+  return {
+    source: "history",
+    ts: r.timestamp,
+    eventType: r.eventType,
+    status,
+    severity: r.severity || null,
+    labels: r.labels,
+    rule: r.slug,
+    fingerprint: r.instanceFingerprint,
+    suppressed: r.suppressed,
+    deliveryTargets: r.deliveryTargets,
+    key: ccEventDedupKey(r.instanceFingerprint, r.timestamp, r.eventType),
+  };
+}
+
+/**
+ * Merge the live buffer over the stored history, newest first, capped at `cap`.
+ *
+ * Dedup runs BETWEEN the two sources only: a stored row whose key also appears in
+ * the live buffer is dropped (the live frame wins: it carries severity and full
+ * annotations). Rows within one source are trusted as distinct, so two same-second
+ * records from ClickHouse (e.g. delivery fan-out) are never collapsed.
+ */
+export function mergeCcEvents(
+  live: CcUnifiedEvent[],
+  history: CcUnifiedEvent[],
+  cap: number = CC_UNIFIED_EVENTS_CAP,
+): CcUnifiedEvent[] {
+  const liveKeys = new Set(live.map((e) => e.key));
+  const merged = [...live, ...history.filter((h) => !liveKeys.has(h.key))];
+  // Stable sort: same-timestamp rows keep live-before-history order from above.
+  // Unparseable timestamps sink to the bottom instead of poisoning the comparator.
+  const epochMs = (ts: string) => {
+    const ms = Date.parse(ts);
+    return Number.isNaN(ms) ? 0 : ms;
+  };
+  merged.sort((a, b) => epochMs(b.ts) - epochMs(a.ts));
+  return merged.length > cap ? merged.slice(0, cap) : merged;
+}

--- a/packages/app/src/routes/_authenticated/_dashboard/cc-alerting/monitor/stream.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/cc-alerting/monitor/stream.tsx
@@ -15,16 +15,28 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@everr/ui/components/select";
+import { type TimeRange, withTimeRange } from "@everr/ui/lib/time-range";
+import { queryOptions, useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { Pause, Play, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
-import type { CcEvent } from "@/data/cc/types";
+import { listCcEventHistory } from "@/data/cc/server";
+import {
+  type CcUnifiedEvent,
+  historyToUnified,
+  liveToUnified,
+  mergeCcEvents,
+} from "@/data/cc/unified-events";
 import { useCcEvents } from "@/hooks/use-cc-events";
+import { useTimeRange } from "@/hooks/use-time-range";
 import {
   CcConnectionBadge,
   CcEmptyState,
   CcEventStatusBadge,
   CcSeverityBadge,
+  CcStatusDot,
+  CcTableSkeleton,
+  ccErrorMessage,
   ccFormatTs,
   LabelSet,
 } from "../-cc-shared";
@@ -36,9 +48,24 @@ const SEVERITY_LABELS: Record<string, string> = {
   critical: "Critical",
 };
 
+const HISTORY_LIMIT = 200;
+
+const historyQuery = (timeRange: TimeRange) =>
+  queryOptions({
+    queryKey: ["cc", "event-history", timeRange],
+    queryFn: () =>
+      listCcEventHistory({ data: { limit: HISTORY_LIMIT, timeRange } }),
+  });
+
 export const Route = createFileRoute(
   "/_authenticated/_dashboard/cc-alerting/monitor/stream",
 )({
+  // The cc-alerting section hides the global time-range picker; this page reads
+  // stored history, so it opts back in (the deepest staticData value wins).
+  staticData: { hideTimeRangePicker: false },
+  loaderDeps: ({ search }) => ({ timeRange: withTimeRange(search).timeRange }),
+  loader: ({ context: { queryClient }, deps }) =>
+    queryClient.prefetchQuery(historyQuery(deps.timeRange)),
   component: CcMonitorStream,
 });
 
@@ -46,28 +73,82 @@ function CcMonitorStream() {
   const { events, connected, clear, setPaused } = useCcEvents();
   const [paused, setLocalPaused] = useState(false);
   const [severity, setSeverity] = useState<string>("all");
+  const { timeRange } = useTimeRange();
+  const history = useQuery(historyQuery(timeRange));
+
+  // Live SSE frames layered over stored history, deduped on (fingerprint,
+  // eval second, event type) with the live frame winning. Bounded memory: the
+  // live buffer caps at 500, the history page at 200, the merged list at 700.
+  const merged = useMemo(
+    () =>
+      mergeCcEvents(
+        events.map(liveToUnified),
+        (history.data ?? []).map(historyToUnified),
+      ),
+    [events, history.data],
+  );
 
   const filtered = useMemo(
     () =>
       severity === "all"
-        ? events
-        : events.filter((e) => e.severity === severity),
-    [events, severity],
+        ? merged
+        : merged.filter((e) => e.severity === severity),
+    [merged, severity],
   );
 
-  const columns: Column<CcEvent>[] = [
-    { header: "Time", cell: (e) => ccFormatTs(e.eval_ts) },
-    { header: "Status", cell: (e) => <CcEventStatusBadge status={e.status} /> },
+  const columns: Column<CcUnifiedEvent>[] = [
+    {
+      header: "Time",
+      cell: (e) => (
+        <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
+          {e.source === "live" ? (
+            <span title="arrived over the live stream">
+              <CcStatusDot tone="live" />
+            </span>
+          ) : (
+            // Keeps live and stored timestamps horizontally aligned.
+            <span className="inline-flex size-1.5 shrink-0" aria-hidden />
+          )}
+          {ccFormatTs(e.ts)}
+        </span>
+      ),
+    },
+    {
+      header: "Event",
+      cell: (e) => (
+        <span className="inline-flex items-center gap-1.5">
+          {e.status ? (
+            <CcEventStatusBadge status={e.status} />
+          ) : (
+            <span className="text-xs text-muted-foreground">{e.eventType}</span>
+          )}
+          {e.suppressed && (
+            <span className="text-[0.6875rem] text-muted-foreground/70">
+              suppressed
+            </span>
+          )}
+        </span>
+      ),
+    },
     {
       header: "Severity",
-      cell: (e) => <CcSeverityBadge severity={e.severity} />,
+      cell: (e) =>
+        e.severity ? (
+          <CcSeverityBadge severity={e.severity} />
+        ) : (
+          <span className="text-xs text-muted-foreground">—</span>
+        ),
     },
-    { header: "Kind", cell: (e) => e.kind ?? "alert" },
     { header: "Labels", cell: (e) => <LabelSet labels={e.labels} /> },
     {
       header: "Rule",
       cell: (e) => (
-        <span className="font-mono text-xs">{e.rule.slice(0, 8)}</span>
+        <span
+          className="inline-block max-w-44 truncate align-bottom font-mono text-xs"
+          title={e.rule}
+        >
+          {e.rule}
+        </span>
       ),
     },
   ];
@@ -76,12 +157,12 @@ function CcMonitorStream() {
     <Card inset="flush-content">
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
-          Live tail
+          Event stream
           <CcConnectionBadge connected={connected} />
         </CardTitle>
         <CardDescription>
-          Last 500 events. CC events are streamed, not stored — a queryable
-          history arrives once CC writes events to ClickHouse.
+          New events stream in live (dotted rows); earlier ones are read from
+          ClickHouse for the selected time range. Newest 700 kept.
         </CardDescription>
         <CardAction>
           <div className="flex items-center gap-1.5">
@@ -124,34 +205,46 @@ function CcMonitorStream() {
               disabled={events.length === 0}
             >
               <Trash2 data-icon="inline-start" />
-              Clear
+              Clear live
             </Button>
           </div>
         </CardAction>
       </CardHeader>
       <CardContent>
-        <DataTable
-          data={filtered}
-          columns={columns}
-          rowKey={(e, i) => `${e.instance_key}-${e.eval_ts}-${i}`}
-          emptyState={
-            <CcEmptyState
-              icon={paused ? Pause : undefined}
-              title={
-                paused
-                  ? "Stream paused"
-                  : severity === "all"
-                    ? "Waiting for events…"
-                    : `No ${severity} events yet`
-              }
-              hint={
-                paused
-                  ? "Resume to keep tailing live events."
-                  : "Events appear here in real time as rules evaluate."
-              }
-            />
-          }
-        />
+        {history.isError && (
+          <div className="px-3 pb-2 text-xs text-destructive">
+            Stored history unavailable ({ccErrorMessage(history.error)}); the
+            live tail is still running.
+          </div>
+        )}
+        {history.isPending && merged.length === 0 ? (
+          <CcTableSkeleton rows={6} />
+        ) : (
+          <DataTable
+            data={filtered}
+            columns={columns}
+            rowKey={(e, i) => `${e.source}-${e.key}-${i}`}
+            emptyState={
+              <CcEmptyState
+                icon={paused ? Pause : undefined}
+                title={
+                  paused
+                    ? "Stream paused"
+                    : severity === "all"
+                      ? "No events in range"
+                      : `No ${severity} events`
+                }
+                hint={
+                  paused
+                    ? "Resume to keep tailing live events. Stored history stays put."
+                    : severity === "all"
+                      ? "Live events appear in real time; stored events load for the selected time range."
+                      : "Stored events carry no severity yet, so this filter matches live frames only."
+                }
+              />
+            }
+          />
+        )}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
Stacked on #302. Closes the loop the page itself admitted: "a queryable history arrives once CC writes events to ClickHouse" — it does now, so show it.

- New rule-agnostic reader over `app.logs` (`ScopeName='everr.alerting'`, plus `ServiceName='alert'` to engage the table's ORDER BY prefix and skip legacy in-process preview rows); tenancy stays on the ClickHouse row policy like the existing history reader.
- The monitor stream page opts back into the global time-range picker, loads stored events for the range, and prepends live SSE frames. Dedup keys on (fingerprint, second-floored eval time, event type), live wins; merged list capped at 700 (documented memory bound). Clear only clears the live buffer; history failure leaves the tail running.
- Drive-by fix: the detail-page history query compared String params against DateTime and threw TYPE_MISMATCH against real ClickHouse; params are now `DateTime64(3)`.

Known issue found while smoke-testing (pre-existing, engine-side, not a regression): CC's `/v1/events/stream` emitted 0 bytes in dev while transitions landed in ClickHouse; filing separately on clickety-clack.

Verified: scoped vitest 32 passed across the touched suites, `tsc --noEmit` clean, biome clean, Playwright smoke on the live dev server (200 stored rows render, picker works, zero console errors).