### PR TITLE
fix(traces): survive wrapped-negative span durations

### DIFF
--- a/collector/exporter/chdbexporter/exporter_traces.go
+++ b/collector/exporter/chdbexporter/exporter_traces.go
@@ -20,6 +20,18 @@ import (
 	"github.com/everr-labs/everr/collector/internal/localgateway/chdb"
 )
 
+// clampedSpanDuration is the span's duration in nanoseconds, clamped to zero
+// when the producer stamped its end before its start (non-monotonic clocks):
+// the raw uint64 subtraction would wrap to ~2^64 and poison every downstream
+// computation that adds the duration to a timestamp.
+func clampedSpanDuration(span ptrace.Span) uint64 {
+	end, start := span.EndTimestamp(), span.StartTimestamp()
+	if end < start {
+		return 0
+	}
+	return uint64(end - start)
+}
+
 type tracesExporter struct {
 	db        driver.Conn
 	handle    *chdb.Handle
@@ -105,7 +117,7 @@ func (e *tracesExporter) pushTraceData(ctx context.Context, td ptrace.Traces) er
 			for k := range ssLen {
 				span := scopeSpans.At(k)
 				spanStatus := span.Status()
-				spanDurationNanos := span.EndTimestamp() - span.StartTimestamp()
+				spanDurationNanos := clampedSpanDuration(span)
 				spanAttrMap := internal.AttributesToMap(span.Attributes())
 
 				eventTimes, eventNames, eventAttrs := convertEvents(span.Events())

--- a/collector/exporter/chdbexporter/exporter_traces_json.go
+++ b/collector/exporter/chdbexporter/exporter_traces_json.go
@@ -154,7 +154,7 @@ func (e *tracesJSONExporter) pushTraceData(ctx context.Context, td ptrace.Traces
 			for k := range ssLen {
 				span := scopeSpans.At(k)
 				spanStatus := span.Status()
-				spanDurationNanos := span.EndTimestamp() - span.StartTimestamp()
+				spanDurationNanos := clampedSpanDuration(span)
 				spanAttr := span.Attributes()
 				spanAttrBytes, spanAttrErr := json.Marshal(spanAttr.AsRaw())
 				if spanAttrErr != nil {

--- a/collector/exporter/chdbexporter/exporter_traces_test.go
+++ b/collector/exporter/chdbexporter/exporter_traces_test.go
@@ -1,0 +1,24 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package chdbexporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+func TestClampedSpanDuration(t *testing.T) {
+	span := ptrace.NewSpan()
+	span.SetStartTimestamp(pcommon.Timestamp(1_000_000))
+	span.SetEndTimestamp(pcommon.Timestamp(1_500_000))
+	require.Equal(t, uint64(500_000), clampedSpanDuration(span))
+
+	// A producer with a non-monotonic clock can stamp end before start; the
+	// raw uint64 subtraction would wrap to ~2^64.
+	span.SetEndTimestamp(pcommon.Timestamp(900_000))
+	require.Equal(t, uint64(0), clampedSpanDuration(span))
+}

--- a/packages/telemetry-explorer/src/traces/data/repository.test.ts
+++ b/packages/telemetry-explorer/src/traces/data/repository.test.ts
@@ -267,6 +267,29 @@ describe("TracesRepository.search", () => {
     expect(params).toMatchObject({ minDurationNs: "1000" });
   });
 
+  it("reads wrapped-negative span durations as zero in the trace aggregate", async () => {
+    // A span whose end precedes its start ingests as a ~2^64 UInt64 Duration;
+    // fed raw into addNanoseconds it overflows DateTime64 and the whole page
+    // 500s (DECIMAL_OVERFLOW).
+    query.mockResolvedValueOnce([]);
+
+    await makeRepo().search({
+      fromTs: "2026-05-20 11:00:00.000",
+      toTs: "2026-05-20 13:00:00.000",
+      namespace: [],
+      service: [],
+      name: "",
+      status: "all",
+      attributes: [],
+      limit: 25,
+    });
+
+    const [sql] = query.mock.calls[0] ?? [];
+    expect(sql).toContain(
+      "addNanoseconds(Timestamp, if(Duration > 9223372036854775807, toUInt64(0), Duration))",
+    );
+  });
+
   it("propagates query errors", async () => {
     query.mockRejectedValueOnce(new Error("clickhouse exploded"));
 
@@ -322,6 +345,11 @@ describe("TracesRepository.getTrace", () => {
     expect(sql).toContain("WHERE TraceId = {traceId:String}");
     expect(sql).toContain("parseDateTime64BestEffort({fromTs:String}, 9)");
     expect(sql).toContain("parseDateTime64BestEffort({toTs:String}, 9)");
+    // Wrapped-negative durations read as zero so the timeline never sizes its
+    // window in centuries.
+    expect(sql).toContain(
+      "toString(if(Duration > 9223372036854775807, toUInt64(0), Duration))",
+    );
     expect(params).toEqual({
       traceId: "t1",
       fromTs: "2026-05-20 11:00:00.000",

--- a/packages/telemetry-explorer/src/traces/data/repository.ts
+++ b/packages/telemetry-explorer/src/traces/data/repository.ts
@@ -45,6 +45,15 @@ const TO_TS_SQL = "parseDateTime64BestEffort({toTs:String}, 9)";
 const TIME_WINDOW_SQL = `Timestamp BETWEEN ${FROM_TS_SQL} AND ${TO_TS_SQL}`;
 const SERVICE_NAMESPACE_RESOURCE_ATTRIBUTE = "service.namespace";
 
+// A span whose end landed before its start (non-monotonic producer clock)
+// ingests as a wrapped-negative UInt64 Duration (just under 2^64). Read those
+// as zero-length everywhere Duration leaves this file: addNanoseconds on the
+// raw value overflows DateTime64's range and one bad span poisons the whole
+// trace list, and the timeline maths downstream would size the window in
+// centuries. Values above Int64::MAX are exactly the wrapped negatives.
+const SANE_DURATION_SQL =
+  "if(Duration > 9223372036854775807, toUInt64(0), Duration)";
+
 // Traces store Timestamp as DateTime64(9); attribute discovery must parse its
 // bounds the same way the search queries do, or sub-second rows near the upper
 // bound get dropped and the offered keys/values disagree with the results.
@@ -215,7 +224,7 @@ export class TracesRepository {
              argMin  (StatusCode,  (Timestamp, SpanId))) AS rootStatus,
           min(Timestamp) AS startTsRaw,
           toUInt64(dateDiff('nanosecond', min(Timestamp),
-                            max(addNanoseconds(Timestamp, Duration)))) AS durationNsRaw,
+                            max(addNanoseconds(Timestamp, ${SANE_DURATION_SQL})))) AS durationNsRaw,
           toUInt32(count())                       AS spanCount,
           toUInt32(countIf(StatusCode = 'Error')) AS errorCount,
           groupUniqArray(ServiceName)             AS services
@@ -259,7 +268,7 @@ export class TracesRepository {
         ${resourceAttribute(SERVICE_NAMESPACE_RESOURCE_ATTRIBUTE)} AS serviceNamespace,
         toString(Timestamp)                     AS timestamp,
         toString(toUnixTimestamp64Nano(Timestamp)) AS timestampNs,
-        toString(Duration)                      AS duration,
+        toString(${SANE_DURATION_SQL})          AS duration,
         StatusCode AS statusCode,
         SpanKind   AS spanKind,
         SpanAttributes     AS spanAttributes,


### PR DESCRIPTION
## What happened

The trace explorer 500'd in dev with ClickHouse `DECIMAL_OVERFLOW` (code 407) from `addNanoseconds(Timestamp, Duration)`. The trail:

1. A single `GET /healthz` span from `clickety-clack-all` was stored with `Duration = 18446744073709360311`, which is `2^64 - 191305`: a span whose end landed **191µs before its start**, wrapped to unsigned.
2. The producer side is `tracing-opentelemetry` (0.31), which stamps span start and end with two independent `SystemTime::now()` calls, no monotonic correction. The engine runs in the Docker Desktop VM, whose wall clock gets stepped by host time sync; one backwards step during a sub-millisecond request is all it takes. It happened exactly once in the whole table. OTLP permits end < start (two independent u64 fields), so any producer can ship this.
3. At ingest, `Duration` is computed as a `uint64` subtraction that silently wraps, both in the upstream contrib `clickhouseexporter` v0.152.0 (the dev app path that stored this row) and in our own `chdbexporter`.
4. On read, the trace-list aggregate does `max(addNanoseconds(Timestamp, Duration))`; the wrapped value points ~584 years out, past `DateTime64(9)`'s range, and the overflow inside the aggregate takes down the whole page. The trace timeline would similarly size its window in centuries via `BigInt(span.duration)`.

## The fix

**Read side** (`telemetry-explorer` traces repository): any `Duration` above `Int64::MAX` — exactly the wrapped negatives — reads as zero-length, in both places `Duration` leaves the SQL layer: the trace-list aggregate and the span query that feeds the timeline. Zero is the honest value for a span whose clocks disagree by microseconds.

**Write side** (`chdbexporter`): the subtraction is clamped to zero instead of wrapping, so the local-collector path never stores a poisoned duration in the first place.

The upstream contrib `clickhouseexporter` still wraps (worth an upstream issue), which is why the read-side guard stays load-bearing rather than belt-and-suspenders.

## Testing

- SQL-shape tests for both guarded queries; unit test for the exporter clamp (runs in CI, the chdbexporter package needs `libchdb` locally).
- Verified live in dev against the actual poisoned row: the traces page over that window rendered the error before the fix and renders the list after it.
- `tsc`, biome, and the full telemetry-explorer suite pass; `go build`/`go vet` clean; desktop-app typecheck clean.