### PR TITLE
refactor(cloud-query): drop regex-derived query shape from spans

### DIFF
--- a/everr/cloud-query.dashboard.yaml
+++ b/everr/cloud-query.dashboard.yaml
@@ -171,8 +171,6 @@ spec:
                   query: |
                     SELECT formatDateTime(Timestamp, '%m-%d %H:%i:%S') AS time,
                            SpanAttributes['everr.org_id'] AS org,
-                           SpanAttributes['everr.cloud_query.tables'] AS tables,
-                           SpanAttributes['everr.cloud_query.attr_keys'] AS attr_keys,
                            round(Duration / 1e6, 0) AS duration_ms,
                            if(SpanAttributes['everr.cloud_query.outcome'] = '', 'unknown',
                               SpanAttributes['everr.cloud_query.outcome']) AS outcome,

--- a/everr/cloud-query.runbook.md
+++ b/everr/cloud-query.runbook.md
@@ -16,7 +16,7 @@ The dominant `kind` names the cause:
 ref: error-kind-breakdown
 ```
 
-- `timeout` / `resource`: queries are too heavy (memory, or the 30s ClickHouse cap). Watch the latency panel below for a climb, and read the `tables` column above for the query involved. Often one tenant running an expensive query.
+- `timeout` / `resource`: queries are too heavy (memory, or the 30s ClickHouse cap). Watch the latency panel below for a climb, and use the `org` column above to see whether one tenant dominates. Often one tenant running an expensive query.
 - `network`: ClickHouse reachability. Check the ClickHouse ECONNRESET runbook and the ClickHouse service health.
 - `quota`: a tenant is exhausting its per-org quota bucket (`X-ClickHouse-Quota`). Confirm which `org` in the table above; the throttle is per-tenant, so this is contained.
 - `internal`: an unexpected exception in the request path, not a ClickHouse error. Open the trace and read the captured exception (`error.source`).

--- a/everr/cloud-query.runbook.yaml
+++ b/everr/cloud-query.runbook.yaml
@@ -29,7 +29,6 @@ spec:
                     SELECT formatDateTime(Timestamp, '%m-%d %H:%i:%S') AS time,
                            SpanAttributes['everr.cloud_query.kind'] AS kind,
                            SpanAttributes['everr.org_id'] AS org,
-                           SpanAttributes['everr.cloud_query.tables'] AS tables,
                            round(Duration / 1e6, 0) AS duration_ms,
                            TraceId AS trace_id
                     FROM traces

--- a/packages/app/src/lib/sql-api-observability.test.ts
+++ b/packages/app/src/lib/sql-api-observability.test.ts
@@ -1,9 +1,6 @@
 import { ClickHouseError } from "@clickhouse/client";
 import { describe, expect, it } from "vitest";
-import {
-  classifyCloudQueryError,
-  extractQueryShape,
-} from "@/lib/sql-api-observability";
+import { classifyCloudQueryError } from "@/lib/sql-api-observability";
 
 // The guard (when present) throws an Error named "SqlApiGuardError"; the
 // classifier matches on the name, so the test reproduces that shape directly.
@@ -82,34 +79,5 @@ describe("classifyCloudQueryError", () => {
       outcome: "system_error",
       kind: "internal",
     });
-  });
-});
-
-describe("extractQueryShape", () => {
-  it("extracts table names after FROM and JOIN", () => {
-    const { tables } = extractQueryShape(
-      "SELECT * FROM traces t JOIN logs l ON t.TraceId = l.TraceId",
-    );
-    expect(tables).toEqual(["traces", "logs"]);
-  });
-
-  it("extracts map-subscript keys but never array-literal values", () => {
-    const { attrKeys } = extractQueryShape(
-      "SELECT * FROM logs WHERE LogAttributes['user.email'] = 'alice@corp.com' " +
-        "AND ServiceName IN ['secret-service']",
-    );
-    expect(attrKeys).toEqual(["user.email"]);
-    // The literal value and the array-literal element must not appear anywhere.
-    expect(attrKeys).not.toContain("alice@corp.com");
-    expect(attrKeys).not.toContain("secret-service");
-  });
-
-  it("dedupes repeated tables and keys", () => {
-    const { tables, attrKeys } = extractQueryShape(
-      "SELECT SpanAttributes['k'], SpanAttributes['k'] FROM traces UNION ALL " +
-        "SELECT SpanAttributes['k'], SpanAttributes['k'] FROM traces",
-    );
-    expect(tables).toEqual(["traces"]);
-    expect(attrKeys).toEqual(["k"]);
   });
 });

--- a/packages/app/src/lib/sql-api-observability.ts
+++ b/packages/app/src/lib/sql-api-observability.ts
@@ -83,30 +83,3 @@ export function classifyCloudQueryError(
 
   return { outcome: "system_error", kind: "internal" };
 }
-
-export type CloudQueryShape = {
-  tables: string[];
-  attrKeys: string[];
-};
-
-// Safe, structured facts about a query — never the query text or any literal
-// value. Both patterns match only schema-identifier positions:
-//   - tables:   the identifier after FROM/JOIN.
-//   - attrKeys: the string inside a map subscript `Ident['key']`. ClickHouse
-//     grammar guarantees a string in subscript position (identifier immediately
-//     followed by `['...']`) is a map key, never an array-literal value — so
-//     `IN ['secret@example.com']` (no identifier before `[`) does NOT match and
-//     no user value leaks.
-export function extractQueryShape(sql: string): CloudQueryShape {
-  const tables = new Set<string>();
-  for (const match of sql.matchAll(/\b(?:from|join)\s+([a-zA-Z_]\w*)/gi)) {
-    tables.add(match[1]);
-  }
-
-  const attrKeys = new Set<string>();
-  for (const match of sql.matchAll(/\w+\['([^']+)'\]/g)) {
-    attrKeys.add(match[1]);
-  }
-
-  return { tables: [...tables], attrKeys: [...attrKeys] };
-}

--- a/packages/app/src/routes/api/cli/sql.ts
+++ b/packages/app/src/routes/api/cli/sql.ts
@@ -2,10 +2,7 @@ import { SpanStatusCode, trace } from "@opentelemetry/api";
 import { createFileRoute } from "@tanstack/react-router";
 import { querySqlApi } from "@/lib/clickhouse";
 import { sanitizeSqlApiError } from "@/lib/sql-api-error";
-import {
-  classifyCloudQueryError,
-  extractQueryShape,
-} from "@/lib/sql-api-observability";
+import { classifyCloudQueryError } from "@/lib/sql-api-observability";
 
 function toNdjson(rows: Array<Record<string, unknown>>): string {
   if (rows.length === 0) {
@@ -30,20 +27,6 @@ export const Route = createFileRoute("/api/cli/sql")({
           span.setAttribute("everr.feature", "cloud_query");
           if (orgId) {
             span.setAttribute("everr.org_id", orgId);
-          }
-          // Safe structured facts only — never the query text or any literal.
-          const shape = extractQueryShape(sql);
-          if (shape.tables.length > 0) {
-            span.setAttribute(
-              "everr.cloud_query.tables",
-              shape.tables.join(","),
-            );
-          }
-          if (shape.attrKeys.length > 0) {
-            span.setAttribute(
-              "everr.cloud_query.attr_keys",
-              shape.attrKeys.join(","),
-            );
           }
         }
 


### PR DESCRIPTION
## What

Removes the `everr.cloud_query.tables` and `everr.cloud_query.attr_keys` span attributes and the `extractQueryShape()` regex that produced them.

## Why

Deriving table names and map-subscript keys from SQL with regexes is unreliable. It is only sound with a real SQL parser: identifier boundaries, aliases, subqueries, CTEs, and quoting all break the heuristic. Rather than ship a fragile approximation, we record no derived query shape until the query path has proper AST parsing.

## Scope

- `sql-api-observability.ts`: delete `extractQueryShape()` and the `CloudQueryShape` type.
- `sql.ts`: stop setting the `tables` / `attr_keys` attributes. The span still carries `feature`, `org_id`, `outcome`, `kind`, and `result_rows`.
- Dashboard slowest-queries panel and runbook recent-system-errors panel: drop the `tables` / `attr_keys` columns; the runbook `timeout`/`resource` step now points at the `org` column.
- Tests: remove the `extractQueryShape` cases. The error-classification tests are unchanged and pass.

Error classification, span status, and the distributed trace are untouched; none of them depended on the parsing.