### PR TITLE
Use Instrument Sans for heading and body

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -13,8 +13,7 @@
   },
   "dependencies": {
     "@everr/ui": "workspace:*",
-    "@fontsource-variable/inter": "^5.2.8",
-    "@fontsource-variable/space-grotesk": "^5.2.10",
+    "@fontsource-variable/instrument-sans": "^5.2.8",
     "@icons-pack/react-simple-icons": "catalog:",
     "@posthog/react": "^1.9.0",
     "@t3-oss/env-core": "catalog:",

--- a/packages/docs/src/routes/api/og/devlog.$slug.tsx
+++ b/packages/docs/src/routes/api/og/devlog.$slug.tsx
@@ -1,6 +1,5 @@
 import { cn } from "@everr/ui/lib/utils";
-import interFontBase64 from "@fontsource-variable/inter/files/inter-latin-standard-normal.woff2?inline";
-import spaceGroteskFontBase64 from "@fontsource-variable/space-grotesk/files/space-grotesk-latin-wght-normal.woff2?inline";
+import instrumentSansFontBase64 from "@fontsource-variable/instrument-sans/files/instrument-sans-latin-wght-normal.woff2?inline";
 import { ImageResponse } from "@takumi-rs/image-response";
 import { createFileRoute } from "@tanstack/react-router";
 import { devlogposts } from "@/lib/source";
@@ -17,8 +16,7 @@ function decodeInlineFont(dataUrl: string): ArrayBuffer {
   return bytes.buffer;
 }
 
-const interFontData = decodeInlineFont(interFontBase64);
-const spaceGroteskFontData = decodeInlineFont(spaceGroteskFontBase64);
+const instrumentSansFontData = decodeInlineFont(instrumentSansFontBase64);
 
 function StatItem({
   icon,
@@ -37,13 +35,13 @@ function StatItem({
       <div className="flex flex-col">
         <span
           className={cn("font-heading text-2xl font-bold", className)}
-          style={{ fontFamily: "Space Grotesk" }}
+          style={{ fontFamily: "Instrument Sans" }}
         >
           {value}
         </span>
         <span
           className="font-heading text-[11px] font-bold uppercase tracking-widest text-neutral-500"
-          style={{ fontFamily: "Space Grotesk" }}
+          style={{ fontFamily: "Instrument Sans" }}
         >
           {label}
         </span>
@@ -81,13 +79,13 @@ export const Route = createFileRoute("/api/og/devlog/$slug")({
             <div className="flex items-center justify-between">
               <div
                 className="font-heading text-[22px] font-semibold tracking-tight"
-                style={{ fontFamily: "Space Grotesk" }}
+                style={{ fontFamily: "Instrument Sans" }}
               >
                 Everr
               </div>
               <div
                 className="font-heading text-base font-semibold uppercase tracking-[0.15em] text-neutral-500"
-                style={{ fontFamily: "Space Grotesk" }}
+                style={{ fontFamily: "Instrument Sans" }}
               >
                 Devlog
               </div>
@@ -97,19 +95,19 @@ export const Route = createFileRoute("/api/og/devlog/$slug")({
             <div className="flex flex-col flex-1 justify-center gap-4">
               <div
                 className="font-heading text-sm font-bold uppercase tracking-[0.15em] text-neutral-500"
-                style={{ fontFamily: "Space Grotesk" }}
+                style={{ fontFamily: "Instrument Sans" }}
               >
                 {formattedDate}
               </div>
               <div
                 className="font-heading text-5xl font-bold leading-[1.05] tracking-tight max-w-[900px]"
-                style={{ fontFamily: "Space Grotesk" }}
+                style={{ fontFamily: "Instrument Sans" }}
               >
                 {title}
               </div>
               <div
                 className="text-xl leading-relaxed text-neutral-400 max-w-[800px]"
-                style={{ fontFamily: "Inter" }}
+                style={{ fontFamily: "Instrument Sans" }}
               >
                 {description}
               </div>
@@ -220,13 +218,8 @@ export const Route = createFileRoute("/api/og/devlog/$slug")({
             stylesheets: [stylesheet],
             fonts: [
               {
-                name: "Inter",
-                data: interFontData,
-                style: "normal" as const,
-              },
-              {
-                name: "Space Grotesk",
-                data: spaceGroteskFontData,
+                name: "Instrument Sans",
+                data: instrumentSansFontData,
                 style: "normal" as const,
               },
             ],

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -11,8 +11,7 @@
   "dependencies": {
     "@base-ui/react": "^1.4.1",
     "@everr/datemath": "workspace:*",
-    "@fontsource-variable/inter": "^5.2.8",
-    "@fontsource-variable/space-grotesk": "^5.2.10",
+    "@fontsource-variable/instrument-sans": "^5.2.8",
     "@tanstack/react-query": "catalog:",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -1,11 +1,10 @@
 @import "tailwindcss";
 @import "tw-animate-css";
-@import "@fontsource-variable/inter";
-@import "@fontsource-variable/space-grotesk";
+@import "@fontsource-variable/instrument-sans";
 
 @theme inline {
-  --font-sans: "Inter Variable", sans-serif;
-  --font-heading: "Space Grotesk Variable", sans-serif;
+  --font-sans: "Instrument Sans Variable", sans-serif;
+  --font-heading: "Instrument Sans Variable", sans-serif;
 
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -515,12 +515,9 @@ importers:
       '@everr/ui':
         specifier: workspace:*
         version: link:../ui
-      '@fontsource-variable/inter':
+      '@fontsource-variable/instrument-sans':
         specifier: ^5.2.8
         version: 5.2.8
-      '@fontsource-variable/space-grotesk':
-        specifier: ^5.2.10
-        version: 5.2.10
       '@icons-pack/react-simple-icons':
         specifier: 'catalog:'
         version: 13.13.0(react@19.2.6)
@@ -679,12 +676,9 @@ importers:
       '@everr/datemath':
         specifier: workspace:*
         version: link:../datemath
-      '@fontsource-variable/inter':
+      '@fontsource-variable/instrument-sans':
         specifier: ^5.2.8
         version: 5.2.8
-      '@fontsource-variable/space-grotesk':
-        specifier: ^5.2.10
-        version: 5.2.10
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.100.9(react@19.2.6)
@@ -1954,11 +1948,8 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
-  '@fontsource-variable/inter@5.2.8':
-    resolution: {integrity: sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==}
-
-  '@fontsource-variable/space-grotesk@5.2.10':
-    resolution: {integrity: sha512-yJQO/o35/hAP3CFnpdFTwQku2yzJOae2HIpBmqkOVoxhhXJaQP3g+b6Jrz7u+eI7A5ZdCIf88uMWpBJdFiGr5w==}
+  '@fontsource-variable/instrument-sans@5.2.8':
+    resolution: {integrity: sha512-mTCaukbdIjjoipj2E3Q5XoZM3ZxJWdzyHevf/LG/0PHlfF9Q85pxOM7B7A9MerFyxmRzz5kVlumgIvgDSG4CPg==}
 
   '@fumadocs/tailwind@0.0.5':
     resolution: {integrity: sha512-ENKPWUDRmriccsrUDE4bDBq3FNr/ms3BP2rWlsAEMV1yP23pcCaan+ceGfeBUsAQjw7sj9Q3R4Kl3g/TCStPzQ==}
@@ -9082,9 +9073,7 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@fontsource-variable/inter@5.2.8': {}
-
-  '@fontsource-variable/space-grotesk@5.2.10': {}
+  '@fontsource-variable/instrument-sans@5.2.8': {}
 
   '@fumadocs/tailwind@0.0.5(@tailwindcss/oxide@4.3.0)(tailwindcss@4.3.0)':
     optionalDependencies:


### PR DESCRIPTION
## What

Switch the project's typography to **Instrument Sans** for both heading and body, replacing the previous split stack (Space Grotesk for headings, Inter for body).

## Changes
- `@everr/ui` global stylesheet: single `@fontsource-variable/instrument-sans` import; both `--font-sans` and `--font-heading` set to `Instrument Sans Variable`.
- Swapped the fontsource dependency in `@everr/ui` and `@everr/docs` (lockfile updated).
- Devlog OG image route: embed Instrument Sans as the single registered font.

Because everything reads from the shared `--font-sans` / `--font-heading` variables, this applies across docs, app, and ui with no per-component changes.

## Verification
- `pnpm types:check` passes.
- Verified in the docs dev server: headings, body, and the OG-embedded font all render Instrument Sans.