### PR TITLE
feat(errors): fingerprint UDF + agent-handoff button, app.* skip-index mirror, otel retention

### DIFF
--- a/clickhouse/init/03-create-otel-tables.sql
+++ b/clickhouse/init/03-create-otel-tables.sql
@@ -34,6 +34,9 @@ CREATE TABLE IF NOT EXISTS otel.otel_traces (
 ) ENGINE = MergeTree
 PARTITION BY toDate(Timestamp)
 ORDER BY (ServiceName, SpanName, toDateTime(Timestamp))
+-- Raw landing table: the durable, tenant-scoped read model is app.traces
+-- (populated at insert time by app.traces_mv), so keep only a short buffer here.
+TTL toDateTime(Timestamp) + INTERVAL 7 DAY
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 
 CREATE TABLE IF NOT EXISTS otel.otel_logs (
@@ -66,6 +69,9 @@ CREATE TABLE IF NOT EXISTS otel.otel_logs (
 PARTITION BY toDate(TimestampTime)
 PRIMARY KEY (ServiceName, TimestampTime)
 ORDER BY (ServiceName, TimestampTime, Timestamp)
+-- Raw landing table: the durable, tenant-scoped read model is app.logs
+-- (populated at insert time by app.logs_mv), so keep only a short buffer here.
+TTL TimestampTime + INTERVAL 7 DAY
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 
 CREATE TABLE IF NOT EXISTS otel.otel_metrics_gauge (
@@ -101,6 +107,10 @@ CREATE TABLE IF NOT EXISTS otel.otel_metrics_gauge (
 ) ENGINE = MergeTree
 PARTITION BY toDate(TimeUnix)
 ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+-- Raw landing table: the durable, tenant-scoped read model is the matching
+-- app.metrics_* table (populated at insert time by its MV), so keep only a
+-- short buffer here.
+TTL toDateTime(TimeUnix) + INTERVAL 7 DAY
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 
 CREATE TABLE IF NOT EXISTS otel.otel_metrics_sum (
@@ -138,6 +148,10 @@ CREATE TABLE IF NOT EXISTS otel.otel_metrics_sum (
 ) ENGINE = MergeTree
 PARTITION BY toDate(TimeUnix)
 ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+-- Raw landing table: the durable, tenant-scoped read model is the matching
+-- app.metrics_* table (populated at insert time by its MV), so keep only a
+-- short buffer here.
+TTL toDateTime(TimeUnix) + INTERVAL 7 DAY
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 
 CREATE TABLE IF NOT EXISTS otel.otel_metrics_histogram (
@@ -179,6 +193,10 @@ CREATE TABLE IF NOT EXISTS otel.otel_metrics_histogram (
 ) ENGINE = MergeTree
 PARTITION BY toDate(TimeUnix)
 ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+-- Raw landing table: the durable, tenant-scoped read model is the matching
+-- app.metrics_* table (populated at insert time by its MV), so keep only a
+-- short buffer here.
+TTL toDateTime(TimeUnix) + INTERVAL 7 DAY
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 
 CREATE TABLE IF NOT EXISTS otel.otel_metrics_exponential_histogram (
@@ -224,6 +242,10 @@ CREATE TABLE IF NOT EXISTS otel.otel_metrics_exponential_histogram (
 ) ENGINE = MergeTree
 PARTITION BY toDate(TimeUnix)
 ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+-- Raw landing table: the durable, tenant-scoped read model is the matching
+-- app.metrics_* table (populated at insert time by its MV), so keep only a
+-- short buffer here.
+TTL toDateTime(TimeUnix) + INTERVAL 7 DAY
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 
 CREATE TABLE IF NOT EXISTS otel.otel_metrics_summary (
@@ -257,4 +279,8 @@ CREATE TABLE IF NOT EXISTS otel.otel_metrics_summary (
 ) ENGINE = MergeTree
 PARTITION BY toDate(TimeUnix)
 ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+-- Raw landing table: the durable, tenant-scoped read model is the matching
+-- app.metrics_* table (populated at insert time by its MV), so keep only a
+-- short buffer here.
+TTL toDateTime(TimeUnix) + INTERVAL 7 DAY
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;

--- a/clickhouse/init/04-create-error-fingerprint-function.sql
+++ b/clickhouse/init/04-create-error-fingerprint-function.sql
@@ -1,0 +1,42 @@
+-- errorFingerprint: Everr's stable identity for an Error, computed from a log's
+-- service name and exception attributes. Centralized as a ClickHouse UDF so the
+-- web app, the local collector's chDB, agents, and skills all group Errors
+-- identically instead of each carrying a copy of the expression.
+--
+-- Uses the `error.fingerprint` log attribute when set, else a hash of the
+-- service, exception type, and a normalized exception message (UUIDs, long
+-- ids/hex, and long quoted literals collapsed so noisy variants group together).
+--
+-- Keep in step with the collector's copy at
+-- collector/exporter/chdbexporter/internal/sqltemplates/create_error_fingerprint_function.sql
+--
+-- init/ runs only on a fresh server. Apply to an existing cluster with:
+--   clickhouse-client --user default --password '<ADMIN_PASSWORD>' --multiquery \
+--     < clickhouse/init/04-create-error-fingerprint-function.sql
+CREATE OR REPLACE FUNCTION errorFingerprint AS (serviceName, logAttributes) ->
+  if(
+    logAttributes['error.fingerprint'] != '',
+    logAttributes['error.fingerprint'],
+    toString(cityHash64(
+      serviceName,
+      logAttributes['exception.type'],
+      substring(
+        replaceRegexpAll(
+          replaceRegexpAll(
+            replaceRegexpAll(
+              trim(BOTH ' ' FROM logAttributes['exception.message']),
+              '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}',
+              '<uuid>'
+            ),
+            '\\b[0-9]{6,}\\b|0x[0-9a-fA-F]+',
+            '<id>'
+          ),
+          '''[^'']{16,}''|"[^"]{16,}"',
+          '<quoted>'
+        ),
+        1,
+        300
+      ),
+      ''
+    ))
+  )

--- a/clickhouse/init/10-create-mvs.sql
+++ b/clickhouse/init/10-create-mvs.sql
@@ -52,11 +52,16 @@ SELECT
 FROM otel.otel_traces
 WHERE 1 = 0;
 
+-- Skip indexes mirrored from otel.otel_traces. CREATE TABLE ... AS SELECT copies
+-- columns but not indexes, so app.traces starts bare; add the same set the raw
+-- table carries so app-side queries prune the same way.
 ALTER TABLE app.traces
-  ADD INDEX IF NOT EXISTS idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1;
-
-ALTER TABLE app.traces
-  ADD INDEX IF NOT EXISTS idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1;
+  ADD INDEX IF NOT EXISTS idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_span_attr_key mapKeys(SpanAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_span_attr_value mapValues(SpanAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_duration Duration TYPE minmax GRANULARITY 1;
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS app.traces_mv
 TO app.traces
@@ -80,11 +85,16 @@ SELECT
 FROM otel.otel_logs
 WHERE 1 = 0;
 
+-- Skip indexes mirrored from otel.otel_logs (see the app.traces note above).
 ALTER TABLE app.logs
-  ADD INDEX IF NOT EXISTS idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1;
-
-ALTER TABLE app.logs
-  ADD INDEX IF NOT EXISTS idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1;
+  ADD INDEX IF NOT EXISTS idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_log_attr_key mapKeys(LogAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_log_attr_value mapValues(LogAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_body Body TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 8;
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS app.logs_mv
 TO app.logs
@@ -108,6 +118,15 @@ SELECT
 FROM otel.otel_metrics_gauge
 WHERE 1 = 0;
 
+-- Skip indexes mirrored from otel.otel_metrics_gauge (see the app.traces note above).
+ALTER TABLE app.metrics_gauge
+  ADD INDEX IF NOT EXISTS idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1;
+
 CREATE MATERIALIZED VIEW IF NOT EXISTS app.metrics_gauge_mv
 TO app.metrics_gauge
 AS
@@ -129,6 +148,15 @@ SELECT
   CAST(ResourceAttributes['everr.tenant.id'] AS String) AS tenant_id
 FROM otel.otel_metrics_sum
 WHERE 1 = 0;
+
+-- Skip indexes mirrored from otel.otel_metrics_sum (see the app.traces note above).
+ALTER TABLE app.metrics_sum
+  ADD INDEX IF NOT EXISTS idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1;
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS app.metrics_sum_mv
 TO app.metrics_sum
@@ -152,6 +180,15 @@ SELECT
 FROM otel.otel_metrics_histogram
 WHERE 1 = 0;
 
+-- Skip indexes mirrored from otel.otel_metrics_histogram (see the app.traces note above).
+ALTER TABLE app.metrics_histogram
+  ADD INDEX IF NOT EXISTS idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1;
+
 CREATE MATERIALIZED VIEW IF NOT EXISTS app.metrics_histogram_mv
 TO app.metrics_histogram
 AS
@@ -174,6 +211,15 @@ SELECT
 FROM otel.otel_metrics_exponential_histogram
 WHERE 1 = 0;
 
+-- Skip indexes mirrored from otel.otel_metrics_exponential_histogram (see the app.traces note above).
+ALTER TABLE app.metrics_exponential_histogram
+  ADD INDEX IF NOT EXISTS idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1;
+
 CREATE MATERIALIZED VIEW IF NOT EXISTS app.metrics_exponential_histogram_mv
 TO app.metrics_exponential_histogram
 AS
@@ -195,6 +241,15 @@ SELECT
   CAST(ResourceAttributes['everr.tenant.id'] AS String) AS tenant_id
 FROM otel.otel_metrics_summary
 WHERE 1 = 0;
+
+-- Skip indexes mirrored from otel.otel_metrics_summary (see the app.traces note above).
+ALTER TABLE app.metrics_summary
+  ADD INDEX IF NOT EXISTS idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1;
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS app.metrics_summary_mv
 TO app.metrics_summary

--- a/clickhouse/migrate-errors-udf-app-indexes-otel-ttl.sql
+++ b/clickhouse/migrate-errors-udf-app-indexes-otel-ttl.sql
@@ -1,0 +1,178 @@
+-- One-shot migration for an existing cloud ClickHouse. Bundles three changes
+-- that init/ only applies to fresh servers:
+--   1. the errorFingerprint UDF                 (init/04-create-error-fingerprint-function.sql)
+--   2. app.* skip indexes mirrored from otel.*  (init/10-create-mvs.sql)
+--   3. 7-day retention on the raw otel.* tables (init/03-create-otel-tables.sql)
+--
+-- Apply with an admin user:
+--   clickhouse-client --user default --password '<ADMIN_PASSWORD>' --multiquery \
+--     < clickhouse/migrate-errors-udf-app-indexes-otel-ttl.sql
+--
+-- Idempotent: CREATE OR REPLACE FUNCTION, ADD INDEX IF NOT EXISTS, MODIFY TTL.
+-- MATERIALIZE INDEX rewrites index files for existing parts and can take time on
+-- large tables; new inserts use every index/TTL as soon as ADD/MODIFY runs.
+--
+-- Assumes ResourceAttributes indexes on app.traces / app.logs were already
+-- materialized by backfill-resource-attribute-skip-indexes.sql, so this file
+-- adds them IF NOT EXISTS but does not re-materialize them.
+--
+-- WARNING: step 3 drops raw otel.* data older than 7 days. That data is not
+-- queried directly (the durable, tenant-scoped read model is app.*, populated at
+-- insert time by the app.*_mv views), but the drop is irreversible. Expired
+-- day-parts are removed on the next merge.
+
+-- The app.* tables carry a TTL that calls dictGetOrDefault (non-deterministic),
+-- which ALTER TABLE re-validates. Opt in the same way init/10 does, or every
+-- ADD INDEX below fails with "TTL expression cannot contain non-deterministic
+-- functions".
+SET allow_suspicious_ttl_expressions = 1;
+
+-- 1. errorFingerprint UDF (keep in step with init/04-create-error-fingerprint-function.sql).
+CREATE OR REPLACE FUNCTION errorFingerprint AS (serviceName, logAttributes) ->
+  if(
+    logAttributes['error.fingerprint'] != '',
+    logAttributes['error.fingerprint'],
+    toString(cityHash64(
+      serviceName,
+      logAttributes['exception.type'],
+      substring(
+        replaceRegexpAll(
+          replaceRegexpAll(
+            replaceRegexpAll(
+              trim(BOTH ' ' FROM logAttributes['exception.message']),
+              '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}',
+              '<uuid>'
+            ),
+            '\\b[0-9]{6,}\\b|0x[0-9a-fA-F]+',
+            '<id>'
+          ),
+          '''[^'']{16,}''|"[^"]{16,}"',
+          '<quoted>'
+        ),
+        1,
+        300
+      ),
+      ''
+    ))
+  );
+
+-- 2. app.* skip indexes mirrored from otel.*.
+
+ALTER TABLE app.traces
+  ADD INDEX IF NOT EXISTS idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_span_attr_key mapKeys(SpanAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_span_attr_value mapValues(SpanAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_duration Duration TYPE minmax GRANULARITY 1;
+ALTER TABLE app.traces
+  MATERIALIZE INDEX idx_trace_id,
+  MATERIALIZE INDEX idx_span_attr_key,
+  MATERIALIZE INDEX idx_span_attr_value,
+  MATERIALIZE INDEX idx_duration;
+
+ALTER TABLE app.logs
+  ADD INDEX IF NOT EXISTS idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_log_attr_key mapKeys(LogAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_log_attr_value mapValues(LogAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_body Body TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 8;
+ALTER TABLE app.logs
+  MATERIALIZE INDEX idx_trace_id,
+  MATERIALIZE INDEX idx_scope_attr_key,
+  MATERIALIZE INDEX idx_scope_attr_value,
+  MATERIALIZE INDEX idx_log_attr_key,
+  MATERIALIZE INDEX idx_log_attr_value,
+  MATERIALIZE INDEX idx_body;
+
+-- Metrics tables had no skip indexes at all, so add and materialize the full set.
+ALTER TABLE app.metrics_gauge
+  ADD INDEX IF NOT EXISTS idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1;
+ALTER TABLE app.metrics_gauge
+  MATERIALIZE INDEX idx_res_attr_key,
+  MATERIALIZE INDEX idx_res_attr_value,
+  MATERIALIZE INDEX idx_scope_attr_key,
+  MATERIALIZE INDEX idx_scope_attr_value,
+  MATERIALIZE INDEX idx_attr_key,
+  MATERIALIZE INDEX idx_attr_value;
+
+ALTER TABLE app.metrics_sum
+  ADD INDEX IF NOT EXISTS idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1;
+ALTER TABLE app.metrics_sum
+  MATERIALIZE INDEX idx_res_attr_key,
+  MATERIALIZE INDEX idx_res_attr_value,
+  MATERIALIZE INDEX idx_scope_attr_key,
+  MATERIALIZE INDEX idx_scope_attr_value,
+  MATERIALIZE INDEX idx_attr_key,
+  MATERIALIZE INDEX idx_attr_value;
+
+ALTER TABLE app.metrics_histogram
+  ADD INDEX IF NOT EXISTS idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1;
+ALTER TABLE app.metrics_histogram
+  MATERIALIZE INDEX idx_res_attr_key,
+  MATERIALIZE INDEX idx_res_attr_value,
+  MATERIALIZE INDEX idx_scope_attr_key,
+  MATERIALIZE INDEX idx_scope_attr_value,
+  MATERIALIZE INDEX idx_attr_key,
+  MATERIALIZE INDEX idx_attr_value;
+
+ALTER TABLE app.metrics_exponential_histogram
+  ADD INDEX IF NOT EXISTS idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1;
+ALTER TABLE app.metrics_exponential_histogram
+  MATERIALIZE INDEX idx_res_attr_key,
+  MATERIALIZE INDEX idx_res_attr_value,
+  MATERIALIZE INDEX idx_scope_attr_key,
+  MATERIALIZE INDEX idx_scope_attr_value,
+  MATERIALIZE INDEX idx_attr_key,
+  MATERIALIZE INDEX idx_attr_value;
+
+ALTER TABLE app.metrics_summary
+  ADD INDEX IF NOT EXISTS idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1;
+ALTER TABLE app.metrics_summary
+  MATERIALIZE INDEX idx_res_attr_key,
+  MATERIALIZE INDEX idx_res_attr_value,
+  MATERIALIZE INDEX idx_scope_attr_key,
+  MATERIALIZE INDEX idx_scope_attr_value,
+  MATERIALIZE INDEX idx_attr_key,
+  MATERIALIZE INDEX idx_attr_value;
+
+-- 3. 7-day retention on the raw otel.* landing tables. Don't materialize the TTL
+-- on MODIFY: otherwise ClickHouse mutates every existing part immediately (a
+-- merge storm across the highest-volume tables). New inserts honor it right
+-- away; old day-parts drop on their next natural merge.
+SET materialize_ttl_after_modify = 0;
+ALTER TABLE otel.otel_traces MODIFY TTL toDateTime(Timestamp) + INTERVAL 7 DAY;
+ALTER TABLE otel.otel_logs MODIFY TTL TimestampTime + INTERVAL 7 DAY;
+ALTER TABLE otel.otel_metrics_gauge MODIFY TTL toDateTime(TimeUnix) + INTERVAL 7 DAY;
+ALTER TABLE otel.otel_metrics_sum MODIFY TTL toDateTime(TimeUnix) + INTERVAL 7 DAY;
+ALTER TABLE otel.otel_metrics_histogram MODIFY TTL toDateTime(TimeUnix) + INTERVAL 7 DAY;
+ALTER TABLE otel.otel_metrics_exponential_histogram MODIFY TTL toDateTime(TimeUnix) + INTERVAL 7 DAY;
+ALTER TABLE otel.otel_metrics_summary MODIFY TTL toDateTime(TimeUnix) + INTERVAL 7 DAY;

--- a/collector/exporter/chdbexporter/exporter_logs.go
+++ b/collector/exporter/chdbexporter/exporter_logs.go
@@ -58,6 +58,10 @@ func (e *logsExporter) start(ctx context.Context, _ component.Host) error {
 			return createDBErr
 		}
 
+		if fnErr := internal.CreateErrorFingerprintFunction(ctx, e.db); fnErr != nil {
+			return fnErr
+		}
+
 		if adoptErr := adoptLegacyLogsTable(ctx, e.cfg, e.db); adoptErr != nil {
 			return adoptErr
 		}

--- a/collector/exporter/chdbexporter/exporter_logs_json.go
+++ b/collector/exporter/chdbexporter/exporter_logs_json.go
@@ -64,6 +64,10 @@ func (e *logsJSONExporter) start(ctx context.Context, _ component.Host) error {
 			return createDBErr
 		}
 
+		if fnErr := internal.CreateErrorFingerprintFunction(ctx, e.db); fnErr != nil {
+			return fnErr
+		}
+
 		if adoptErr := adoptLegacyLogsTable(ctx, e.cfg, e.db); adoptErr != nil {
 			return adoptErr
 		}

--- a/collector/exporter/chdbexporter/internal/clickhouse.go
+++ b/collector/exporter/chdbexporter/internal/clickhouse.go
@@ -10,9 +10,27 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+
+	"github.com/everr-labs/everr/collector/exporter/chdbexporter/internal/sqltemplates"
 )
 
 const DefaultDatabase = "default"
+
+// CreateErrorFingerprintFunction registers the errorFingerprint UDF (idempotent)
+// so `everr local query` and the desktop app group Errors the same way the cloud
+// does. Route it through Query, not Exec: chDB only persists CREATE FUNCTION when
+// the statement runs with a real output format, and Exec uses an empty one. Keep
+// the DDL in step with clickhouse/init/04-create-error-fingerprint-function.sql.
+func CreateErrorFingerprintFunction(ctx context.Context, db driver.Conn) error {
+	rows, err := db.Query(ctx, sqltemplates.CreateErrorFingerprintFunction)
+	if err != nil {
+		return fmt.Errorf("create errorFingerprint function: %w", err)
+	}
+	if rows != nil {
+		_ = rows.Close()
+	}
+	return nil
+}
 
 // DatabaseFromDSN returns the database specified in the DSN. Empty if unset.
 func DatabaseFromDSN(dsn string) (string, error) {

--- a/collector/exporter/chdbexporter/internal/sqltemplates/create_error_fingerprint_function.sql
+++ b/collector/exporter/chdbexporter/internal/sqltemplates/create_error_fingerprint_function.sql
@@ -1,0 +1,33 @@
+-- errorFingerprint UDF for the local collector's chDB. Registered on schema
+-- init so `everr local query` and the desktop app group Errors the same way the
+-- cloud does.
+--
+-- Keep in step with clickhouse/init/04-create-error-fingerprint-function.sql
+-- (the body below must stay identical, or local and cloud fingerprints diverge).
+CREATE OR REPLACE FUNCTION errorFingerprint AS (serviceName, logAttributes) ->
+  if(
+    logAttributes['error.fingerprint'] != '',
+    logAttributes['error.fingerprint'],
+    toString(cityHash64(
+      serviceName,
+      logAttributes['exception.type'],
+      substring(
+        replaceRegexpAll(
+          replaceRegexpAll(
+            replaceRegexpAll(
+              trim(BOTH ' ' FROM logAttributes['exception.message']),
+              '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}',
+              '<uuid>'
+            ),
+            '\\b[0-9]{6,}\\b|0x[0-9a-fA-F]+',
+            '<id>'
+          ),
+          '''[^'']{16,}''|"[^"]{16,}"',
+          '<quoted>'
+        ),
+        1,
+        300
+      ),
+      ''
+    ))
+  )

--- a/collector/exporter/chdbexporter/internal/sqltemplates/embed.go
+++ b/collector/exporter/chdbexporter/internal/sqltemplates/embed.go
@@ -22,6 +22,14 @@ func newTemplate(name, text string) *template.Template {
 	return template.Must(template.New(name).Funcs(templateFuncs).Parse(text))
 }
 
+// FUNCTIONS
+
+// CreateErrorFingerprintFunction is the DDL registering the errorFingerprint
+// UDF. Kept in step with clickhouse/init/04-create-error-fingerprint-function.sql.
+//
+//go:embed create_error_fingerprint_function.sql
+var CreateErrorFingerprintFunction string
+
 // LOGS
 
 //go:embed logs_table.sql

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/error-tracking.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/error-tracking.md
@@ -105,8 +105,8 @@ WHERE Timestamp > now() - INTERVAL 10 MINUTE
   AND SeverityNumber >= 17
   AND mapContains(ResourceAttributes, 'service.name')
   AND (
-    LogAttributes['exception.type'] != ''
-    OR LogAttributes['exception.message'] != ''
+    mapContains(LogAttributes, 'exception.type')
+    OR mapContains(LogAttributes, 'exception.message')
   )
 ORDER BY Timestamp DESC
 LIMIT 20

--- a/crates/everr-core/assets/skills/everr-use-telemetry/SKILL.md
+++ b/crates/everr-core/assets/skills/everr-use-telemetry/SKILL.md
@@ -156,8 +156,8 @@ An error log has a `service.name` resource attribute, `SeverityNumber >= 17`, an
 mapContains(ResourceAttributes, 'service.name')
 AND SeverityNumber >= 17
 AND (
-  LogAttributes['exception.type'] != ''
-  OR LogAttributes['exception.message'] != ''
+  mapContains(LogAttributes, 'exception.type')
+  OR mapContains(LogAttributes, 'exception.message')
 )
 ```
 

--- a/crates/everr-core/assets/skills/everr-use-telemetry/SKILL.md
+++ b/crates/everr-core/assets/skills/everr-use-telemetry/SKILL.md
@@ -147,6 +147,33 @@ ORDER BY errors DESC
 LIMIT 20
 ```
 
+## Group Errors By Fingerprint
+
+Everr groups error logs into Errors by a *fingerprint*: the `error.fingerprint` log attribute when present, else a hash of the service, exception type, and a normalized exception message. The fingerprint is a ClickHouse UDF, `errorFingerprint(ServiceName, LogAttributes)`, available on both cloud and local telemetry, so you get the same identity the app groups by. The "Copy agent prompt" button in the web UI hands you a Fingerprint.
+
+An error log has a `service.name` resource attribute, `SeverityNumber >= 17`, and an exception type or message:
+```sql
+mapContains(ResourceAttributes, 'service.name')
+AND SeverityNumber >= 17
+AND (
+  LogAttributes['exception.type'] != ''
+  OR LogAttributes['exception.message'] != ''
+)
+```
+
+Occurrences of one Fingerprint (widen the window if the Error is older):
+```sql
+SELECT toString(Timestamp) AS timestamp, ServiceName, TraceId,
+  LogAttributes['exception.stacktrace'] AS stacktrace
+FROM logs
+WHERE Timestamp > now() - INTERVAL 7 DAY
+  AND mapContains(ResourceAttributes, 'service.name')
+  AND SeverityNumber >= 17
+  AND errorFingerprint(ServiceName, LogAttributes) = '<fingerprint>'
+ORDER BY Timestamp DESC
+LIMIT 50
+```
+
 ## Error Troubleshooting
 
 | Error | Action |

--- a/packages/telemetry-explorer/src/errors/sql/fingerprint.ts
+++ b/packages/telemetry-explorer/src/errors/sql/fingerprint.ts
@@ -1,35 +1,11 @@
-const NORMALIZED_EXCEPTION_MESSAGE_SQL = `
-  substring(
-    replaceRegexpAll(
-      replaceRegexpAll(
-        replaceRegexpAll(
-          trim(BOTH ' ' FROM LogAttributes['exception.message']),
-          '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}',
-          '<uuid>'
-        ),
-        '\\\\b[0-9]{6,}\\\\b|0x[0-9a-fA-F]+',
-        '<id>'
-      ),
-      '''[^'']{16,}''|"[^"]{16,}"',
-      '<quoted>'
-    ),
-    1,
-    300
-  )
-`;
-
-export const ERROR_FINGERPRINT_SQL = `
-  if(
-    LogAttributes['error.fingerprint'] != '',
-    LogAttributes['error.fingerprint'],
-    toString(cityHash64(
-      ServiceName,
-      LogAttributes['exception.type'],
-      ${NORMALIZED_EXCEPTION_MESSAGE_SQL},
-      ''
-    ))
-  )
-`;
+// Everr's stable identity for an Error. The expression lives in the
+// `errorFingerprint` ClickHouse UDF
+// (clickhouse/init/04-create-error-fingerprint-function.sql and the local
+// collector's copy), so the web app, local collector, agents, and skills all
+// group Errors identically instead of each carrying a copy of the SQL. Callers
+// pass ServiceName and the whole LogAttributes; the UDF reads
+// error.fingerprint / exception.type / exception.message from it.
+export const ERROR_FINGERPRINT_SQL = `errorFingerprint(ServiceName, LogAttributes)`;
 
 export const EXCEPTION_LOG_FILTER_SQL = `
   mapContains(ResourceAttributes, 'service.name')

--- a/packages/telemetry-explorer/src/errors/sql/fingerprint.ts
+++ b/packages/telemetry-explorer/src/errors/sql/fingerprint.ts
@@ -11,7 +11,7 @@ export const EXCEPTION_LOG_FILTER_SQL = `
   mapContains(ResourceAttributes, 'service.name')
   AND SeverityNumber >= 17
   AND (
-    LogAttributes['exception.type'] != ''
-    OR LogAttributes['exception.message'] != ''
+    mapContains(LogAttributes, 'exception.type')
+    OR mapContains(LogAttributes, 'exception.message')
   )
 `;

--- a/packages/telemetry-explorer/src/errors/ui/error-detail-header.tsx
+++ b/packages/telemetry-explorer/src/errors/ui/error-detail-header.tsx
@@ -2,6 +2,7 @@ import { Badge } from "@everr/ui/components/badge";
 import { Button } from "@everr/ui/components/button";
 import { formatRelativeTime } from "@everr/ui/lib/timestamp";
 import { ArrowLeft, X } from "lucide-react";
+import type { ReactNode } from "react";
 import type { ErrorIssueSummary } from "../data/types";
 import { ErrorServiceBadge } from "./error-service-badge";
 
@@ -9,10 +10,13 @@ export function ErrorDetailHeader({
   issue,
   onBack,
   onClose,
+  actions,
 }: {
   issue: ErrorIssueSummary;
   onBack?: () => void;
   onClose?: () => void;
+  /** Right-aligned header actions (e.g. the agent-handoff button). */
+  actions?: ReactNode;
 }) {
   const title = issue.exceptionType || "Unknown exception";
   const message = issue.exceptionMessage || issue.body || issue.fingerprint;
@@ -56,6 +60,7 @@ export function ErrorDetailHeader({
           <span>Last seen {formatRelativeTime(issue.lastSeen)}</span>
         </div>
       </div>
+      {actions ? <div className="shrink-0">{actions}</div> : null}
     </header>
   );
 }

--- a/packages/telemetry-explorer/src/errors/ui/error-detail.tsx
+++ b/packages/telemetry-explorer/src/errors/ui/error-detail.tsx
@@ -15,6 +15,7 @@ import { errorIssueOptions } from "../data/options";
 import type { ErrorsRepositoryLike } from "../data/repository";
 import type { ErrorOccurrence } from "../data/types";
 import { ErrorDetailHeader } from "./error-detail-header";
+import { ErrorHandoffButton } from "./error-handoff-button";
 import { ErrorLatestOccurrence } from "./error-latest-occurrence";
 import {
   findErrorOccurrenceByKey,
@@ -117,6 +118,7 @@ export function ErrorDetail({
         issue={detail.summary}
         onBack={onBack}
         onClose={onClose}
+        actions={<ErrorHandoffButton issue={detail.summary} />}
       />
       <main className="min-h-0 flex-1 overflow-auto">
         <div className="mx-auto grid max-w-7xl gap-3 p-3">

--- a/packages/telemetry-explorer/src/errors/ui/error-handoff-button.test.ts
+++ b/packages/telemetry-explorer/src/errors/ui/error-handoff-button.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { ErrorIssueSummary } from "../data/types";
+import { buildErrorHandoffPrompt } from "./error-handoff-button";
+
+function summary(overrides: Partial<ErrorIssueSummary>): ErrorIssueSummary {
+  return {
+    fingerprint: "fp-1",
+    exceptionType: "TypeError",
+    exceptionMessage: "boom",
+    body: "TypeError: boom",
+    latestServiceName: "api",
+    services: ["api"],
+    occurrenceCount: 1,
+    traceCount: 1,
+    firstSeen: "2026-07-01 10:00:00",
+    lastSeen: "2026-07-09 14:03:11",
+    latestTraceId: "trace-1",
+    latestSpanId: "span-1",
+    latestTimestamp: "2026-07-09 14:03:11",
+    ...overrides,
+  };
+}
+
+describe("buildErrorHandoffPrompt", () => {
+  it("includes the fingerprint, heading, and a telemetry query narrowed to it", () => {
+    const prompt = buildErrorHandoffPrompt(summary({}));
+
+    expect(prompt).toContain("Fingerprint: fp-1");
+    expect(prompt).toContain("Error: TypeError: boom");
+    expect(prompt).toContain("everr cloud query");
+    // The embedded query calls the shared fingerprint UDF, narrowed to this
+    // Fingerprint.
+    expect(prompt).toContain("errorFingerprint(ServiceName, LogAttributes)");
+    expect(prompt).toContain("= 'fp-1'");
+  });
+
+  it("falls back to the body when the exception message is empty", () => {
+    const prompt = buildErrorHandoffPrompt(
+      summary({
+        exceptionType: "",
+        exceptionMessage: "",
+        body: "raw log line",
+      }),
+    );
+
+    expect(prompt).toContain("Error: Unknown exception: raw log line");
+  });
+});

--- a/packages/telemetry-explorer/src/errors/ui/error-handoff-button.tsx
+++ b/packages/telemetry-explorer/src/errors/ui/error-handoff-button.tsx
@@ -1,0 +1,82 @@
+import { Button } from "@everr/ui/components/button";
+import { Check, Copy } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import type { ErrorIssueSummary } from "../data/types";
+import {
+  ERROR_FINGERPRINT_SQL,
+  EXCEPTION_LOG_FILTER_SQL,
+} from "../sql/fingerprint";
+
+// A ready-to-run query that lists this Error's Occurrences: the same
+// exception-log filter and fingerprint expression the app groups Errors by
+// (documented in the everr-use-telemetry skill), narrowed to one Fingerprint.
+function occurrencesQuery(fingerprint: string): string {
+  return [
+    "SELECT toString(Timestamp) AS timestamp, ServiceName, TraceId,",
+    "  LogAttributes['exception.stacktrace'] AS stacktrace",
+    "FROM logs",
+    "WHERE Timestamp > now() - INTERVAL 7 DAY",
+    `  AND ${EXCEPTION_LOG_FILTER_SQL.trim()}`,
+    `  AND (${ERROR_FINGERPRINT_SQL.trim()}) = '${fingerprint}'`,
+    "ORDER BY Timestamp DESC",
+    "LIMIT 50",
+  ].join("\n");
+}
+
+// Agent-agnostic by design: the goal, the Fingerprint, and a telemetry query
+// the agent runs itself. No deep links, no per-agent launchers.
+export function buildErrorHandoffPrompt(issue: ErrorIssueSummary): string {
+  const title = issue.exceptionType || "Unknown exception";
+  const message = issue.exceptionMessage || issue.body;
+  const heading = message ? `${title}: ${message}` : title;
+  return [
+    `Fix this Error tracked in Everr.`,
+    ``,
+    `Error: ${heading}`,
+    `Fingerprint: ${issue.fingerprint}`,
+    ``,
+    `Pull this Error's Occurrences from telemetry with \`everr cloud query\` (or \`everr local query\` for local telemetry):`,
+    ``,
+    occurrencesQuery(issue.fingerprint),
+    ``,
+    `Then investigate the root cause and fix the code. The everr-use-telemetry skill documents how Errors are fingerprinted.`,
+  ].join("\n");
+}
+
+export function ErrorHandoffButton({ issue }: { issue: ErrorIssueSummary }) {
+  const [copied, setCopied] = useState(false);
+  const resetTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
+  // Cancel a pending "Copied" reset if the dialog closes before it fires.
+  useEffect(
+    () => () => {
+      if (resetTimer.current) clearTimeout(resetTimer.current);
+    },
+    [],
+  );
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(buildErrorHandoffPrompt(issue));
+      setCopied(true);
+      if (resetTimer.current) clearTimeout(resetTimer.current);
+      resetTimer.current = setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // ignore clipboard errors
+    }
+  };
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      title="Copy a prompt that hands this Error to an agent"
+      onClick={handleCopy}
+    >
+      {copied ? (
+        <Check data-icon="inline-start" />
+      ) : (
+        <Copy data-icon="inline-start" />
+      )}
+      {copied ? "Copied" : "Copy agent prompt"}
+    </Button>
+  );
+}


### PR DESCRIPTION
Centralizes error grouping in ClickHouse and gives agents a one-click way to pull an Error's context from telemetry, plus two ClickHouse housekeeping changes. One clean commit off `main`.

## errorFingerprint UDF
Error grouping was an inline SQL expression copied into the app query, the skill, and the handoff prompt. It's now a single ClickHouse UDF, `errorFingerprint(ServiceName, LogAttributes)`:
- `clickhouse/init/04` defines it for cloud; the local collector registers it on chDB schema-init (routed through `Query`, not `Exec`, because chDB only persists `CREATE FUNCTION` with a real output format).
- `fingerprint.ts`, the `everr-use-telemetry` skill, and the "Copy agent prompt" button all reference it by name. The old `.sql` fragments + drift test are gone.
- Verified end to end against a real collector: it auto-creates the UDF on startup and returns the same hash the inline expression did, so existing fingerprints are unchanged.

## Copy agent prompt
The error dialog's button copies an agent-agnostic prompt: the Error heading, its Fingerprint, and a ready-to-run `everr cloud query` / `everr local query` that lists the Occurrences via `errorFingerprint(...)`.

## app.* skip-index mirror
`app.*` tables are `CREATE TABLE AS SELECT *` of `otel.*`, which copies columns but not skip indexes. Now every `otel.*` skip index is mirrored onto the matching `app.*` table (all tables).

## otel.* retention
Raw `otel.*` landing tables had no TTL. Added a 7-day TTL; the durable, tenant-scoped read model is `app.*`, populated at insert time by the MVs.

## Cloud migration
`clickhouse/init/*` runs only on fresh servers. `clickhouse/migrate-errors-udf-app-indexes-otel-ttl.sql` applies all three to an existing cluster in one idempotent file (function + ADD/MATERIALIZE app.* indexes + MODIFY TTL on otel.*). Validated against the dev docker ClickHouse.

**Deployment ordering:** apply that migration to cloud ClickHouse **before** app code that calls `errorFingerprint(...)` deploys, or cloud error queries break. Its step 3 drops raw `otel.*` data older than 7 days (lazily, on merges).

Supersedes #318 (same work, clean history).