### PR TITLE
feat(cloud-query): feature-driven observability for everr cloud query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,7 +1376,7 @@ dependencies = [
 
 [[package]]
 name = "everr-app"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1452,6 +1452,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "webbrowser",
 ]
@@ -1470,6 +1471,7 @@ dependencies = [
  "mockito",
  "nix",
  "notify",
+ "opentelemetry",
  "pathdiff",
  "reqwest 0.12.28",
  "serde",
@@ -1477,6 +1479,8 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "tokio",
+ "tracing",
+ "tracing-opentelemetry",
 ]
 
 [[package]]
@@ -6185,6 +6189,22 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]

--- a/crates/everr-core/Cargo.toml
+++ b/crates/everr-core/Cargo.toml
@@ -17,6 +17,9 @@ serde_json = "1.0.140"
 serde_yaml = "0.9"
 ignore = "0.4"
 notify = "8"
+opentelemetry = "0.32"
+tracing = "0.1"
+tracing-opentelemetry = "0.33"
 tokio = { version = "1.44.2", features = ["io-util", "macros", "time", "sync"] }
 
 [dev-dependencies]

--- a/crates/everr-core/src/api.rs
+++ b/crates/everr-core/src/api.rs
@@ -3,11 +3,15 @@ use std::fmt;
 use anyhow::{Context, Result};
 use eventsource_stream::Eventsource;
 use futures_util::StreamExt;
+use opentelemetry::global;
+use opentelemetry::propagation::Injector;
 use reqwest::StatusCode;
-use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
+use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
+use tracing::Instrument;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::build;
 use crate::state::Session;
@@ -166,28 +170,42 @@ impl ApiClient {
     }
 
     pub async fn post_sql(&self, sql: &str) -> Result<String> {
-        let response = self
-            .http
-            .post(format!("{}/sql", self.base_endpoint))
-            .header(CONTENT_TYPE, "text/plain")
-            .body(sql.to_string())
-            .send()
-            .await
-            .context("CLI SQL request failed")?;
+        // A CLIENT span whose W3C context is injected into the request, so the
+        // server continues this trace (CLI → server → ClickHouse). No-op unless
+        // the caller installed a tracer provider + propagator (the CLI does).
+        let span = tracing::info_span!(
+            target: "everr_api",
+            "POST /api/cli/sql",
+            otel.kind = "client",
+            http.request.method = "POST",
+        );
+        async move {
+            let response = self
+                .http
+                .post(format!("{}/sql", self.base_endpoint))
+                .header(CONTENT_TYPE, "text/plain")
+                .headers(current_trace_headers())
+                .body(sql.to_string())
+                .send()
+                .await
+                .context("CLI SQL request failed")?;
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let text = response
+            if !response.status().is_success() {
+                let status = response.status();
+                let text = response
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "<failed to read body>".to_string());
+                return Err(http_status_error(status, text, "CLI SQL request"));
+            }
+
+            response
                 .text()
                 .await
-                .unwrap_or_else(|_| "<failed to read body>".to_string());
-            return Err(http_status_error(status, text, "CLI SQL request"));
+                .context("failed to read CLI SQL response body")
         }
