### PR TITLE
feat(skills): full-stack OTel rules for Vite SSR and TanStack Start

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -27,6 +27,8 @@
     // size-limit's own config file, resolved by its CLI at runtime; nothing
     // in the package imports it.
     "packages/otel-web/.size-limit.cjs",
+    // On-demand skill eval runner, invoked directly with `node`.
+    "evals/setup-telemetry/run.mjs",
   ],
   // The two @opentelemetry/* entries are imported only by the OTel web SDK
   // sample in content/docs/guides/browser-telemetry.mdx (the reader

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/SKILL.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/SKILL.md
@@ -36,6 +36,8 @@ Always read the relevant rule files before editing instrumentation. Use the tabl
 | `nodejs` | Node.js instrumentation setup and runtime pitfalls |
 | `nextjs` | Next.js App Router, server/client split, trace propagation |
 | `browser` | Web frontends exporting OTLP directly from the browser with a public origin-bound key |
+| `vite-ssr` | Full-stack Vite apps with Node SSR: wiring both halves and joining browser and server traces |
+| `tanstack-start` | TanStack Start: router-aware browser telemetry, request spans, and server function middleware |
 | `tauri` | Tauri v2 desktop/mobile: Rust backend + browser frontend proxying telemetry through IPC |
 | `electron` | Electron desktop: Node main process + Chromium renderer proxying telemetry through IPC |
 | `rust` | Rust tracing-based OpenTelemetry setup and runtime pitfalls |

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/nextjs.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/nextjs.md
@@ -4,7 +4,9 @@ Use this rule for Next.js 13+ App Router projects that need server-side
 OpenTelemetry instrumentation.
 
 This rule is intentionally server-only. Keep device-side instrumentation out of
