### PR TITLE
fix(app): set the installed PWA name to Everr

### DIFF
--- a/packages/app/public/manifest.json
+++ b/packages/app/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "TanStack App",
-  "name": "Create TanStack App Sample",
+  "short_name": "Everr",
+  "name": "Everr",
   "icons": [
     {
       "src": "favicon.ico",
@@ -21,5 +21,5 @@
   "start_url": ".",
   "display": "standalone",
   "theme_color": "#000000",
-  "background_color": "#ffffff"
+  "background_color": "#000000"
 }


### PR DESCRIPTION
The web app manifest (`packages/app/public/manifest.json`) still carried the TanStack starter defaults, so Chrome's "Install app" dialog showed **Create TanStack App Sample** instead of Everr.

- `name` and `short_name` → `Everr`
- `background_color` `#ffffff` → `#000000` (avoids a white splash on the dark app; `theme_color` was already black)

Icons were already Everr's lemon, so they're untouched.

Note: Chrome caches the manifest, so already-installed instances keep the old name until they reinstall.