-
-        response
-            .text()
-            .await
-            .context("failed to read CLI SQL response body")
+        .instrument(span)
+        .await
     }
 
     pub async fn get_step_logs(
@@ -449,6 +467,33 @@ impl ApiClient {
 /// The API path identifying one resource, shared by show/delete/adopt.
 fn resource_path(kind: &str, project: &str, slug: &str) -> String {
     format!("/resources/{kind}/{project}/{slug}")
+}
+
+/// Writes W3C propagation headers (traceparent/tracestate) into a HeaderMap.
+struct HeaderInjector<'a>(&'a mut HeaderMap);
+
+impl Injector for HeaderInjector<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        if let (Ok(name), Ok(val)) = (
+            HeaderName::from_bytes(key.as_bytes()),
+            HeaderValue::from_str(&value),
+        ) {
+            self.0.insert(name, val);
+        }
+    }
+}
+
+/// Trace-propagation headers for the current span, to add to an outgoing
+/// request. Empty when no tracer/propagator is installed (e.g. in tests, the
+/// desktop app, or when telemetry is disabled) — the global propagator defaults
+/// to a no-op, so nothing is injected and the request is unchanged.
+fn current_trace_headers() -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    let context = tracing::Span::current().context();
+    global::get_text_map_propagator(|propagator| {
+        propagator.inject_context(&context, &mut HeaderInjector(&mut headers));
+    });
+    headers
 }
 
 fn http_status_error(status: StatusCode, text: String, context: &str) -> anyhow::Error {

--- a/everr/cloud-query.alert.yaml
+++ b/everr/cloud-query.alert.yaml
@@ -1,0 +1,24 @@
+kind: AlertRule
+metadata:
+  name: cloud-query-system-errors
+spec:
+  runbook: cloud-query
+  display:
+    name: Cloud query system errors
+    description: >-
+      `everr cloud query` is failing for our-fault reasons (ClickHouse timeout,
+      quota, resource exhaustion, network, or an unexpected exception) rather
+      than bad user SQL.
+  notificationMessage:
+    title: "everr cloud query is failing (${system_errors} system errors in 5 min)"
+    description: "Kinds: ${kinds}. User errors are excluded; these are infrastructure failures."
+  evaluationInterval: 1m
+  query: |
+    SELECT
+      count() AS system_errors,
+      arrayStringConcat(groupUniqArray(SpanAttributes['everr.cloud_query.kind']), ', ') AS kinds
+    FROM traces
+    WHERE SpanName = 'POST /api/cli/sql' AND SpanKind = 'Server'
+      AND SpanAttributes['everr.cloud_query.outcome'] = 'system_error'
+      AND Timestamp >= now() - INTERVAL 5 MINUTE
+    HAVING system_errors >= 2

--- a/everr/cloud-query.dashboard.yaml
+++ b/everr/cloud-query.dashboard.yaml
@@ -1,0 +1,289 @@
+kind: Dashboard
+metadata:
+  name: cloud-query
+spec:
+  display:
+    name: Cloud Query
+    description: >-
+      Health of `everr cloud query` (POST /api/cli/sql): traffic, outcome split
+      (ok / user_error / system_error), latency, the slowest queries with a
+      trace to open, per-tenant usage, and how reliably the CLI leg of each
+      trace is landing.
+  duration: 24h
+  refreshInterval: 1m
+  panels:
+    total-requests:
+      kind: Panel
+      spec:
+        display: { name: Requests }
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: sum
+            sparkline: true
+        queries:
+          - kind: ClickHouseSQL
+            spec:
+              plugin:
+                kind: ClickHouseSQL
+                spec:
+                  query: |
+                    SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} SECOND) AS ts,
+                           count() AS requests
+                    FROM traces
+                    WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                      AND SpanName = 'POST /api/cli/sql' AND SpanKind = 'Server'
+                    GROUP BY ts
+                    ORDER BY ts
+    system-errors:
+      kind: Panel
+      spec:
+        display: { name: System errors, description: Our-fault failures (timeout, quota, resource, network, internal). The pager fires at 2 in 5 min. }
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: sum
+            thresholds:
+              mode: absolute
+              defaultColor: "#22c55e"
+              steps:
+                - { value: 1, color: "#f59e0b" }
+                - { value: 2, color: "#ef4444" }
+        queries:
+          - kind: ClickHouseSQL
+            spec:
+              plugin:
+                kind: ClickHouseSQL
+                spec:
+                  query: |
+                    SELECT countIf(SpanAttributes['everr.cloud_query.outcome'] = 'system_error') AS system_errors
+                    FROM traces
+                    WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                      AND SpanName = 'POST /api/cli/sql' AND SpanKind = 'Server'
+    user-errors:
+      kind: Panel
+      spec:
+        display: { name: User errors, description: Caller's SQL at fault (bad query, blocked function, probing an unreadable table). Never pages. }
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: sum
+        queries:
+          - kind: ClickHouseSQL
+            spec:
+              plugin:
+                kind: ClickHouseSQL
+                spec:
+                  query: |
+                    SELECT countIf(SpanAttributes['everr.cloud_query.outcome'] = 'user_error') AS user_errors
+                    FROM traces
+                    WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                      AND SpanName = 'POST /api/cli/sql' AND SpanKind = 'Server'
+    p95-latency:
+      kind: Panel
+      spec:
+        display: { name: p95 edge latency, description: 95th percentile server-side request duration. }
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            unit: ms
+            decimals: 0
+        queries:
+          - kind: ClickHouseSQL
+            spec:
+              plugin:
+                kind: ClickHouseSQL
+                spec:
+                  query: |
+                    SELECT round(quantile(0.95)(Duration) / 1e6, 0) AS p95_ms
+                    FROM traces
+                    WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                      AND SpanName = 'POST /api/cli/sql' AND SpanKind = 'Server'
+    volume-by-outcome:
+      kind: Panel
+      spec:
+        display: { name: Requests by outcome }
+        plugin:
+          kind: TimeSeriesChart
+          spec: { showLegend: true, stacked: true }
+        queries:
+          - kind: ClickHouseSQL
+            spec:
+              plugin:
+                kind: ClickHouseSQL
+                spec:
+                  query: |
+                    SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} SECOND) AS ts,
+                           if(SpanAttributes['everr.cloud_query.outcome'] = '', 'unknown',
+                              SpanAttributes['everr.cloud_query.outcome']) AS outcome,
+                           count() AS requests
+                    FROM traces
+                    WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                      AND SpanName = 'POST /api/cli/sql' AND SpanKind = 'Server'
+                    GROUP BY ts, outcome
+                    ORDER BY ts
+    latency:
+      kind: Panel
+      spec:
+        display: { name: Edge latency percentiles, description: Server-side request duration p50/p95/max. Sparse at low volume. }
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            unit: ms
+            showLegend: true
+            lineWidth: 1.5
+            curveType: monotone
+        queries:
+          - kind: ClickHouseSQL
+            spec:
+              plugin:
+                kind: ClickHouseSQL
+                spec:
+                  query: |
+                    SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} SECOND) AS ts,
+                           round(quantile(0.5)(Duration) / 1e6, 1) AS p50,
+                           round(quantile(0.95)(Duration) / 1e6, 1) AS p95,
+                           round(max(Duration) / 1e6, 1) AS max
+                    FROM traces
+                    WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                      AND SpanName = 'POST /api/cli/sql' AND SpanKind = 'Server'
+                    GROUP BY ts
+                    ORDER BY ts
+    slowest-queries:
+      kind: Panel
+      spec:
+        display:
+          name: Slowest queries
+          description: >-
+            The slowest individual requests in the window. Watch here for queries
+            creeping toward the 30s ClickHouse cap. Open the trace to see the full
+            CLI to ClickHouse waterfall.
+        plugin:
+          kind: Table
+          spec: { stickyHeader: true }
+        queries:
+          - kind: ClickHouseSQL
+            spec:
+              plugin:
+                kind: ClickHouseSQL
+                spec:
+                  query: |
+                    SELECT formatDateTime(Timestamp, '%m-%d %H:%i:%S') AS time,
+                           SpanAttributes['everr.org_id'] AS org,
+                           SpanAttributes['everr.cloud_query.tables'] AS tables,
+                           SpanAttributes['everr.cloud_query.attr_keys'] AS attr_keys,
+                           round(Duration / 1e6, 0) AS duration_ms,
+                           if(SpanAttributes['everr.cloud_query.outcome'] = '', 'unknown',
+                              SpanAttributes['everr.cloud_query.outcome']) AS outcome,
+                           TraceId AS trace_id
+                    FROM traces
+                    WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                      AND SpanName = 'POST /api/cli/sql' AND SpanKind = 'Server'
+                    ORDER BY Duration DESC
+                    LIMIT 30
+    errors-by-kind:
+      kind: Panel
+      spec:
+        display:
+          name: Errors by kind
+          description: Failure breakdown by classified kind. system_* pages, user_* does not.
+        plugin:
+          kind: Table
+          spec: { stickyHeader: true }
+        queries:
+          - kind: ClickHouseSQL
+            spec:
+              plugin:
+                kind: ClickHouseSQL
+                spec:
+                  query: |
+                    SELECT SpanAttributes['everr.cloud_query.outcome'] AS outcome,
+                           SpanAttributes['everr.cloud_query.kind'] AS kind,
+                           count() AS count,
+                           formatDateTime(max(Timestamp), '%m-%d %H:%i') AS last_seen
+                    FROM traces
+                    WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                      AND SpanName = 'POST /api/cli/sql' AND SpanKind = 'Server'
+                      AND SpanAttributes['everr.cloud_query.outcome'] IN ('user_error', 'system_error')
+                    GROUP BY outcome, kind
+                    ORDER BY count DESC
+                    LIMIT 20
+    top-tenants:
+      kind: Panel
+      spec:
+        display:
+          name: Top tenants
+          description: Organizations using cloud query, with their error counts.
+        plugin:
+          kind: Table
+          spec: { stickyHeader: true }
+        queries:
+          - kind: ClickHouseSQL
+            spec:
+              plugin:
+                kind: ClickHouseSQL
+                spec:
+                  query: |
+                    SELECT SpanAttributes['everr.org_id'] AS org,
+                           count() AS requests,
+                           countIf(SpanAttributes['everr.cloud_query.outcome'] = 'user_error') AS user_errors,
+                           countIf(SpanAttributes['everr.cloud_query.outcome'] = 'system_error') AS system_errors
+                    FROM traces
+                    WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                      AND SpanName = 'POST /api/cli/sql' AND SpanKind = 'Server'
+                    GROUP BY org
+                    ORDER BY requests DESC
+                    LIMIT 30
+    trace-join-health:
+      kind: Panel
+      spec:
+        display:
+          name: Trace join health
+          description: >-
+            Percent of cloud-query requests whose CLI leg also landed (same
+            TraceId carries an everr-cli span). Below 100% means the CLI trace
+            was dropped by the 750ms flush cap or the caller had no ingest key.
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            unit: "%"
+            decimals: 0
+            thresholds:
+              mode: absolute
+              defaultColor: "#ef4444"
+              steps:
+                - { value: 50, color: "#f59e0b" }
+                - { value: 90, color: "#22c55e" }
+        queries:
+          - kind: ClickHouseSQL
+            spec:
+              plugin:
+                kind: ClickHouseSQL
+                spec:
+                  query: |
+                    SELECT round(100 *
+                             uniqExactIf(TraceId, ServiceName = 'everr-cli') /
+                             nullIf(uniqExactIf(TraceId, SpanName = 'POST /api/cli/sql' AND SpanKind = 'Server'), 0),
+                           0) AS joined_pct
+                    FROM traces
+                    WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                      AND (
+                        (SpanName = 'POST /api/cli/sql' AND SpanKind = 'Server')
+                        OR ServiceName = 'everr-cli'
+                      )
+  layouts:
+    - kind: Grid
+      spec:
+        items:
+          - { x: 0,  y: 0,  width: 6,  height: 5,  content: { $ref: "#/spec/panels/total-requests" } }
+          - { x: 6,  y: 0,  width: 6,  height: 5,  content: { $ref: "#/spec/panels/system-errors" } }
+          - { x: 12, y: 0,  width: 6,  height: 5,  content: { $ref: "#/spec/panels/user-errors" } }
+          - { x: 18, y: 0,  width: 6,  height: 5,  content: { $ref: "#/spec/panels/p95-latency" } }
+          - { x: 0,  y: 5,  width: 24, height: 8,  content: { $ref: "#/spec/panels/volume-by-outcome" } }
+          - { x: 0,  y: 13, width: 24, height: 8,  content: { $ref: "#/spec/panels/latency" } }
+          - { x: 0,  y: 21, width: 24, height: 9,  content: { $ref: "#/spec/panels/slowest-queries" } }
+          - { x: 0,  y: 30, width: 12, height: 8,  content: { $ref: "#/spec/panels/errors-by-kind" } }
+          - { x: 12, y: 30, width: 12, height: 8,  content: { $ref: "#/spec/panels/top-tenants" } }
+          - { x: 0,  y: 38, width: 8,  height: 5,  content: { $ref: "#/spec/panels/trace-join-health" } }