-this setup.
+this setup: the browser half is `browser.md` (`@everr/otel-web`), and joining
+browser and server traces into one trace follows the seam section of
+`vite-ssr.md`, which applies to Next.js unchanged.
 
 ## Prerequisites
 

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/tanstack-start.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/tanstack-start.md
@@ -1,0 +1,84 @@
+# TanStack Start Instrumentation
+
+Use this rule for TanStack Start apps (Vite + Nitro, React). Read `vite-ssr.md` first: it owns the two-halves layout, environment split, and the browser-to-server seam. This rule adds only what TanStack Start changes.
+
+## Browser Half
+
+Follow `browser.md` for the `@everr/otel-web` setup. TanStack Start specifics:
+
+- Put the `WebSDK` construction in a side-effect module and import it at the top of `src/routes/__root.tsx`, so it runs once when the client bundle loads. The WebSDK is inert during SSR, so no environment guard is needed.
+- Register the router with the SDK's route resolver so pageviews and errors carry the route id (`/blog/$slug`) instead of raw paths. Telemetry setup runs before the router exists, so bridge through an app-owned module:
+
+```ts
+// src/telemetry/route-pattern.ts
+import { setRouteResolver } from "@everr/otel-web";
+
+type RouterLike = {
+  matchRoutes(pathname: string): ReadonlyArray<{ routeId: string }>;
+};
+
+/** Call from `getRouter()` right after creating the router. */
+export function registerRouter(router: RouterLike): void {
+  setRouteResolver((url) => {
+    const matches = router.matchRoutes(new URL(url).pathname);
+    return matches[matches.length - 1]?.routeId;
+  });
+}
+```
+
+- Server function calls go over `POST /_serverFn/<id>`. Give `network()` a `resolveRouteTemplate` that parameterizes that path (for example to `/_serverFn/:id`) with the same helper the server uses for `http.route`, per the seam section of `vite-ssr.md`.
+
+## Server Half
+
+Follow `nodejs.md` for the NodeSDK setup module, including the hot-reload guard: `vite dev` runs the server in-process and re-evaluates on reload.
+
+### Request Spans In The Server Entry
+
+The framework entrypoint for server telemetry is a custom `src/server.ts`: import the setup module first, then wrap the Start fetch handler so every request gets a SERVER span.
+
+```ts
+// src/server.ts
+import {
+  createStartHandler,
+  defaultStreamHandler,
+  defineHandlerCallback,
+} from "@tanstack/react-start/server";
+import { instrumentServerFetch } from "@/telemetry/server";
+import "@/telemetry/node";
+
+const startFetch = createStartHandler(defineHandlerCallback(defaultStreamHandler));
+
+export default {
+  fetch: (...args: Parameters<typeof startFetch>) =>
+    instrumentServerFetch(args[0], () => startFetch(...args)),
+};
+```
+
+`instrumentServerFetch` starts a SERVER span named `<METHOD> <route-template>`:
+
+- Extract the parent context from the request headers with `propagation.extract` so browser-injected `traceparent` (and any first-party client's) parents the span. Requests without the header extract to an empty context and root themselves.
+- Parameterize the path before it becomes the span name or `http.route`; raw paths are unbounded cardinality.
+- Set `http.response.status_code` from the response; capture 5xx responses and thrown errors with `captureError` and `error.handled: false`.
+- When wrapping the handler this way, disable the HTTP auto-instrumentation's incoming-request span (`disableIncomingRequestInstrumentation: true`) so each request gets one SERVER span, not two.
+
+### Server Functions
+
+Wrap every server function through global middleware in `src/start.ts` instead of instrumenting call sites:
+
+```ts
+// src/start.ts
+import { createStart } from "@tanstack/react-start";
+import { serverFnTelemetryMiddleware } from "@/telemetry/server-fn";
+
+export const startInstance = createStart(() => ({
+  functionMiddleware: [serverFnTelemetryMiddleware],
+}));
+```
+
+The middleware (`createMiddleware({ type: "function" })`) starts an INTERNAL span per invocation with the function id, name, and filename from `serverFnMeta` as attributes (prefix non-semconv attributes with `everr.`). It nests under the request's SERVER span automatically because the fetch wrapper's context is active.
+
+TanStack Start signals control flow with throwables: `redirect()` and `notFound()` surface as thrown values inside server functions. Filter those out before calling `captureError`, or every redirect becomes a phantom error.
+
+## Validation
+
+Run the seam validation from `vite-ssr.md`. Additionally trigger one server function from the browser and verify its INTERNAL span shares a `TraceId` with the browser request and the SERVER span.

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/vite-ssr.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/vite-ssr.md
@@ -1,0 +1,63 @@
+# Full-Stack Vite SSR Instrumentation
+
+Use this rule for full-stack apps built on Vite with server-side rendering on Node.js: a custom SSR server (Express, Hono, plain `node server.js`), a Nitro-based output, or a framework CLI that runs Vite in the middle. For TanStack Start specifics, read `tanstack-start.md` on top of this rule. For Next.js, use `nextjs.md` instead.
+
+Node.js servers only. Edge and worker runtimes (Cloudflare Workers, Deno Deploy) are out of scope: the OpenTelemetry Node SDK does not run there.
+
+## Two Halves, Two Rules
+
+A full-stack Vite app is two services that happen to share a repo:
+
+- **Browser half**: `@everr/otel-web` per `browser.md`. One side-effect module imported before the app renders. Public origin-bound key in production, local collector in dev.
+- **Server half**: `@opentelemetry/sdk-node` per `nodejs.md`. A setup module loaded before framework, HTTP, and database imports.
+
+This rule owns only what neither half covers alone: wiring both into one Vite project and joining their traces.
+
+## Server Setup Placement
+
+- Put the NodeSDK setup in its own module (`src/telemetry/node.ts` or similar) and import it first in the server entry, before the framework or any I/O library.
+- `vite dev` runs the SSR server inside the Vite process and re-evaluates modules on reload. Guard the setup with an idempotent global (`globalThis` key or `Symbol.for`) so hot reload cannot start a second SDK.
+- The production build runs the same module from the built server entry (`.output/server/index.mjs` for Nitro). Confirm the setup module survives the build by checking the built entry imports it, not by assuming.
+- Keep the setup module out of any code path the client bundle imports. Vite will happily bundle Node-only packages into the browser and fail late; the browser half imports only `@everr/otel-web`.
+
+## Environment Split
+
+Vite exposes `import.meta.env.VITE_*` to the client and `process.env` to the server. Keep the two surfaces separate:
+
+| Variable | Side | Purpose |
+| --- | --- | --- |
+| `VITE_EVERR_PUBLIC_INGEST_KEY` | client | Public origin-bound key, production browser export |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | server | Optional local/custom collector override |
+| `EVERR_INGEST_KEY` | server | Secret key, production server export |
+
+Never move `EVERR_INGEST_KEY` into a `VITE_`-prefixed variable: the `VITE_` prefix is exactly the boundary that ships values to every visitor.
+
+## The Seam: Joining Browser And Server Traces
+
+- Give each half its own `service.name` (for example `shop-web` and `shop-server`) so the sides stay separable in queries. Never share one name.
+- `@everr/otel-web`'s `network()` instrumentation injects `traceparent` on same-origin requests by default, so browser-initiated requests parent the server spans with no extra configuration. Cross-origin APIs need the target listed in `network()` options and `traceparent` in the server's CORS `Access-Control-Allow-Headers`.
+- On the server, the HTTP auto-instrumentation extracts incoming W3C context automatically. If incoming-request instrumentation is disabled in favor of a manual SERVER span, extract explicitly with `propagation.extract(context.active(), request.headers, getter)` and pass the result as the span's parent context.
+- Align route templates across the seam: give `network()` a `resolveRouteTemplate` callback that applies the same parameterization the server stamps on `http.route`, so a request's `url.template` matches its server span's route. Share one parameterization helper between both halves.
+
+## CORS In Development
+
+The browser posts OTLP to the collector from the page's origin. The local CLI collector accepts any origin, but if dev telemetry routes through another collector, its CORS allowlist must include the exact dev origin, port included. A disallowed origin fails preflight and the SDK drops batches silently: when browser rows are missing but server rows arrive, check the collector's CORS allowlist against the page origin before touching the app code.
+
+## Validation
+
+Validate the seam, not just each half:
+
+1. Load the app in a real browser and trigger a page that fetches from the server.
+2. `everr local query` for fresh rows under the browser `ServiceName` and separately under the server `ServiceName`.
+3. Prove the join: at least one `TraceId` with spans from both service names.
+
+```sql
+SELECT TraceId, groupUniqArray(ServiceName) AS services
+FROM traces
+WHERE Timestamp > now() - INTERVAL 5 MINUTE
+GROUP BY TraceId
+HAVING length(services) > 1
+LIMIT 5
+```
+
+No joined rows with both halves emitting usually means `network()` is missing, the request was cross-origin without a configured target, or the server span ignored the incoming `traceparent`.

--- a/evals/setup-telemetry/README.md
+++ b/evals/setup-telemetry/README.md
@@ -1,0 +1,21 @@
+# everr-setup-telemetry skill evals
+
+Agent-driven, end-to-end: each run scaffolds a fresh project, hands it to a headless Claude Code agent with only the `everr-setup-telemetry` skill and a one-paragraph prompt, then grades the outcome objectively against the local collector.
+
+```bash
+node evals/setup-telemetry/run.mjs --framework tanstack-start
+node evals/setup-telemetry/run.mjs --framework nextjs
+node evals/setup-telemetry/run.mjs --framework vite-ssr
+```
+
+Pass criteria (all required):
+
+1. `npm run build` succeeds after the agent's changes.
+2. The app boots and serves a page.
+3. Fresh rows arrive under the prompted browser service name (`<run-id>-web`).
+4. Fresh rows arrive under the prompted server service name (`<run-id>-server`).
+5. At least one `TraceId` contains spans from both service names (the browser-to-server seam).
+
+The verdict prints as JSON and the exit code is 0 only on pass. Failed runs keep the scaffolded project on disk for inspection; pass `--keep` to keep passing runs too.
+
+Requirements: the `everr-dev` local collector running, the `claude` CLI, and the `agent-browser` CLI. Runs are token-costly and non-deterministic: they exercise the real agent, so run them on demand (before skill changes ship), not in CI.

--- a/evals/setup-telemetry/run.mjs
+++ b/evals/setup-telemetry/run.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+// Agent-driven eval for the everr-setup-telemetry skill.
+//
+// For one framework it scaffolds a fresh project in a temp dir, copies the
+// skill into the project's .claude/skills/, lets a headless Claude Code agent
+// instrument the app from the prompt alone, then grades objectively: the
+// production build passes, the app boots, and the local collector holds fresh
+// browser rows, server rows, and at least one trace joining both halves.
+//
+// Usage:
+//   node evals/setup-telemetry/run.mjs --framework tanstack-start|nextjs|vite-ssr [--keep]
+//
+// Requires: everr-dev collector running, `claude` CLI, `agent-browser` CLI.
+
+import { execSync, spawn } from "node:child_process";
+import { mkdtempSync, cpSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const SKILL_DIR = join(
+  REPO_ROOT,
+  "crates/everr-core/assets/skills/everr-setup-telemetry",
+);
+const AGENT_TIMEOUT_MS = 30 * 60 * 1000;
+const BOOT_TIMEOUT_MS = 90 * 1000;
+const FLUSH_WAIT_MS = 12 * 1000;
+const PORT = 4173;
+
+const FRAMEWORKS = {
+  "tanstack-start": {
+    scaffold: (dir) =>
+      run(
+        `npx --yes @tanstack/cli@latest create app --framework React --package-manager npm --no-toolchain --no-examples --deployment nitro`,
+        dir,
+      ),
+    build: "npm run build",
+    serve: "npm run dev",
+  },
+  nextjs: {
+    scaffold: (dir) =>
+      run(
+        `npx --yes create-next-app@latest app --ts --app --eslint --no-tailwind --no-src-dir --use-npm --yes`,
+        dir,
+      ),
+    build: "npm run build",
+    serve: "npm run dev",
+  },
+  "vite-ssr": {
+    scaffold: (dir) =>
+      run(`npm create vite-extra@latest app -- --template ssr-react-ts`, dir),
+    build: "npm run build",
+    serve: "npm run dev",
+  },
+};
+
+function run(cmd, cwd, opts = {}) {
+  return execSync(cmd, {
+    cwd,
+    stdio: opts.capture ? "pipe" : "inherit",
+    encoding: "utf8",
+    env: { ...process.env, ...opts.env, CI: "1" },
+    timeout: opts.timeout ?? 10 * 60 * 1000,
+  });
+}
+
+function localQuery(sql) {
+  const out = run(`everr-dev local query ${JSON.stringify(sql)}`, REPO_ROOT, {
+    capture: true,
+  });
+  return out
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function prompt(runId) {
+  return [
+    `Set up Everr telemetry for this app using the everr-setup-telemetry skill: browser and server halves, with browser and server traces joined into single traces.`,
+    `Use service.name "${runId}-web" for the browser and "${runId}-server" for the server, exactly.`,
+    `Export to the local collector (no production key exists). Validate your work by exercising the app and querying the collector before finishing.`,
+  ].join("\n");
+}
+
+async function waitForBoot(url) {
+  const deadline = Date.now() + BOOT_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch {}
+    await new Promise((r) => setTimeout(r, 1500));
+  }
+  throw new Error(`app did not boot at ${url}`);
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const framework = args[args.indexOf("--framework") + 1];
+  const keep = args.includes("--keep");
+  const fw = FRAMEWORKS[framework];
+  if (!fw) {
+    console.error(`--framework must be one of: ${Object.keys(FRAMEWORKS)}`);
+    process.exit(2);
+  }
+
+  run("everr-dev local status", REPO_ROOT, { capture: true });
+
+  const runId = `eval-${framework}-${Date.now().toString(36)}`;
+  const workDir = mkdtempSync(join(tmpdir(), `everr-eval-`));
+  const appDir = join(workDir, "app");
+  const verdict = {
+    runId,
+    framework,
+    scaffold: false,
+    agent: false,
+    build: false,
+    boot: false,
+    browserRows: 0,
+    serverRows: 0,
+    joinedTraces: 0,
+    pass: false,
+  };
+
+  let server;
+  try {
+    console.log(`[eval] scaffolding ${framework} in ${appDir}`);
+    fw.scaffold(workDir);
+    run("git init -q && git add -A && git commit -qm scaffold", appDir);
+    verdict.scaffold = true;
+
+    cpSync(SKILL_DIR, join(appDir, ".claude/skills/everr-setup-telemetry"), {
+      recursive: true,
+    });
+    writeFileSync(join(appDir, "EVAL_PROMPT.md"), prompt(runId));
+
+    console.log(`[eval] running agent (up to 30m)`);
+    run(`claude -p ${JSON.stringify(prompt(runId))} --dangerously-skip-permissions`, appDir, {
+      timeout: AGENT_TIMEOUT_MS,
+    });
+    verdict.agent = true;
+
+    console.log(`[eval] building`);
+    run(fw.build, appDir);
+    verdict.build = true;
+
+    console.log(`[eval] booting`);
+    server = spawn("sh", ["-c", fw.serve], {
+      cwd: appDir,
+      env: { ...process.env, PORT: String(PORT) },
+      stdio: "ignore",
+      detached: true,
+    });
+    await waitForBoot(`http://localhost:${PORT}/`);
+    verdict.boot = true;
+
+    console.log(`[eval] driving a real browser`);
+    run(`agent-browser open http://localhost:${PORT}/`, appDir);
+    run(`agent-browser wait --load networkidle`, appDir);
+    run(`agent-browser reload`, appDir);
+    await new Promise((r) => setTimeout(r, FLUSH_WAIT_MS));
+    run(`agent-browser close`, appDir);
+
+    const counts = localQuery(
+      `SELECT ServiceName, count() AS c FROM traces WHERE Timestamp > now() - INTERVAL 15 MINUTE AND ServiceName IN ('${runId}-web','${runId}-server') GROUP BY ServiceName`,
+    );
+    verdict.browserRows =
+      counts.find((r) => r.ServiceName === `${runId}-web`)?.c ?? 0;
+    verdict.serverRows =
+      counts.find((r) => r.ServiceName === `${runId}-server`)?.c ?? 0;
+    verdict.joinedTraces = localQuery(
+      `SELECT count() AS c FROM (SELECT TraceId, groupUniqArray(ServiceName) AS s FROM traces WHERE Timestamp > now() - INTERVAL 15 MINUTE AND ServiceName IN ('${runId}-web','${runId}-server') GROUP BY TraceId HAVING length(s) > 1)`,
+    )[0]?.c ?? 0;
+
+    verdict.pass =
+      verdict.build &&
+      verdict.boot &&
+      verdict.browserRows > 0 &&
+      verdict.serverRows > 0 &&
+      verdict.joinedTraces > 0;
+  } catch (error) {
+    verdict.error = String(error?.message ?? error);
+  } finally {
+    if (server) process.kill(-server.pid, "SIGTERM");
+    if (keep || !verdict.pass) {
+      console.log(`[eval] project kept at ${appDir}`);
+    } else {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  }
+
+  console.log(JSON.stringify(verdict, null, 2));
+  process.exit(verdict.pass ? 0 : 1);
+}
+
+await main();

--- a/packages/app/src/telemetry/client.ts
+++ b/packages/app/src/telemetry/client.ts
@@ -11,8 +11,8 @@ import { parameterizeTelemetryPath } from "@/telemetry/paths";
 
 // Everr-native browser telemetry for the web app (dogfooding): pageviews,
 // frustration clicks, web vitals, and errors flow to Everr as OTel log
-// records under the app's service name, next to its server telemetry
-// (`node.ts`). Error capture rides the SDK's own errors() instrumentation
+// records under a browser service name distinct from the server's
+// (`node.ts`), so the two sides stay separable in queries. Error capture rides the SDK's own errors() instrumentation
 // (window.onerror, unhandledrejection, and the router's error component via
 // the re-exported `captureReactError`), stamped with the same analytics
 // envelope.
@@ -26,7 +26,7 @@ import { parameterizeTelemetryPath } from "@/telemetry/paths";
 // the router with it.
 new WebSDK({
   persistence: readConsent() === "granted" ? "localStorage" : "memory",
-  serviceName: "everr-dev-app",
+  serviceName: "everr-dev-app-web",
   deploymentEnvironment: import.meta.env.MODE,
   ingestKey: import.meta.env.VITE_EVERR_PUBLIC_INGEST_KEY,
   endpoint: import.meta.env.VITE_EVERR_INGEST_ENDPOINT,


### PR DESCRIPTION
Add rules/vite-ssr.md (two-halves layout, env split, browser-to-server trace seam, CORS pitfalls, joined-trace validation) and rules/tanstack-start.md (route resolver bridge, server entry request spans, server function middleware), point nextjs.md at the browser half and the seam, and register both rules in the SKILL.md table.

Rename the app's browser service.name to everr-dev-app-web so the two halves stay separable in queries, as browser.md requires; verified locally with joined traces across both service names.

Add an agent-driven eval harness (evals/setup-telemetry) that scaffolds a fresh TanStack Start, Next.js, or Vite SSR project, runs a headless agent with the skill, and grades build, boot, per-half ingestion, and the cross-service trace join against the local collector.