### PR TITLE
docs: add Errors & Triage section to everr-use-telemetry skill, polish docs pages

### DIFF
--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/runbooks.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/runbooks.md
@@ -1,6 +1,15 @@
 # Writing Everr Runbooks
 
-An Everr **runbook** is an as-code markdown document — an operational runbook, an agent skill, or an investigation doc — with dashboard visualizations embedded directly in the prose. A runbook is one `kind: Runbook` YAML file plus the `.md` files it points at, named `<slug>.runbook.yaml` in the apply tree. It renders read-only in the webapp at `/runbooks/<project>/<slug>`.
+An Everr **runbook** is an\markdown document with visualizations embedded directly in the prose.
+
+Don't ask the user to (unless explicitly requested):
+- run a SQL query themselves
+- go to a given dashboard or check a telemetry manually
+
+Instead, bake into the runbook visualizations needed to do the investigations/analysis steps.
+
+A runbook is one `kind: Runbook` YAML file plus the `.md` files it points at, named `<slug>.runbook.yaml` in the apply tree. 
+It renders read-only in the webapp at `/runbooks/<project>/<slug>`.
 
 Runbooks reuse the exact same panel, variable, and query model as dashboards — a panel object inside a runbook **is** a dashboard panel, byte for byte. Read `rules/queries.md` for that model; this file covers the runbook-specific schema and the ```panel embed syntax.
 

--- a/packages/docs/content/docs/concepts/how-alerts-work.mdx
+++ b/packages/docs/content/docs/concepts/how-alerts-work.mdx
@@ -1,13 +1,12 @@
 ---
 title: How alerts work
-description: Every row an alert query returns is a firing instance; an empty result means resolved.
 ---
 
-**Every row the alert query returns is a firing instance. An empty result means resolved.** There is no separate threshold field, no pending duration, no state machine to configure — the SQL is the whole condition.
+Every row the alert query returns is a firing instance. An empty result means resolved.
 
 ## The evaluation loop
 
-Everr runs `spec.query` every `evaluationInterval`. Notifications fire on the **edges** — when an instance newly starts firing and when it resolves — not on every evaluation while it stays firing. A service whose event loop has been blocked for an hour produces one "firing" notification, not one per minute.
+Everr runs `spec.query` every `evaluationInterval`. Notifications fire on the **edges** — when an instance newly starts firing and when it resolves, not on every evaluation while it stays firing. A service whose event loop has been blocked for an hour produces one "firing" notification, not one per minute.
 
 ```yaml
 kind: AlertRule
@@ -24,15 +23,11 @@ spec:
     HAVING p99_delay_ms > 100
 ```
 
-The threshold lives in the SQL — a `WHERE` filter, a `HAVING` clause, whatever comparison defines "something is wrong." A healthy service sits around 10ms, so `HAVING p99_delay_ms > 100` returns rows only when the loop is genuinely blocked.
+The threshold lives in the SQL, a `WHERE` filter, a `HAVING` clause, whatever comparison defines "something is wrong." A healthy service sits around 10ms, so `HAVING p99_delay_ms > 100` returns rows only when the event loop is stuck for more than 100ms.
 
 ## Instance identity
 
-By default an instance's identity is the set of **string** columns the query returns; numeric columns are measurements, not identity. The rule above returns `ServiceName` (a string) and `p99_delay_ms` (a number), so it produces one instance per service automatically — a single rule scales across every service, firing independently for `checkout`, `payments`, and anything else. Because the numeric column is not part of identity, a service stays the same instance as its delay rises and falls. To carry an extra string column in the message without churning identity, override which columns count. See [alert queries](/docs/reference/alert-queries).
-
-## Flapping and windows
-
-The **query window is the smoothing mechanism**: a 5-minute lookback evaluated every minute averages a single momentary blip into the window instead of notifying on it. Align the window to the interval to control flapping.
+By default an instance's identity is the set of **string** columns the query returns; numeric columns are measurements, not identity. The rule above returns `ServiceName` (a string) and `p99_delay_ms` (a number), so it produces one instance per service automatically, a single rule scales across every service, firing independently for `checkout`, `payments`, and anything else. Because the numeric column is not part of identity, a service stays the same instance as its delay rises and falls. To carry an extra string column in the message without churning identity, override which columns count. See [alert queries](/docs/reference/alert-queries).
 
 ## Notifications
 

--- a/packages/docs/content/docs/index.mdx
+++ b/packages/docs/content/docs/index.mdx
@@ -1,9 +1,11 @@
 ---
 title: What Everr is
-description: Collect your traces, logs, and metrics as OpenTelemetry and query them with plain SQL, from your laptop, CI, and production.
+description: Observability with the DX of web development
 ---
 
 Most observability tools are complex, built for organizations that can afford dedicated telemetry engineers and the time to wire everything up.
+
+As web developers we are used to work with great dev tools, but observability tooling hasn't catched up yet.
 
 Everr is an observability platform for teams that need to ship fast: deep insight into your systems without losing days to setup or standing up a team to run it.
 
@@ -14,9 +16,9 @@ Everr is an observability platform for teams that need to ship fast: deep insigh
 
 ## Two places telemetry lives
 
-Your code emits OpenTelemetry over OTLP, and it lands in one of two stores that share the same query model:
+Your code emits OpenTelemetry over OTLP, and it lands in one of two places that share the same query model:
 
-- **The Collector** is a service the desktop app runs on your machine. It holds your local telemetry for a fast feedback loop while you write and debug code.
+- **Your laptop**, using a local collector the desktop app runs on your machine. It holds your local telemetry for a fast feedback loop while you write and debug code.
 - **The Cloud** is Everr's hosted backend. It holds CI and production telemetry in a shared, per-organization workspace.
 
 A query you write against local traces reads the same against production ones.


### PR DESCRIPTION
### Changes

- **everr-use-telemetry SKILL.md**: Added a full Errors And Triage section covering `everr cloud errors` commands and the Fix Loop workflow for AI agents
- **how-alerts-work.mdx**: Tightened prose, removed flapping section, cleaned up instance identity explanation
- **index.mdx**: Refreshed description and local/cloud framing