### PR TITLE
Cover browser ingestion with public keys in the everr-setup-telemetry skill

### DIFF
--- a/.changeset/browser-telemetry-skill.md
+++ b/.changeset/browser-telemetry-skill.md
@@ -1,0 +1,5 @@
+---
+"@everr/desktop-app": patch
+---
+
+The `everr-setup-telemetry` skill now covers direct browser ingestion: a new `browser` rule explains public origin-bound ingest keys, endpoint gating for keyless deploys, error capture, and validation. The old guidance saying all browser telemetry must proxy through a backend now applies to secret keys only.

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/SKILL.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/SKILL.md
@@ -35,6 +35,7 @@ Always read the relevant rule files before editing instrumentation. Use the tabl
 | `validation` | Telemetry validation locally and after deployment |
 | `nodejs` | Node.js instrumentation setup and runtime pitfalls |
 | `nextjs` | Next.js App Router, server/client split, trace propagation |
+| `browser` | Web frontends exporting OTLP directly from the browser with a public origin-bound key |
 | `tauri` | Tauri v2 desktop/mobile: Rust backend + browser frontend proxying telemetry through IPC |
 | `electron` | Electron desktop: Node main process + Chromium renderer proxying telemetry through IPC |
 | `rust` | Rust tracing-based OpenTelemetry setup and runtime pitfalls |
@@ -127,7 +128,7 @@ Implementation expectations:
 - Use hosted ingest only when `EVERR_INGEST_KEY` is set.
 - Keep production telemetry lower-noise than local debug telemetry.
 - Keep secrets, tokens, emails, request bodies, and raw customer payloads out of attributes and log bodies.
-- Do not expose `EVERR_INGEST_KEY` in browser bundles. Browser production telemetry should go through a backend or collector that can attach the ingest key server-side.
+- Do not expose `EVERR_INGEST_KEY` in browser bundles. Browser production telemetry authenticates with a public origin-bound ingest key instead; see `rules/browser.md`.
 - Preserve normal crash and shutdown behavior while flushing telemetry.
 
 ## Validation
@@ -144,4 +145,4 @@ See `rules/validation.md` for the full validation checklist.
 | Adding a run, request, or test marker but querying only by service and time | Filter the query by the marker too, or do not claim the marker proved freshness. |
 | Mirroring every `console.*` call into logs | Prefer targeted OTel logs or the app's structured logger; any bridge must be temporary, gated, redacted, and bounded. |
 | Verifying by UI visibility or absence of exporter errors | Run `everr local query` and show rows from the exercised path. |