--- a/everr/cloud-query.runbook.md
+++ b/everr/cloud-query.runbook.md
@@ -1,0 +1,28 @@
+# Cloud query system errors
+
+`everr cloud query` (POST /api/cli/sql) is failing for our-fault reasons. The alert fires on 2 or more `system_error` outcomes in 5 minutes. User errors (bad SQL, blocked functions, unreadable tables) are classified separately and never fire this alert, so every firing is an infrastructure problem.
+
+## Confirm the blast radius
+
+Read **Recent system errors** and **System error kinds**. The dominant `kind` names the cause:
+
+- `timeout` / `resource`: queries are too heavy (memory, or the 30s ClickHouse cap). Check **Edge latency percentiles** for a climb, and **Recent system errors** for the `tables` involved. Often one tenant running an expensive query.
+- `network`: ClickHouse reachability. Check the ClickHouse ECONNRESET runbook and the ClickHouse service health.
+- `quota`: a tenant is exhausting its per-org quota bucket (`X-ClickHouse-Quota`). Confirm which `org` in **Recent system errors**; the throttle is per-tenant, so this is contained.
+- `internal`: an unexpected exception in the request path, not a ClickHouse error. Open the trace and read the captured exception (`error.source`).
+
+## Pivot into the trace
+
+Every row in **Recent system errors** has a `trace_id`. Open it to see the full waterfall: the CLI command span (`everr-cli`), the server request span, and the leaf `ClickHouse QUERY` span. **ClickHouse execution vs edge time** shows whether the time is inside ClickHouse or in the request path around it (guard, per-org user provisioning, serialization).
+
+If the CLI span is missing from the trace, that is expected when the caller has no `EVERR_INGEST_KEY` or the 750ms flush cap dropped it. It does not affect the failure; the server span is authoritative.
+
+## What is not an incident
+
+- A spike in **user errors** on the dashboard. Those are caller SQL mistakes and are excluded from this alert by design.
+- A single `system_error`. The 2-in-5-min threshold debounces transient ClickHouse ECONNRESET blips, which resolve on retry.
+
+## Related
+
+- ClickHouse ECONNRESET runbook (for `network`-kind failures).
+- Cloud Query dashboard (traffic, outcome split, per-tenant usage, trace-join health).

--- a/everr/cloud-query.runbook.md
+++ b/everr/cloud-query.runbook.md
@@ -4,22 +4,44 @@
 
 ## Confirm the blast radius
 
-Read **Recent system errors** and **System error kinds**. The dominant `kind` names the cause:
+These are the failing requests behind the alert, newest first:
 
