### PR TITLE
style(app): render dashboard panels as a flush hairline grid

### DIFF
--- a/packages/app/src/components/dashboards/dashboard-grid.tsx
+++ b/packages/app/src/components/dashboards/dashboard-grid.tsx
@@ -29,7 +29,12 @@ export function DashboardGrid() {
           width={width}
           className="layout"
           layout={layout}
-          gridConfig={{ cols: GRID_COLS, rowHeight: ROW_HEIGHT }}
+          gridConfig={{
+            cols: GRID_COLS,
+            rowHeight: ROW_HEIGHT,
+            margin: [0, 0],
+            containerPadding: [0, 0],
+          }}
           dragConfig={{ enabled: false }}
           resizeConfig={{ enabled: false }}
           // No compaction: render panels at their authored x/y so intentional

--- a/packages/app/src/components/dashboards/dashboard-panel.tsx
+++ b/packages/app/src/components/dashboards/dashboard-panel.tsx
@@ -95,7 +95,7 @@ export function DashboardPanel({
         description={display?.description}
         status={status}
         errorMessage={errorMessage}
-        className="h-full"
+        className="h-full rounded-none border ring-0"
         inset={getVisualizationInset(plugin.kind)}
         action={
           action || specWarnings.length > 0 ? (


### PR DESCRIPTION
Dashboard panels were rounded cards floating in a 10px gutter, which made a dashboard read as a set of separate widgets rather than one surface.

## Changes

- `dashboard-panel.tsx`: square corners, and a 1px border in place of the card's ring.
- `dashboard-grid.tsx`: `margin: [0, 0]` and `containerPadding: [0, 0]` so adjacent panels share an edge.

Panel sizing is untouched. Only the inter-panel gutter and the panel chrome move, so authored layouts keep their column spans and row heights.

## Note

Zeroing `containerPadding` also removes the outer inset, so the grid now runs flush to the viewport edge and to the sidebar. If we want the outer inset back while keeping panels flush against each other, `containerPadding` can be set independently of `margin`.

## Testing

Checked manually against the Web Vitals dashboard in the dev app: panels share edges, no gutter, no rounded corners, and the stat / timeseries / bar / table visualizations all still render and size correctly.