### PR TITLE
Bake public browser ingest key into the prod app image

### DIFF
--- a/.github/workflows/build-and-push-images.yml
+++ b/.github/workflows/build-and-push-images.yml
@@ -102,6 +102,8 @@ jobs:
           context: .
           file: packages/app/Dockerfile
           push: true
+          build-args: |
+            VITE_EVERR_PUBLIC_INGEST_KEY=${{ vars.APP_EVERR_PUBLIC_INGEST_KEY }}
           tags: |
             ${{ env.SCW_REGISTRY_HOST }}/${{ env.SCW_REGISTRY_NAMESPACE }}/app:${{ github.sha }}
             ${{ env.SCW_REGISTRY_HOST }}/${{ env.SCW_REGISTRY_NAMESPACE }}/app:latest

--- a/packages/app/.env.example
+++ b/packages/app/.env.example
@@ -76,3 +76,11 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:54318
 EVERR_INGEST_KEY=
 SERVICE_VERSION=
 DEPLOYMENT_ENVIRONMENT=
+
+# Browser telemetry (build-time, inlined into the client bundle by Vite).
+# Public (origin-bound, ingest-only) `ek_` key. Safe to ship in the client
+# bundle. When unset in a production build, browser error tracking stays off;
+# in dev it falls back to the local collector. Set VITE_EVERR_INGEST_ENDPOINT
+# only to override the hosted ingest endpoint.
+VITE_EVERR_PUBLIC_INGEST_KEY=
+VITE_EVERR_INGEST_ENDPOINT=

--- a/packages/app/Dockerfile
+++ b/packages/app/Dockerfile
@@ -15,6 +15,10 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 
 # Stage 2: build
 FROM deps AS build
+# Public (origin-bound, ingest-only) browser key baked into the client bundle by
+# Vite at build time. Optional: when unset, browser error tracking stays off.
+ARG VITE_EVERR_PUBLIC_INGEST_KEY
+ENV VITE_EVERR_PUBLIC_INGEST_KEY=$VITE_EVERR_PUBLIC_INGEST_KEY
 COPY packages/auto-otel-errors ./packages/auto-otel-errors
 COPY packages/datemath ./packages/datemath
 COPY packages/ui ./packages/ui


### PR DESCRIPTION
## What

Wires `VITE_EVERR_PUBLIC_INGEST_KEY` through the app Docker build so the production web app bundle can send browser error tracking to Everr.

The browser telemetry client (`packages/app/src/telemetry/client.ts`) reads this key from `import.meta.env`, which Vite **inlines at build time**. Until now the app `Dockerfile` and CI passed nothing, so a prod build always shipped with browser tracking off. This mirrors the existing PostHog wiring on the docs image.

## Changes

- **`packages/app/Dockerfile`**: declare `ARG`/`ENV VITE_EVERR_PUBLIC_INGEST_KEY` in the build stage. Optional, so builds without it still succeed (tracking stays off).
- **`.github/workflows/build-and-push-images.yml`**: pass it as a `build-arg` on the app image job, sourced from `vars.APP_EVERR_PUBLIC_INGEST_KEY`.
- **`packages/app/.env.example`**: document `VITE_EVERR_PUBLIC_INGEST_KEY` and `VITE_EVERR_INGEST_ENDPOINT`.

## Follow-up (manual, outside this PR)

1. Mint a public browser key from the app's **API keys → Public keys** page, with the prod origin (e.g. `https://app.everr.dev`) in its allowed origins.
2. Store it as the GitHub Actions variable `APP_EVERR_PUBLIC_INGEST_KEY`.

The key is origin-bound and ingest-only, so it is safe to inline in the client bundle. Rotating it requires a rebuild, since it is baked in at build time.