-- `timeout` / `resource`: queries are too heavy (memory, or the 30s ClickHouse cap). Check **Edge latency percentiles** for a climb, and **Recent system errors** for the `tables` involved. Often one tenant running an expensive query.
+```panel
+ref: recent-system-errors
+```
+
+The dominant `kind` names the cause:
+
+```panel
+ref: error-kind-breakdown
+```
+
+- `timeout` / `resource`: queries are too heavy (memory, or the 30s ClickHouse cap). Watch the latency panel below for a climb, and read the `tables` column above for the query involved. Often one tenant running an expensive query.
 - `network`: ClickHouse reachability. Check the ClickHouse ECONNRESET runbook and the ClickHouse service health.
-- `quota`: a tenant is exhausting its per-org quota bucket (`X-ClickHouse-Quota`). Confirm which `org` in **Recent system errors**; the throttle is per-tenant, so this is contained.
+- `quota`: a tenant is exhausting its per-org quota bucket (`X-ClickHouse-Quota`). Confirm which `org` in the table above; the throttle is per-tenant, so this is contained.
 - `internal`: an unexpected exception in the request path, not a ClickHouse error. Open the trace and read the captured exception (`error.source`).
+
+## Watch latency
+
+```panel
+ref: latency
+```
+
+A climb toward 30s precedes timeout-kind failures. If p95 rises while volume stays flat, one class of query got heavier.
 
 ## Pivot into the trace
 
-Every row in **Recent system errors** has a `trace_id`. Open it to see the full waterfall: the CLI command span (`everr-cli`), the server request span, and the leaf `ClickHouse QUERY` span. **ClickHouse execution vs edge time** shows whether the time is inside ClickHouse or in the request path around it (guard, per-org user provisioning, serialization).
+Every row in the system-errors table has a `trace_id`. Open it to see the full waterfall: the CLI command span (`everr-cli`), the server request span, and the leaf `ClickHouse QUERY` span. The panel below shows whether the time is inside ClickHouse or in the request path around it (guard, per-org user provisioning, serialization):
+
+```panel
+ref: clickhouse-spans
+```
 
 If the CLI span is missing from the trace, that is expected when the caller has no `EVERR_INGEST_KEY` or the 750ms flush cap dropped it. It does not affect the failure; the server span is authoritative.
 
 ## What is not an incident
 
-- A spike in **user errors** on the dashboard. Those are caller SQL mistakes and are excluded from this alert by design.
+- A spike in user errors. Those are caller SQL mistakes and are excluded from this alert by design.
 - A single `system_error`. The 2-in-5-min threshold debounces transient ClickHouse ECONNRESET blips, which resolve on retry.
 
 ## Related

--- a/everr/cloud-query.runbook.yaml
+++ b/everr/cloud-query.runbook.yaml
@@ -1,0 +1,127 @@
+kind: Runbook
+metadata:
+  name: cloud-query
+  # no project → "default", matching the cloud-query-system-errors alert
+spec:
+  display:
+    name: Cloud query system errors — runbook
+    description: Triage steps for the cloud-query-system-errors alert (infrastructure failures on POST /api/cli/sql).
+  duration: 6h
+  refreshInterval: 1m
+  panels:
+    recent-system-errors:
+      kind: Panel
+      spec:
+        display:
+          name: Recent system errors
+          description: The failing requests behind the alert, newest first. Open the trace to see where in the CLI to ClickHouse path it broke.
+        plugin:
+          kind: Table
+          spec:
+            stickyHeader: true
+        queries:
+          - kind: ClickHouseSQL
+            spec:
+              plugin:
+                kind: ClickHouseSQL
+                spec:
+                  query: |
+                    SELECT formatDateTime(Timestamp, '%m-%d %H:%i:%S') AS time,
+                           SpanAttributes['everr.cloud_query.kind'] AS kind,
+                           SpanAttributes['everr.org_id'] AS org,
+                           SpanAttributes['everr.cloud_query.tables'] AS tables,
+                           round(Duration / 1e6, 0) AS duration_ms,
+                           TraceId AS trace_id
+                    FROM traces
+                    WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                      AND SpanName = 'POST /api/cli/sql' AND SpanKind = 'Server'
+                      AND SpanAttributes['everr.cloud_query.outcome'] = 'system_error'
+                    ORDER BY Timestamp DESC
+                    LIMIT 50
+    error-kind-breakdown:
+      kind: Panel
+      spec:
+        display:
+          name: System error kinds
+          description: Which failure kind dominates points at the cause (timeout/resource = heavy queries; network = ClickHouse reachability; quota = tenant throttling; internal = a bug).
+        plugin:
+          kind: TimeSeriesChart
+          spec: { showLegend: true, stacked: true }
+        queries:
+          - kind: ClickHouseSQL
+            spec:
+              plugin:
+                kind: ClickHouseSQL
+                spec:
+                  query: |
+                    SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} SECOND) AS ts,
+                           SpanAttributes['everr.cloud_query.kind'] AS kind,
+                           count() AS errors
+                    FROM traces
+                    WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                      AND SpanName = 'POST /api/cli/sql' AND SpanKind = 'Server'
+                      AND SpanAttributes['everr.cloud_query.outcome'] = 'system_error'
+                    GROUP BY ts, kind
+                    ORDER BY ts
+    latency:
+      kind: Panel
+      spec:
+        display:
+          name: Edge latency percentiles
+          description: Request duration p50/p95/max. A climb toward 30s precedes timeout-kind failures.
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            unit: ms
+            showLegend: true
+            lineWidth: 1.5
+            curveType: monotone
+        queries:
+          - kind: ClickHouseSQL
+            spec:
+              plugin:
+                kind: ClickHouseSQL
+                spec:
+                  query: |
+                    SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} SECOND) AS ts,
+                           round(quantile(0.5)(Duration) / 1e6, 1) AS p50,
+                           round(quantile(0.95)(Duration) / 1e6, 1) AS p95,
+                           round(max(Duration) / 1e6, 1) AS max
+                    FROM traces
+                    WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                      AND SpanName = 'POST /api/cli/sql' AND SpanKind = 'Server'
+                    GROUP BY ts
+                    ORDER BY ts
+    clickhouse-spans:
+      kind: Panel
+      spec:
+        display:
+          name: ClickHouse execution vs edge time
+          description: Compares the leaf ClickHouse span against the whole request. A gap means time spent outside ClickHouse (guard, provisioning, serialization).
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            unit: ms
+            showLegend: true
+            lineWidth: 1.5
+            curveType: monotone
+        queries:
+          - kind: ClickHouseSQL
+            spec:
+              plugin:
+                kind: ClickHouseSQL
+                spec:
+                  query: |
+                    SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} SECOND) AS ts,
+                           round(quantile(0.95)(Duration) / 1e6, 1) AS p95_ms,
+                           SpanName AS span
+                    FROM traces
+                    WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                      AND (
+                        (SpanName = 'POST /api/cli/sql' AND SpanKind = 'Server')
+                        OR (SpanName = 'ClickHouse QUERY' AND SpanAttributes['clickhouse.client'] = 'sql_api')
+                      )
+                    GROUP BY ts, span
+                    ORDER BY ts
+  markdown:
+    file: ./cloud-query.runbook.md

