### PR TITLE
feat: expand log detail and improve attributes readability

### DIFF
--- a/packages/telemetry-explorer/src/logs/ui/log-inspector.tsx
+++ b/packages/telemetry-explorer/src/logs/ui/log-inspector.tsx
@@ -17,6 +17,7 @@ import {
   FileSearch,
   Fingerprint,
   GitBranch,
+  Maximize2,
   Server,
   X,
 } from "lucide-react";
@@ -49,6 +50,7 @@ export interface LogInspectorPanelProps {
   repo: LogsRepositoryLike;
   log: LogExplorerRow;
   onClose: () => void;
+  onExpand?: () => void;
   renderRunLink?: LogInspectorProps["renderRunLink"];
   resolveJobId?: LogInspectorProps["resolveJobId"];
 }
@@ -202,6 +204,7 @@ export function LogInspectorPanel({
   repo,
   log,
   onClose,
+  onExpand,
   renderRunLink,
   resolveJobId,
 }: LogInspectorPanelProps) {
@@ -233,6 +236,16 @@ export function LogInspectorPanel({
             >
               {log.level}
             </Badge>
+            {onExpand ? (
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Expand log details"
+                onClick={onExpand}
+              >
+                <Maximize2 />
+              </Button>
+            ) : null}
             <Button
               variant="ghost"
               size="icon-sm"

--- a/packages/telemetry-explorer/src/logs/ui/logs-explorer.tsx
+++ b/packages/telemetry-explorer/src/logs/ui/logs-explorer.tsx
@@ -1,3 +1,8 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@everr/ui/components/dialog";
 import { RetryError } from "@everr/ui/components/retry-error";
 import { Skeleton } from "@everr/ui/components/skeleton";
 import type { TimeRange } from "@everr/ui/lib/time-range";
@@ -195,6 +200,7 @@ export function LogsExplorer({
     log: LogExplorerRow;
     key: string;
   } | null>(null);
+  const [isInspectorExpanded, setIsInspectorExpanded] = useState(false);
 
   // Optimistic local mirror of the search filter state. Filter toggles update
   // synchronously so the UI feels instant; onSearchChange runs alongside.
@@ -272,6 +278,11 @@ export function LogsExplorer({
     [],
   );
 
+  const handleCloseInspector = useCallback(() => {
+    setSelectedLogState(null);
+    setIsInspectorExpanded(false);
+  }, []);
+
   return (
     <div className="min-h-0 flex-1 overflow-hidden">
       <section className="bg-background text-foreground flex h-full min-h-0 flex-col overflow-hidden">
@@ -311,7 +322,7 @@ export function LogsExplorer({
                 isPending={isHistogramPending}
                 showVolume={showVolume}
                 onRangeSelect={(from, to) => {
-                  setSelectedLogState(null);
+                  handleCloseInspector();
                   onTimeRangeSelect?.(from, to);
                 }}
                 onShowVolumeChange={(isExpanded) =>
@@ -354,13 +365,37 @@ export function LogsExplorer({
               <LogInspectorPanel
                 repo={repo}
                 log={selectedLogState.log}
-                onClose={() => setSelectedLogState(null)}
+                onClose={handleCloseInspector}
+                onExpand={() => setIsInspectorExpanded(true)}
                 renderRunLink={renderRunLink}
                 resolveJobId={resolveJobId}
               />
             </aside>
           ) : null}
         </div>
+
+        <Dialog
+          open={isInspectorExpanded && selectedLogState !== null}
+          onOpenChange={(open) => {
+            if (!open) setIsInspectorExpanded(false);
+          }}
+        >
+          <DialogContent
+            showCloseButton={false}
+            className="flex h-[85vh] w-[90vw] max-w-none gap-0 overflow-hidden rounded-lg p-0 sm:max-w-4xl"
+          >
+            <DialogTitle className="sr-only">Log event</DialogTitle>
+            {selectedLogState ? (
+              <LogInspectorPanel
+                repo={repo}
+                log={selectedLogState.log}
+                onClose={() => setIsInspectorExpanded(false)}
+                renderRunLink={renderRunLink}
+                resolveJobId={resolveJobId}
+              />
+            ) : null}
+          </DialogContent>
+        </Dialog>
       </section>
     </div>
   );

--- a/packages/ui/src/components/detail-panel.tsx
+++ b/packages/ui/src/components/detail-panel.tsx
@@ -31,14 +31,14 @@ export function DetailItem({
   mono?: boolean;
 }) {
   return (
-    <div className="group relative grid min-w-0 grid-cols-[96px_minmax(0,1fr)] gap-3 rounded-md border bg-background/70 px-2.5 py-2 text-xs">
+    <div className="group relative min-w-0 gap-2 rounded-md border bg-background/70 px-2.5 py-2 text-xs flex flex-col overflow-x-hidden">
       <span className="text-muted-foreground flex min-w-0 items-center gap-1">
         {icon ? <span className="[&>svg]:size-3">{icon}</span> : null}
         <span className="truncate">{label}</span>
       </span>
       <span
         className={cn(
-          "min-w-0 truncate text-right",
+          "min-w-0",
           mono && "font-mono",
           !value && "text-muted-foreground",
         )}
@@ -48,7 +48,7 @@ export function DetailItem({
       {value ? (
         <CopyValueButton
           value={value}
-          className="absolute right-1.5 top-1/2 -translate-y-1/2 bg-background shadow-sm"
+          className="absolute right-1.5 top-2 bg-background shadow-sm"
         />
       ) : null}
     </div>


### PR DESCRIPTION
Added an expand button and changed the log attributes layout to make their content always readable

<img width="1713" height="960" alt="Screenshot 2026-08-03 at 18 46 56" src="https://github.com/user-attachments/assets/a405c119-654d-4bd5-b806-d9be0406da9e" />
<img width="1723" height="962" alt="Screenshot 2026-08-03 at 18 47 06" src="https://github.com/user-attachments/assets/20625e7c-3885-44dc-946b-958e3c944ec0" />
