### PR TITLE
feat(otel-errors)!: new Node-only errors package, successor to auto-otel-errors

### DIFF
--- a/.changeset/otel-errors-node-instrumentation.md
+++ b/.changeset/otel-errors-node-instrumentation.md
@@ -1,5 +1,5 @@
 ---
-"@everr/otel-errors": minor
+"@everr/otel-errors": patch
 ---
 
 Renamed from `@everr/auto-otel-errors`, and reduced to the Node runtime.

--- a/.changeset/otel-errors-node-instrumentation.md
+++ b/.changeset/otel-errors-node-instrumentation.md
@@ -1,5 +1,5 @@
 ---
-"@everr/otel-errors": patch
+"@everr/otel-errors": minor
 ---
 
 Renamed from `@everr/auto-otel-errors`, and reduced to the Node runtime.

--- a/.changeset/otel-errors-node-instrumentation.md
+++ b/.changeset/otel-errors-node-instrumentation.md
@@ -1,0 +1,21 @@
+---
+"@everr/otel-errors": minor
+---
+
+Renamed from `@everr/auto-otel-errors`, and reduced to the Node runtime.
+
+`init()` is gone. The package now exports an OpenTelemetry instrumentation, registered with the SDK like any other:
+
+```ts
+new NodeSDK({ instrumentations: [new ErrorsInstrumentation()] });
+```
+
+The SDK injects its own `LoggerProvider`, so the package no longer reads the `logs` global to emit, and a fatal error now flushes logs, spans, and metrics (previously logs only) before exiting.
+
+Removed: the `browser`, `express`, `fastify`, and `react` entries. Browser error capture lives in `@everr/otel-web`, which owns the `window` handlers, the React error boundary, and its own capture path.
+
+Added: a `./core` entry with the runtime-neutral capture path (`Client`, normalization, redaction, rate limiting) for SDKs that drive it themselves.
+
+`Client` takes only options now: the `runtime` and `integrations` parameters are gone, and it always marks the active span. The `Mechanism` type accepts any string so a consuming SDK can report its own vocabulary.
+
+The OTel instrumentation scope on every emitted record changes from `@everr/auto-otel-errors` to `@everr/otel-errors`. Queries filtering on the old scope name return no rows after upgrading.