--- a/packages/app/src/lib/sql-api-observability.test.ts
+++ b/packages/app/src/lib/sql-api-observability.test.ts
@@ -1,0 +1,115 @@
+import { ClickHouseError } from "@clickhouse/client";
+import { describe, expect, it } from "vitest";
+import {
+  classifyCloudQueryError,
+  extractQueryShape,
+} from "@/lib/sql-api-observability";
+
+// The guard (when present) throws an Error named "SqlApiGuardError"; the
+// classifier matches on the name, so the test reproduces that shape directly.
+function guardError(): Error {
+  const error = new Error("blocked");
+  error.name = "SqlApiGuardError";
+  return error;
+}
+
+// ClickHouseError's constructor is internal; build one with the fields the
+// classifier reads (code, type) via the prototype so `instanceof` holds.
+function clickhouseError(code: string, type?: string): ClickHouseError {
+  const error = Object.create(ClickHouseError.prototype) as ClickHouseError & {
+    code: string;
+    type?: string;
+    message: string;
+  };
+  error.code = code;
+  error.type = type;
+  error.message = `ClickHouse error ${code}`;
+  return error;
+}
+
+describe("classifyCloudQueryError", () => {
+  it("classifies a guard rejection as a blocked user error", () => {
+    expect(classifyCloudQueryError(guardError())).toEqual({
+      outcome: "user_error",
+      kind: "guard_blocked",
+    });
+  });
+
+  it("classifies schema-probe codes as a user error", () => {
+    for (const code of ["497", "60", "81"]) {
+      expect(classifyCloudQueryError(clickhouseError(code))).toEqual({
+        outcome: "user_error",
+        kind: "schema_probe",
+      });
+    }
+  });
+
+  it("classifies schema-probe by error type too", () => {
+    expect(
+      classifyCloudQueryError(clickhouseError("999", "UNKNOWN_TABLE")),
+    ).toEqual({ outcome: "user_error", kind: "schema_probe" });
+  });
+
+  it("classifies known infrastructure codes as system errors", () => {
+    expect(classifyCloudQueryError(clickhouseError("159"))).toEqual({
+      outcome: "system_error",
+      kind: "timeout",
+    });
+    expect(classifyCloudQueryError(clickhouseError("241"))).toEqual({
+      outcome: "system_error",
+      kind: "resource",
+    });
+    expect(classifyCloudQueryError(clickhouseError("201"))).toEqual({
+      outcome: "system_error",
+      kind: "quota",
+    });
+    expect(classifyCloudQueryError(clickhouseError("210"))).toEqual({
+      outcome: "system_error",
+      kind: "network",
+    });
+  });
+
+  it("treats any other ClickHouse error as a malformed query (fails safe, no page)", () => {
+    // 47 = UNKNOWN_IDENTIFIER, a typo — must not page.
+    expect(classifyCloudQueryError(clickhouseError("47"))).toEqual({
+      outcome: "user_error",
+      kind: "sql_invalid",
+    });
+  });
+
+  it("treats a non-ClickHouse, non-guard throw as an internal system error", () => {
+    expect(classifyCloudQueryError(new Error("boom"))).toEqual({
+      outcome: "system_error",
+      kind: "internal",
+    });
+  });
+});
+
+describe("extractQueryShape", () => {
+  it("extracts table names after FROM and JOIN", () => {
+    const { tables } = extractQueryShape(
+      "SELECT * FROM traces t JOIN logs l ON t.TraceId = l.TraceId",
+    );
+    expect(tables).toEqual(["traces", "logs"]);
+  });
+
+  it("extracts map-subscript keys but never array-literal values", () => {
+    const { attrKeys } = extractQueryShape(
+      "SELECT * FROM logs WHERE LogAttributes['user.email'] = 'alice@corp.com' " +
+        "AND ServiceName IN ['secret-service']",
+    );
+    expect(attrKeys).toEqual(["user.email"]);
+    // The literal value and the array-literal element must not appear anywhere.
+    expect(attrKeys).not.toContain("alice@corp.com");
+    expect(attrKeys).not.toContain("secret-service");
+  });
+
+  it("dedupes repeated tables and keys", () => {
+    const { tables, attrKeys } = extractQueryShape(
+      "SELECT SpanAttributes['k'], SpanAttributes['k'] FROM traces UNION ALL " +
+        "SELECT SpanAttributes['k'], SpanAttributes['k'] FROM traces",
+    );
+    expect(tables).toEqual(["traces"]);
+    expect(attrKeys).toEqual(["k"]);
+  });
+});

