### PR TITLE
feat(sql-api): block server-introspection functions

### DIFF
--- a/packages/app/src/lib/clickhouse.test.ts
+++ b/packages/app/src/lib/clickhouse.test.ts
@@ -125,6 +125,16 @@ describe("querySqlApi", () => {
     );
     expect(mockQuery).not.toHaveBeenCalled();
   });
+
+  it("rejects server-introspection functions before reaching ClickHouse", async () => {
+    await expect(querySqlApi("SELECT hostName()", ORG)).rejects.toThrow(
+      /server introspection functions/,
+    );
+    await expect(querySqlApiWithMeta("SELECT uptime()", ORG)).rejects.toThrow(
+      /server introspection functions/,
+    );
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
 });
 
 describe("querySqlApiWithMeta", () => {

--- a/packages/app/src/lib/clickhouse.ts
+++ b/packages/app/src/lib/clickhouse.ts
@@ -1,6 +1,7 @@
 import { createHmac, randomUUID } from "node:crypto";
 import { env } from "@/env";
 import { createClient } from "@/lib/clickhouse-client";
+import { assertSqlApiQueryAllowed } from "@/lib/sql-api-guard";
 import { instrumentClickhouseOperation } from "@/telemetry/clickhouse";
 
 // The client default of 2500ms forces a fresh TLS handshake on most queries
@@ -88,6 +89,8 @@ function runSqlApiQuery<Format extends "JSONEachRow" | "JSON">(
   if (typeof organizationId !== "string" || !organizationId) {
     throw new Error("Missing ClickHouse tenant context");
   }
+
+  assertSqlApiQueryAllowed(query);
 
   const username = sqlApiOrgUserName(organizationId);
   const password = sqlApiOrgPassword(organizationId);

--- a/packages/app/src/lib/sql-api-guard.test.ts
+++ b/packages/app/src/lib/sql-api-guard.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { assertSqlApiQueryAllowed } from "./sql-api-guard";
+
+describe("assertSqlApiQueryAllowed", () => {
+  it.each([
+    ["canonical call", "SELECT hostName()"],
+    ["lowercase alias", "SELECT hostname()"],
+    ["uptime", "SELECT uptime()"],
+    ["FQDN", "SELECT FQDN()"],
+    ["FQDN case-insensitive alias", "SELECT fqdn()"],
+    ["fullHostName alias", "SELECT fullHostName()"],
+    ["displayName", "SELECT displayName()"],
+    ["serverUUID", "SELECT serverUUID()"],
+    ["tcpPort", "SELECT tcpPort()"],
+    ["getServerSetting", "SELECT getServerSetting('tcp_port')"],
+    ["getMacro", "SELECT getMacro('replica')"],
+    ["backtick-quoted call", "SELECT `hostName`()"],
+    ["double-quote-quoted call", 'SELECT "hostName"()'],
+    ["comment between name and parens", "SELECT uptime/*x*/()"],
+    ["nested in an expression", "SELECT concat(hostName(), 'x') FROM traces"],
+    ["inside a subquery", "SELECT * FROM (SELECT hostName() AS h)"],
+    [
+      "inside WHERE on a granted table",
+      "SELECT count() FROM traces WHERE ServiceName = hostName()",
+    ],
+    ["APPLY with the function name", "SELECT * APPLY hostName FROM traces"],
+  ])("rejects %s", (_name, sql) => {
+    expect(() => assertSqlApiQueryAllowed(sql)).toThrowError(
+      /server introspection functions/,
+    );
+  });
+
+  it.each([
+    ["plain telemetry query", "SELECT ServiceName FROM traces LIMIT 10"],
+    [
+      "blocked word inside a string literal",
+      "SELECT SpanAttributes['process.uptime'] FROM traces",
+    ],
+    [
+      "blocked word inside a literal with escaped quotes",
+      "SELECT 'it''s the uptime' , 'a \\' hostname'",
+    ],
+    ["blocked word inside a line comment", "SELECT 1 -- check uptime later"],
+    ["blocked word inside a block comment", "SELECT 1 /* hostName() */"],
+    [
+      "identifier that merely contains a blocked word",
+      "SELECT uptime_seconds, host_name FROM (SELECT 1 AS uptime_seconds, 'x' AS host_name)",
+    ],
+    [
+      "column alias resembling but not matching",
+      "SELECT count() AS uptimes FROM traces",
+    ],
+  ])("allows %s", (_name, sql) => {
+    expect(() => assertSqlApiQueryAllowed(sql)).not.toThrow();
+  });
+
+  it("names the offending function in the error", () => {
+    expect(() => assertSqlApiQueryAllowed("SELECT hostName()")).toThrowError(
+      /"hostName"/,
+    );
+  });
+});

--- a/packages/app/src/lib/sql-api-guard.ts
+++ b/packages/app/src/lib/sql-api-guard.ts
@@ -1,0 +1,91 @@
+// ClickHouse has no per-function access control: readonly=1 and the
+// sql_api_role grants still leave every built-in scalar function callable, so
+// server-introspection functions (hostName(), uptime(), ...) would leak infra
+// details to tenants. This guard rejects the query before it reaches
+// ClickHouse. Matching is case-insensitive because some names are registered
+// as case-insensitive aliases (FQDN → fqdn) — over-matching a differently
+// cased user alias is the safe direction.
+const BLOCKED_FUNCTIONS = [
+  // Hostname of the ClickHouse server
+  "hostName",
+  "hostname", // alias of hostName
+  "FQDN", // case-insensitive
+  "fullHostName", // alias of FQDN
+  "displayName", // falls back to the hostname when display_name is unset
+  // Server uptime
+  "uptime",
+  "zookeeperSessionUptime",
+  // Other server-identity introspection with no tenant-facing use
+  "serverUUID",
+  "tcpPort",
+  "getServerPort",
+  "getOSKernelVersion",
+  "getMacro",
+  "getServerSetting",
+  "buildId",
+] as const;
+
+const BLOCKED_PATTERN = new RegExp(
+  `\\b(${[...new Set(BLOCKED_FUNCTIONS.map((name) => name.toLowerCase()))].join("|")})\\b`,
+  "i",
+);
+
+// Blank out single-quoted string literals and comments so words inside them
+// (e.g. SpanAttributes['process.uptime']) don't trip the scanner. Backtick and
+// double-quoted identifiers are intentionally KEPT: `hostName`() is a valid
+// function call and must still match. The stripper is deliberately
+// conservative — anything it fails to recognize as a literal stays in the text
+// and can only cause a false rejection, never a bypass.
+function stripLiteralsAndComments(sql: string): string {
+  let out = "";
+  let i = 0;
+  while (i < sql.length) {
+    const ch = sql[i];
+    if (ch === "'") {
+      i++;
+      while (i < sql.length) {
+        if (sql[i] === "\\") {
+          i += 2;
+        } else if (sql[i] === "'") {
+          // '' inside a literal is an escaped quote, not the terminator
+          if (sql[i + 1] === "'") {
+            i += 2;
+          } else {
+            i++;
+            break;
+          }
+        } else {
+          i++;
+        }
+      }
+      out += " ";
+    } else if (ch === "-" && sql[i + 1] === "-") {
+      while (i < sql.length && sql[i] !== "\n") i++;
+      out += " ";
+    } else if (ch === "/" && sql[i + 1] === "*") {
+      i += 2;
+      while (i < sql.length && !(sql[i] === "*" && sql[i + 1] === "/")) i++;
+      i += 2;
+      out += " ";
+    } else {
+      out += ch;
+      i++;
+    }
+  }
+  return out;
+}
+
+/**
+ * Throw if the SQL references a blocked server-introspection function.
+ * The error message is safe to forward to the client verbatim.
+ */
+export function assertSqlApiQueryAllowed(sql: string): void {
+  const match = stripLiteralsAndComments(sql).match(BLOCKED_PATTERN);
+  if (match) {
+    throw new Error(
+      `Query references "${match[1]}", which is not available: ` +
+        "server introspection functions (hostname, uptime, server identity) " +
+        "are blocked on this endpoint.",
+    );
+  }
+}


### PR DESCRIPTION
## Problem

ClickHouse has no per-function access control: `readonly = 1` and the `sql_api_role` grants still leave every built-in scalar function callable, so any tenant could run `SELECT hostName()`, `SELECT uptime()`, `SELECT FQDN()` (and friends) through the SQL API and learn infra details.

## Fix

Reject those queries app-side, before they reach ClickHouse. A new guard (`sql-api-guard.ts`) runs inside `runSqlApiQuery`, so all four user-SQL surfaces are covered: the CLI `/api/cli/sql` route, the MCP `query` tool, dashboard panels/variables, and alert evaluation.

Blocked (verified against ClickHouse 26 `system.functions`, aliases included):

- hostname: `hostName` / `hostname`, `FQDN` (case-insensitive) / `fullHostName`, `displayName`
- uptime: `uptime`, `zookeeperSessionUptime`
- other server identity with no tenant-facing use: `serverUUID`, `tcpPort`, `getServerPort`, `getOSKernelVersion`, `getMacro`, `getServerSetting`, `buildId`

`version()` stays allowed: clients commonly use it and it is already exposed in response headers.

## Design notes

- The guard strips string literals and comments before scanning, so attribute keys like `SpanAttributes['process.uptime']` still pass, while quoted identifiers are kept so `` `hostName`() `` / `"hostName"()` (both valid call syntaxes) cannot slip through.
- The stripper is deliberately conservative: anything it fails to recognize as a literal stays in the scanned text, so a parsing gap can only cause a false rejection, never a bypass.
- Ruled out at the ClickHouse layer: no GRANT/profile mechanism exists for built-in scalar functions, and `{x:Identifier}` query params cannot invoke a function, so the SQL text is the only channel.
- The error message is stable and self-explanatory, and flows through `sanitizeSqlApiError` unchanged so CLI/MCP/dashboard callers can self-correct.

## Testing

- Unit tests for the guard (call syntaxes, aliases, literals, comments, near-miss identifiers) plus seam tests asserting `querySqlApi`/`querySqlApiWithMeta` reject before the client is called.
- Verified end-to-end against the dev app: blocked functions return a 400 with the guard message; normal telemetry queries and queries mentioning blocked names inside string literals still work.

One behavioral note: an existing dashboard panel or alert rule using one of these functions would now fail with the guard message at run time.