--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -38,13 +38,17 @@
   // in packages/docs/.source/*.ts — fallow can't trace through the glob.
   "dynamicallyLoaded": [
     "packages/docs/content/**/*.{md,mdx}",
-    "packages/auto-otel-errors/test/fixtures/*.mjs"
+    "packages/auto-otel-errors/test/fixtures/*.mjs",
+    "packages/otel-errors/test/fixtures/*.mjs"
   ],
   "overrides": [
     {
       // Child-process fixtures intentionally import built package output, which
       // does not exist during CI's pre-build dead-code scan.
-      "files": ["packages/auto-otel-errors/test/fixtures/*.mjs"],
+      "files": [
+        "packages/auto-otel-errors/test/fixtures/*.mjs",
+        "packages/otel-errors/test/fixtures/*.mjs"
+      ],
       "rules": { "unresolved-imports": "off" }
     },
     {
@@ -64,7 +68,10 @@
   "publicPackages": [
     "@everr/ui",
     "@everr/logs-explorer",
-    "@everr/auto-otel-errors"
+    "@everr/auto-otel-errors",
+    // Published to npm: the exported surface is the product, so exports with
+    // no in-repo consumer are intentional.
+    "@everr/otel-errors"
   ],
   // Error subclasses commonly set `name` and are discriminated via
   // `err.name === "..."` rather than `instanceof`; fallow can't see those
@@ -80,6 +87,23 @@
     {
       "implements": "SpanExporter",
       "members": ["export", "shutdown", "forceFlush"]
+    },
+    {
+      // The OTel SDK drives an instrumentation entirely through this
+      // interface (registerInstrumentations calls enable/setConfig/the
+      // provider setters); our code never names them.
+      "implements": "Instrumentation",
+      "members": [
+        "instrumentationName",
+        "instrumentationVersion",
+        "enable",
+        "disable",
+        "setConfig",
+        "getConfig",
+        "setTracerProvider",
+        "setMeterProvider",
+        "setLoggerProvider"
+      ]
     }
   ],
   "duplicates": {

--- a/biome.json
+++ b/biome.json
@@ -22,6 +22,8 @@
 
       "packages/telemetry-explorer/**/src/**/*",
 
+      "packages/otel-errors/**/src/**/*",
+
       "packages/datemath/**/src/**/*",
       "packages/datemath/vite.config.ts",
 

--- a/docs/otel-errors-release-secrets.md
+++ b/docs/otel-errors-release-secrets.md
@@ -1,6 +1,6 @@
-# Auto OTel Errors Release Secrets
+# npm Release Secrets
 
-This guide sets up the GitHub Actions secrets used by `.github/workflows/release-pr.yml` to publish `@everr/auto-otel-errors` to npm during a Changesets release.
+This guide sets up the GitHub Actions secrets used by `.github/workflows/release-pr.yml` to publish this repository's public npm packages during a Changesets release: `@everr/otel-errors` and `@everr/otel-web`.
 
 ## Required Access
 
@@ -12,13 +12,13 @@ You need:
 
 ## Create The npm Publish Token
 
-Create an npm access token that can publish `@everr/auto-otel-errors` under the `@everr` scope.
+Create an npm access token that can publish under the `@everr` scope. One token covers both packages; `scripts/publish-packages.mjs` publishes each one that is not already on the registry at its current version.
 
 Use an automation or granular token that is valid for CI publishing. If the npm organization requires two-factor authentication for writes, use a token type that npm allows for automated publishing without an interactive one-time password prompt.
 
 Create this GitHub repository secret:
 
-- `NPM_TOKEN`: the npm token with publish access for `@everr/auto-otel-errors`
+- `NPM_TOKEN`: the npm token with publish access for the `@everr` scope
 
 The workflow passes this secret to `actions/setup-node` as `NODE_AUTH_TOKEN`. You do not need to create a separate `NODE_AUTH_TOKEN` secret.
 
@@ -35,7 +35,7 @@ The GitHub App must be installed on `everr-labs/everr` and needs enough reposito
 
 ## Run A Release
 
-Add a changeset for `@everr/auto-otel-errors` when the package needs a new npm version:
+Add a changeset for each package that needs a new npm version:
 
 ```bash
 pnpm changeset
@@ -45,13 +45,13 @@ After the changeset lands on `main`, the release workflow opens or updates the V
 
 On the next `main` run, the same workflow:
 
-1. Builds `@everr/auto-otel-errors`.
-2. Publishes `@everr/auto-otel-errors` to npm if the checked-in version is not already published.
+1. Builds each package in `scripts/publish-packages.mjs`, in dependency order.
+2. Publishes each one to npm if the checked-in version is not already published.
 3. Creates the Changesets release tags.
 
 ## Troubleshooting
 
 - **npm returns 401 or 403**: check that `NPM_TOKEN` exists in this repository and has publish access to the `@everr` scope.
 - **npm asks for a one-time password**: replace the token with one that supports CI publishing for an organization with two-factor authentication enabled.
-- **The package is already published**: the release script skips npm publish for the existing version and still lets Changesets create missing tags.
+- **A package is already published**: the release script skips npm publish for that version, moves on to the next package, and still lets Changesets create missing tags.
 - **The Version Packages PR is not created**: check `EVERR_DEPLOY_BOT_APP_ID`, `EVERR_DEPLOY_BOT_PRIVATE_KEY`, and the GitHub App repository permissions.

--- a/packages/otel-errors/CHANGELOG.md
+++ b/packages/otel-errors/CHANGELOG.md
@@ -1,0 +1,31 @@
+# @everr/otel-errors
+
+The entries below 0.1.0 belong to `@everr/auto-otel-errors`, this package's
+former name, which is deprecated on npm. Its version line reached 0.2.3; 0.1.0
+restarts numbering because the rename also dropped the browser and framework
+entries and replaced `init()` with an OpenTelemetry instrumentation. There is
+no in-place upgrade between the two lines.
+
+## 0.2.3
+
+### Patch Changes
+
+- 28e8199: Retry release with NPM_TOKEN authentication.
+
+## 0.2.2
+
+### Patch Changes
+
+- 6b94d92: Retry release with NPM_TOKEN authentication.
+
+## 0.2.1
+
+### Patch Changes
+
+- 34d39ac: Fix npm package publishing to use trusted publishing.
+
+## 0.2.0
+
+### Minor Changes
+
+- 34e86aa: Rename sensitive data configuration options from `scrubKeys` and `scrubPatterns` to `redactKeys` and `redactPatterns`, and preserve attributes when key-based redaction is disabled.

--- a/packages/otel-errors/README.md
+++ b/packages/otel-errors/README.md
@@ -83,7 +83,7 @@ new ErrorsInstrumentation({
 
 ## `@everr/otel-errors/core`
 
-The capture path with no Node and no `@opentelemetry/instrumentation` dependency: `Client`, `normalizeError`, `RateLimiter`, and the scrub helpers. It exists so a browser-targeted SDK can reuse the normalization, redaction, and attribute contract without pulling `@types/node` into its globals. [`@everr/otel-web`](https://github.com/everr-labs/everr/tree/main/packages/otel-web)'s server entry is its consumer.
+The capture path with no Node and no `@opentelemetry/instrumentation` dependency: `Client`, `normalizeError`, `RateLimiter`, and the redaction helpers. It exists so a browser-targeted SDK can reuse the normalization, redaction, and attribute contract without pulling `@types/node` into its globals. [`@everr/otel-web`](https://github.com/everr-labs/everr/tree/main/packages/otel-web)'s server entry is its consumer.
 
 ```ts
 import { Client } from "@everr/otel-errors/core";

--- a/packages/otel-errors/README.md
+++ b/packages/otel-errors/README.md
@@ -1,0 +1,98 @@
+# @everr/otel-errors
+
+OpenTelemetry instrumentation for uncaught Node.js errors. It captures `uncaughtException` and `unhandledRejection` as OTel exception log records, marks the active span as errored, and exposes `captureError` for manual reports.
+
+It emits through the SDK you already registered. No exporter, no endpoint, no init of its own.
+
+> Previously published as `@everr/auto-otel-errors`. That package is deprecated. The browser, express, fastify, and react entries are gone: browser error capture lives in [`@everr/otel-web`](https://github.com/everr-labs/everr/tree/main/packages/otel-web).
+
+## Install
+
+```bash
+pnpm add @everr/otel-errors @opentelemetry/api @opentelemetry/api-logs @opentelemetry/instrumentation
+```
+
+## Use
+
+```ts
+import { ErrorsInstrumentation } from "@everr/otel-errors";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+
+new NodeSDK({
+  instrumentations: [new ErrorsInstrumentation()],
+}).start();
+```
+
+Manual capture works anywhere, with or without the instrumentation. Records emitted before an SDK registers a `LoggerProvider` are lost (a one-time diag warning says so). When an `ErrorsInstrumentation` exists, its options (redaction, rate limits, `beforeSend`) apply to manual captures too.
+
+```ts
+import { captureError } from "@everr/otel-errors";
+
+try {
+  await chargeCard(order);
+} catch (error) {
+  captureError(error, { "order.id": order.id });
+}
+```
+
+## What it emits
+
+One log record per error, with `eventName: "exception"`:
+
+| Attribute | Value |
+| --- | --- |
+| `exception.type` | The error's constructor name, or `NonError` |
+| `exception.message` | The message, redacted |
+| `exception.stacktrace` | The stack, when there is one |
+| `everr.error.handled` | `false` for the two fatal handlers, `true` for `captureError` |
+| `everr.error.mechanism` | `uncaughtException`, `unhandledrejection`, or `manual` |
+| `log.record.uid` | A generated id, never redacted |
+
+The record body is `"{type}: {message}"`, redacted. Severity is `FATAL` for the two fatal handlers and `ERROR` for `captureError`. When a span is active, the record joins its trace and the span gets `recordException` plus `setStatus(ERROR)`.
+
+## On a fatal error
+
+The instrumentation captures the error, flushes the logger, tracer, and meter providers (2 seconds for all three), then calls `process.exit(1)`.
+
+The exit is deliberate. Installing an `uncaughtException` listener stops the crash Node would otherwise perform, so the instrumentation performs it. Two ways to keep the process alive:
+
+- `new ErrorsInstrumentation({ onFatal: "continue" })`.
+- Register your own listener for the same event. The instrumentation then leaves the decision to you.
+
+## Config
+
+```ts
+new ErrorsInstrumentation({
+  enabled: true,
+  onFatal: "exit",
+  rateLimit: { count: 5, windowMs: 5000 },
+  redactPatterns: [/\bsk_live_\w+/g],
+  redactKeys: { deny: ["session"] },
+  beforeSend: (event) => (event.message.includes("ECONNRESET") ? null : event),
+});
+```
+
+| Option | Default | Effect |
+| --- | --- | --- |
+| `enabled` | `true` | `false` defers installation until the SDK registers the instrumentation |
+| `onFatal` | `"exit"` | `"continue"` keeps the process alive after a fatal error |
+| `rateLimit` | 5 per 5s | Per-fingerprint throttle. `false` disables it |
+| `redactPatterns` | emails, tokens, cards | Patterns replaced with `[Filtered]` in the body and string attributes |
+| `redactKeys` | `true` | Drops attributes whose key looks sensitive. Also accepts `{ allow }` or `{ deny }` |
+| `beforeSend` | none | Rewrites the event, or returns `null` to drop it |
+
+## `@everr/otel-errors/core`
+
+The capture path with no Node and no `@opentelemetry/instrumentation` dependency: `Client`, `normalizeError`, `RateLimiter`, and the scrub helpers. It exists so a browser-targeted SDK can reuse the normalization, redaction, and attribute contract without pulling `@types/node` into its globals. [`@everr/otel-web`](https://github.com/everr-labs/everr/tree/main/packages/otel-web)'s server entry is its consumer.
+
+```ts
+import { Client } from "@everr/otel-errors/core";
+
+const client = new Client({ rateLimit: false });
+client.setLogger(myLoggerProvider.getLogger("my-sdk"));
+client.capture({ error, mechanism: "react", handled: true });
+```
+
+## License
+
+MIT

--- a/packages/otel-errors/README.md
+++ b/packages/otel-errors/README.md
@@ -44,7 +44,6 @@ One log record per error, with `eventName: "exception"`:
 | `exception.type` | The error's constructor name, or `NonError` |
 | `exception.message` | The message, redacted |
 | `exception.stacktrace` | The stack, when there is one |
-| `everr.error.handled` | `false` for the two fatal handlers, `true` for `captureError` |
 | `everr.error.mechanism` | `uncaughtException`, `unhandledrejection`, or `manual` |
 | `log.record.uid` | A generated id, never redacted |
 
@@ -90,7 +89,7 @@ import { Client } from "@everr/otel-errors/core";
 
 const client = new Client({ rateLimit: false });
 client.setLogger(myLoggerProvider.getLogger("my-sdk"));
-client.capture({ error, mechanism: "react", handled: true });
+client.capture({ error, mechanism: "react" });
 ```
 
 ## License

--- a/packages/otel-errors/README.md
+++ b/packages/otel-errors/README.md
@@ -23,7 +23,7 @@ new NodeSDK({
 }).start();
 ```
 
-Manual capture works anywhere, with or without the instrumentation. Records emitted before an SDK registers a `LoggerProvider` are lost (a one-time diag warning says so). When an `ErrorsInstrumentation` exists, its options (redaction, rate limits, `beforeSend`) apply to manual captures too.
+Manual capture works anywhere, with or without the instrumentation. Records emitted before an SDK registers a `LoggerProvider` are lost (a one-time diag warning says so). Every error path in the process shares one client, so whatever you pass to `configure` covers manual captures and crashes alike.
 
 ```ts
 import { captureError } from "@everr/otel-errors";
@@ -60,10 +60,12 @@ The exit is deliberate. Installing an `uncaughtException` listener stops the cra
 
 ## Config
 
+The process has one error client. `configure` sets it up, merging over whatever is already there: an absent key keeps its current value, and a present one replaces that field.
+
 ```ts
-new ErrorsInstrumentation({
-  enabled: true,
-  onFatal: "exit",
+import { configure } from "@everr/otel-errors";
+
+configure({
   rateLimit: { count: 5, windowMs: 5000 },
   redactPatterns: [/\bsk_live_\w+/g],
   redactKeys: { deny: ["session"] },
@@ -73,23 +75,31 @@ new ErrorsInstrumentation({
 
 | Option | Default | Effect |
 | --- | --- | --- |
-| `enabled` | `true` | `false` defers installation until the SDK registers the instrumentation |
-| `onFatal` | `"exit"` | `"continue"` keeps the process alive after a fatal error |
-| `rateLimit` | 5 per 5s | Per-fingerprint throttle. `false` disables it |
+| `rateLimit` | 5 per 5s | Per-fingerprint throttle. `false` disables it. Re-stating it restarts the windows |
 | `redactPatterns` | emails, tokens, cards | Patterns replaced with `[Filtered]` in the body and string attributes |
 | `redactKeys` | `true` | Drops attributes whose key looks sensitive. Also accepts `{ allow }` or `{ deny }` |
-| `beforeSend` | none | Rewrites the event, or returns `null` to drop it |
+| `beforeSend` | none | Rewrites the event, or returns `null` to drop it. `null` removes an installed hook |
+
+Call it whenever you like: capture works before the first call, and a later call applies to every error path from then on.
+
+The instrumentation itself takes only what belongs to crash handling:
+
+| Option | Default | Effect |
+| --- | --- | --- |
+| `enabled` | `true` | `false` defers installation until the SDK registers the instrumentation |
+| `onFatal` | `"exit"` | `"continue"` keeps the process alive after a fatal error |
 
 ## `@everr/otel-errors/core`
 
-The capture path with no Node and no `@opentelemetry/instrumentation` dependency: `Client`, `normalizeError`, `RateLimiter`, and the redaction helpers. It exists so a browser-targeted SDK can reuse the normalization, redaction, and attribute contract without pulling `@types/node` into its globals. [`@everr/otel-web`](https://github.com/everr-labs/everr/tree/main/packages/otel-web)'s server entry is its consumer.
+The capture path with no Node and no `@opentelemetry/instrumentation` dependency: `capture`, `configure`, `setLogger`, `normalizeError`, `RateLimiter`, and the redaction helpers. It exists so a browser-targeted SDK can reuse the normalization, redaction, and attribute contract without pulling `@types/node` into its globals. [`@everr/otel-web`](https://github.com/everr-labs/everr/tree/main/packages/otel-web)'s server entry is its consumer.
+
+`capture` is the surface for SDKs that report their own mechanisms, where an application wants `captureError`:
 
 ```ts
-import { Client } from "@everr/otel-errors/core";
+import { capture, setLogger } from "@everr/otel-errors/core";
 
-const client = new Client({ rateLimit: false });
-client.setLogger(myLoggerProvider.getLogger("my-sdk"));
-client.capture({ error, mechanism: "react" });
+setLogger(myLoggerProvider.getLogger("my-sdk"));
+capture({ error, mechanism: "react" });
 ```
 
 ## License

--- a/packages/otel-errors/package.json
+++ b/packages/otel-errors/package.json
@@ -80,6 +80,7 @@
     "@opentelemetry/sdk-node": "^0.218.0",
     "@opentelemetry/sdk-trace-base": "^2.7.1",
     "@types/node": "^25.6.2",
+    "fast-check": "^4.9.0",
     "tsdown": "^0.22.2",
     "typescript": "catalog:"
   }

--- a/packages/otel-errors/package.json
+++ b/packages/otel-errors/package.json
@@ -1,0 +1,86 @@
+{
+  "name": "@everr/otel-errors",
+  "version": "0.0.0",
+  "description": "OpenTelemetry instrumentation for uncaught Node.js errors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/everr-labs/everr.git",
+    "directory": "packages/otel-errors"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": "./src/node.ts",
+    "./node": "./src/node.ts",
+    "./core": "./src/core.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "import": {
+          "types": "./dist/node.d.ts",
+          "default": "./dist/node.js"
+        },
+        "require": {
+          "types": "./dist/node.d.cts",
+          "default": "./dist/node.cjs"
+        }
+      },
+      "./node": {
+        "import": {
+          "types": "./dist/node.d.ts",
+          "default": "./dist/node.js"
+        },
+        "require": {
+          "types": "./dist/node.d.cts",
+          "default": "./dist/node.cjs"
+        }
+      },
+      "./core": {
+        "import": {
+          "types": "./dist/core.d.ts",
+          "default": "./dist/core.js"
+        },
+        "require": {
+          "types": "./dist/core.d.cts",
+          "default": "./dist/core.cjs"
+        }
+      }
+    }
+  },
+  "scripts": {
+    "build": "tsdown",
+    "test": "vitest run",
+    "test:ci": "vitest run",
+    "test:watch": "vitest run --watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/api-logs": "^0.218.0",
+    "@opentelemetry/instrumentation": "^0.218.0"
+  },
+  "peerDependenciesMeta": {
+    "@opentelemetry/instrumentation": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/api-logs": "^0.218.0",
+    "@opentelemetry/context-async-hooks": "^2.7.1",
+    "@opentelemetry/instrumentation": "^0.218.0",
+    "@opentelemetry/sdk-logs": "^0.218.0",
+    "@opentelemetry/sdk-metrics": "^2.7.1",
+    "@opentelemetry/sdk-node": "^0.218.0",
+    "@opentelemetry/sdk-trace-base": "^2.7.1",
+    "@types/node": "^25.6.2",
+    "tsdown": "^0.22.2",
+    "typescript": "catalog:"
+  }
+}

--- a/packages/otel-errors/src/capture.test.ts
+++ b/packages/otel-errors/src/capture.test.ts
@@ -1,0 +1,134 @@
+import { diag } from "@opentelemetry/api";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  capture,
+  captureError,
+  configure,
+  resetSharedClient,
+} from "./capture.js";
+import { setupTestTelemetry } from "./test-utils.js";
+
+// The singleton layer: one client for the whole process, configured through
+// `configure` alone. What each test asserts is the merge contract (an absent
+// key keeps the current value, a present one replaces it wholesale), not the
+// capture path itself, which client.test.ts covers against its own instances.
+
+let otel: ReturnType<typeof setupTestTelemetry>;
+
+beforeEach(() => {
+  otel = setupTestTelemetry();
+});
+
+afterEach(async () => {
+  resetSharedClient();
+  await otel.dispose();
+});
+
+describe("configure", () => {
+  it("leaves untouched keys at their current value", () => {
+    configure({ redactPatterns: [/tok_\w+/g], rateLimit: false });
+    // Only redaction is re-stated: the disabled rate limit must survive, so
+    // all twenty reports land.
+    configure({ redactPatterns: [/key_\w+/g] });
+    for (let i = 0; i < 20; i++) captureError(new Error("same"));
+    expect(otel.records()).toHaveLength(20);
+    expect(otel.records()[0]?.body).toBe("Error: same");
+  });
+
+  it("replaces a present key wholesale rather than merging into it", () => {
+    configure({ redactPatterns: [/tok_\w+/g] });
+    configure({ redactPatterns: [/key_\w+/g] });
+    captureError(new Error("tok_abc and key_def"));
+    // The first pattern is gone, not unioned with the second.
+    expect(otel.records()[0]?.body).toBe("Error: tok_abc and [Filtered]");
+  });
+
+  it("treats an explicitly passed undefined as absent", () => {
+    const error = new Error("same");
+    configure({
+      beforeSend: () => null,
+      rateLimit: { count: 2, windowMs: 60_000 },
+    });
+    // What forwarding an optional config looks like. Neither field is set, so
+    // neither may take effect: the hook stays installed and the limiter keeps
+    // its windows.
+    configure({ beforeSend: undefined, rateLimit: undefined });
+    captureError(error);
+    expect(otel.records()).toHaveLength(0);
+
+    configure({ beforeSend: null });
+    captureError(error);
+    captureError(error);
+    // One record, not two: the throttle runs before beforeSend, so the
+    // dropped capture above already spent one of the two. A restarted window
+    // would have let both of these through.
+    expect(otel.records()).toHaveLength(1);
+  });
+
+  it("takes the last writer without warning", () => {
+    const warn = vi.spyOn(diag, "warn").mockImplementation(() => {});
+    configure({ redactKeys: false });
+    configure({ redactKeys: true });
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("clears beforeSend when passed null, and only then", () => {
+    configure({ beforeSend: () => null });
+    captureError(new Error("dropped"));
+    expect(otel.records()).toHaveLength(0);
+
+    // An absent key must not clear the hook.
+    configure({ redactKeys: true });
+    captureError(new Error("still dropped"));
+    expect(otel.records()).toHaveLength(0);
+
+    configure({ beforeSend: null });
+    captureError(new Error("kept"));
+    expect(otel.records()).toHaveLength(1);
+  });
+
+  // One error object throughout: the limiter fingerprints on type, message,
+  // and top frame, so separately constructed errors would each get their own
+  // budget and never throttle.
+  it("keeps the rate-limit window when the limit itself is not re-stated", () => {
+    const error = new Error("same");
+    configure({ rateLimit: { count: 2, windowMs: 60_000 } });
+    captureError(error);
+    captureError(error);
+    // Two are through, the window is full. A configure() that says nothing
+    // about rateLimit must not hand out a fresh budget.
+    configure({ redactKeys: true });
+    captureError(error);
+    expect(otel.records()).toHaveLength(2);
+  });
+
+  it("restarts the rate-limit window when the limit is re-stated", () => {
+    const error = new Error("same");
+    configure({ rateLimit: { count: 2, windowMs: 60_000 } });
+    captureError(error);
+    captureError(error);
+    configure({ rateLimit: { count: 2, windowMs: 60_000 } });
+    captureError(error);
+    expect(otel.records()).toHaveLength(3);
+  });
+});
+
+describe("capture", () => {
+  it("reports through the same configured client as captureError", () => {
+    configure({ redactPatterns: [/tok_\w+/g] });
+    capture({ error: new Error("tok_abc"), mechanism: "react" });
+    const [record] = otel.records();
+    expect(record?.attributes["everr.error.mechanism"]).toBe("react");
+    expect(record?.body).toBe("Error: [Filtered]");
+  });
+});
+
+describe("captureError", () => {
+  it("works with no configure() call at all", () => {
+    captureError(new Error("boom"), { "order.id": "o_1" });
+    const [record] = otel.records();
+    expect(record?.attributes["everr.error.mechanism"]).toBe("manual");
+    expect(record?.attributes["order.id"]).toBe("o_1");
+  });
+});

--- a/packages/otel-errors/src/capture.ts
+++ b/packages/otel-errors/src/capture.ts
@@ -1,0 +1,87 @@
+import { type Attributes, diag } from "@opentelemetry/api";
+import { logs } from "@opentelemetry/api-logs";
+import { Client } from "./client.js";
+import { resolveFlushable } from "./providers.js";
+import { PKG_NAME } from "./version.js";
+
+// The one module-level slot, owned by capture rather than the
+// instrumentation: captureError always has a client to report through. The
+// default one is built lazily with default options against the global logger
+// registry; an ErrorsInstrumentation adopts the slot to apply user options
+// (scrubbing, rate limits) to manual captures too.
+let sharedClient: Client | null = null;
+let adoptedBy: object | null = null;
+let providerSeen = false;
+let warnedNoProvider = false;
+
+export function getSharedClient(): Client {
+  if (!sharedClient) {
+    sharedClient = new Client();
+  }
+  return sharedClient;
+}
+
+/**
+ * Points captureError at an instrumentation-configured client. Two
+ * instrumentations is a misconfiguration (both capture every fatal error), so
+ * a change of owner warns rather than silently redirecting manual reports;
+ * the same owner re-adopting (setConfig) is fine.
+ */
+export function adoptSharedClient(client: Client, owner: object): void {
+  if (adoptedBy && adoptedBy !== owner) {
+    diag.warn(
+      `${PKG_NAME}: a second ErrorsInstrumentation was constructed; captureError now reports through it`,
+    );
+  }
+  sharedClient = client;
+  adoptedBy = owner;
+}
+
+/** Test-only: restores the lazy default-client state. */
+export function resetSharedClient(): void {
+  sharedClient = null;
+  adoptedBy = null;
+  providerSeen = false;
+  warnedNoProvider = false;
+}
+
+export interface CaptureErrorOptions {
+  handled?: boolean;
+}
+
+/**
+ * Reports a handled error as an OTel exception log record. Works without an
+ * ErrorsInstrumentation: records go through the global logger provider, which
+ * resolves at emit time once an SDK registers. When an instrumentation is
+ * constructed, its options (scrubbing, rate limits) apply here too.
+ */
+export function captureError(
+  error: unknown,
+  attributes?: Attributes,
+  options?: CaptureErrorOptions,
+): void {
+  const handledAttr = attributes?.["error.handled"];
+  const handled =
+    options?.handled ?? (typeof handledAttr === "boolean" ? handledAttr : true);
+
+  // Records emitted before an SDK registers are dropped, not buffered, so
+  // say so once. A registered provider never unregisters, so the successful
+  // probe latches and the steady-state cost is one boolean test.
+  if (!providerSeen && !warnedNoProvider) {
+    if (resolveFlushable(logs.getLoggerProvider())) {
+      providerSeen = true;
+    } else {
+      warnedNoProvider = true;
+      diag.warn(
+        `${PKG_NAME}: captureError emitted before a LoggerProvider was registered; records are lost until an SDK starts.`,
+      );
+    }
+  }
+
+  getSharedClient().capture({
+    error,
+    mechanism: "manual",
+    handled,
+    attributes,
+  });
+}

--- a/packages/otel-errors/src/capture.ts
+++ b/packages/otel-errors/src/capture.ts
@@ -8,7 +8,7 @@ import { PKG_NAME } from "./version.js";
 // instrumentation: captureError always has a client to report through. The
 // default one is built lazily with default options against the global logger
 // registry; an ErrorsInstrumentation adopts the slot to apply user options
-// (scrubbing, rate limits) to manual captures too.
+// (redaction, rate limits) to manual captures too.
 let sharedClient: Client | null = null;
 let adoptedBy: object | null = null;
 let providerSeen = false;
@@ -53,7 +53,7 @@ export interface CaptureErrorOptions {
  * Reports a handled error as an OTel exception log record. Works without an
  * ErrorsInstrumentation: records go through the global logger provider, which
  * resolves at emit time once an SDK registers. When an instrumentation is
- * constructed, its options (scrubbing, rate limits) apply here too.
+ * constructed, its options (redaction, rate limits) apply here too.
  */
 export function captureError(
   error: unknown,

--- a/packages/otel-errors/src/capture.ts
+++ b/packages/otel-errors/src/capture.ts
@@ -45,25 +45,14 @@ export function resetSharedClient(): void {
   warnedNoProvider = false;
 }
 
-export interface CaptureErrorOptions {
-  handled?: boolean;
-}
-
 /**
- * Reports a handled error as an OTel exception log record. Works without an
+ * Reports an error as an OTel exception log record, with optional context
+ * attributes. Works without an
  * ErrorsInstrumentation: records go through the global logger provider, which
  * resolves at emit time once an SDK registers. When an instrumentation is
  * constructed, its options (redaction, rate limits) apply here too.
  */
-export function captureError(
-  error: unknown,
-  attributes?: Attributes,
-  options?: CaptureErrorOptions,
-): void {
-  const handledAttr = attributes?.["error.handled"];
-  const handled =
-    options?.handled ?? (typeof handledAttr === "boolean" ? handledAttr : true);
-
+export function captureError(error: unknown, context?: Attributes): void {
   // Records emitted before an SDK registers are dropped, not buffered, so
   // say so once. A registered provider never unregisters, so the successful
   // probe latches and the steady-state cost is one boolean test.
@@ -81,7 +70,6 @@ export function captureError(
   getSharedClient().capture({
     error,
     mechanism: "manual",
-    handled,
-    attributes,
+    context,
   });
 }

--- a/packages/otel-errors/src/capture.ts
+++ b/packages/otel-errors/src/capture.ts
@@ -1,56 +1,65 @@
-import { type Attributes, diag } from "@opentelemetry/api";
-import { logs } from "@opentelemetry/api-logs";
-import { Client } from "./client.js";
+import type { Attributes } from "@opentelemetry/api";
+import { diag } from "@opentelemetry/api";
+import { type Logger, logs } from "@opentelemetry/api-logs";
+import { type CaptureInput, Client } from "./client.js";
 import { resolveFlushable } from "./providers.js";
+import type { ClientOptions } from "./types.js";
 import { PKG_NAME } from "./version.js";
 
-// The one module-level slot, owned by capture rather than the
-// instrumentation: captureError always has a client to report through. The
-// default one is built lazily with default options against the global logger
-// registry; an ErrorsInstrumentation adopts the slot to apply user options
-// (redaction, rate limits) to manual captures too.
-let sharedClient: Client | null = null;
-let adoptedBy: object | null = null;
+// The process's one error client. Everything that reports an error goes
+// through it: `captureError`, the ErrorsInstrumentation's crash handlers, and
+// @everr/otel-web's server entry. It is built lazily against the global
+// logger registry, so capture works before anything configures it and no
+// caller has to sequence a setup step.
+//
+// One client means one configuration, which is the point: redaction an app
+// sets for its crash handlers necessarily covers every other error path too.
+let instance: Client | null = null;
 let providerSeen = false;
 let warnedNoProvider = false;
 
-export function getSharedClient(): Client {
-  if (!sharedClient) {
-    sharedClient = new Client();
+function sharedClient(): Client {
+  if (!instance) {
+    instance = new Client();
   }
-  return sharedClient;
+  return instance;
 }
 
 /**
- * Points captureError at an instrumentation-configured client. Two
- * instrumentations is a misconfiguration (both capture every fatal error), so
- * a change of owner warns rather than silently redirecting manual reports;
- * the same owner re-adopting (setConfig) is fine.
+ * Applies options to the shared client. Merges: an absent key keeps its
+ * current value, so two callers configuring different fields do not overwrite
+ * each other, and the last writer of any one field wins silently.
  */
-export function adoptSharedClient(client: Client, owner: object): void {
-  if (adoptedBy && adoptedBy !== owner) {
-    diag.warn(
-      `${PKG_NAME}: a second ErrorsInstrumentation was constructed; captureError now reports through it`,
-    );
-  }
-  sharedClient = client;
-  adoptedBy = owner;
+export function configure(options: ClientOptions): void {
+  sharedClient().configure(options);
+}
+
+/**
+ * Reports one error through the shared client. The lower-level surface behind
+ * `captureError`, for SDKs that report their own mechanisms (a React error
+ * boundary, a browser `onerror` handler) rather than manual captures.
+ */
+export function capture(input: CaptureInput): void {
+  sharedClient().capture(input);
+}
+
+/** Binds the shared client to a provider's logger instead of the global one. */
+export function setLogger(logger: Logger): void {
+  sharedClient().setLogger(logger);
 }
 
 /** Test-only: restores the lazy default-client state. */
 export function resetSharedClient(): void {
-  sharedClient = null;
-  adoptedBy = null;
+  instance = null;
   providerSeen = false;
   warnedNoProvider = false;
 }
 
 /**
  * Reports an error as an OTel exception log record, with optional context
- * attributes. Works without an
- * ErrorsInstrumentation: records go through the global logger provider, which
- * resolves at emit time once an SDK registers. When an instrumentation is
- * constructed, its options (redaction, rate limits) apply here too.
+ * attributes. Works without an ErrorsInstrumentation and without a
+ * `configure` call: records go through the global logger provider, which
+ * resolves at emit time once an SDK registers.
  */
 export function captureError(error: unknown, context?: Attributes): void {
   // Records emitted before an SDK registers are dropped, not buffered, so
@@ -67,7 +76,7 @@ export function captureError(error: unknown, context?: Attributes): void {
     }
   }
 
-  getSharedClient().capture({
+  sharedClient().capture({
     error,
     mechanism: "manual",
     context,

--- a/packages/otel-errors/src/client.test.ts
+++ b/packages/otel-errors/src/client.test.ts
@@ -3,7 +3,7 @@ import { SeverityNumber } from "@opentelemetry/api-logs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Client } from "./client.js";
 import { setupTestTelemetry } from "./test-utils.js";
-import type { Options } from "./types.js";
+import type { ClientOptions } from "./types.js";
 
 let otel: ReturnType<typeof setupTestTelemetry>;
 
@@ -15,7 +15,7 @@ afterEach(async () => {
   await otel.dispose();
 });
 
-function makeClient(options: Options = {}) {
+function makeClient(options: ClientOptions = {}) {
   return new Client(options);
 }
 

--- a/packages/otel-errors/src/client.test.ts
+++ b/packages/otel-errors/src/client.test.ts
@@ -24,7 +24,6 @@ describe("Client.capture", () => {
     makeClient().capture({
       error: new TypeError("boom"),
       mechanism: "manual",
-      handled: true,
     });
     const [record] = otel.records();
     expect(record.eventName).toBe("exception");
@@ -36,7 +35,6 @@ describe("Client.capture", () => {
     expect(record.attributes["exception.stacktrace"]).toContain(
       "client.test.ts",
     );
-    expect(record.attributes["everr.error.handled"]).toBe(true);
     expect(record.attributes["everr.error.mechanism"]).toBe("manual");
     expect(record.attributes["log.record.uid"]).toMatch(/^[0-9a-f-]{32,36}$/);
   });
@@ -53,7 +51,6 @@ describe("Client.capture", () => {
       makeClient().capture({
         error: new Error("boom"),
         mechanism: "manual",
-        handled: true,
       });
       const [record] = otel.records();
       expect(record.attributes["log.record.uid"]).toBe(uid);
@@ -66,7 +63,6 @@ describe("Client.capture", () => {
     makeClient().capture({
       error: new Error("dead"),
       mechanism: "uncaughtException",
-      handled: false,
       severity: "fatal",
     });
     const [record] = otel.records();
@@ -78,7 +74,7 @@ describe("Client.capture", () => {
     const client = makeClient({ rateLimit: { count: 5, windowMs: 60_000 } });
     const error = new Error("same");
     for (let i = 0; i < 10; i++) {
-      client.capture({ error, mechanism: "manual", handled: true });
+      client.capture({ error, mechanism: "manual" });
     }
     expect(otel.records()).toHaveLength(5);
   });
@@ -87,19 +83,17 @@ describe("Client.capture", () => {
     const client = makeClient({
       beforeSend: (event) => {
         if (event.message.includes("drop-me")) return null;
-        event.attributes = { ...event.attributes, app: "test" };
+        event.context = { ...event.context, app: "test" };
         return event;
       },
     });
     client.capture({
       error: new Error("drop-me"),
       mechanism: "manual",
-      handled: true,
     });
     client.capture({
       error: new Error("keep"),
       mechanism: "manual",
-      handled: true,
     });
     const records = otel.records();
     expect(records).toHaveLength(1);
@@ -110,8 +104,7 @@ describe("Client.capture", () => {
     makeClient().capture({
       error: new Error("login failed for a@b.com"),
       mechanism: "manual",
-      handled: true,
-      attributes: { "url.full": "/cb?token=s3cret" },
+      context: { "url.full": "/cb?token=s3cret" },
     });
     const [record] = otel.records();
     expect(record.body).toBe("Error: login failed for [Filtered]");
@@ -125,8 +118,7 @@ describe("Client.capture", () => {
     }).capture({
       error: new Error("secret"),
       mechanism: "manual",
-      handled: true,
-      attributes: { "x-api-key": "keep" },
+      context: { "x-api-key": "keep" },
     });
 
     const [record] = otel.records();
@@ -140,7 +132,6 @@ describe("Client.capture", () => {
         client.capture({
           error: new Error("nested"),
           mechanism: "manual",
-          handled: true,
         });
         return event;
       },
@@ -148,7 +139,6 @@ describe("Client.capture", () => {
     client.capture({
       error: new Error("outer"),
       mechanism: "manual",
-      handled: true,
     });
     expect(otel.records()).toHaveLength(1);
   });
@@ -160,7 +150,6 @@ describe("Client.capture", () => {
       client.capture({
         error: new Error("in-trace"),
         mechanism: "manual",
-        handled: true,
       });
       requestSpan.end();
     });
@@ -178,7 +167,6 @@ describe("Client.capture", () => {
       client.capture({
         error: new Error("boom"),
         mechanism: "manual",
-        handled: true,
       });
       requestSpan.end();
     });
@@ -196,7 +184,6 @@ describe("Client.capture", () => {
     client.capture({
       error: new Error("routed"),
       mechanism: "manual",
-      handled: true,
     });
 
     expect(otel.records()).toHaveLength(0);
@@ -208,7 +195,6 @@ describe("Client.capture", () => {
     makeClient().capture({
       error: new Error("bare"),
       mechanism: "manual",
-      handled: true,
     });
     expect(otel.spans()).toHaveLength(0);
   });

--- a/packages/otel-errors/src/client.test.ts
+++ b/packages/otel-errors/src/client.test.ts
@@ -1,0 +1,215 @@
+import { SpanStatusCode, trace } from "@opentelemetry/api";
+import { SeverityNumber } from "@opentelemetry/api-logs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Client } from "./client.js";
+import { setupTestTelemetry } from "./test-utils.js";
+import type { Options } from "./types.js";
+
+let otel: ReturnType<typeof setupTestTelemetry>;
+
+beforeEach(() => {
+  otel = setupTestTelemetry();
+});
+
+afterEach(async () => {
+  await otel.dispose();
+});
+
+function makeClient(options: Options = {}) {
+  return new Client(options);
+}
+
+describe("Client.capture", () => {
+  it("emits a semconv log record", () => {
+    makeClient().capture({
+      error: new TypeError("boom"),
+      mechanism: "manual",
+      handled: true,
+    });
+    const [record] = otel.records();
+    expect(record.eventName).toBe("exception");
+    expect(record.severityNumber).toBe(SeverityNumber.ERROR);
+    expect(record.severityText).toBe("ERROR");
+    expect(record.body).toBe("TypeError: boom");
+    expect(record.attributes["exception.type"]).toBe("TypeError");
+    expect(record.attributes["exception.message"]).toBe("boom");
+    expect(record.attributes["exception.stacktrace"]).toContain(
+      "client.test.ts",
+    );
+    expect(record.attributes["everr.error.handled"]).toBe(true);
+    expect(record.attributes["everr.error.mechanism"]).toBe("manual");
+    expect(record.attributes["log.record.uid"]).toMatch(/^[0-9a-f-]{32,36}$/);
+  });
+
+  it("never scrubs the uid, even when it matches the credit-card pattern", () => {
+    // A numeric-heavy UUID whose leading groups are all digits — the default
+    // credit-card scrub pattern would redact it to "[Filtered]" if the uid went
+    // through scrubbing.
+    const uid = "40000000-0000-4000-8000-000000000002";
+    const spy = vi
+      .spyOn(globalThis.crypto, "randomUUID")
+      .mockReturnValue(uid as ReturnType<typeof crypto.randomUUID>);
+    try {
+      makeClient().capture({
+        error: new Error("boom"),
+        mechanism: "manual",
+        handled: true,
+      });
+      const [record] = otel.records();
+      expect(record.attributes["log.record.uid"]).toBe(uid);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("maps fatal severity", () => {
+    makeClient().capture({
+      error: new Error("dead"),
+      mechanism: "uncaughtException",
+      handled: false,
+      severity: "fatal",
+    });
+    const [record] = otel.records();
+    expect(record.severityNumber).toBe(SeverityNumber.FATAL);
+    expect(record.severityText).toBe("FATAL");
+  });
+
+  it("rate-limits identical errors", () => {
+    const client = makeClient({ rateLimit: { count: 5, windowMs: 60_000 } });
+    const error = new Error("same");
+    for (let i = 0; i < 10; i++) {
+      client.capture({ error, mechanism: "manual", handled: true });
+    }
+    expect(otel.records()).toHaveLength(5);
+  });
+
+  it("beforeSend can mutate and drop events", () => {
+    const client = makeClient({
+      beforeSend: (event) => {
+        if (event.message.includes("drop-me")) return null;
+        event.attributes = { ...event.attributes, app: "test" };
+        return event;
+      },
+    });
+    client.capture({
+      error: new Error("drop-me"),
+      mechanism: "manual",
+      handled: true,
+    });
+    client.capture({
+      error: new Error("keep"),
+      mechanism: "manual",
+      handled: true,
+    });
+    const records = otel.records();
+    expect(records).toHaveLength(1);
+    expect(records[0].attributes.app).toBe("test");
+  });
+
+  it("redacts message and string attributes", () => {
+    makeClient().capture({
+      error: new Error("login failed for a@b.com"),
+      mechanism: "manual",
+      handled: true,
+      attributes: { "url.full": "/cb?token=s3cret" },
+    });
+    const [record] = otel.records();
+    expect(record.body).toBe("Error: login failed for [Filtered]");
+    expect(record.attributes["url.full"]).toBe("/cb");
+  });
+
+  it("honors custom redaction options", () => {
+    makeClient({
+      redactKeys: false,
+      redactPatterns: [/secret/g],
+    }).capture({
+      error: new Error("secret"),
+      mechanism: "manual",
+      handled: true,
+      attributes: { "x-api-key": "keep" },
+    });
+
+    const [record] = otel.records();
+    expect(record.body).toBe("Error: [Filtered]");
+    expect(record.attributes["x-api-key"]).toBe("keep");
+  });
+
+  it("ignores re-entrant captures", () => {
+    const client = makeClient({
+      beforeSend: (event) => {
+        client.capture({
+          error: new Error("nested"),
+          mechanism: "manual",
+          handled: true,
+        });
+        return event;
+      },
+    });
+    client.capture({
+      error: new Error("outer"),
+      mechanism: "manual",
+      handled: true,
+    });
+    expect(otel.records()).toHaveLength(1);
+  });
+
+  it("emits the error log in the active span's trace context", () => {
+    const client = makeClient();
+    const tracer = trace.getTracer("test");
+    tracer.startActiveSpan("request", (requestSpan) => {
+      client.capture({
+        error: new Error("in-trace"),
+        mechanism: "manual",
+        handled: true,
+      });
+      requestSpan.end();
+    });
+
+    const [record] = otel.records();
+    const requestSpan = otel.spans().find((s) => s.name === "request");
+    expect(record.spanContext?.traceId).toBe(
+      requestSpan?.spanContext().traceId,
+    );
+  });
+
+  it("marks the active span as errored", () => {
+    const client = makeClient();
+    trace.getTracer("test").startActiveSpan("request", (requestSpan) => {
+      client.capture({
+        error: new Error("boom"),
+        mechanism: "manual",
+        handled: true,
+      });
+      requestSpan.end();
+    });
+
+    const requestSpan = otel.spans().find((s) => s.name === "request");
+    expect(requestSpan?.status.code).toBe(SpanStatusCode.ERROR);
+    expect(requestSpan?.status.message).toBe("Error: boom");
+    expect(requestSpan?.events.map((e) => e.name)).toContain("exception");
+  });
+
+  it("setLogger redirects emission to a provider's logger", () => {
+    const client = makeClient();
+    const emit = vi.fn();
+    client.setLogger({ emit } as unknown as Parameters<Client["setLogger"]>[0]);
+    client.capture({
+      error: new Error("routed"),
+      mechanism: "manual",
+      handled: true,
+    });
+
+    expect(otel.records()).toHaveLength(0);
+    expect(emit).toHaveBeenCalledOnce();
+    expect(emit.mock.calls[0][0]).toMatchObject({ eventName: "exception" });
+  });
+
+  it("emits no error.context span", () => {
+    makeClient().capture({
+      error: new Error("bare"),
+      mechanism: "manual",
+      handled: true,
+    });
+    expect(otel.spans()).toHaveLength(0);
+  });
+});

--- a/packages/otel-errors/src/client.test.ts
+++ b/packages/otel-errors/src/client.test.ts
@@ -41,10 +41,10 @@ describe("Client.capture", () => {
     expect(record.attributes["log.record.uid"]).toMatch(/^[0-9a-f-]{32,36}$/);
   });
 
-  it("never scrubs the uid, even when it matches the credit-card pattern", () => {
+  it("never redacts the uid, even when it matches the credit-card pattern", () => {
     // A numeric-heavy UUID whose leading groups are all digits — the default
-    // credit-card scrub pattern would redact it to "[Filtered]" if the uid went
-    // through scrubbing.
+    // credit-card redaction pattern would redact it to "[Filtered]" if the uid went
+    // through redaction.
     const uid = "40000000-0000-4000-8000-000000000002";
     const spy = vi
       .spyOn(globalThis.crypto, "randomUUID")

--- a/packages/otel-errors/src/client.ts
+++ b/packages/otel-errors/src/client.ts
@@ -1,0 +1,197 @@
+import {
+  type Attributes,
+  context,
+  diag,
+  type Span,
+  SpanStatusCode,
+  trace,
+} from "@opentelemetry/api";
+import { type Logger, logs, SeverityNumber } from "@opentelemetry/api-logs";
+import { type NormalizedError, normalizeError } from "./normalize.js";
+import { RateLimiter } from "./rate-limit.js";
+import {
+  type CollectBehavior,
+  DEFAULT_SCRUB_PATTERNS,
+  filterKeyValueData,
+  scrubAttributes,
+  scrubString,
+} from "./scrub.js";
+import type { ErrorEvent, ErrorSeverity, Mechanism, Options } from "./types.js";
+import { PKG_NAME, PKG_VERSION } from "./version.js";
+
+export interface CaptureInput {
+  error: unknown;
+  mechanism: Mechanism;
+  handled: boolean;
+  severity?: ErrorSeverity;
+  message?: string;
+  attributes?: Attributes;
+}
+
+/**
+ * The runtime-neutral capture path: normalize, scrub, rate limit, mark the
+ * active span, emit one log record. It holds no process or DOM state, so any
+ * runtime can drive it. `ErrorsInstrumentation` drives it on Node;
+ * `@everr/otel-web`'s server entry constructs its own instance.
+ */
+export class Client {
+  readonly options: Options;
+  private logger: Logger;
+  private readonly rateLimiter: RateLimiter | null;
+  private readonly redactPatterns: RegExp[];
+  private readonly redactKeys: CollectBehavior;
+  private processing = false;
+
+  constructor(options: Options = {}) {
+    this.options = options;
+    // Falls back to the global API registry, which is a no-op logger until
+    // an SDK registers. setLogger swaps in an SDK-injected one.
+    this.logger = logs.getLogger(PKG_NAME, PKG_VERSION);
+    this.rateLimiter =
+      options.rateLimit === false
+        ? null
+        : new RateLimiter(
+            options.rateLimit?.count ?? 5,
+            options.rateLimit?.windowMs ?? 5000,
+          );
+    this.redactPatterns = options.redactPatterns ?? DEFAULT_SCRUB_PATTERNS;
+    this.redactKeys = options.redactKeys ?? true;
+  }
+
+  /** Binds emission to a specific provider's logger instead of the global. */
+  setLogger(logger: Logger): void {
+    this.logger = logger;
+  }
+
+  capture(input: CaptureInput): void {
+    // Reentrancy guard: an error thrown inside process() must not recurse
+    // through the global handlers back into capture().
+    if (this.processing) {
+      return;
+    }
+
+    this.processing = true;
+    try {
+      this.process(input);
+    } catch (err) {
+      diag.error(`${PKG_NAME}: capture failed`, err);
+    } finally {
+      this.processing = false;
+    }
+  }
+
+  private process(input: CaptureInput): void {
+    const errorTime = Date.now();
+    const normalized = normalizeError(input.error);
+    const dedupKey = `${normalized.type}|${normalized.message}|${normalized.topFrame ?? ""}`;
+
+    if (this.rateLimiter && !this.rateLimiter.allow(dedupKey, errorTime)) {
+      return;
+    }
+
+    let event: ErrorEvent | null = {
+      error: input.error,
+      message:
+        input.message ??
+        (normalized.message
+          ? `${normalized.type}: ${normalized.message}`
+          : normalized.type),
+      severity: input.severity ?? "error",
+      mechanism: input.mechanism,
+      handled: input.handled,
+      attributes: input.attributes ?? {},
+    };
+
+    if (this.options.beforeSend) {
+      event = this.options.beforeSend(event);
+      if (!event) {
+        return;
+      }
+    }
+
+    const errorId = generateErrorId();
+    const rawAttributes: Attributes = {
+      ...event.attributes,
+      "exception.type": normalized.type,
+      "exception.message": normalized.message,
+      ...(normalized.stacktrace
+        ? { "exception.stacktrace": normalized.stacktrace }
+        : {}),
+      "everr.error.handled": event.handled,
+      "everr.error.mechanism": event.mechanism,
+    };
+    const filteredAttributes = filterKeyValueData(
+      rawAttributes,
+      this.redactKeys,
+    );
+    const attributes = {
+      ...scrubAttributes(filteredAttributes, this.redactPatterns),
+      // The uid is a library-generated identifier, never user data, so it's set
+      // after scrubbing: a numeric-heavy UUID would otherwise trip the
+      // credit-card pattern and get partially redacted to "[Filtered]".
+      "log.record.uid": errorId,
+    };
+    const body = scrubString(event.message, this.redactPatterns);
+    const activeSpan = trace.getActiveSpan();
+
+    // Attach the error to the surrounding span so traces show the failure.
+    // A browser SDK usually has no active span, in which case this is a no-op.
+    if (activeSpan) {
+      markActiveSpan(activeSpan, normalized, input.error);
+    }
+
+    this.logger.emit({
+      eventName: "exception",
+      severityNumber: severityNumber(event.severity),
+      severityText: event.severity.toUpperCase(),
+      body,
+      attributes,
+      exception: input.error,
+      context: context.active(),
+    });
+  }
+}
+
+function markActiveSpan(
+  span: Span,
+  normalized: NormalizedError,
+  error: unknown,
+): void {
+  span.recordException(
+    error instanceof Error
+      ? error
+      : { name: normalized.type, message: normalized.message },
+  );
+  span.setStatus({
+    code: SpanStatusCode.ERROR,
+    message: normalized.message
+      ? `${normalized.type}: ${normalized.message}`
+      : normalized.type,
+  });
+}
+
+function severityNumber(severity: ErrorSeverity): SeverityNumber {
+  switch (severity) {
+    case "debug":
+      return SeverityNumber.DEBUG;
+    case "info":
+      return SeverityNumber.INFO;
+    case "warn":
+      return SeverityNumber.WARN;
+    case "fatal":
+      return SeverityNumber.FATAL;
+    case "error":
+      return SeverityNumber.ERROR;
+  }
+}
+
+function generateErrorId(): string {
+  const cryptoRef = globalThis.crypto as Crypto | undefined;
+  if (cryptoRef?.randomUUID) {
+    return cryptoRef.randomUUID();
+  }
+
+  return Array.from({ length: 32 }, () =>
+    Math.floor(Math.random() * 16).toString(16),
+  ).join("");
+}

--- a/packages/otel-errors/src/client.ts
+++ b/packages/otel-errors/src/client.ts
@@ -11,11 +11,11 @@ import { type NormalizedError, normalizeError } from "./normalize.js";
 import { RateLimiter } from "./rate-limit.js";
 import {
   type CollectBehavior,
-  DEFAULT_SCRUB_PATTERNS,
-  filterKeyValueData,
-  scrubAttributes,
-  scrubString,
-} from "./scrub.js";
+  DEFAULT_REDACT_PATTERNS,
+  redactAttributeKeys,
+  redactAttributes,
+  redactString,
+} from "./redact.js";
 import type { ErrorEvent, ErrorSeverity, Mechanism, Options } from "./types.js";
 import { PKG_NAME, PKG_VERSION } from "./version.js";
 
@@ -29,7 +29,7 @@ export interface CaptureInput {
 }
 
 /**
- * The runtime-neutral capture path: normalize, scrub, rate limit, mark the
+ * The runtime-neutral capture path: normalize, redact, rate limit, mark the
  * active span, emit one log record. It holds no process or DOM state, so any
  * runtime can drive it. `ErrorsInstrumentation` drives it on Node;
  * `@everr/otel-web`'s server entry constructs its own instance.
@@ -54,7 +54,7 @@ export class Client {
             options.rateLimit?.count ?? 5,
             options.rateLimit?.windowMs ?? 5000,
           );
-    this.redactPatterns = options.redactPatterns ?? DEFAULT_SCRUB_PATTERNS;
+    this.redactPatterns = options.redactPatterns ?? DEFAULT_REDACT_PATTERNS;
     this.redactKeys = options.redactKeys ?? true;
   }
 
@@ -120,18 +120,18 @@ export class Client {
       "everr.error.handled": event.handled,
       "everr.error.mechanism": event.mechanism,
     };
-    const filteredAttributes = filterKeyValueData(
+    const filteredAttributes = redactAttributeKeys(
       rawAttributes,
       this.redactKeys,
     );
     const attributes = {
-      ...scrubAttributes(filteredAttributes, this.redactPatterns),
+      ...redactAttributes(filteredAttributes, this.redactPatterns),
       // The uid is a library-generated identifier, never user data, so it's set
-      // after scrubbing: a numeric-heavy UUID would otherwise trip the
+      // after redaction: a numeric-heavy UUID would otherwise trip the
       // credit-card pattern and get partially redacted to "[Filtered]".
       "log.record.uid": errorId,
     };
-    const body = scrubString(event.message, this.redactPatterns);
+    const body = redactString(event.message, this.redactPatterns);
     const activeSpan = trace.getActiveSpan();
 
     // Attach the error to the surrounding span so traces show the failure.
@@ -171,18 +171,7 @@ function markActiveSpan(
 }
 
 function severityNumber(severity: ErrorSeverity): SeverityNumber {
-  switch (severity) {
-    case "debug":
-      return SeverityNumber.DEBUG;
-    case "info":
-      return SeverityNumber.INFO;
-    case "warn":
-      return SeverityNumber.WARN;
-    case "fatal":
-      return SeverityNumber.FATAL;
-    case "error":
-      return SeverityNumber.ERROR;
-  }
+  return severity === "fatal" ? SeverityNumber.FATAL : SeverityNumber.ERROR;
 }
 
 function generateErrorId(): string {

--- a/packages/otel-errors/src/client.ts
+++ b/packages/otel-errors/src/client.ts
@@ -16,7 +16,12 @@ import {
   redactAttributes,
   redactString,
 } from "./redact.js";
-import type { ErrorEvent, ErrorSeverity, Mechanism, Options } from "./types.js";
+import type {
+  ClientOptions,
+  ErrorEvent,
+  ErrorSeverity,
+  Mechanism,
+} from "./types.js";
 import { PKG_NAME, PKG_VERSION } from "./version.js";
 
 export interface CaptureInput {
@@ -31,31 +36,65 @@ export interface CaptureInput {
 /**
  * The runtime-neutral capture path: normalize, redact, rate limit, mark the
  * active span, emit one log record. It holds no process or DOM state, so any
- * runtime can drive it. `ErrorsInstrumentation` drives it on Node;
- * `@everr/otel-web`'s server entry constructs its own instance.
+ * runtime can drive it.
+ *
+ * The class is deliberately not exported from either package entry: one
+ * instance per process is the contract, and `capture.ts` owns it. It stays a
+ * class rather than module state so the tests can exercise the capture path
+ * against isolated instances.
  */
 export class Client {
-  readonly options: Options;
+  private options: ClientOptions = {};
   private logger: Logger;
-  private readonly rateLimiter: RateLimiter | null;
-  private readonly redactPatterns: RegExp[];
-  private readonly redactKeys: CollectBehavior;
+  private rateLimiter: RateLimiter | null;
+  private redactPatterns: RegExp[] = DEFAULT_REDACT_PATTERNS;
+  private redactKeys: CollectBehavior = true;
   private processing = false;
 
-  constructor(options: Options = {}) {
-    this.options = options;
+  constructor(options: ClientOptions = {}) {
     // Falls back to the global API registry, which is a no-op logger until
     // an SDK registers. setLogger swaps in an SDK-injected one.
     this.logger = logs.getLogger(PKG_NAME, PKG_VERSION);
-    this.rateLimiter =
-      options.rateLimit === false
-        ? null
-        : new RateLimiter(
-            options.rateLimit?.count ?? 5,
-            options.rateLimit?.windowMs ?? 5000,
-          );
-    this.redactPatterns = options.redactPatterns ?? DEFAULT_REDACT_PATTERNS;
-    this.redactKeys = options.redactKeys ?? true;
+    // The default limiter, replaced by configure() only when the caller
+    // states a rateLimit of its own.
+    this.rateLimiter = new RateLimiter(5, 5000);
+    this.configure(options);
+  }
+
+  /**
+   * Merges options over the current configuration. An absent key keeps its
+   * current value, so a caller that re-states one field never resets the
+   * others to their defaults. The rate limiter is rebuilt only when
+   * `rateLimit` is present, because rebuilding drops the accumulated
+   * per-fingerprint windows.
+   */
+  configure(options: ClientOptions): void {
+    // `undefined` counts as absent everywhere, including when it is passed
+    // explicitly: a caller forwarding an optional config
+    // (`configure({ beforeSend: cfg.beforeSend })`) must not uninstall a hook
+    // or restart the rate-limit windows just because its own field is unset.
+    // That is what `beforeSend: null` is for. A plain spread would not hold
+    // this line, so the merge is a filtered copy.
+    for (const [key, value] of Object.entries(options)) {
+      if (value !== undefined) {
+        (this.options as Record<string, unknown>)[key] = value;
+      }
+    }
+    // Rebuilt only on an explicit rateLimit, because a rebuild drops the
+    // accumulated per-fingerprint windows.
+    if (options.rateLimit !== undefined) {
+      const rateLimit = options.rateLimit;
+      this.rateLimiter =
+        rateLimit === false
+          ? null
+          : new RateLimiter(rateLimit.count, rateLimit.windowMs);
+    }
+    if (options.redactPatterns !== undefined) {
+      this.redactPatterns = options.redactPatterns;
+    }
+    if (options.redactKeys !== undefined) {
+      this.redactKeys = options.redactKeys;
+    }
   }
 
   /** Binds emission to a specific provider's logger instead of the global. */

--- a/packages/otel-errors/src/client.ts
+++ b/packages/otel-errors/src/client.ts
@@ -22,10 +22,10 @@ import { PKG_NAME, PKG_VERSION } from "./version.js";
 export interface CaptureInput {
   error: unknown;
   mechanism: Mechanism;
-  handled: boolean;
   severity?: ErrorSeverity;
   message?: string;
-  attributes?: Attributes;
+  /** Caller-supplied attributes, merged under the `exception.*` set. */
+  context?: Attributes;
 }
 
 /**
@@ -98,8 +98,7 @@ export class Client {
           : normalized.type),
       severity: input.severity ?? "error",
       mechanism: input.mechanism,
-      handled: input.handled,
-      attributes: input.attributes ?? {},
+      context: input.context ?? {},
     };
 
     if (this.options.beforeSend) {
@@ -111,13 +110,12 @@ export class Client {
 
     const errorId = generateErrorId();
     const rawAttributes: Attributes = {
-      ...event.attributes,
+      ...event.context,
       "exception.type": normalized.type,
       "exception.message": normalized.message,
       ...(normalized.stacktrace
         ? { "exception.stacktrace": normalized.stacktrace }
         : {}),
-      "everr.error.handled": event.handled,
       "everr.error.mechanism": event.mechanism,
     };
     const filteredAttributes = redactAttributeKeys(

--- a/packages/otel-errors/src/core.ts
+++ b/packages/otel-errors/src/core.ts
@@ -7,11 +7,11 @@ export { type NormalizedError, normalizeError } from "./normalize.js";
 export { RateLimiter } from "./rate-limit.js";
 export {
   type CollectBehavior,
-  DEFAULT_SCRUB_PATTERNS,
-  scrubAttributes,
-  scrubString,
+  DEFAULT_REDACT_PATTERNS,
+  redactAttributes,
+  redactString,
   stripUrlQueryAndFragment,
-} from "./scrub.js";
+} from "./redact.js";
 export type {
   ErrorEvent,
   ErrorSeverity,

--- a/packages/otel-errors/src/core.ts
+++ b/packages/otel-errors/src/core.ts
@@ -1,0 +1,21 @@
+// The runtime-neutral entry: the capture path with no Node and no
+// @opentelemetry/instrumentation dependency, so a browser-targeted tsc
+// program can consume it without pulling @types/node into its globals.
+// @everr/otel-web's server entry is its consumer.
+export { type CaptureInput, Client } from "./client.js";
+export { type NormalizedError, normalizeError } from "./normalize.js";
+export { RateLimiter } from "./rate-limit.js";
+export {
+  type CollectBehavior,
+  DEFAULT_SCRUB_PATTERNS,
+  scrubAttributes,
+  scrubString,
+  stripUrlQueryAndFragment,
+} from "./scrub.js";
+export type {
+  ErrorEvent,
+  ErrorSeverity,
+  Mechanism,
+  Options,
+} from "./types.js";
+export { PKG_NAME, PKG_VERSION } from "./version.js";

--- a/packages/otel-errors/src/core.ts
+++ b/packages/otel-errors/src/core.ts
@@ -2,7 +2,11 @@
 // @opentelemetry/instrumentation dependency, so a browser-targeted tsc
 // program can consume it without pulling @types/node into its globals.
 // @everr/otel-web's server entry is its consumer.
-export { type CaptureInput, Client } from "./client.js";
+// `capture` is exported here and not from ./node: it is the surface for SDKs
+// built on this package, which report their own mechanisms. An application
+// wants `captureError`.
+export { capture, configure, setLogger } from "./capture.js";
+export type { CaptureInput } from "./client.js";
 export { type NormalizedError, normalizeError } from "./normalize.js";
 export { RateLimiter } from "./rate-limit.js";
 export {
@@ -13,9 +17,9 @@ export {
   stripUrlQueryAndFragment,
 } from "./redact.js";
 export type {
+  ClientOptions,
   ErrorEvent,
   ErrorSeverity,
   Mechanism,
-  Options,
 } from "./types.js";
 export { PKG_NAME, PKG_VERSION } from "./version.js";

--- a/packages/otel-errors/src/instrumentation.fixtures.test.ts
+++ b/packages/otel-errors/src/instrumentation.fixtures.test.ts
@@ -1,0 +1,64 @@
+// Real Node processes, driven by a real NodeSDK, because the fatal path ends
+// in process.exit and cannot be observed in-process. Each fixture registers
+// the instrumentation the way an application does and prints what its
+// exporters receive, one JSON object per line.
+import { execSync, spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const TEST_FILE_DIR = dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = resolve(TEST_FILE_DIR, "..");
+
+type Line = { kind: "log" | "span" | "metric" } & Record<string, unknown>;
+
+function runFixture(name: string) {
+  const result = spawnSync(
+    process.execPath,
+    [fileURLToPath(pathToFileURL(resolve(PKG_ROOT, "test/fixtures", name)))],
+    { encoding: "utf8", timeout: 15_000 },
+  );
+  const lines = result.stdout.trim().split("\n").filter(Boolean);
+  const records = lines.map((l) => JSON.parse(l) as Line);
+  return {
+    status: result.status,
+    stderr: result.stderr,
+    logs: records.filter((r) => r.kind === "log"),
+    spans: records.filter((r) => r.kind === "span"),
+    metrics: records.filter((r) => r.kind === "metric"),
+  };
+}
+
+describe("node fatal exit semantics (fixtures)", () => {
+  beforeAll(() => {
+    execSync("pnpm build", { cwd: PKG_ROOT, stdio: "inherit" });
+  }, 120_000);
+
+  it("uncaughtException: flushes the record then exits 1", () => {
+    const { status, logs } = runFixture("uncaught-exit.mjs");
+    expect(status).toBe(1);
+    expect(logs.at(-1)).toMatchObject({
+      eventName: "exception",
+      mechanism: "uncaughtException",
+      severityNumber: 21,
+    });
+  });
+
+  it("uncaughtException: flushes queued spans and metrics too, not only logs", () => {
+    const { spans, metrics } = runFixture("uncaught-exit.mjs");
+    expect(spans.map((s) => s.name)).toContain("pre-crash");
+    expect(metrics.map((m) => m.name)).toContain("pre_crash_total");
+  });
+
+  it("unhandledRejection: flushes the record then exits 1", () => {
+    const { status, logs } = runFixture("rejection-exit.mjs");
+    expect(status).toBe(1);
+    expect(logs.at(-1)).toMatchObject({ mechanism: "unhandledrejection" });
+  });
+
+  it("onFatal continue: captures but does not exit", () => {
+    const { status, logs } = runFixture("uncaught-continue.mjs");
+    expect(status).toBe(0);
+    expect(logs.at(-1)).toMatchObject({ mechanism: "uncaughtException" });
+  });
+});

--- a/packages/otel-errors/src/instrumentation.test.ts
+++ b/packages/otel-errors/src/instrumentation.test.ts
@@ -129,7 +129,7 @@ describe("standalone captureError", () => {
 });
 
 describe("ErrorsInstrumentation capture", () => {
-  it("captures uncaughtException as fatal and unhandled", () => {
+  it("captures uncaughtException as fatal", () => {
     enable();
     process.emit("uncaughtException", new Error("crash"));
     const [record] = otel.records();
@@ -137,7 +137,6 @@ describe("ErrorsInstrumentation capture", () => {
     expect(record.attributes["everr.error.mechanism"]).toBe(
       "uncaughtException",
     );
-    expect(record.attributes["everr.error.handled"]).toBe(false);
     expect(record.severityText).toBe("FATAL");
   });
 
@@ -156,26 +155,7 @@ describe("ErrorsInstrumentation capture", () => {
     captureError(new Error("manual boom"), { feature: "billing" });
     const [record] = otel.records();
     expect(record.attributes["everr.error.mechanism"]).toBe("manual");
-    expect(record.attributes["everr.error.handled"]).toBe(true);
     expect(record.attributes.feature).toBe("billing");
-  });
-
-  it("captureError reads handled from the error.handled attribute", () => {
-    enable();
-    captureError(new Error("boom"), { "error.handled": false });
-    const [record] = otel.records();
-    expect(record.attributes["everr.error.handled"]).toBe(false);
-  });
-
-  it("captureError options win over the attribute", () => {
-    enable();
-    captureError(
-      new Error("boom"),
-      { "error.handled": false },
-      { handled: true },
-    );
-    const [record] = otel.records();
-    expect(record.attributes["everr.error.handled"]).toBe(true);
   });
 
   it("emits through an SDK-injected LoggerProvider instead of the global", () => {

--- a/packages/otel-errors/src/instrumentation.test.ts
+++ b/packages/otel-errors/src/instrumentation.test.ts
@@ -1,6 +1,6 @@
 import { diag } from "@opentelemetry/api";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { captureError, resetSharedClient } from "./capture.js";
+import { captureError, configure, resetSharedClient } from "./capture.js";
 import { ErrorsInstrumentation } from "./instrumentation.js";
 import { setupTestTelemetry } from "./test-utils.js";
 import { PKG_NAME } from "./version.js";
@@ -83,12 +83,15 @@ describe("ErrorsInstrumentation lifecycle", () => {
     }
   });
 
-  it("setConfig reinstalls with the new options", () => {
+  it("setConfig reinstalls with the new crash options", () => {
     const it_ = enable();
-    it_.setConfig({ onFatal: "continue", beforeSend: () => null });
-    process.emit("uncaughtException", new Error("suppressed"));
-    expect(otel.records()).toHaveLength(0);
+    const before = process.listenerCount("uncaughtException");
+    it_.setConfig({ onFatal: "continue" });
     expect(it_.getConfig().onFatal).toBe("continue");
+    // Reinstalled, not doubled: setConfig removes before it re-adds.
+    expect(process.listenerCount("uncaughtException")).toBe(before);
+    process.emit("uncaughtException", new Error("crash"));
+    expect(otel.records()).toHaveLength(1);
   });
 });
 
@@ -114,17 +117,37 @@ describe("standalone captureError", () => {
     otel = setupTestTelemetry();
   });
 
-  it("applies instrumentation options to manual captures", () => {
-    enable({ beforeSend: () => null });
+  it("reports through the configured shared client", () => {
+    configure({ beforeSend: () => null });
+    enable();
     captureError(new Error("suppressed"));
     expect(otel.records()).toHaveLength(0);
   });
 
-  it("keeps instrumentation options after disable", () => {
-    const it_ = enable({ beforeSend: () => null });
-    it_.disable();
+  it("leaves the shared configuration alone on disable", () => {
+    configure({ beforeSend: () => null });
+    enable().disable();
     captureError(new Error("still suppressed"));
     expect(otel.records()).toHaveLength(0);
+  });
+
+  it("warns when a second instrumentation installs its own crash handlers", () => {
+    const warn = vi.spyOn(diag, "warn").mockImplementation(() => {});
+    enable();
+    const second = new ErrorsInstrumentation({ onFatal: "continue" });
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0]?.[0]).toContain("captured twice");
+    second.disable();
+    warn.mockRestore();
+  });
+
+  it("does not warn when one instrumentation re-installs", () => {
+    const warn = vi.spyOn(diag, "warn").mockImplementation(() => {});
+    const it_ = enable();
+    it_.disable();
+    it_.enable();
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
   });
 });
 

--- a/packages/otel-errors/src/instrumentation.test.ts
+++ b/packages/otel-errors/src/instrumentation.test.ts
@@ -1,0 +1,192 @@
+import { diag } from "@opentelemetry/api";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { captureError, resetSharedClient } from "./capture.js";
+import { ErrorsInstrumentation } from "./instrumentation.js";
+import { setupTestTelemetry } from "./test-utils.js";
+import { PKG_NAME } from "./version.js";
+
+let otel: ReturnType<typeof setupTestTelemetry>;
+let instrumentation: ErrorsInstrumentation | null = null;
+
+function enable(
+  config: ConstructorParameters<typeof ErrorsInstrumentation>[0] = {},
+) {
+  instrumentation = new ErrorsInstrumentation({
+    onFatal: "continue",
+    ...config,
+  });
+  return instrumentation;
+}
+
+beforeEach(() => {
+  otel = setupTestTelemetry();
+});
+
+afterEach(async () => {
+  instrumentation?.disable();
+  instrumentation = null;
+  resetSharedClient();
+  await otel.dispose();
+});
+
+describe("ErrorsInstrumentation lifecycle", () => {
+  it("carries the package name and version as its scope", () => {
+    const it_ = enable();
+    expect(it_.instrumentationName).toBe(PKG_NAME);
+    expect(it_.instrumentationVersion).toBeTypeOf("string");
+  });
+
+  it("installs the process listeners on construction", () => {
+    const before = process.listenerCount("uncaughtException");
+    enable();
+    expect(process.listenerCount("uncaughtException")).toBe(before + 1);
+    expect(process.listenerCount("unhandledRejection")).toBeGreaterThan(0);
+  });
+
+  it("does not install when constructed with enabled: false", () => {
+    const before = process.listenerCount("uncaughtException");
+    enable({ enabled: false });
+    expect(process.listenerCount("uncaughtException")).toBe(before);
+    expect(otel.records()).toHaveLength(0);
+  });
+
+  it("reports enabled through getConfig so registerInstrumentations does not double-install", () => {
+    const it_ = enable();
+    const after = process.listenerCount("uncaughtException");
+    expect(it_.getConfig().enabled).toBe(true);
+    it_.enable();
+    expect(process.listenerCount("uncaughtException")).toBe(after);
+  });
+
+  it("disable removes the listeners but captureError keeps working", () => {
+    const before = process.listenerCount("uncaughtException");
+    const it_ = enable();
+    it_.disable();
+    expect(process.listenerCount("uncaughtException")).toBe(before);
+
+    captureError(new Error("still reported"));
+    expect(otel.records()).toHaveLength(1);
+  });
+
+  it("disabling a replaced instrumentation leaves the live one's captureError working", () => {
+    const first = enable();
+    const warn = vi.spyOn(diag, "warn").mockImplementation(() => {});
+    const second = new ErrorsInstrumentation({ onFatal: "continue" });
+    try {
+      expect(warn).toHaveBeenCalledOnce();
+      first.disable();
+      captureError(new Error("still reported"));
+      expect(otel.records()).toHaveLength(1);
+    } finally {
+      warn.mockRestore();
+      second.disable();
+    }
+  });
+
+  it("setConfig reinstalls with the new options", () => {
+    const it_ = enable();
+    it_.setConfig({ onFatal: "continue", beforeSend: () => null });
+    process.emit("uncaughtException", new Error("suppressed"));
+    expect(otel.records()).toHaveLength(0);
+    expect(it_.getConfig().onFatal).toBe("continue");
+  });
+});
+
+describe("standalone captureError", () => {
+  it("emits through the global logger provider with no instrumentation", () => {
+    captureError(new Error("standalone"), { feature: "billing" });
+    const [record] = otel.records();
+    expect(record.eventName).toBe("exception");
+    expect(record.attributes["everr.error.mechanism"]).toBe("manual");
+    expect(record.attributes.feature).toBe("billing");
+  });
+
+  it("warns once when no LoggerProvider is registered", async () => {
+    await otel.dispose();
+    resetSharedClient();
+
+    const warn = vi.spyOn(diag, "warn").mockImplementation(() => {});
+    captureError(new Error("lost"));
+    captureError(new Error("also lost"));
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+
+    otel = setupTestTelemetry();
+  });
+
+  it("applies instrumentation options to manual captures", () => {
+    enable({ beforeSend: () => null });
+    captureError(new Error("suppressed"));
+    expect(otel.records()).toHaveLength(0);
+  });
+
+  it("keeps instrumentation options after disable", () => {
+    const it_ = enable({ beforeSend: () => null });
+    it_.disable();
+    captureError(new Error("still suppressed"));
+    expect(otel.records()).toHaveLength(0);
+  });
+});
+
+describe("ErrorsInstrumentation capture", () => {
+  it("captures uncaughtException as fatal and unhandled", () => {
+    enable();
+    process.emit("uncaughtException", new Error("crash"));
+    const [record] = otel.records();
+    expect(record.eventName).toBe("exception");
+    expect(record.attributes["everr.error.mechanism"]).toBe(
+      "uncaughtException",
+    );
+    expect(record.attributes["everr.error.handled"]).toBe(false);
+    expect(record.severityText).toBe("FATAL");
+  });
+
+  it("captures unhandledRejection including non-Error reasons", () => {
+    enable();
+    process.emit("unhandledRejection", "string reason", Promise.resolve());
+    const [record] = otel.records();
+    expect(record.attributes["everr.error.mechanism"]).toBe(
+      "unhandledrejection",
+    );
+    expect(record.attributes["exception.type"]).toBe("NonError");
+  });
+
+  it("backs captureError with mechanism manual", () => {
+    enable();
+    captureError(new Error("manual boom"), { feature: "billing" });
+    const [record] = otel.records();
+    expect(record.attributes["everr.error.mechanism"]).toBe("manual");
+    expect(record.attributes["everr.error.handled"]).toBe(true);
+    expect(record.attributes.feature).toBe("billing");
+  });
+
+  it("captureError reads handled from the error.handled attribute", () => {
+    enable();
+    captureError(new Error("boom"), { "error.handled": false });
+    const [record] = otel.records();
+    expect(record.attributes["everr.error.handled"]).toBe(false);
+  });
+
+  it("captureError options win over the attribute", () => {
+    enable();
+    captureError(
+      new Error("boom"),
+      { "error.handled": false },
+      { handled: true },
+    );
+    const [record] = otel.records();
+    expect(record.attributes["everr.error.handled"]).toBe(true);
+  });
+
+  it("emits through an SDK-injected LoggerProvider instead of the global", () => {
+    const it_ = enable();
+    const emit = vi.fn();
+    it_.setLoggerProvider({
+      getLogger: () => ({ emit }),
+    } as unknown as Parameters<ErrorsInstrumentation["setLoggerProvider"]>[0]);
+
+    process.emit("uncaughtException", new Error("routed"));
+    expect(otel.records()).toHaveLength(0);
+    expect(emit).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/otel-errors/src/instrumentation.ts
+++ b/packages/otel-errors/src/instrumentation.ts
@@ -1,0 +1,198 @@
+import {
+  diag,
+  type MeterProvider,
+  metrics,
+  type TracerProvider,
+  trace,
+} from "@opentelemetry/api";
+import { type LoggerProvider, logs } from "@opentelemetry/api-logs";
+import type {
+  Instrumentation,
+  InstrumentationConfig,
+} from "@opentelemetry/instrumentation";
+import { adoptSharedClient } from "./capture.js";
+import { Client } from "./client.js";
+import { resolveFlushable } from "./providers.js";
+import type { Options } from "./types.js";
+import { PKG_NAME, PKG_VERSION } from "./version.js";
+
+const FLUSH_TIMEOUT_MS = 2000;
+
+export interface ErrorsInstrumentationConfig
+  extends InstrumentationConfig,
+    Options {}
+
+type FatalEventName = "uncaughtException" | "unhandledRejection";
+
+const FATAL_EVENTS: Array<[FatalEventName, string]> = [
+  ["uncaughtException", "uncaughtException"],
+  ["unhandledRejection", "unhandledrejection"],
+];
+
+/**
+ * Captures uncaught exceptions and unhandled rejections as OTel exception log
+ * records, and backs `captureError` for manual reports. Register it with the
+ * SDK like any other instrumentation:
+ *
+ * ```ts
+ * new NodeSDK({ instrumentations: [new ErrorsInstrumentation()] })
+ * ```
+ *
+ * It patches no modules, so it implements `Instrumentation` directly instead
+ * of extending `InstrumentationBase` (whose whole contract is module patching).
+ */
+export class ErrorsInstrumentation
+  implements Instrumentation<ErrorsInstrumentationConfig>
+{
+  readonly instrumentationName = PKG_NAME;
+  readonly instrumentationVersion = PKG_VERSION;
+
+  private _config: ErrorsInstrumentationConfig = {};
+  private client: Client;
+  private loggerProvider: LoggerProvider | undefined;
+  private tracerProvider: TracerProvider | undefined;
+  private meterProvider: MeterProvider | undefined;
+  private teardownFns: Array<() => void> = [];
+
+  constructor(config: ErrorsInstrumentationConfig = {}) {
+    this._config = { enabled: true, ...config };
+    this.client = new Client(this._config);
+    // captureError works without any instrumentation, but once one exists its
+    // options must apply to manual captures too: scrubbing that only covered
+    // crashes would silently leak the data it was configured to redact.
+    adoptSharedClient(this.client, this);
+    // Instrumentations enable themselves on construction; registerInstrumentations
+    // only calls enable() for one that opted out with `enabled: false`.
+    if (this._config.enabled) {
+      this.install();
+    }
+  }
+
+  setConfig(config: ErrorsInstrumentationConfig = {}): void {
+    const wasEnabled = this.teardownFns.length > 0;
+    if (wasEnabled) {
+      this.remove();
+    }
+    this._config = { enabled: true, ...config };
+    this.client = new Client(this._config);
+    adoptSharedClient(this.client, this);
+    this.applyProviders();
+    if (this._config.enabled) {
+      this.install();
+    }
+  }
+
+  getConfig(): ErrorsInstrumentationConfig {
+    return this._config;
+  }
+
+  enable(): void {
+    this._config.enabled = true;
+    this.install();
+  }
+
+  disable(): void {
+    this._config.enabled = false;
+    this.remove();
+  }
+
+  setTracerProvider(tracerProvider: TracerProvider): void {
+    this.tracerProvider = tracerProvider;
+  }
+
+  setMeterProvider(meterProvider: MeterProvider): void {
+    this.meterProvider = meterProvider;
+  }
+
+  setLoggerProvider(loggerProvider: LoggerProvider): void {
+    this.loggerProvider = loggerProvider;
+    this.applyProviders();
+  }
+
+  private applyProviders(): void {
+    if (this.loggerProvider) {
+      this.client.setLogger(
+        this.loggerProvider.getLogger(PKG_NAME, PKG_VERSION),
+      );
+    }
+  }
+
+  private install(): void {
+    // Idempotent: registerInstrumentations may enable an instrumentation the
+    // constructor already enabled.
+    if (this.teardownFns.length > 0) {
+      return;
+    }
+
+    for (const [eventName, mechanism] of FATAL_EVENTS) {
+      const handler = (...args: unknown[]) => {
+        const [reason] = args;
+        this.client.capture({
+          error: reason,
+          mechanism,
+          handled: false,
+          severity: "fatal",
+        });
+
+        void this.flush().finally(() => {
+          if (this._config.onFatal === "continue") {
+            return;
+          }
+
+          // Installing a listener suppresses the crash Node would otherwise
+          // perform, so we perform it. Unless the app installed its own
+          // listener too, in which case the exit decision is the app's.
+          const others = process
+            .listeners(eventName)
+            .filter((listener) => listener !== (handler as unknown));
+          if (others.length === 0) {
+            process.exit(1);
+          }
+        });
+      };
+
+      process.on(eventName, handler);
+      this.teardownFns.push(() => process.off(eventName, handler));
+    }
+  }
+
+  // Detaches only the crash listeners. captureError stays live through the
+  // shared client: disable() is the SDK lifecycle hook, not an off switch for
+  // manual reports.
+  private remove(): void {
+    for (const fn of this.teardownFns) {
+      fn();
+    }
+    this.teardownFns = [];
+  }
+
+  /**
+   * Flushes logs, spans, and metrics before the process exits. All three
+   * matter on a crash: the log record carries the error, and the span that
+   * was active carries where it happened. They share one timeout budget, so a
+   * stalled exporter cannot hold the process open past it.
+   */
+  private async flush(): Promise<void> {
+    const targets = [
+      resolveFlushable(this.loggerProvider) ??
+        resolveFlushable(logs.getLoggerProvider()),
+      resolveFlushable(this.tracerProvider) ??
+        resolveFlushable(trace.getTracerProvider()),
+      resolveFlushable(this.meterProvider) ??
+        resolveFlushable(metrics.getMeterProvider()),
+    ];
+
+    await Promise.race([
+      Promise.all(
+        targets.map((target) =>
+          target
+            ?.forceFlush()
+            .catch((err) =>
+              diag.error(`${PKG_NAME}: flush on fatal failed`, err),
+            ),
+        ),
+      ),
+      new Promise<void>((resolve) => setTimeout(resolve, FLUSH_TIMEOUT_MS)),
+    ]);
+  }
+}

--- a/packages/otel-errors/src/instrumentation.ts
+++ b/packages/otel-errors/src/instrumentation.ts
@@ -130,7 +130,6 @@ export class ErrorsInstrumentation
         this.client.capture({
           error: reason,
           mechanism,
-          handled: false,
           severity: "fatal",
         });
 

--- a/packages/otel-errors/src/instrumentation.ts
+++ b/packages/otel-errors/src/instrumentation.ts
@@ -48,24 +48,17 @@ export class ErrorsInstrumentation
   readonly instrumentationVersion = PKG_VERSION;
 
   private _config: ErrorsInstrumentationConfig = {};
-  private client: Client;
+  // Definitely assigned: the constructor's configure() call always sets it.
+  private client!: Client;
   private loggerProvider: LoggerProvider | undefined;
   private tracerProvider: TracerProvider | undefined;
   private meterProvider: MeterProvider | undefined;
   private teardownFns: Array<() => void> = [];
 
   constructor(config: ErrorsInstrumentationConfig = {}) {
-    this._config = { enabled: true, ...config };
-    this.client = new Client(this._config);
-    // captureError works without any instrumentation, but once one exists its
-    // options must apply to manual captures too: scrubbing that only covered
-    // crashes would silently leak the data it was configured to redact.
-    adoptSharedClient(this.client, this);
     // Instrumentations enable themselves on construction; registerInstrumentations
     // only calls enable() for one that opted out with `enabled: false`.
-    if (this._config.enabled) {
-      this.install();
-    }
+    this.configure(config);
   }
 
   setConfig(config: ErrorsInstrumentationConfig = {}): void {
@@ -73,10 +66,17 @@ export class ErrorsInstrumentation
     if (wasEnabled) {
       this.remove();
     }
+    this.configure(config);
+    this.applyProviders();
+  }
+
+  private configure(config: ErrorsInstrumentationConfig): void {
     this._config = { enabled: true, ...config };
     this.client = new Client(this._config);
+    // captureError works without any instrumentation, but once one exists its
+    // options must apply to manual captures too: redaction that only covered
+    // crashes would silently leak the data it was configured to redact.
     adoptSharedClient(this.client, this);
-    this.applyProviders();
     if (this._config.enabled) {
       this.install();
     }

--- a/packages/otel-errors/src/instrumentation.ts
+++ b/packages/otel-errors/src/instrumentation.ts
@@ -10,17 +10,30 @@ import type {
   Instrumentation,
   InstrumentationConfig,
 } from "@opentelemetry/instrumentation";
-import { adoptSharedClient } from "./capture.js";
-import { Client } from "./client.js";
+import { capture, setLogger } from "./capture.js";
 import { resolveFlushable } from "./providers.js";
-import type { Options } from "./types.js";
 import { PKG_NAME, PKG_VERSION } from "./version.js";
 
 const FLUSH_TIMEOUT_MS = 2000;
 
-export interface ErrorsInstrumentationConfig
-  extends InstrumentationConfig,
-    Options {}
+/**
+ * Crash-handling only. Redaction, rate limiting, and `beforeSend` belong to
+ * the shared client and are set through `configure`, so an app configures
+ * capture in one place whether or not it registers this instrumentation.
+ */
+export interface ErrorsInstrumentationConfig extends InstrumentationConfig {
+  /**
+   * What to do after a fatal error is flushed. "exit" (the default) restores
+   * the crash Node would have performed had no listener been installed;
+   * "continue" leaves the process running.
+   */
+  onFatal?: "exit" | "continue";
+}
+
+// Two instrumentations means two sets of crash handlers, so every crash is
+// captured twice and the exits race. Module-level because the collision is
+// between instances, and warn-only because the second one still works.
+let installed: object | null = null;
 
 type FatalEventName = "uncaughtException" | "unhandledRejection";
 
@@ -48,8 +61,6 @@ export class ErrorsInstrumentation
   readonly instrumentationVersion = PKG_VERSION;
 
   private _config: ErrorsInstrumentationConfig = {};
-  // Definitely assigned: the constructor's configure() call always sets it.
-  private client!: Client;
   private loggerProvider: LoggerProvider | undefined;
   private tracerProvider: TracerProvider | undefined;
   private meterProvider: MeterProvider | undefined;
@@ -72,11 +83,6 @@ export class ErrorsInstrumentation
 
   private configure(config: ErrorsInstrumentationConfig): void {
     this._config = { enabled: true, ...config };
-    this.client = new Client(this._config);
-    // captureError works without any instrumentation, but once one exists its
-    // options must apply to manual captures too: redaction that only covered
-    // crashes would silently leak the data it was configured to redact.
-    adoptSharedClient(this.client, this);
     if (this._config.enabled) {
       this.install();
     }
@@ -111,9 +117,7 @@ export class ErrorsInstrumentation
 
   private applyProviders(): void {
     if (this.loggerProvider) {
-      this.client.setLogger(
-        this.loggerProvider.getLogger(PKG_NAME, PKG_VERSION),
-      );
+      setLogger(this.loggerProvider.getLogger(PKG_NAME, PKG_VERSION));
     }
   }
 
@@ -124,10 +128,17 @@ export class ErrorsInstrumentation
       return;
     }
 
+    if (installed && installed !== this) {
+      diag.warn(
+        `${PKG_NAME}: a second ErrorsInstrumentation was installed; every crash is now captured twice`,
+      );
+    }
+    installed = this;
+
     for (const [eventName, mechanism] of FATAL_EVENTS) {
       const handler = (...args: unknown[]) => {
         const [reason] = args;
-        this.client.capture({
+        capture({
           error: reason,
           mechanism,
           severity: "fatal",
@@ -163,6 +174,9 @@ export class ErrorsInstrumentation
       fn();
     }
     this.teardownFns = [];
+    if (installed === this) {
+      installed = null;
+    }
   }
 
   /**

--- a/packages/otel-errors/src/node.ts
+++ b/packages/otel-errors/src/node.ts
@@ -1,0 +1,14 @@
+// The Node entry: everything that needs `process` or
+// @opentelemetry/instrumentation. Runtime-neutral pieces live in ./core.
+export { type CaptureErrorOptions, captureError } from "./capture.js";
+export { type CaptureInput, Client } from "./client.js";
+export {
+  ErrorsInstrumentation,
+  type ErrorsInstrumentationConfig,
+} from "./instrumentation.js";
+export type {
+  ErrorEvent,
+  ErrorSeverity,
+  Mechanism,
+  Options,
+} from "./types.js";

--- a/packages/otel-errors/src/node.ts
+++ b/packages/otel-errors/src/node.ts
@@ -1,6 +1,6 @@
 // The Node entry: everything that needs `process` or
 // @opentelemetry/instrumentation. Runtime-neutral pieces live in ./core.
-export { type CaptureErrorOptions, captureError } from "./capture.js";
+export { captureError } from "./capture.js";
 export { type CaptureInput, Client } from "./client.js";
 export {
   ErrorsInstrumentation,

--- a/packages/otel-errors/src/node.ts
+++ b/packages/otel-errors/src/node.ts
@@ -1,14 +1,15 @@
 // The Node entry: everything that needs `process` or
 // @opentelemetry/instrumentation. Runtime-neutral pieces live in ./core.
-export { captureError } from "./capture.js";
-export { type CaptureInput, Client } from "./client.js";
+// CaptureInput is deliberately absent: `capture` is a ./core surface, so on
+// this entry the type describes an argument nobody can pass.
+export { captureError, configure, setLogger } from "./capture.js";
 export {
   ErrorsInstrumentation,
   type ErrorsInstrumentationConfig,
 } from "./instrumentation.js";
 export type {
+  ClientOptions,
   ErrorEvent,
   ErrorSeverity,
   Mechanism,
-  Options,
 } from "./types.js";

--- a/packages/otel-errors/src/normalize.properties.test.ts
+++ b/packages/otel-errors/src/normalize.properties.test.ts
@@ -1,0 +1,91 @@
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import { normalizeError, safeStringify } from "./normalize.js";
+
+// Property tests for normalization: whatever JavaScript can throw,
+// normalizeError must never throw back and always produce the string-typed
+// wire shape, no matter how hostile the stack, cause chain, or value is.
+
+describe("normalizeError", () => {
+  it("never throws and always returns string type and message", () => {
+    fc.assert(
+      fc.property(fc.anything(), (thrown) => {
+        const normalized = normalizeError(thrown);
+        expect(typeof normalized.type).toBe("string");
+        expect(normalized.type.length).toBeGreaterThan(0);
+        expect(typeof normalized.message).toBe("string");
+      }),
+    );
+  });
+
+  it("keeps type and message intact under arbitrary stack strings", () => {
+    fc.assert(
+      fc.property(fc.string(), fc.string(), (message, stack) => {
+        const error = new Error(message);
+        error.stack = stack;
+        const normalized = normalizeError(error);
+        expect(normalized.type).toBe("Error");
+        expect(normalized.message).toBe(message);
+        expect(typeof normalized.stacktrace).toBe("string");
+      }),
+    );
+  });
+
+  it("renders every cause message in an arbitrary-depth chain, up to the cap", () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.uuid(), { minLength: 1, maxLength: 8 }),
+        (messages) => {
+          const [head, ...rest] = messages;
+          let error = new Error(head);
+          const root = error;
+          for (const message of rest) {
+            const cause = new Error(message);
+            error.cause = cause;
+            error = cause;
+          }
+          const normalized = normalizeError(root);
+          // Depth 0 is the root, so the cap admits the first 6 messages.
+          for (const message of messages.slice(0, 6)) {
+            expect(normalized.stacktrace).toContain(message);
+          }
+        },
+      ),
+    );
+  });
+
+  it("terminates on cyclic cause chains", () => {
+    const a = new Error("a");
+    const b = new Error("b");
+    a.cause = b;
+    b.cause = a;
+    expect(() => normalizeError(a)).not.toThrow();
+  });
+});
+
+describe("safeStringify", () => {
+  it("returns a string for anything, including throwing getters", () => {
+    fc.assert(
+      fc.property(fc.anything(), (value) => {
+        expect(typeof safeStringify(value)).toBe("string");
+      }),
+    );
+    const hostile = {
+      get boom(): never {
+        throw new Error("boom");
+      },
+      toJSON(): never {
+        throw new Error("boom");
+      },
+    };
+    expect(typeof safeStringify(hostile)).toBe("string");
+  });
+
+  it("is the identity on strings", () => {
+    fc.assert(
+      fc.property(fc.string(), (value) => {
+        expect(safeStringify(value)).toBe(value);
+      }),
+    );
+  });
+});

--- a/packages/otel-errors/src/normalize.test.ts
+++ b/packages/otel-errors/src/normalize.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { normalizeError } from "./normalize.js";
+
+describe("normalizeError", () => {
+  it("extracts type, message, stacktrace, and top frame from an Error", () => {
+    const result = normalizeError(new TypeError("boom"));
+    expect(result.type).toBe("TypeError");
+    expect(result.message).toBe("boom");
+    expect(result.stacktrace).toContain("normalize.test.ts");
+    expect(result.topFrame).toMatch(/^at /);
+  });
+
+  it("appends cause chains to the stacktrace", () => {
+    const error = new Error("outer", { cause: new RangeError("inner") });
+    const result = normalizeError(error);
+    expect(result.stacktrace).toContain("[cause] RangeError: inner");
+  });
+
+  it("appends AggregateError members", () => {
+    const error = new AggregateError([new Error("a"), new Error("b")], "agg");
+    const result = normalizeError(error);
+    expect(result.stacktrace).toContain("[aggregate] Error: a");
+    expect(result.stacktrace).toContain("[aggregate] Error: b");
+  });
+
+  it("does not recurse infinitely on self-referential causes", () => {
+    const error = new Error("loop");
+    (error as { cause?: unknown }).cause = error;
+    expect(() => normalizeError(error)).not.toThrow();
+  });
+
+  it("normalizes non-Error throwables as NonError", () => {
+    expect(normalizeError("just a string")).toEqual({
+      type: "NonError",
+      message: "just a string",
+    });
+    expect(normalizeError({ code: 42 })).toEqual({
+      type: "NonError",
+      message: '{"code":42}',
+    });
+  });
+
+  it("survives unstringifiable values", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(normalizeError(circular).type).toBe("NonError");
+  });
+});

--- a/packages/otel-errors/src/normalize.ts
+++ b/packages/otel-errors/src/normalize.ts
@@ -1,0 +1,74 @@
+export interface NormalizedError {
+  type: string;
+  message: string;
+  stacktrace?: string;
+  topFrame?: string;
+}
+
+const MAX_CAUSE_DEPTH = 5;
+
+export function normalizeError(error: unknown): NormalizedError {
+  if (error instanceof Error) {
+    const stacktrace = renderStack(error, 0);
+    return {
+      type: error.name || "Error",
+      message: error.message,
+      stacktrace,
+      topFrame: extractTopFrame(stacktrace),
+    };
+  }
+
+  return { type: "NonError", message: safeStringify(error) };
+}
+
+function renderStack(error: Error, depth: number): string {
+  let text = error.stack ?? `${error.name}: ${error.message}`;
+  if (depth >= MAX_CAUSE_DEPTH) {
+    return text;
+  }
+
+  if (error instanceof AggregateError) {
+    for (const inner of error.errors) {
+      text +=
+        inner instanceof Error && inner !== error
+          ? `\n[aggregate] ${renderStack(inner, depth + 1)}`
+          : `\n[aggregate] ${safeStringify(inner)}`;
+    }
+  }
+
+  if (error.cause !== undefined) {
+    text +=
+      error.cause instanceof Error && error.cause !== error
+        ? `\n[cause] ${renderStack(error.cause, depth + 1)}`
+        : `\n[cause] ${safeStringify(error.cause)}`;
+  }
+
+  return text;
+}
+
+function extractTopFrame(stacktrace: string): string | undefined {
+  for (const line of stacktrace.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("at ") || /\S+@\S+:\d+/.test(trimmed)) {
+      return trimmed;
+    }
+  }
+
+  return undefined;
+}
+
+export function safeStringify(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    try {
+      return String(value);
+    } catch {
+      return "[unserializable]";
+    }
+  }
+}

--- a/packages/otel-errors/src/providers.ts
+++ b/packages/otel-errors/src/providers.ts
@@ -1,0 +1,34 @@
+export interface Flushable {
+  forceFlush(): Promise<void>;
+}
+
+/**
+ * `forceFlush` lives on the SDK provider, but the API hands out proxies:
+ * `trace.getTracerProvider()` always returns a ProxyTracerProvider, and
+ * `logs.getLoggerProvider()` returns a ProxyLoggerProvider until an SDK
+ * registers. Both keep the real provider behind a delegate getter.
+ */
+export function resolveFlushable(candidate: unknown): Flushable | null {
+  if (typeof candidate !== "object" || candidate === null) {
+    return null;
+  }
+
+  const provider = candidate as Partial<Flushable> & {
+    getDelegate?: () => unknown;
+    _getDelegate?: () => unknown;
+  };
+
+  if (typeof provider.forceFlush === "function") {
+    return provider as Flushable;
+  }
+
+  const delegate = provider.getDelegate ?? provider._getDelegate;
+  if (typeof delegate === "function") {
+    const inner = delegate.call(provider);
+    // A proxy whose delegate is unset returns the noop provider, which has no
+    // forceFlush, so this terminates.
+    return inner === candidate ? null : resolveFlushable(inner);
+  }
+
+  return null;
+}

--- a/packages/otel-errors/src/rate-limit.properties.test.ts
+++ b/packages/otel-errors/src/rate-limit.properties.test.ts
@@ -1,0 +1,83 @@
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import { RateLimiter } from "./rate-limit.js";
+
+// Property tests for the rate limiter: under any interleaving of keys and
+// any (monotonic) clock, a key never gets more than `count` allowances per
+// window, and keys never influence each other.
+
+const clock = fc
+  .array(fc.integer({ min: 0, max: 50 }), { minLength: 1, maxLength: 200 })
+  .map((deltas) => {
+    let now = 0;
+    return deltas.map((d) => (now += d));
+  });
+
+describe("RateLimiter", () => {
+  it("never allows more than count hits inside one window", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 5 }),
+        fc.integer({ min: 10, max: 500 }),
+        clock,
+        (count, windowMs, times) => {
+          const limiter = new RateLimiter(count, windowMs);
+          const allowed: number[] = [];
+          for (const now of times) {
+            if (limiter.allow("k", now)) allowed.push(now);
+          }
+          // Sliding-window check over the allowed timestamps themselves.
+          for (let i = 0; i < allowed.length; i++) {
+            const inWindow = allowed.filter(
+              (t) => t > allowed[i]! - windowMs && t <= allowed[i]!,
+            );
+            expect(inWindow.length).toBeLessThanOrEqual(count);
+          }
+        },
+      ),
+    );
+  });
+
+  it("always allows a hit once the window has fully passed", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 5 }),
+        fc.integer({ min: 10, max: 500 }),
+        clock,
+        (count, windowMs, times) => {
+          const limiter = new RateLimiter(count, windowMs);
+          for (const now of times) {
+            limiter.allow("k", now);
+          }
+          const last = times[times.length - 1]!;
+          expect(limiter.allow("k", last + windowMs + 1)).toBe(true);
+        },
+      ),
+    );
+  });
+
+  it("tracks keys independently", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 5 }),
+        fc.integer({ min: 10, max: 500 }),
+        clock,
+        fc.array(fc.constantFrom("a", "b", "c"), {
+          minLength: 1,
+          maxLength: 200,
+        }),
+        (count, windowMs, times, keys) => {
+          const limiter = new RateLimiter(count, windowMs);
+          const solo = new Map<string, RateLimiter>();
+          for (let i = 0; i < times.length; i++) {
+            const key = keys[i % keys.length]!;
+            if (!solo.has(key)) solo.set(key, new RateLimiter(count, windowMs));
+            expect(limiter.allow(key, times[i]!)).toBe(
+              solo.get(key)!.allow(key, times[i]!),
+            );
+          }
+        },
+      ),
+    );
+  });
+});

--- a/packages/otel-errors/src/rate-limit.test.ts
+++ b/packages/otel-errors/src/rate-limit.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { RateLimiter } from "./rate-limit.js";
+
+describe("RateLimiter", () => {
+  it("allows up to count emissions per key per window", () => {
+    const limiter = new RateLimiter(3, 1000);
+    expect(limiter.allow("k", 0)).toBe(true);
+    expect(limiter.allow("k", 10)).toBe(true);
+    expect(limiter.allow("k", 20)).toBe(true);
+    expect(limiter.allow("k", 30)).toBe(false);
+  });
+
+  it("tracks keys independently", () => {
+    const limiter = new RateLimiter(1, 1000);
+    expect(limiter.allow("a", 0)).toBe(true);
+    expect(limiter.allow("b", 0)).toBe(true);
+    expect(limiter.allow("a", 1)).toBe(false);
+  });
+
+  it("allows again once the window slides past old hits", () => {
+    const limiter = new RateLimiter(2, 1000);
+    expect(limiter.allow("k", 0)).toBe(true);
+    expect(limiter.allow("k", 100)).toBe(true);
+    expect(limiter.allow("k", 500)).toBe(false);
+    expect(limiter.allow("k", 1101)).toBe(true);
+  });
+});

--- a/packages/otel-errors/src/rate-limit.ts
+++ b/packages/otel-errors/src/rate-limit.ts
@@ -1,0 +1,40 @@
+const PRUNE_THRESHOLD = 1000;
+
+export class RateLimiter {
+  private hits = new Map<string, number[]>();
+
+  constructor(
+    private readonly count: number,
+    private readonly windowMs: number,
+  ) {}
+
+  allow(key: string, now: number = Date.now()): boolean {
+    const cutoff = now - this.windowMs;
+    const timestamps = (this.hits.get(key) ?? []).filter((t) => t > cutoff);
+
+    if (timestamps.length >= this.count) {
+      this.hits.set(key, timestamps);
+      return false;
+    }
+
+    timestamps.push(now);
+    this.hits.set(key, timestamps);
+
+    if (this.hits.size > PRUNE_THRESHOLD) {
+      this.prune(cutoff);
+    }
+
+    return true;
+  }
+
+  private prune(cutoff: number): void {
+    for (const [key, timestamps] of this.hits) {
+      const live = timestamps.filter((t) => t > cutoff);
+      if (live.length === 0) {
+        this.hits.delete(key);
+      } else {
+        this.hits.set(key, live);
+      }
+    }
+  }
+}

--- a/packages/otel-errors/src/redact.properties.test.ts
+++ b/packages/otel-errors/src/redact.properties.test.ts
@@ -1,20 +1,20 @@
 import fc from "fast-check";
 import { describe, expect, it } from "vitest";
 import {
-  DEFAULT_SCRUB_PATTERNS,
-  filterKeyValueData,
+  DEFAULT_REDACT_PATTERNS,
+  redactAttributeKeys,
+  redactString,
   SENSITIVE_KEY_SNIPPETS,
-  scrubString,
   stripUrlQueryAndFragment,
-} from "./scrub.js";
+} from "./redact.js";
 
-// Property tests for scrubbing: key filtering preserves the key set and only
+// Property tests for redaction: key filtering preserves the key set and only
 // ever swaps values for the redaction marker, and the default patterns remove
 // constructed secrets wherever they land inside a string.
 
 const word = fc.stringMatching(/^[a-z]{1,8}$/);
 
-describe("filterKeyValueData", () => {
+describe("redactAttributeKeys", () => {
   const behavior = fc.oneof(
     fc.constant<boolean>(true),
     fc.constant<boolean>(false),
@@ -26,7 +26,7 @@ describe("filterKeyValueData", () => {
   it("preserves the key set and only substitutes the marker", () => {
     fc.assert(
       fc.property(data, behavior, (attrs, b) => {
-        const out = filterKeyValueData(attrs, b);
+        const out = redactAttributeKeys(attrs, b);
         expect(Object.keys(out).sort()).toEqual(Object.keys(attrs).sort());
         for (const key of Object.keys(out)) {
           expect([attrs[key], "[Filtered]"]).toContainEqual(out[key]);
@@ -41,7 +41,7 @@ describe("filterKeyValueData", () => {
       .map(([snippet, before, after]) => `${before}_${snippet}_${after}`);
     fc.assert(
       fc.property(sensitiveKey, behavior, fc.string(), (key, b, value) => {
-        const out = filterKeyValueData({ [key]: value }, b);
+        const out = redactAttributeKeys({ [key]: value }, b);
         expect(out[key]).toBe(b === false ? value : "[Filtered]");
       }),
     );
@@ -53,7 +53,7 @@ describe("filterKeyValueData", () => {
         fc.dictionary(word, fc.string()),
         fc.array(word, { minLength: 1, maxLength: 3 }),
         (attrs, allow) => {
-          const out = filterKeyValueData(attrs, { allow });
+          const out = redactAttributeKeys(attrs, { allow });
           for (const key of Object.keys(attrs)) {
             const allowed = allow.some((t) => key.includes(t));
             if (!allowed) expect(out[key]).toBe("[Filtered]");
@@ -64,16 +64,16 @@ describe("filterKeyValueData", () => {
   });
 });
 
-describe("scrubString with the default patterns", () => {
+describe("redactString with the default patterns", () => {
   it("removes constructed email addresses wherever they appear", () => {
     const email = fc
       .tuple(word, word, fc.constantFrom("com", "io", "dev"))
       .map(([local, domain, tld]) => `${local}@${domain}.${tld}`);
     fc.assert(
       fc.property(word, email, word, (prefix, address, suffix) => {
-        const out = scrubString(
+        const out = redactString(
           `${prefix} ${address} ${suffix}`,
-          DEFAULT_SCRUB_PATTERNS,
+          DEFAULT_REDACT_PATTERNS,
         );
         expect(out).not.toContain(address);
         expect(out).toContain("[Filtered]");
@@ -85,9 +85,9 @@ describe("scrubString with the default patterns", () => {
     const token = fc.stringMatching(/^[A-Za-z0-9._-]{8,40}$/);
     fc.assert(
       fc.property(token, (t) => {
-        const out = scrubString(
+        const out = redactString(
           `Authorization: Bearer ${t}`,
-          DEFAULT_SCRUB_PATTERNS,
+          DEFAULT_REDACT_PATTERNS,
         );
         expect(out).toBe("Authorization: [Filtered]");
       }),
@@ -101,9 +101,9 @@ describe("scrubString with the default patterns", () => {
     const value = fc.stringMatching(/^[A-Z0-9]{6,20}$/);
     fc.assert(
       fc.property(param, value, (p, v) => {
-        const out = scrubString(
+        const out = redactString(
           `https://example.com/cb?${p}=${v}&ok=1`,
-          DEFAULT_SCRUB_PATTERNS,
+          DEFAULT_REDACT_PATTERNS,
         );
         expect(out).toContain(`${p}=`);
         expect(out).not.toContain(v);

--- a/packages/otel-errors/src/redact.test.ts
+++ b/packages/otel-errors/src/redact.test.ts
@@ -1,51 +1,51 @@
 import { describe, expect, it } from "vitest";
 import {
-  DEFAULT_SCRUB_PATTERNS,
-  filterKeyValueData,
-  scrubAttributes,
-  scrubString,
-} from "./scrub.js";
+  DEFAULT_REDACT_PATTERNS,
+  redactAttributeKeys,
+  redactAttributes,
+  redactString,
+} from "./redact.js";
 
-describe("scrubString", () => {
+describe("redactString", () => {
   it("filters bearer tokens", () => {
     expect(
-      scrubString("auth: Bearer abc.def-123", DEFAULT_SCRUB_PATTERNS),
+      redactString("auth: Bearer abc.def-123", DEFAULT_REDACT_PATTERNS),
     ).toBe("auth: [Filtered]");
   });
 
   it("filters sensitive query params but keeps the param name", () => {
     expect(
-      scrubString("GET /cb?token=s3cret&page=2", DEFAULT_SCRUB_PATTERNS),
+      redactString("GET /cb?token=s3cret&page=2", DEFAULT_REDACT_PATTERNS),
     ).toBe("GET /cb?token=[Filtered]&page=2");
   });
 
   it("does not use lookbehind in default patterns", () => {
-    expect(DEFAULT_SCRUB_PATTERNS.map((pattern) => pattern.source)).not.toEqual(
-      expect.arrayContaining([expect.stringMatching(/\(\?<[=!]/)]),
-    );
+    expect(
+      DEFAULT_REDACT_PATTERNS.map((pattern) => pattern.source),
+    ).not.toEqual(expect.arrayContaining([expect.stringMatching(/\(\?<[=!]/)]));
   });
 
   it("filters card-shaped numbers and emails", () => {
     expect(
-      scrubString(
+      redactString(
         "card 4242 4242 4242 4242 for a@b.com",
-        DEFAULT_SCRUB_PATTERNS,
+        DEFAULT_REDACT_PATTERNS,
       ),
     ).toBe("card [Filtered] for [Filtered]");
   });
 
   it("applies custom patterns", () => {
-    expect(scrubString("ssn 123-45-6789", [/\d{3}-\d{2}-\d{4}/g])).toBe(
+    expect(redactString("ssn 123-45-6789", [/\d{3}-\d{2}-\d{4}/g])).toBe(
       "ssn [Filtered]",
     );
   });
 });
 
-describe("scrubAttributes", () => {
-  it("scrubs string values and leaves other types alone", () => {
-    const result = scrubAttributes(
+describe("redactAttributes", () => {
+  it("redacts string values and leaves other types alone", () => {
+    const result = redactAttributes(
       { url: "/cb?password=hunter2", count: 3, ok: true },
-      DEFAULT_SCRUB_PATTERNS,
+      DEFAULT_REDACT_PATTERNS,
     );
     expect(result).toEqual({
       url: "/cb",
@@ -55,12 +55,12 @@ describe("scrubAttributes", () => {
   });
 
   it("strips query and fragment from url.full before applying redaction", () => {
-    const result = scrubAttributes(
+    const result = redactAttributes(
       {
         "url.full": "https://example.com/cb?token=s3cret&page=2#section",
         other: "/cb?token=s3cret&page=2#section",
       },
-      DEFAULT_SCRUB_PATTERNS,
+      DEFAULT_REDACT_PATTERNS,
     );
     expect(result).toEqual({
       "url.full": "https://example.com/cb",
@@ -69,12 +69,12 @@ describe("scrubAttributes", () => {
   });
 
   it("strips query from url keys", () => {
-    const result = scrubAttributes(
+    const result = redactAttributes(
       {
         url: "https://example.com/path?secret=abc",
         "request.url": "https://example.com/path?secret=abc",
       },
-      DEFAULT_SCRUB_PATTERNS,
+      DEFAULT_REDACT_PATTERNS,
     );
     expect(result).toEqual({
       url: "https://example.com/path",
@@ -83,9 +83,9 @@ describe("scrubAttributes", () => {
   });
 });
 
-describe("filterKeyValueData", () => {
+describe("redactAttributeKeys", () => {
   it("filters sensitive keys with default denylist", () => {
-    const result = filterKeyValueData(
+    const result = redactAttributeKeys(
       {
         authorization: "Bearer token123",
         "x-auth-token": "token456",
@@ -107,7 +107,7 @@ describe("filterKeyValueData", () => {
   });
 
   it("does not filter ordinary words containing short sensitive snippets", () => {
-    const result = filterKeyValueData(
+    const result = redactAttributeKeys(
       {
         monkey: "banana",
         keyboard: "ansi",
@@ -125,7 +125,7 @@ describe("filterKeyValueData", () => {
   });
 
   it("leaves keys unfiltered when behavior is false", () => {
-    const result = filterKeyValueData(
+    const result = redactAttributeKeys(
       { authorization: "Bearer token123" },
       false,
     );
@@ -133,7 +133,7 @@ describe("filterKeyValueData", () => {
   });
 
   it("filters with custom deny terms", () => {
-    const result = filterKeyValueData(
+    const result = redactAttributeKeys(
       {
         "x-custom-header": "value",
         authorization: "Bearer token",
@@ -147,7 +147,7 @@ describe("filterKeyValueData", () => {
   });
 
   it("filters with allow list", () => {
-    const result = filterKeyValueData(
+    const result = redactAttributeKeys(
       {
         "content-type": "application/json",
         authorization: "Bearer token",
@@ -163,7 +163,7 @@ describe("filterKeyValueData", () => {
   });
 
   it("always filters sensitive keys even in allow list", () => {
-    const result = filterKeyValueData(
+    const result = redactAttributeKeys(
       {
         authorization: "Bearer token",
         password: "secret",

--- a/packages/otel-errors/src/redact.ts
+++ b/packages/otel-errors/src/redact.ts
@@ -83,7 +83,7 @@ function isAlphaNumeric(char: string): boolean {
   return /^[a-z0-9]$/.test(char);
 }
 
-export function filterKeyValueData(
+export function redactAttributeKeys(
   data: Attributes,
   behavior: CollectBehavior,
 ): Attributes {
@@ -114,14 +114,14 @@ export function filterKeyValueData(
   return result;
 }
 
-export const DEFAULT_SCRUB_PATTERNS: RegExp[] = [
+export const DEFAULT_REDACT_PATTERNS: RegExp[] = [
   /\bBearer\s+[\w.+/=-]+/gi,
   SENSITIVE_QUERY_PARAM_PATTERN,
   /\b\d(?:[ -]?\d){12,15}\b/g,
   /[\w.+-]+@[\w-]+\.[\w.-]+/g,
 ];
 
-export function scrubString(value: string, patterns: RegExp[]): string {
+export function redactString(value: string, patterns: RegExp[]): string {
   let out = value;
   for (const pattern of patterns) {
     out =
@@ -132,7 +132,7 @@ export function scrubString(value: string, patterns: RegExp[]): string {
   return out;
 }
 
-export function scrubAttributes(
+export function redactAttributes(
   attributes: Attributes,
   patterns: RegExp[],
 ): Attributes {
@@ -144,7 +144,7 @@ export function scrubAttributes(
     }
 
     const sanitized = isUrlKey(key) ? stripUrlQueryAndFragment(value) : value;
-    out[key] = scrubString(sanitized, patterns);
+    out[key] = redactString(sanitized, patterns);
   }
   return out;
 }

--- a/packages/otel-errors/src/scrub.properties.test.ts
+++ b/packages/otel-errors/src/scrub.properties.test.ts
@@ -1,0 +1,123 @@
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_SCRUB_PATTERNS,
+  filterKeyValueData,
+  SENSITIVE_KEY_SNIPPETS,
+  scrubString,
+  stripUrlQueryAndFragment,
+} from "./scrub.js";
+
+// Property tests for scrubbing: key filtering preserves the key set and only
+// ever swaps values for the redaction marker, and the default patterns remove
+// constructed secrets wherever they land inside a string.
+
+const word = fc.stringMatching(/^[a-z]{1,8}$/);
+
+describe("filterKeyValueData", () => {
+  const behavior = fc.oneof(
+    fc.constant<boolean>(true),
+    fc.constant<boolean>(false),
+    fc.record({ allow: fc.array(word, { maxLength: 3 }) }),
+    fc.record({ deny: fc.array(word, { maxLength: 3 }) }),
+  );
+  const data = fc.dictionary(word, fc.oneof(fc.string(), fc.integer()));
+
+  it("preserves the key set and only substitutes the marker", () => {
+    fc.assert(
+      fc.property(data, behavior, (attrs, b) => {
+        const out = filterKeyValueData(attrs, b);
+        expect(Object.keys(out).sort()).toEqual(Object.keys(attrs).sort());
+        for (const key of Object.keys(out)) {
+          expect([attrs[key], "[Filtered]"]).toContainEqual(out[key]);
+        }
+      }),
+    );
+  });
+
+  it("filters every sensitive key regardless of behavior, except false", () => {
+    const sensitiveKey = fc
+      .tuple(fc.constantFrom(...SENSITIVE_KEY_SNIPPETS), word, word)
+      .map(([snippet, before, after]) => `${before}_${snippet}_${after}`);
+    fc.assert(
+      fc.property(sensitiveKey, behavior, fc.string(), (key, b, value) => {
+        const out = filterKeyValueData({ [key]: value }, b);
+        expect(out[key]).toBe(b === false ? value : "[Filtered]");
+      }),
+    );
+  });
+
+  it("with an allow-list, keeps only keys matching an allowed term", () => {
+    fc.assert(
+      fc.property(
+        fc.dictionary(word, fc.string()),
+        fc.array(word, { minLength: 1, maxLength: 3 }),
+        (attrs, allow) => {
+          const out = filterKeyValueData(attrs, { allow });
+          for (const key of Object.keys(attrs)) {
+            const allowed = allow.some((t) => key.includes(t));
+            if (!allowed) expect(out[key]).toBe("[Filtered]");
+          }
+        },
+      ),
+    );
+  });
+});
+
+describe("scrubString with the default patterns", () => {
+  it("removes constructed email addresses wherever they appear", () => {
+    const email = fc
+      .tuple(word, word, fc.constantFrom("com", "io", "dev"))
+      .map(([local, domain, tld]) => `${local}@${domain}.${tld}`);
+    fc.assert(
+      fc.property(word, email, word, (prefix, address, suffix) => {
+        const out = scrubString(
+          `${prefix} ${address} ${suffix}`,
+          DEFAULT_SCRUB_PATTERNS,
+        );
+        expect(out).not.toContain(address);
+        expect(out).toContain("[Filtered]");
+      }),
+    );
+  });
+
+  it("removes bearer tokens", () => {
+    const token = fc.stringMatching(/^[A-Za-z0-9._-]{8,40}$/);
+    fc.assert(
+      fc.property(token, (t) => {
+        const out = scrubString(
+          `Authorization: Bearer ${t}`,
+          DEFAULT_SCRUB_PATTERNS,
+        );
+        expect(out).toBe("Authorization: [Filtered]");
+      }),
+    );
+  });
+
+  it("filters sensitive query param values but keeps the param name", () => {
+    const param = fc.constantFrom("token", "api_key", "password", "secret");
+    // Uppercase-only so the secret can never collide with a substring of the
+    // lowercase URL scaffolding or the [Filtered] marker.
+    const value = fc.stringMatching(/^[A-Z0-9]{6,20}$/);
+    fc.assert(
+      fc.property(param, value, (p, v) => {
+        const out = scrubString(
+          `https://example.com/cb?${p}=${v}&ok=1`,
+          DEFAULT_SCRUB_PATTERNS,
+        );
+        expect(out).toContain(`${p}=`);
+        expect(out).not.toContain(v);
+      }),
+    );
+  });
+});
+
+describe("stripUrlQueryAndFragment", () => {
+  it("never leaves a query or fragment behind", () => {
+    fc.assert(
+      fc.property(fc.oneof(fc.webUrl(), fc.string()), (value) => {
+        expect(stripUrlQueryAndFragment(value)).not.toMatch(/[?#]/);
+      }),
+    );
+  });
+});

--- a/packages/otel-errors/src/scrub.test.ts
+++ b/packages/otel-errors/src/scrub.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_SCRUB_PATTERNS,
+  filterKeyValueData,
+  scrubAttributes,
+  scrubString,
+} from "./scrub.js";
+
+describe("scrubString", () => {
+  it("filters bearer tokens", () => {
+    expect(
+      scrubString("auth: Bearer abc.def-123", DEFAULT_SCRUB_PATTERNS),
+    ).toBe("auth: [Filtered]");
+  });
+
+  it("filters sensitive query params but keeps the param name", () => {
+    expect(
+      scrubString("GET /cb?token=s3cret&page=2", DEFAULT_SCRUB_PATTERNS),
+    ).toBe("GET /cb?token=[Filtered]&page=2");
+  });
+
+  it("does not use lookbehind in default patterns", () => {
+    expect(DEFAULT_SCRUB_PATTERNS.map((pattern) => pattern.source)).not.toEqual(
+      expect.arrayContaining([expect.stringMatching(/\(\?<[=!]/)]),
+    );
+  });
+
+  it("filters card-shaped numbers and emails", () => {
+    expect(
+      scrubString(
+        "card 4242 4242 4242 4242 for a@b.com",
+        DEFAULT_SCRUB_PATTERNS,
+      ),
+    ).toBe("card [Filtered] for [Filtered]");
+  });
+
+  it("applies custom patterns", () => {
+    expect(scrubString("ssn 123-45-6789", [/\d{3}-\d{2}-\d{4}/g])).toBe(
+      "ssn [Filtered]",
+    );
+  });
+});
+
+describe("scrubAttributes", () => {
+  it("scrubs string values and leaves other types alone", () => {
+    const result = scrubAttributes(
+      { url: "/cb?password=hunter2", count: 3, ok: true },
+      DEFAULT_SCRUB_PATTERNS,
+    );
+    expect(result).toEqual({
+      url: "/cb",
+      count: 3,
+      ok: true,
+    });
+  });
+
+  it("strips query and fragment from url.full before applying redaction", () => {
+    const result = scrubAttributes(
+      {
+        "url.full": "https://example.com/cb?token=s3cret&page=2#section",
+        other: "/cb?token=s3cret&page=2#section",
+      },
+      DEFAULT_SCRUB_PATTERNS,
+    );
+    expect(result).toEqual({
+      "url.full": "https://example.com/cb",
+      other: "/cb?token=[Filtered]&page=2#section",
+    });
+  });
+
+  it("strips query from url keys", () => {
+    const result = scrubAttributes(
+      {
+        url: "https://example.com/path?secret=abc",
+        "request.url": "https://example.com/path?secret=abc",
+      },
+      DEFAULT_SCRUB_PATTERNS,
+    );
+    expect(result).toEqual({
+      url: "https://example.com/path",
+      "request.url": "https://example.com/path",
+    });
+  });
+});
+
+describe("filterKeyValueData", () => {
+  it("filters sensitive keys with default denylist", () => {
+    const result = filterKeyValueData(
+      {
+        authorization: "Bearer token123",
+        "x-auth-token": "token456",
+        "content-type": "application/json",
+        password: "secret",
+        "x-api-key": "key123",
+        apiKey: "key456",
+      },
+      true,
+    );
+    expect(result).toEqual({
+      authorization: "[Filtered]",
+      "x-auth-token": "[Filtered]",
+      "content-type": "application/json",
+      password: "[Filtered]",
+      "x-api-key": "[Filtered]",
+      apiKey: "[Filtered]",
+    });
+  });
+
+  it("does not filter ordinary words containing short sensitive snippets", () => {
+    const result = filterKeyValueData(
+      {
+        monkey: "banana",
+        keyboard: "ansi",
+        author: "Ada",
+        authority: "docs",
+      },
+      true,
+    );
+    expect(result).toEqual({
+      monkey: "banana",
+      keyboard: "ansi",
+      author: "Ada",
+      authority: "docs",
+    });
+  });
+
+  it("leaves keys unfiltered when behavior is false", () => {
+    const result = filterKeyValueData(
+      { authorization: "Bearer token123" },
+      false,
+    );
+    expect(result).toEqual({ authorization: "Bearer token123" });
+  });
+
+  it("filters with custom deny terms", () => {
+    const result = filterKeyValueData(
+      {
+        "x-custom-header": "value",
+        authorization: "Bearer token",
+      },
+      { deny: ["custom"] },
+    );
+    expect(result).toEqual({
+      "x-custom-header": "[Filtered]",
+      authorization: "[Filtered]",
+    });
+  });
+
+  it("filters with allow list", () => {
+    const result = filterKeyValueData(
+      {
+        "content-type": "application/json",
+        authorization: "Bearer token",
+        "x-request-id": "123",
+      },
+      { allow: ["content-type"] },
+    );
+    expect(result).toEqual({
+      "content-type": "application/json",
+      authorization: "[Filtered]",
+      "x-request-id": "[Filtered]",
+    });
+  });
+
+  it("always filters sensitive keys even in allow list", () => {
+    const result = filterKeyValueData(
+      {
+        authorization: "Bearer token",
+        password: "secret",
+      },
+      { allow: ["authorization", "password"] },
+    );
+    expect(result).toEqual({
+      authorization: "[Filtered]",
+      password: "[Filtered]",
+    });
+  });
+});

--- a/packages/otel-errors/src/scrub.ts
+++ b/packages/otel-errors/src/scrub.ts
@@ -1,0 +1,166 @@
+import type { Attributes } from "@opentelemetry/api";
+
+const FILTERED = "[Filtered]";
+const SENSITIVE_QUERY_PARAM_PATTERN =
+  /([?&](?:key|api_key|apikey|token|access_token|password|secret|sig|signature)=)[^&#\s]+/gi;
+
+export const SENSITIVE_KEY_SNIPPETS = [
+  "auth",
+  "token",
+  "secret",
+  "session",
+  "password",
+  "passwd",
+  "pwd",
+  "key",
+  "jwt",
+  "bearer",
+  "sso",
+  "saml",
+  "csrf",
+  "xsrf",
+  "credentials",
+  "sid",
+  "identity",
+];
+
+const SHORT_SENSITIVE_KEY_SNIPPETS = new Set([
+  "auth",
+  "key",
+  "sid",
+  "pwd",
+  "jwt",
+  "sso",
+  "saml",
+  "csrf",
+  "xsrf",
+]);
+
+export type CollectBehavior =
+  | boolean
+  | { allow: string[] }
+  | { deny: string[] };
+
+function isSensitiveKey(lower: string): boolean {
+  return SENSITIVE_KEY_SNIPPETS.some((snippet) =>
+    SHORT_SENSITIVE_KEY_SNIPPETS.has(snippet)
+      ? hasSensitiveShortKey(lower, snippet)
+      : lower.includes(snippet),
+  );
+}
+
+function hasSensitiveShortKey(lower: string, snippet: string): boolean {
+  if (hasDelimitedTerm(lower, snippet)) {
+    return true;
+  }
+
+  if (snippet === "auth") {
+    return lower.includes("authorization") || lower.includes("authenticat");
+  }
+
+  if (snippet === "key") {
+    return lower.includes("apikey") || lower.includes("accesskey");
+  }
+
+  return false;
+}
+
+function hasDelimitedTerm(value: string, term: string): boolean {
+  let index = value.indexOf(term);
+  while (index !== -1) {
+    const before = index === 0 ? "" : value[index - 1]!;
+    const afterIndex = index + term.length;
+    const after = afterIndex >= value.length ? "" : value[afterIndex]!;
+    if (!isAlphaNumeric(before) && !isAlphaNumeric(after)) {
+      return true;
+    }
+    index = value.indexOf(term, index + 1);
+  }
+  return false;
+}
+
+function isAlphaNumeric(char: string): boolean {
+  return /^[a-z0-9]$/.test(char);
+}
+
+export function filterKeyValueData(
+  data: Attributes,
+  behavior: CollectBehavior,
+): Attributes {
+  if (behavior === false) {
+    return { ...data };
+  }
+
+  const denyTerms =
+    behavior !== true && "deny" in behavior
+      ? behavior.deny.map((t) => t.toLowerCase())
+      : null;
+  const allowTerms =
+    behavior !== true && "allow" in behavior
+      ? behavior.allow.map((t) => t.toLowerCase())
+      : null;
+
+  const shouldFilter = (lower: string): boolean => {
+    if (isSensitiveKey(lower)) return true;
+    if (denyTerms) return denyTerms.some((term) => lower.includes(term));
+    if (allowTerms) return !allowTerms.some((term) => lower.includes(term));
+    return false; // behavior === true: only sensitive keys are filtered
+  };
+
+  const result: Attributes = {};
+  for (const key of Object.keys(data)) {
+    result[key] = shouldFilter(key.toLowerCase()) ? FILTERED : data[key]!;
+  }
+  return result;
+}
+
+export const DEFAULT_SCRUB_PATTERNS: RegExp[] = [
+  /\bBearer\s+[\w.+/=-]+/gi,
+  SENSITIVE_QUERY_PARAM_PATTERN,
+  /\b\d(?:[ -]?\d){12,15}\b/g,
+  /[\w.+-]+@[\w-]+\.[\w.-]+/g,
+];
+
+export function scrubString(value: string, patterns: RegExp[]): string {
+  let out = value;
+  for (const pattern of patterns) {
+    out =
+      pattern === SENSITIVE_QUERY_PARAM_PATTERN
+        ? out.replace(pattern, `$1${FILTERED}`)
+        : out.replace(pattern, FILTERED);
+  }
+  return out;
+}
+
+export function scrubAttributes(
+  attributes: Attributes,
+  patterns: RegExp[],
+): Attributes {
+  const out: Attributes = {};
+  for (const [key, value] of Object.entries(attributes)) {
+    if (typeof value !== "string") {
+      out[key] = value;
+      continue;
+    }
+
+    const sanitized = isUrlKey(key) ? stripUrlQueryAndFragment(value) : value;
+    out[key] = scrubString(sanitized, patterns);
+  }
+  return out;
+}
+
+function isUrlKey(key: string): boolean {
+  const lower = key.toLowerCase();
+  return lower === "url.full" || lower === "url" || lower.endsWith(".url");
+}
+
+export function stripUrlQueryAndFragment(value: string): string {
+  try {
+    const url = new URL(value);
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return value.split(/[?#]/, 1)[0] ?? "";
+  }
+}

--- a/packages/otel-errors/src/test-utils.ts
+++ b/packages/otel-errors/src/test-utils.ts
@@ -1,0 +1,46 @@
+import { context, trace } from "@opentelemetry/api";
+import { logs } from "@opentelemetry/api-logs";
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
+import {
+  InMemoryLogRecordExporter,
+  LoggerProvider,
+  SimpleLogRecordProcessor,
+} from "@opentelemetry/sdk-logs";
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+
+export function setupTestTelemetry() {
+  const contextManager = new AsyncLocalStorageContextManager();
+  context.setGlobalContextManager(contextManager.enable());
+
+  const logExporter = new InMemoryLogRecordExporter();
+  const loggerProvider = new LoggerProvider({
+    processors: [new SimpleLogRecordProcessor(logExporter)],
+  });
+  logs.setGlobalLoggerProvider(loggerProvider);
+
+  const spanExporter = new InMemorySpanExporter();
+  const tracerProvider = new BasicTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(spanExporter)],
+  });
+  trace.setGlobalTracerProvider(tracerProvider);
+
+  return {
+    records: () => logExporter.getFinishedLogRecords(),
+    spans: () => spanExporter.getFinishedSpans(),
+    reset() {
+      logExporter.reset();
+      spanExporter.reset();
+    },
+    async dispose() {
+      await loggerProvider.shutdown();
+      await tracerProvider.shutdown();
+      context.disable();
+      logs.disable();
+      trace.disable();
+    },
+  };
+}

--- a/packages/otel-errors/src/types.ts
+++ b/packages/otel-errors/src/types.ts
@@ -1,0 +1,41 @@
+import type { Attributes } from "@opentelemetry/api";
+import type { CollectBehavior } from "./scrub.js";
+
+/**
+ * How the error reached us. The three names this package produces stay in the
+ * union for completions; the `(string & {})` arm lets other SDKs built on the
+ * core Client (notably @everr/otel-web, which reports `onerror` and `react`)
+ * pass their own vocabulary uncast, rather than encoding a browser SDK's
+ * mechanisms in a Node package's closed type.
+ */
+export type Mechanism =
+  | "uncaughtException"
+  | "unhandledrejection"
+  | "manual"
+  | (string & {});
+
+export type ErrorSeverity = "debug" | "info" | "warn" | "error" | "fatal";
+
+export interface ErrorEvent {
+  error: unknown;
+  message: string;
+  severity: ErrorSeverity;
+  mechanism: Mechanism;
+  handled: boolean;
+  attributes: Attributes;
+}
+
+export interface Options {
+  /** Drops the event when it returns null, or rewrites it in place. */
+  beforeSend?: (event: ErrorEvent) => ErrorEvent | null;
+  redactPatterns?: RegExp[];
+  redactKeys?: CollectBehavior;
+  /** Per-fingerprint throttle. `false` disables it. Defaults to 5 per 5s. */
+  rateLimit?: { count: number; windowMs: number } | false;
+  /**
+   * What to do after a fatal error is flushed. "exit" (the default) restores
+   * the crash Node would have performed had no listener been installed;
+   * "continue" leaves the process running.
+   */
+  onFatal?: "exit" | "continue";
+}

--- a/packages/otel-errors/src/types.ts
+++ b/packages/otel-errors/src/types.ts
@@ -21,8 +21,8 @@ export interface ErrorEvent {
   message: string;
   severity: ErrorSeverity;
   mechanism: Mechanism;
-  handled: boolean;
-  attributes: Attributes;
+  /** The caller-supplied attributes attached to this error. */
+  context: Attributes;
 }
 
 export interface Options {

--- a/packages/otel-errors/src/types.ts
+++ b/packages/otel-errors/src/types.ts
@@ -25,17 +25,22 @@ export interface ErrorEvent {
   context: Attributes;
 }
 
-export interface Options {
+/**
+ * The shared client's configuration, applied through `configure`. Every field
+ * is optional and every call merges: an absent key keeps its current value, a
+ * present one replaces that field wholesale. There is no deep merge, so a
+ * `redactPatterns` array is the whole set and never a union with the last one.
+ *
+ * Each field carries its own "off" value (`rateLimit: false`,
+ * `redactPatterns: []`, `redactKeys: false`). `beforeSend` is the exception:
+ * `undefined` is indistinguishable from absent under a merge, so `null` is
+ * how a caller removes a hook it installed.
+ */
+export interface ClientOptions {
   /** Drops the event when it returns null, or rewrites it in place. */
-  beforeSend?: (event: ErrorEvent) => ErrorEvent | null;
+  beforeSend?: ((event: ErrorEvent) => ErrorEvent | null) | null;
   redactPatterns?: RegExp[];
   redactKeys?: CollectBehavior;
   /** Per-fingerprint throttle. `false` disables it. Defaults to 5 per 5s. */
   rateLimit?: { count: number; windowMs: number } | false;
-  /**
-   * What to do after a fatal error is flushed. "exit" (the default) restores
-   * the crash Node would have performed had no listener been installed;
-   * "continue" leaves the process running.
-   */
-  onFatal?: "exit" | "continue";
 }

--- a/packages/otel-errors/src/types.ts
+++ b/packages/otel-errors/src/types.ts
@@ -1,5 +1,5 @@
 import type { Attributes } from "@opentelemetry/api";
-import type { CollectBehavior } from "./scrub.js";
+import type { CollectBehavior } from "./redact.js";
 
 /**
  * How the error reached us. The three names this package produces stay in the
@@ -14,7 +14,7 @@ export type Mechanism =
   | "manual"
   | (string & {});
 
-export type ErrorSeverity = "debug" | "info" | "warn" | "error" | "fatal";
+export type ErrorSeverity = "error" | "fatal";
 
 export interface ErrorEvent {
   error: unknown;

--- a/packages/otel-errors/src/version.ts
+++ b/packages/otel-errors/src/version.ts
@@ -1,0 +1,9 @@
+// The OTel instrumentation scope stamped on every record this package emits.
+// Renamed from @everr/auto-otel-errors in 0.1.0: queries filtering on the old
+// scope name see no rows after upgrading.
+export const PKG_NAME = "@everr/otel-errors";
+
+declare const __PACKAGE_VERSION__: string | undefined;
+
+export const PKG_VERSION =
+  typeof __PACKAGE_VERSION__ === "string" ? __PACKAGE_VERSION__ : "0.0.0-dev";

--- a/packages/otel-errors/test/fixtures/fixture-sdk.mjs
+++ b/packages/otel-errors/test/fixtures/fixture-sdk.mjs
@@ -13,77 +13,60 @@ function writeLine(payload) {
   process.stdout.write(`${JSON.stringify(payload)}\n`);
 }
 
-class StdoutLogExporter {
-  export(records, resultCallback) {
-    for (const record of records) {
-      writeLine({
-        kind: "log",
-        body: record.body,
-        eventName: record.eventName,
-        severityNumber: record.severityNumber,
-        mechanism: record.attributes["everr.error.mechanism"],
-      });
-    }
-    resultCallback({ code: 0 });
-  }
-
-  shutdown() {
-    return Promise.resolve();
-  }
-
-  forceFlush() {
-    return Promise.resolve();
-  }
-}
-
-class StdoutMetricExporter {
-  export(metrics, resultCallback) {
-    for (const scope of metrics.scopeMetrics ?? []) {
-      for (const metric of scope.metrics ?? []) {
-        writeLine({ kind: "metric", name: metric.descriptor.name });
+/** An exporter that writes one JSON line per payload produced by `toPayloads`. */
+function stdoutExporter(toPayloads) {
+  return {
+    export(batch, resultCallback) {
+      for (const payload of toPayloads(batch)) {
+        writeLine(payload);
       }
-    }
-    resultCallback({ code: 0 });
-  }
-
-  shutdown() {
-    return Promise.resolve();
-  }
-
-  forceFlush() {
-    return Promise.resolve();
-  }
+      resultCallback({ code: 0 });
+    },
+    shutdown() {
+      return Promise.resolve();
+    },
+    forceFlush() {
+      return Promise.resolve();
+    },
+  };
 }
 
-class StdoutSpanExporter {
-  export(spans, resultCallback) {
-    for (const span of spans) {
-      writeLine({ kind: "span", name: span.name });
-    }
-    resultCallback({ code: 0 });
-  }
+const stdoutLogExporter = () =>
+  stdoutExporter((records) =>
+    records.map((record) => ({
+      kind: "log",
+      body: record.body,
+      eventName: record.eventName,
+      severityNumber: record.severityNumber,
+      mechanism: record.attributes["everr.error.mechanism"],
+    })),
+  );
 
-  shutdown() {
-    return Promise.resolve();
-  }
+const stdoutMetricExporter = () =>
+  stdoutExporter((metrics) =>
+    (metrics.scopeMetrics ?? []).flatMap((scope) =>
+      (scope.metrics ?? []).map((metric) => ({
+        kind: "metric",
+        name: metric.descriptor.name,
+      })),
+    ),
+  );
 
-  forceFlush() {
-    return Promise.resolve();
-  }
-}
+const stdoutSpanExporter = () =>
+  stdoutExporter((spans) => spans.map((span) => ({ kind: "span", name: span.name })));
 
 /** Registers the SDK exactly as an application does, and returns it. */
 export function startSdk(config = {}) {
   const sdk = new NodeSDK({
     logRecordProcessors: [
-      new BatchLogRecordProcessor(new StdoutLogExporter(), NEVER_ON_A_TIMER),
+      new BatchLogRecordProcessor(stdoutLogExporter(), NEVER_ON_A_TIMER),
     ],
     spanProcessors: [
-      new BatchSpanProcessor(new StdoutSpanExporter(), NEVER_ON_A_TIMER),
+      new BatchSpanProcessor(stdoutSpanExporter(), NEVER_ON_A_TIMER),
     ],
     metricReaders: [
       new PeriodicExportingMetricReader({
-        exporter: new StdoutMetricExporter(),
+        exporter: stdoutMetricExporter(),
         exportIntervalMillis: 300_000,
       }),
     ],

--- a/packages/otel-errors/test/fixtures/fixture-sdk.mjs
+++ b/packages/otel-errors/test/fixtures/fixture-sdk.mjs
@@ -1,0 +1,94 @@
+import { BatchLogRecordProcessor } from "@opentelemetry/sdk-logs";
+import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { ErrorsInstrumentation } from "../../dist/node.js";
+
+// Batch processors with a delay far longer than the fixture's life: nothing
+// reaches stdout unless the fatal path's forceFlush delivers it. A simple
+// processor would pass these tests without a flush at all.
+const NEVER_ON_A_TIMER = { scheduledDelayMillis: 300_000 };
+
+function writeLine(payload) {
+  process.stdout.write(`${JSON.stringify(payload)}\n`);
+}
+
+class StdoutLogExporter {
+  export(records, resultCallback) {
+    for (const record of records) {
+      writeLine({
+        kind: "log",
+        body: record.body,
+        eventName: record.eventName,
+        severityNumber: record.severityNumber,
+        mechanism: record.attributes["everr.error.mechanism"],
+      });
+    }
+    resultCallback({ code: 0 });
+  }
+
+  shutdown() {
+    return Promise.resolve();
+  }
+
+  forceFlush() {
+    return Promise.resolve();
+  }
+}
+
+class StdoutMetricExporter {
+  export(metrics, resultCallback) {
+    for (const scope of metrics.scopeMetrics ?? []) {
+      for (const metric of scope.metrics ?? []) {
+        writeLine({ kind: "metric", name: metric.descriptor.name });
+      }
+    }
+    resultCallback({ code: 0 });
+  }
+
+  shutdown() {
+    return Promise.resolve();
+  }
+
+  forceFlush() {
+    return Promise.resolve();
+  }
+}
+
+class StdoutSpanExporter {
+  export(spans, resultCallback) {
+    for (const span of spans) {
+      writeLine({ kind: "span", name: span.name });
+    }
+    resultCallback({ code: 0 });
+  }
+
+  shutdown() {
+    return Promise.resolve();
+  }
+
+  forceFlush() {
+    return Promise.resolve();
+  }
+}
+
+/** Registers the SDK exactly as an application does, and returns it. */
+export function startSdk(config = {}) {
+  const sdk = new NodeSDK({
+    logRecordProcessors: [
+      new BatchLogRecordProcessor(new StdoutLogExporter(), NEVER_ON_A_TIMER),
+    ],
+    spanProcessors: [
+      new BatchSpanProcessor(new StdoutSpanExporter(), NEVER_ON_A_TIMER),
+    ],
+    metricReaders: [
+      new PeriodicExportingMetricReader({
+        exporter: new StdoutMetricExporter(),
+        exportIntervalMillis: 300_000,
+      }),
+    ],
+    instrumentations: [new ErrorsInstrumentation(config)],
+  });
+  sdk.start();
+  return sdk;
+}

--- a/packages/otel-errors/test/fixtures/rejection-exit.mjs
+++ b/packages/otel-errors/test/fixtures/rejection-exit.mjs
@@ -1,0 +1,5 @@
+import { startSdk } from "./fixture-sdk.mjs";
+
+startSdk();
+
+Promise.reject(new Error("fixture-rejection"));

--- a/packages/otel-errors/test/fixtures/uncaught-continue.mjs
+++ b/packages/otel-errors/test/fixtures/uncaught-continue.mjs
@@ -1,0 +1,9 @@
+import { startSdk } from "./fixture-sdk.mjs";
+
+startSdk({ onFatal: "continue" });
+
+setTimeout(() => {
+  throw new Error("fixture-survivable");
+}, 10);
+
+setTimeout(() => process.exit(0), 200);

--- a/packages/otel-errors/test/fixtures/uncaught-exit.mjs
+++ b/packages/otel-errors/test/fixtures/uncaught-exit.mjs
@@ -1,0 +1,16 @@
+import { metrics, trace } from "@opentelemetry/api";
+import { startSdk } from "./fixture-sdk.mjs";
+
+startSdk();
+
+// Ends a span that stays queued in the batch processor. It can only reach
+// stdout if the fatal path flushes the TracerProvider as well as the logs.
+trace.getTracer("fixture").startSpan("pre-crash").end();
+
+// Same for a metric: the reader's interval is far longer than this process
+// lives, so it can only reach stdout if the fatal path flushes the meter.
+metrics.getMeter("fixture").createCounter("pre_crash_total").add(1);
+
+setTimeout(() => {
+  throw new Error("fixture-crash");
+}, 10);

--- a/packages/otel-errors/tsconfig.json
+++ b/packages/otel-errors/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "src/test-utils.ts"],
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/packages/otel-errors/tsdown.config.ts
+++ b/packages/otel-errors/tsdown.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "tsdown";
+
+const packageVersion = process.env.npm_package_version ?? "0.0.0-dev";
+
+export default defineConfig({
+  entry: {
+    node: "src/node.ts",
+    core: "src/core.ts",
+  },
+  format: ["esm", "cjs"],
+  dts: true,
+  platform: "neutral",
+  external: [/^@opentelemetry\//, /^node:/],
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageVersion),
+  },
+});

--- a/packages/otel-errors/vitest.config.ts
+++ b/packages/otel-errors/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    reporters: ["verbose"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -610,6 +610,42 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0(typescript@6.0.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/otel-errors:
+    devDependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.1
+        version: 1.9.1
+      '@opentelemetry/api-logs':
+        specifier: ^0.218.0
+        version: 0.218.0
+      '@opentelemetry/context-async-hooks':
+        specifier: ^2.7.1
+        version: 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation':
+        specifier: ^0.218.0
+        version: 0.218.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs':
+        specifier: ^0.218.0
+        version: 0.218.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics':
+        specifier: ^2.7.1
+        version: 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-node':
+        specifier: ^0.218.0
+        version: 0.218.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^2.7.1
+        version: 2.7.1(@opentelemetry/api@1.9.1)
+      '@types/node':
+        specifier: ^25.6.2
+        version: 25.6.2
+      tsdown:
+        specifier: ^0.22.2
+        version: 0.22.2(tsx@4.21.0)(typescript@6.0.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+
   packages/telemetry-explorer:
     dependencies:
       '@everr/datemath':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -639,6 +639,9 @@ importers:
       '@types/node':
         specifier: ^25.6.2
         version: 25.6.2
+      fast-check:
+        specifier: ^4.9.0
+        version: 4.9.0
       tsdown:
         specifier: ^0.22.2
         version: 0.22.2(tsx@4.21.0)(typescript@6.0.3)
@@ -5423,6 +5426,10 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  fast-check@4.9.0:
+    resolution: {integrity: sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==}
+    engines: {node: '>=12.17.0'}
+
   fast-decode-uri-component@1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
 
@@ -6866,6 +6873,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@8.4.2:
+    resolution: {integrity: sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==}
 
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
@@ -12818,6 +12828,10 @@ snapshots:
       '@fallow-cli/win32-arm64-msvc': 2.75.0
       '@fallow-cli/win32-x64-msvc': 2.75.0
 
+  fast-check@4.9.0:
+    dependencies:
+      pure-rand: 8.4.2
+
   fast-decode-uri-component@1.0.1: {}
 
   fast-deep-equal@3.1.3: {}
@@ -14574,6 +14588,8 @@ snapshots:
       ipaddr.js: 1.9.1
 
   punycode@2.3.1: {}
+
+  pure-rand@8.4.2: {}
 
   qs@6.15.2:
     dependencies:


### PR DESCRIPTION
Part 1/4 of the browser telemetry stack (#337 → #338 → #339 → #340). Replaces #335, split for review.

## User-facing changes

- **For SDK users**: error tracking is now wired like any other OpenTelemetry instrumentation — `new NodeSDK({ instrumentations: [new ErrorsInstrumentation()] })`. No separate `init()` call, no double setup.
- A fatal error now flushes **logs, spans, and metrics** before the process exits (previously logs only), so the last trace of a crash is never lost.
- **Query impact**: the instrumentation scope on emitted records changes from `@everr/auto-otel-errors` to `@everr/otel-errors`. Saved queries filtering on the old scope name return no rows after upgrading.

## What's inside

New `@everr/otel-errors` package replacing `@everr/auto-otel-errors` (the old package stays in-tree until its consumers migrate in part 3, where it is deleted).

- Node runtime only: the `browser`, `express`, `fastify`, and `react` entries are removed. Browser error capture moves to `@everr/otel-web` (part 2).
- New `./core` entry with the runtime-neutral capture path (Client, normalization, redaction, rate limiting) for SDKs that drive it themselves.
- Property tests (fast-check) over the pure seams: normalization never throws for anything JavaScript can throw, scrubbing never leaks constructed secrets, and the rate limiter never exceeds its window.