--- a/packages/app/src/lib/sql-api-observability.ts
+++ b/packages/app/src/lib/sql-api-observability.ts
@@ -1,0 +1,112 @@
+import { ClickHouseError } from "@clickhouse/client";
+
+// How a cloud-query request ended, from the alerting point of view:
+//   - user_error   the caller's SQL is at fault (typo, blocked function, probing
+//                  a table they can't read). Expected; never pages.
+//   - system_error our infrastructure is at fault (ClickHouse timed out, ran out
+//                  of memory/quota, was unreachable, or an unexpected exception).
+//                  Marks the span as an error and drives the pager.
+export type CloudQueryOutcome = "ok" | "user_error" | "system_error";
+
+export type CloudQueryErrorKind =
+  | "empty"
+  | "guard_blocked"
+  | "schema_probe"
+  | "sql_invalid"
+  | "timeout"
+  | "quota"
+  | "resource"
+  | "network"
+  | "internal";
+
+export type CloudQueryClassification = {
+  outcome: Exclude<CloudQueryOutcome, "ok">;
+  kind: CloudQueryErrorKind;
+};
+
+// ClickHouse spells out table/column names in these; sanitizeSqlApiError already
+// collapses them into one uniform message. For telemetry they are a user error
+// (querying something they can't read), not an outage.
+const SCHEMA_PROBE_CODES = new Set(["497", "60", "81"]);
+const SCHEMA_PROBE_TYPES = new Set([
+  "ACCESS_DENIED",
+  "UNKNOWN_TABLE",
+  "UNKNOWN_DATABASE",
+]);
+
+// ClickHouse error codes that mean our infrastructure failed, not the user's
+// SQL. Everything else from ClickHouse is treated as a malformed query
+// (user_error) — the common case for a read-only SQL surface. Keeping the
+// system set explicit means a new, unclassified code fails safe as a user error
+// (no false page) rather than a system error (false page).
+const SYSTEM_ERROR_CODES: Record<string, CloudQueryErrorKind> = {
+  "159": "timeout", // TIMEOUT_EXCEEDED
+  "160": "timeout", // TOO_SLOW
+  "201": "quota", // QUOTA_EXCEEDED
+  "241": "resource", // MEMORY_LIMIT_EXCEEDED
+  "202": "resource", // TOO_MANY_SIMULTANEOUS_QUERIES
+  "203": "resource", // NO_FREE_CONNECTION
+  "209": "network", // SOCKET_TIMEOUT
+  "210": "network", // NETWORK_ERROR
+  "279": "network", // ALL_CONNECTION_TRIES_FAILED
+};
+
+// Classify a thrown cloud-query error into an alertable outcome + a finer kind.
+// The order matters: the guard runs before ClickHouse, schema probes are a
+// specific ClickHouse sub-case, then known system codes, then everything else
+// from ClickHouse is a bad query. A non-ClickHouse, non-guard throw is an
+// unexpected bug in our code path — a system error.
+export function classifyCloudQueryError(
+  error: unknown,
+): CloudQueryClassification {
+  // The SQL-API introspection guard rejects a blocked query with an Error named
+  // "SqlApiGuardError". Match on the name so this carries no compile dependency
+  // on the guard module (which some builds don't have); when the guard is
+  // absent, no such error is thrown and this branch simply never fires.
+  if (error instanceof Error && error.name === "SqlApiGuardError") {
+    return { outcome: "user_error", kind: "guard_blocked" };
+  }
+
+  if (error instanceof ClickHouseError) {
+    if (
+      SCHEMA_PROBE_CODES.has(error.code) ||
+      SCHEMA_PROBE_TYPES.has(error.type ?? "")
+    ) {
+      return { outcome: "user_error", kind: "schema_probe" };
+    }
+    const systemKind = SYSTEM_ERROR_CODES[error.code];
+    if (systemKind) {
+      return { outcome: "system_error", kind: systemKind };
+    }
+    return { outcome: "user_error", kind: "sql_invalid" };
+  }
+
+  return { outcome: "system_error", kind: "internal" };
+}
+
+export type CloudQueryShape = {
+  tables: string[];
+  attrKeys: string[];
+};
+
+// Safe, structured facts about a query — never the query text or any literal
+// value. Both patterns match only schema-identifier positions:
+//   - tables:   the identifier after FROM/JOIN.
+//   - attrKeys: the string inside a map subscript `Ident['key']`. ClickHouse
+//     grammar guarantees a string in subscript position (identifier immediately
+//     followed by `['...']`) is a map key, never an array-literal value — so
+//     `IN ['secret@example.com']` (no identifier before `[`) does NOT match and
+//     no user value leaks.
+export function extractQueryShape(sql: string): CloudQueryShape {
+  const tables = new Set<string>();
+  for (const match of sql.matchAll(/\b(?:from|join)\s+([a-zA-Z_]\w*)/gi)) {
+    tables.add(match[1]);
+  }
+
+  const attrKeys = new Set<string>();
+  for (const match of sql.matchAll(/\w+\['([^']+)'\]/g)) {
+    attrKeys.add(match[1]);
+  }
+
+  return { tables: [...tables], attrKeys: [...attrKeys] };
+}

--- a/packages/app/src/routes/api/cli/sql.ts
+++ b/packages/app/src/routes/api/cli/sql.ts
@@ -1,6 +1,11 @@
+import { SpanStatusCode, trace } from "@opentelemetry/api";
 import { createFileRoute } from "@tanstack/react-router";
 import { querySqlApi } from "@/lib/clickhouse";
 import { sanitizeSqlApiError } from "@/lib/sql-api-error";