-| Exposing `EVERR_INGEST_KEY` to the browser | Route browser telemetry through a backend or collector that attaches credentials server-side. |
+| Exposing `EVERR_INGEST_KEY` to the browser | Browsers use a public origin-bound ingest key (`rules/browser.md`); secret keys stay server-side. |

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/browser.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/browser.md
@@ -1,0 +1,67 @@
+# Browser Instrumentation
+
+Use this rule for web apps that send OpenTelemetry directly from the browser: SPAs, websites, and any frontend that is not wrapped in Electron or Tauri. Wrapped frontends proxy through their backend process instead; use `electron.md` or `tauri.md` for those.
+
+## Key Model
+
+Anything shipped to a browser is visible to every visitor, so browser ingestion never uses a secret key. Everr has two API key kinds and the split is strict:
+
+- **Public keys**: created with **Public browser key** enabled and an origin allowlist. Safe to ship in page source: they only authenticate requests whose `Origin` header matches the allowlist, they are rejected without an `Origin` header (so they are useless server-side), and they can only send telemetry, never `everr apply` or any other API.
+- **Secret keys** (`EVERR_INGEST_KEY`): server-to-server only. Rejected the moment a browser `Origin` header appears. Never put one in a browser bundle, client env var, or page source.
+
+If production browser telemetry is needed and no public key exists, tell the user to mint one in the Everr dashboard: user menu, **API keys**, **New key**, turn on **Public browser key**, and add every origin the app is served from (`scheme://host` with an optional port, no paths). Origins cannot be edited later; changing them means minting a new key and rotating the value in the frontend config. Do not invent, print, or commit key values.
+
+## Endpoint And Gating
+
+- Local development: export to the local collector URL from `everr local status`. It accepts browser OTLP with no key and no origin setup.
+- Production: export to `https://ingest.everr.dev/` with `Authorization: Bearer <public-key>`.
+- Inject the public key through a client build-time variable, for example `VITE_EVERR_PUBLIC_INGEST_KEY` in Vite. Public keys are not secrets, but keep the value out of the repo so it can rotate without a commit.
+- Gate on the key: when the variable is unset in a production build, telemetry must be a no-op so a keyless deploy never POSTs anywhere. In dev builds, fall back to the local collector so developers see their own browser telemetry with no setup.
+- Guard for the browser (`typeof window === "undefined"` returns early) so the module is a no-op during SSR.
+
+## Setup
+
+Run normal OTel web providers with OTLP/HTTP exporters pointed at the resolved endpoint. Logs, with error capture wired on top:
+
+```ts
+import { init as initErrorTracking } from "@everr/auto-otel-errors/browser";
+import { logs } from "@opentelemetry/api-logs";
+import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import { BatchLogRecordProcessor, LoggerProvider } from "@opentelemetry/sdk-logs";
+
+const loggerProvider = new LoggerProvider({
+  resource: resourceFromAttributes({
+    "service.name": "<browser-service-name>",
+    "service.version": "<version>",
+    "deployment.environment.name": "<environment>",
+    "service.instance.id": crypto.randomUUID(),
+  }),
+  processors: [
+    new BatchLogRecordProcessor(
+      new OTLPLogExporter({
+        url: `${endpoint}/v1/logs`,
+        headers, // { Authorization: `Bearer ${publicKey}` } in production, none locally
+      }),
+    ),
+  ],
+});
+logs.setGlobalLoggerProvider(loggerProvider);
+
+// Transport-less: init() is a no-op unless a global LoggerProvider is
+// registered first. Installs window error / unhandledrejection handlers.
+initErrorTracking();
+
+window.addEventListener("beforeunload", () => {
+  void loggerProvider.shutdown(); // best-effort flush of batched records
+});
+```
+
+Traces work the same way with `WebTracerProvider` plus `OTLPTraceExporter` (`/v1/traces`), metrics with `/v1/metrics`. For React render errors, add the `@everr/auto-otel-errors/react` `ErrorBoundary` at the root.
+
+Choose a browser `service.name` distinct from the server's, per `resources.md`, so the two sides stay separable in queries.
+
+## Validation
+
+- Trigger the instrumented path in a real browser, then verify with `everr local query` filtered by the browser `ServiceName` and a fresh time window.
+- A request from an origin missing from the key's allowlist returns 401 and the SDK drops the batch silently. When production rows are missing, check the page's origin against the key's allowlist before touching the code.

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/resolve-values.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/resolve-values.md
@@ -77,4 +77,4 @@ For production Everr ingest:
 - Set `Authorization: Bearer <ingest-key>` server-side only.
 - Never commit keys, print keys, invent keys, or expose `EVERR_INGEST_KEY` in browser bundles.
 
-Browser production telemetry must go through a backend or collector that attaches credentials server-side.
+Browser production telemetry authenticates with a **public** ingest key instead: origin-bound, ingest-only, safe in page source, injected through a client build variable such as `VITE_EVERR_PUBLIC_INGEST_KEY`. Never ship a secret key to the browser. See `rules/browser.md`.


### PR DESCRIPTION
## What

The `everr-setup-telemetry` skill predates public browser ingest keys (#296) and actively contradicted them: it instructed agents to route all browser telemetry through a backend or collector that attaches credentials server-side. An agent following it would refuse to wire direct browser ingestion or build an unnecessary proxy.

- New `rules/browser.md`: when to use it (plain web frontends, vs. the Electron/Tauri proxy rules), the public vs. secret key split (origin allowlist, browser-only, ingest-only), how to mint a key from the API keys page, endpoint selection and gating (keyless production deploys stay no-op, dev falls back to the local collector, SSR guard), provider wiring with error capture via `@everr/auto-otel-errors/browser`, and validation including the silent 401 drop on origin mismatch. Mirrors the web app's own setup from #297 and the [browser telemetry docs](https://everr.dev/docs/reference/browser-telemetry).
- `SKILL.md`: `browser` row in the rule-loading table; the production-export bullet and the common-mistakes row now scope the "never in browser bundles" rule to secret keys and point at the new rule.
- `rules/resolve-values.md`: the authentication section keeps the secret-key rules and adds the public-key path (`VITE_EVERR_PUBLIC_INGEST_KEY`-style client build variable).
- Changeset (`@everr/desktop-app` patch) so the bundled skill ships with the next release.

## Verification

`cargo test -p everr-core --test skills`: 14 passed, 6 failed. The 6 failures are the same stale `using-everr` baseline failures present on clean `main` (verified by stashing the change and re-running; also documented in #290). Skills are embedded via `include_dir` over the whole assets tree, so the new rule file needs no registration.