+import {
+  classifyCloudQueryError,
+  extractQueryShape,
+} from "@/lib/sql-api-observability";
 
 function toNdjson(rows: Array<Record<string, unknown>>): string {
   if (rows.length === 0) {
@@ -15,8 +20,36 @@ export const Route = createFileRoute("/api/cli/sql")({
     handlers: {
       POST: async ({ request, context }) => {
         const sql = await request.text();
+        // The active span here is the SERVER span opened by instrumentServerFetch
+        // (it wraps the whole fetch). We annotate it directly rather than open a
+        // child, so cloud-query health is queryable off the request span itself.
+        const span = trace.getActiveSpan();
+        const orgId = context.session.session.activeOrganizationId;
+
+        if (span) {
+          span.setAttribute("everr.feature", "cloud_query");
+          if (orgId) {
+            span.setAttribute("everr.org_id", orgId);
+          }
+          // Safe structured facts only — never the query text or any literal.
+          const shape = extractQueryShape(sql);
+          if (shape.tables.length > 0) {
+            span.setAttribute(
+              "everr.cloud_query.tables",
+              shape.tables.join(","),
+            );
+          }
+          if (shape.attrKeys.length > 0) {
+            span.setAttribute(
+              "everr.cloud_query.attr_keys",
+              shape.attrKeys.join(","),
+            );
+          }
+        }
 
         if (!sql.trim()) {
+          span?.setAttribute("everr.cloud_query.outcome", "user_error");
+          span?.setAttribute("everr.cloud_query.kind", "empty");
           return Response.json(
             { error: "SQL query is required." },
             { status: 400 },
@@ -24,10 +57,10 @@ export const Route = createFileRoute("/api/cli/sql")({
         }
 
         try {
-          const rows = await querySqlApi<Record<string, unknown>>(
-            sql,
-            context.session.session.activeOrganizationId,
-          );
+          const rows = await querySqlApi<Record<string, unknown>>(sql, orgId);
+
+          span?.setAttribute("everr.cloud_query.outcome", "ok");
+          span?.setAttribute("everr.cloud_query.result_rows", rows.length);
 
           return new Response(toNdjson(rows), {
             headers: {
@@ -35,6 +68,16 @@ export const Route = createFileRoute("/api/cli/sql")({
             },
           });
         } catch (error) {
+          const { outcome, kind } = classifyCloudQueryError(error);
+          if (span) {
+            span.setAttribute("everr.cloud_query.outcome", outcome);
+            span.setAttribute("everr.cloud_query.kind", kind);
+            // Only our-fault failures mark the span as an error, so error-rate
+            // and the pager ignore user typos. User errors stay Ok-status.
+            if (outcome === "system_error") {
+              span.setStatus({ code: SpanStatusCode.ERROR, message: kind });
+            }
+          }
           return Response.json(
             { error: sanitizeSqlApiError(error) },
             { status: 400 },

--- a/packages/app/src/telemetry/server.ts
+++ b/packages/app/src/telemetry/server.ts
@@ -1,8 +1,15 @@
-import type { Attributes } from "@opentelemetry/api";
+import type { Attributes, TextMapGetter } from "@opentelemetry/api";
+import { context, propagation } from "@opentelemetry/api";
 import { captureError, getTelemetryTracer, SpanKind } from "./node";
 import { parameterizeTelemetryPath } from "./paths";
 
 const tracer = getTelemetryTracer();
+
+// Read W3C headers off a Fetch `Headers` object for context extraction.
+const headersGetter: TextMapGetter<Headers> = {
+  keys: (carrier) => [...carrier.keys()],
+  get: (carrier, key) => carrier.get(key) ?? undefined,
+};
 
 export async function instrumentServerFetch(
   request: Request,
@@ -11,12 +18,22 @@ export async function instrumentServerFetch(
   const route = parameterizeTelemetryPath(new URL(request.url).pathname);
   const method = request.method.toUpperCase();
 
+  // Continue a trace started by a first-party client (e.g. the CLI, which
+  // injects `traceparent`) instead of starting a fresh root. Requests without
+  // the header extract to an empty context, so this span roots itself as before.
+  const parentContext = propagation.extract(
+    context.active(),
+    request.headers,
+    headersGetter,
+  );
+
   return tracer.startActiveSpan(
     `${method} ${route}`,
     {
       attributes: requestAttributes(request, route, method),
       kind: SpanKind.SERVER,
     },
+    parentContext,
     async (span) => {
       try {
         const response = await run();

--- a/packages/desktop-app/src-cli/Cargo.toml
+++ b/packages/desktop-app/src-cli/Cargo.toml
@@ -18,10 +18,11 @@ dirs = "6.0.0"
 everr-core = { path = "../../../crates/everr-core" }
 flate2 = "1.1"
 futures-util = "0.3"
-opentelemetry = { version = "0.32", features = ["logs"] }
+opentelemetry = { version = "0.32", features = ["logs", "trace"] }
 opentelemetry-appender-tracing = "0.32"
-opentelemetry-otlp = { version = "0.32", default-features = false, features = ["http-proto", "logs", "reqwest-blocking-client", "reqwest-rustls"] }
-opentelemetry_sdk = { version = "0.32", features = ["logs", "rt-tokio"] }
+opentelemetry-otlp = { version = "0.32", default-features = false, features = ["http-proto", "logs", "trace", "reqwest-blocking-client", "reqwest-rustls"] }
+opentelemetry_sdk = { version = "0.32", features = ["logs", "trace", "rt-tokio"] }
+tracing-opentelemetry = "0.33"
 reqwest = { version = "0.12.15", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"

--- a/packages/desktop-app/src-cli/src/command_telemetry.rs
+++ b/packages/desktop-app/src-cli/src/command_telemetry.rs
@@ -4,9 +4,13 @@ use std::ffi::OsString;
 use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
+use opentelemetry::global;
+use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_otlp::{Protocol, WithExportConfig, WithHttpConfig};
 use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::logs::{BatchConfigBuilder, BatchLogProcessor, SdkLoggerProvider};
+use opentelemetry_sdk::propagation::TraceContextPropagator;
+use opentelemetry_sdk::trace::SdkTracerProvider;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -20,10 +24,14 @@ const SERVICE_NAME: &str = "everr-cli";
 const EVENT_NAME: &str = "everr.cli.command";
 const RESULT_EVENT_NAME: &str = "everr.cli.command.result";
 const EVENT_TARGET: &str = "everr_cli_command";
+// Tracing target of the spans everr-core emits around its HTTP calls. Must match
+// the literal used in `everr_core::api` so this filter captures them.
+const API_TARGET: &str = "everr_api";
 const EXPORT_TIMEOUT: Duration = Duration::from_millis(750);
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(750);
 
 static LOGGER_PROVIDER: OnceLock<Mutex<Option<SdkLoggerProvider>>> = OnceLock::new();
+static TRACER_PROVIDER: OnceLock<Mutex<Option<SdkTracerProvider>>> = OnceLock::new();
 
 pub struct TelemetryGuard {
     active: bool,
@@ -97,6 +105,9 @@ pub fn record_result(
             );
         }
         Err(err) => {
+            // Mark the active command span (see command_span) as failed so
+            // failed invocations are distinguishable in traces, not just logs.
+            tracing::Span::current().record("otel.status_code", "ERROR");
             let error = format!("{err:#}");
             tracing::event!(
                 target: EVENT_TARGET,
@@ -115,7 +126,34 @@ pub fn record_result(
     }
 }
 
+/// The root span for one CLI invocation. All work runs inside it (main
+/// instruments `run_command` with it), so once everr-core injects the trace
+/// context into its HTTP calls the trace stitches CLI → server → ClickHouse.
+/// Reuses the command/subcommand identity that the log events already carry.
+pub fn command_span(command: &'static str, subcommand: Option<&'static str>) -> tracing::Span {
+    tracing::info_span!(
+        target: EVENT_TARGET,
+        "everr.cli.command",
+        everr.cli.command = command,
+        everr.cli.subcommand = subcommand.unwrap_or_default(),
+        os.type = operating_system(),
+        otel.status_code = tracing::field::Empty,
+    )
+}
+
 pub fn shutdown() {
+    if let Some(lock) = TRACER_PROVIDER.get() {
+        if let Some(provider) = lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
+        {
+            // The span exporter's per-request timeout (EXPORT_TIMEOUT) bounds how
+            // long this can block, keeping the trace flush inside the same budget
+            // as the log flush so an interactive command still exits promptly.
+            let _ = provider.shutdown();
+        }
+    }
     if let Some(lock) = LOGGER_PROVIDER.get() {
         if let Some(provider) = lock
             .lock()
@@ -135,6 +173,23 @@ pub fn exit(code: i32) -> ! {
 fn init_inner() -> Result<TelemetryGuard, Box<dyn std::error::Error + Send + Sync>> {
     let config = TelemetryConfig::from_env();
     let resource = resource();
+
+    let span_exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_http()
+        .with_protocol(Protocol::HttpBinary)
+        .with_endpoint(signal_endpoint(&config.endpoint, "traces"))
+        .with_timeout(EXPORT_TIMEOUT)
+        .with_headers(config.headers.clone())
+        .build()?;
+    let tracer_provider = SdkTracerProvider::builder()
+        .with_resource(resource.clone())
+        .with_batch_exporter(span_exporter)
+        .build();
+    global::set_tracer_provider(tracer_provider.clone());
+    // W3C traceparent so everr-core's HTTP calls carry the context to the server.
+    global::set_text_map_propagator(TraceContextPropagator::new());
+    let trace_layer =
+        tracing_opentelemetry::layer().with_tracer(tracer_provider.tracer(SERVICE_NAME));
 
     let log_exporter = opentelemetry_otlp::LogExporter::builder()
         .with_http()
@@ -160,7 +215,10 @@ fn init_inner() -> Result<TelemetryGuard, Box<dyn std::error::Error + Send + Syn
         opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge::new(&logger_provider);
 
     tracing_subscriber::registry()
-        .with(EnvFilter::new(format!("{EVENT_TARGET}=info")))
+        .with(EnvFilter::new(format!(
+            "{EVENT_TARGET}=info,{API_TARGET}=info"
+        )))
+        .with(trace_layer)
         .with(log_layer)
         .try_init()?;
 
@@ -169,6 +227,11 @@ fn init_inner() -> Result<TelemetryGuard, Box<dyn std::error::Error + Send + Syn
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
         .replace(logger_provider);
+    let _ = TRACER_PROVIDER
+        .get_or_init(|| Mutex::new(None))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .replace(tracer_provider);
 
     Ok(TelemetryGuard { active: true })
 }

--- a/packages/desktop-app/src-cli/src/main.rs
+++ b/packages/desktop-app/src-cli/src/main.rs
@@ -21,6 +21,7 @@ mod test_support {
 use anyhow::Result;
 use clap::Parser;
 use cli::{CiSubcommand, Cli, CloudSubcommand, Commands};
+use tracing::Instrument;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -28,11 +29,21 @@ async fn main() -> Result<()> {
     let cli = Cli::parse_from(argv.clone());
     let telemetry = command_telemetry::init();
     let (command, subcommand) = command_telemetry::command_names(&cli);
-    command_telemetry::record_invocation(&cli, argv);
-    update_notice::maybe_print(&cli).await;
 
-    let result = run_command(cli.command).await;
-    command_telemetry::record_result(command, subcommand, &result);
+    // Run the whole command inside the root span so every everr-core HTTP call
+    // is a child of it and the injected trace context stitches the trace across
+    // the CLI → server → ClickHouse boundary.
+    let span = command_telemetry::command_span(command, subcommand);
+    let result = async move {
+        command_telemetry::record_invocation(&cli, argv);
+        update_notice::maybe_print(&cli).await;
+        let result = run_command(cli.command).await;
+        command_telemetry::record_result(command, subcommand, &result);
+        result
+    }
+    .instrument(span)
+    .await;
+
     telemetry.shutdown();
 
     result


### PR DESCRIPTION
Feature-driven observability for `everr cloud query` (the `POST /api/cli/sql` path), instrumented end to end plus its as-code dashboard, alert, and runbook.

## Why
`everr cloud query` is a low-volume (~30/day) but high-leverage feature. Today the request already produces a server span and a leaf ClickHouse span, but failures are invisible as errors (everything is caught and returned as HTTP 400), there is no error taxonomy, and the CLI emits logs only, so a single invocation cannot be followed across the CLI, server, and ClickHouse.

## What

**Server**
- Classify failures into `ok` / `user_error` / `system_error` (plus a finer `kind`) and annotate the request span. Only `system_error` sets the span status to Error, so error-rate and alerting ignore user SQL mistakes (typos, blocked functions, unreadable tables). The system-error set is explicit, so an unclassified ClickHouse code fails safe as a user error (no false page).
- Record safe, structured facts on the span: `org_id`, referenced `tables` and map-access `attr_keys`, and `result_rows`. Never the query text or any literal value (the `attr_keys` extraction matches only map-subscript positions, so array-literal values cannot leak).
- Extract the inbound W3C `traceparent` in `instrumentServerFetch` so the request span continues a trace started by a first-party client.

**CLI**
- Add a tracer provider and OTLP trace exporter, and open a root span per command, reusing the existing invocation/result seam (so all commands benefit; cloud query filters in).
- `everr-core` injects the trace context into `POST /api/cli/sql`, so one invocation is a single trace across CLI, server, and ClickHouse. No-op when no tracer/propagator is installed (tests, desktop app, telemetry disabled).
- Bounded 750ms flush on shutdown. A dashboard panel measures the resulting trace-join coverage so the real flush loss is observed, not guessed.

**Resources (`everr/`)**
- `cloud-query.dashboard.yaml`: traffic, outcome split, latency, slowest queries, errors by kind, top tenants, trace-join health.
- `cloud-query.alert.yaml`: `cloud-query-system-errors`, fires on 2+ system errors in 5 minutes (debounced so a transient ECONNRESET does not page).
- `cloud-query.runbook.yaml` + `.md`: triage panels and steps.

## Notes
- `guard_blocked` classification is intentionally decoupled: the classifier matches a `SqlApiGuardError` by name, carrying no dependency on the SQL-API guard module (not yet on `main`). It lights up automatically once the guard lands.
- Apply the resources with `everr apply ./everr` (validated here with `--dry-run`).

## Validation
- App: `sql-api-observability` unit tests pass (9), `tsc --noEmit` clean.
- Rust: `everr-cli` + `everr-core` build clean; `everr-core` lib tests pass (94).
- Resources: `everr apply ./everr --dry-run` plans the dashboard, alert, and runbook as created.