### PR TITLE
feat(skills): full-stack OTel rules for Vite SSR and TanStack Start, skill eval harness

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -27,6 +27,8 @@
     // size-limit's own config file, resolved by its CLI at runtime; nothing
     // in the package imports it.
     "packages/otel-web/.size-limit.cjs",
+    // On-demand skill eval runner, invoked directly with `node`.
+    "evals/setup-telemetry/run.mjs",
   ],
   // The two @opentelemetry/* entries are imported only by the OTel web SDK
   // sample in content/docs/guides/browser-telemetry.mdx (the reader

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,3 +39,5 @@ When I mention "production" as target, use everr instead of everr-dev.
 ## Web SDK `packages/otel-web`
 
 Keep the bundle size minimal and measure the size using `pnpm size` at each meaningful iteration.
+
+When adding, renaming, or removing an emitted event or attribute, update the catalog in `crates/everr-core/assets/skills/everr-use-telemetry/rules/browser-events.md`.

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/SKILL.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/SKILL.md
@@ -27,20 +27,22 @@ Always read the relevant rule files before editing instrumentation. Use the tabl
 | --- | --- |
 | `resolve-values` | Resolve configuration values from the codebase before hardcoding or asking |
 | `resources` | Resource attributes: service identity, version, environment, instance |
+| `error-tracking` | Error capture contract for stacks without an `@everr` SDK (Python, Go, Java, ...) |
 | `spans` | Spans: naming, kind, status, attributes, and hygiene |
 | `logs` | Logs: structured logging, severity, trace correlation, delivery |
 | `metrics` | Metrics: instrument types, naming, units, and cardinality |
-| `error-tracking` | Error tracking: exceptions, release context, crash capture |
 | `sensitive-data` | PII prevention, sanitization, hashing, redaction |
 | `validation` | Telemetry validation locally and after deployment |
 | `nodejs` | Node.js instrumentation setup and runtime pitfalls |
 | `nextjs` | Next.js App Router, server/client split, trace propagation |
 | `browser` | Web frontends exporting OTLP directly from the browser with a public origin-bound key |
+| `vite-ssr` | Full-stack Vite apps with Node SSR: wiring both halves and joining browser and server traces |
+| `tanstack-start` | TanStack Start: router-aware browser telemetry, request spans, and server function middleware |
 | `tauri` | Tauri v2 desktop/mobile: Rust backend + browser frontend proxying telemetry through IPC |
 | `electron` | Electron desktop: Node main process + Chromium renderer proxying telemetry through IPC |
 | `rust` | Rust tracing-based OpenTelemetry setup and runtime pitfalls |
 
-For most runtime work, read `resolve-values`, `resources`, `error-tracking`, `sensitive-data`, `validation`, and the signal/runtime rules that match the task.
+For most runtime work, read `resolve-values`, `resources`, `sensitive-data`, `validation`, and the signal/runtime rules that match the task.
 
 ## Default Workflow
 
@@ -55,7 +57,8 @@ For most runtime work, read `resolve-values`, `resources`, `error-tracking`, `se
 7. Configure endpoint selection for both environments: local development exports to the `otlp:` URL from `everr local status`; production exports to `https://ingest.everr.dev/` with an ingest key from the secret manager.
 8. Gate local-only exporters so local collector URLs do not ship in production bundles, and gate hosted ingest so it only runs when a production ingest key is present.
 9. Trigger the instrumented path and verify fresh local rows with `everr local query`, filtered by the expected `ServiceName`, a recent time window, and a unique run, request, or test id when practical.
-10. Do not claim setup works until query results prove the new telemetry came from the path just exercised.
+10. Run the project's production build (or its typecheck when no build exists). Dev servers skip strict type checking, so telemetry that flows in dev can still break the build.
+11. Do not claim setup works until query results prove the new telemetry came from the path just exercised and the build passes.
 
 ## Command Choice
 
@@ -145,4 +148,5 @@ See `rules/validation.md` for the full validation checklist.
 | Adding a run, request, or test marker but querying only by service and time | Filter the query by the marker too, or do not claim the marker proved freshness. |
 | Mirroring every `console.*` call into logs | Prefer targeted OTel logs or the app's structured logger; any bridge must be temporary, gated, redacted, and bounded. |
 | Verifying by UI visibility or absence of exporter errors | Run `everr local query` and show rows from the exercised path. |
+| Validating only against the dev server | Run the production build too; strict type checking is skipped in dev, and OTLP exporter `headers` options are a common casualty (a conditional headers value uses `undefined` for the keyless branch, never `{}`). |
 | Exposing `EVERR_INGEST_KEY` to the browser | Browsers use a public origin-bound ingest key (`rules/browser.md`); secret keys stay server-side. |

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/browser.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/browser.md
@@ -4,62 +4,63 @@ Use this rule for web apps that send OpenTelemetry directly from the browser: SP
 
 ## Key Model
 
-Anything shipped to a browser is visible to every visitor, so browser ingestion never uses a secret key. Everr has two API key kinds and the split is strict:
-
-- **Public keys**: created with **Public browser key** enabled and an origin allowlist. Safe to ship in page source: they only authenticate requests whose `Origin` header matches the allowlist, they are rejected without an `Origin` header (so they are useless server-side), and they can only send telemetry, never `everr apply` or any other API.
-- **Secret keys** (`EVERR_INGEST_KEY`): server-to-server only. Rejected the moment a browser `Origin` header appears. Never put one in a browser bundle, client env var, or page source.
-
 If production browser telemetry is needed and no public key exists, tell the user to mint one in the Everr dashboard: user menu, **API keys**, **New key**, turn on **Public browser key**, and add every origin the app is served from (`scheme://host` with an optional port, no paths). Origins cannot be edited later; changing them means minting a new key and rotating the value in the frontend config. Do not invent, print, or commit key values.
 
 ## Endpoint And Gating
 
 - Local development: export to the local collector URL from `everr local status`. It accepts browser OTLP with no key and no origin setup.
 - Production: export to `https://ingest.everr.dev/` with `Authorization: Bearer <public-key>`.
-- Inject the public key through a client build-time variable, for example `VITE_EVERR_PUBLIC_INGEST_KEY` in Vite. Public keys are not secrets, but keep the value out of the repo so it can rotate without a commit.
-- Gate on the key: when the variable is unset in a production build, telemetry must be a no-op so a keyless deploy never POSTs anywhere. In dev builds, fall back to the local collector so developers see their own browser telemetry with no setup.
-- Guard for the browser (`typeof window === "undefined"` returns early) so the module is a no-op during SSR.
+- Inject the public key through a client build-time variable, for example `VITE_EVERR_PUBLIC_INGEST_KEY` in Vite.
+- No SSR guard is needed: `@everr/otel-web`'s WebSDK resolves a server entry under the `node` export condition and is inert there.
 
 ## Setup
 
-Run normal OTel web providers with OTLP/HTTP exporters pointed at the resolved endpoint. Logs, with error capture wired on top:
+```bash
+npm install @everr/otel-web
+```
 
 ```ts
-import { init as initErrorTracking } from "@everr/auto-otel-errors/browser";
-import { logs } from "@opentelemetry/api-logs";
-import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
-import { resourceFromAttributes } from "@opentelemetry/resources";
-import { BatchLogRecordProcessor, LoggerProvider } from "@opentelemetry/sdk-logs";
+// src/telemetry.ts, imported once before the app renders
+import { errors, interactions, network, pageviews, performance, WebSDK } from "@everr/otel-web";
 
-const loggerProvider = new LoggerProvider({
-  resource: resourceFromAttributes({
-    "service.name": "<browser-service-name>",
-    "service.version": "<version>",
-    "deployment.environment.name": "<environment>",
-    "service.instance.id": crypto.randomUUID(),
-  }),
-  processors: [
-    new BatchLogRecordProcessor(
-      new OTLPLogExporter({
-        url: `${endpoint}/v1/logs`,
-        headers, // { Authorization: `Bearer ${publicKey}` } in production, none locally
-      }),
-    ),
-  ],
-});
-logs.setGlobalLoggerProvider(loggerProvider);
-
-// Transport-less: init() is a no-op unless a global LoggerProvider is
-// registered first. Installs window error / unhandledrejection handlers.
-initErrorTracking();
-
-window.addEventListener("beforeunload", () => {
-  void loggerProvider.shutdown(); // best-effort flush of batched records
+new WebSDK({
+  serviceName: "<browser-service-name>",
+  serviceVersion: "<version>",
+  deploymentEnvironment: import.meta.env.MODE,
+  // Unset in a production build makes the WebSDK inert: no emitter is built, so
+  // a keyless deploy structurally cannot POST anywhere. Dev with no key falls
+  // back to the local collector.
+  ingestKey: import.meta.env.VITE_EVERR_PUBLIC_INGEST_KEY,
+  dev: import.meta.env.DEV,
+  // Capture is opt-in. errors() owns the window error/unhandledrejection
+  // handlers; never register your own alongside it, that double-captures.
+  instrumentations: [errors(), pageviews(), interactions(), performance(), network()],
 });
 ```
 
-Traces work the same way with `WebTracerProvider` plus `OTLPTraceExporter` (`/v1/traces`), metrics with `/v1/metrics`. For React render errors, add the `@everr/auto-otel-errors/react` `ErrorBoundary` at the root.
+Batches flush on a timer and on page hide, over `fetch` with `keepalive`.
+
+For React render errors, add the error boundary at the root:
+
+```tsx
+import { ErrorBoundary } from "@everr/otel-web/react";
+
+<ErrorBoundary fallback={<Oops />}>{children}</ErrorBoundary>;
+```
+
+Manual capture rides the same pipeline: `captureError(error, attributes)`, `logger.info(message, attributes)`, `identify(userId, traits)`, `setAttributes({ ... })`.
+
+Error tracking hint: `errors()` plus the `ErrorBoundary` is the whole browser story; each error must be recorded exactly once, so throw a synthetic error and check the collector shows one record, not two (a hand-rolled `window` listener next to `errors()` is the usual double).
 
 Choose a browser `service.name` distinct from the server's, per `resources.md`, so the two sides stay separable in queries.
+
+### Identity And Consent
+
+`persistence: "localStorage"` (the default) keeps a random visitor id and 30-minute-inactivity sessions across reloads and tabs. `persistence: "memory"` uses zero cookies and zero storage. The event schema is identical either way, so a consent-gated app boots with `"memory"` and re-initializes with `"localStorage"` once consent is granted.
+
+### When The App Already Runs An OTel SDK
+
+If the page already has a `LoggerProvider` for other reasons, keep it and let `@everr/otel-web` run its own pipeline alongside; they do not conflict. Do not hand-roll `window` error listeners to feed the existing provider, and do not add `@everr/otel-errors`: that package is Node-only.
 
 ## Validation
 

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/electron.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/electron.md
@@ -2,16 +2,9 @@
 
 Use this rule for Electron apps that need error telemetry from both the Node main process and the Chromium renderer.
 
-An Electron app has three contexts: the **main** process (Node), the **renderer** (Chromium, sandboxed), and the **preload** script (the bridge). The renderer should not hold the ingest key or reach the collector directly, so the main process is an **OTLP passthrough proxy**: the renderer runs a normal OTel provider + exporter, serializes each log batch to encoded OTLP, and sends the bytes to the main process over IPC, which forwards them to the collector unchanged.
+The renderer should not hold the ingest key or reach the collector directly, so the main process is an **OTLP passthrough proxy**: the renderer runs a normal OTel provider + exporter, serializes each log batch to encoded OTLP, and sends the bytes to the main process over IPC, which forwards them to the collector unchanged.
 
-The main process is itself a Node process: set up its own telemetry and error capture per `nodejs.md` (`@everr/auto-otel-errors/node`), and reuse that exporter config to drive the proxy.
-
-This rule is app-agnostic. Resolve concrete values from the app before editing code. Use placeholders in plans until the values are known:
-
-- `<service-name>`
-- `<release-version>`
-- `<deployment-environment>`
-- `<otlp-url-from-status>`
+The main process is itself a Node process: set up its own telemetry and error capture per `nodejs.md` (`@everr/otel-errors`), and reuse that exporter config to drive the proxy.
 
 ## Resource Attributes
 
@@ -29,17 +22,19 @@ Hardcode one stable `service.name` for the app (`<service-name>`) and use `proce
 
 ## Package Setup
 
-Renderer dependencies — `@opentelemetry/otlp-transformer` provides the serializer that turns logs into OTLP the proxy forwards:
+Renderer dependencies:
 
 ```bash
-npm install @everr/auto-otel-errors @opentelemetry/api @opentelemetry/api-logs @opentelemetry/core @opentelemetry/otlp-transformer @opentelemetry/resources @opentelemetry/sdk-logs @opentelemetry/semantic-conventions
+npm install @everr/otel-web
 ```
 
-Main-process dependencies are the Node setup from `nodejs.md` (`@everr/auto-otel-errors @opentelemetry/sdk-node @opentelemetry/auto-instrumentations-node` and the OTLP exporters). The proxy itself needs no extra package — it POSTs with Electron's `net` module.
+That is the whole renderer dependency list: the SDK builds OTLP itself, so the renderer carries no OpenTelemetry packages at all.
+
+Main-process dependencies are the Node setup from `nodejs.md` (`@everr/otel-errors @opentelemetry/instrumentation @opentelemetry/sdk-node @opentelemetry/auto-instrumentations-node` and the OTLP exporters). The proxy itself needs no extra package: it POSTs with Electron's `net` module.
 
 ## Runtime Configuration
 
-Only the main process reads exporter configuration. The renderer runs its own `LoggerProvider` with a custom exporter that serializes each log batch to OTLP/JSON and calls the preload-exposed `proxyOtlpLogs`. The main process forwards the encoded bytes to `{endpoint}/v1/logs` with the configured headers. The main process's own telemetry exports directly through its SDK.
+Only the main process reads exporter configuration. The renderer runs `@everr/otel-web`, which builds each OTLP/JSON payload itself and calls the preload-exposed `proxyOtlp`. The main process forwards the encoded bytes to `{endpoint}/v1/{signal}` with the configured headers. The main process's own telemetry exports directly through its SDK.
 
 ```bash
 # Local development
@@ -52,13 +47,13 @@ EVERR_INGEST_KEY=<secret-manager-reference>
 
 ## Main Process: Telemetry Context And Proxy
 
-Create one telemetry context at startup, set up the main-process SDK + error capture (per `nodejs.md`), and register the IPC handlers. The `everr:proxy-otlp-logs` handler is transport, not an application telemetry API: it validates the payload size, attaches the configured headers, and POSTs the bytes. It never deserializes or rebuilds telemetry.
+Create one telemetry context at startup, set up the main-process SDK + error capture (per `nodejs.md`), and register the IPC handlers. The `everr:proxy-otlp` handler is transport, not an application telemetry API: it validates the payload size, attaches the configured headers, and POSTs the bytes. It never deserializes or rebuilds telemetry.
 
 ```ts
 // main/telemetry.ts
 import { randomUUID } from 'node:crypto';
 import { app, ipcMain, net } from 'electron';
-import { init as initErrorTracking } from '@everr/auto-otel-errors/node';
+import { ErrorsInstrumentation } from '@everr/otel-errors';
 // ... plus the NodeSDK setup from nodejs.md ...
 
 const SERVICE_NAME = '<service-name>';
@@ -85,8 +80,9 @@ export function setupMainTelemetry(): void {
 
   // Main-process SDK uses the nodejs.md NodeSDK setup with SERVICE_NAME, and must
   // add process.type = main to its resource (nodejs.md does not add it by default).
+  // Its `instrumentations` array carries `new ErrorsInstrumentation()` for the
+  // main process's own crash handlers.
   startMainSdk({ ...baseContext, processType: 'main' });
-  initErrorTracking();
 
   const rendererContext: TelemetryContext = {
     ...baseContext,
@@ -98,28 +94,30 @@ export function setupMainTelemetry(): void {
 function registerTelemetryIpc(config: TelemetryConfig, context: TelemetryContext) {
   ipcMain.handle('everr:telemetry-context', () => context);
 
-  ipcMain.handle('everr:proxy-otlp-logs', async (_event, body: string) => {
-    if (!config) return; // telemetry disabled
-    if (body.length > MAX_OTLP_BODY_BYTES) {
-      throw new Error(`otlp payload too large: ${body.length} bytes`);
-    }
+  ipcMain.handle(
+    'everr:proxy-otlp',
+    async (_event, signal: 'logs' | 'traces', body: string) => {
+      if (!config) return; // telemetry disabled
+      if (body.length > MAX_OTLP_BODY_BYTES) {
+        throw new Error(`otlp payload too large: ${body.length} bytes`);
+      }
 
-    // net.fetch respects the app's proxy/cert configuration. OTLP/JSON is UTF-8
-    // text, so body is forwarded as-is with content-type application/json.
-    const response = await net.fetch(logsUrl(config.endpoint), {
-      method: 'POST',
-      headers: { 'content-type': 'application/json', ...config.headers },
-      body,
-    });
-    if (!response.ok) {
-      throw new Error(`collector returned ${response.status}`);
-    }
-  });
+      // net.fetch respects the app's proxy/cert configuration. OTLP/JSON is UTF-8
+      // text, so body is forwarded as-is with content-type application/json.
+      const response = await net.fetch(signalUrl(config.endpoint, signal), {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', ...config.headers },
+        body,
+      });
+      if (!response.ok) {
+        throw new Error(`collector returned ${response.status}`);
+      }
+    },
+  );
 }
 
-function logsUrl(endpoint: string) {
-  const base = endpoint.replace(/\/+$/, '');
-  return base.endsWith('/v1/logs') ? base : `${base}/v1/logs`;
+function signalUrl(endpoint: string, signal: 'logs' | 'traces') {
+  return `${endpoint.replace(/\/+$/, '')}/v1/${signal}`;
 }
 ```
 
@@ -135,8 +133,8 @@ import { contextBridge, ipcRenderer } from 'electron';
 
 contextBridge.exposeInMainWorld('everrTelemetry', {
   getContext: () => ipcRenderer.invoke('everr:telemetry-context'),
-  proxyOtlpLogs: (body: string) =>
-    ipcRenderer.invoke('everr:proxy-otlp-logs', body),
+  proxyOtlp: (signal: 'logs' | 'traces', body: string) =>
+    ipcRenderer.invoke('everr:proxy-otlp', signal, body),
 });
 ```
 
@@ -146,78 +144,42 @@ declare global {
   interface Window {
     everrTelemetry: {
       getContext(): Promise<TelemetryContext>;
-      proxyOtlpLogs(body: string): Promise<void>;
+      proxyOtlp(signal: 'logs' | 'traces', body: string): Promise<void>;
     };
   }
 }
 ```
 
-## Renderer Exporters
+## Renderer Telemetry
 
-The exporter serializes each log batch to OTLP/JSON with `@opentelemetry/otlp-transformer` and hands the bytes to `window.everrTelemetry.proxyOtlpLogs`. No body allowlist, no attribute mapping — the encoded request carries the log's body, severity, and attributes.
+`@everr/otel-web` builds the OTLP/JSON payload and hands it to the preload bridge through `send`. There is no exporter, no provider, and no serializer in the renderer.
 
 ```ts
-import { type ExportResult, ExportResultCode } from '@opentelemetry/core';
-import { JsonLogsSerializer } from '@opentelemetry/otlp-transformer';
-import { logs } from '@opentelemetry/api-logs';
-import { resourceFromAttributes } from '@opentelemetry/resources';
-import {
-  BatchLogRecordProcessor,
-  LoggerProvider,
-  type LogRecordExporter,
-  type ReadableLogRecord,
-} from '@opentelemetry/sdk-logs';
-import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
-
-const decoder = new TextDecoder();
-
-async function proxyLogs(payload: Uint8Array, done: (result: ExportResult) => void) {
-  try {
-    await window.everrTelemetry.proxyOtlpLogs(decoder.decode(payload));
-    done({ code: ExportResultCode.SUCCESS });
-  } catch (error) {
-    done({ code: ExportResultCode.FAILED, error: error as Error });
-  }
-}
-
-class OtlpProxyLogExporter implements LogRecordExporter {
-  export(records: ReadableLogRecord[], done: (result: ExportResult) => void) {
-    void proxyLogs(JsonLogsSerializer.serializeRequest(records), done);
-  }
-  async shutdown() {}
-  async forceFlush() {}
-}
+// renderer, imported once before the app renders
+import { errors, WebSDK } from '@everr/otel-web';
 
 export async function initRendererTelemetry() {
   const context = await window.everrTelemetry.getContext();
-  const batch = { maxQueueSize: 100, maxExportBatchSize: 32, scheduledDelayMillis: 5_000, exportTimeoutMillis: 30_000 };
 
-  const loggerProvider = new LoggerProvider({
-    resource: resourceFromAttributes({
-      [ATTR_SERVICE_NAME]: context.serviceName,
-      'service.version': context.serviceVersion,
-      'service.instance.id': context.serviceInstanceId,
-      'deployment.environment.name': context.deploymentEnvironment,
-      'process.type': context.processType,
-    }),
-    processors: [new BatchLogRecordProcessor(new OtlpProxyLogExporter(), batch)],
+  return new WebSDK({
+    serviceName: context.serviceName,
+    serviceVersion: context.serviceVersion,
+    serviceInstanceId: context.serviceInstanceId,
+    deploymentEnvironment: context.deploymentEnvironment,
+    // The host owns delivery: ingestKey, endpoint, and dev are unused, and
+    // the SDK issues no request of its own. Only the main process reads
+    // exporter configuration.
+    send: (signal, body) => window.everrTelemetry.proxyOtlp(signal, body),
+    instrumentations: [errors()],
   });
-  logs.setGlobalLoggerProvider(loggerProvider);
 }
 ```
 
-## Renderer Error Capture
+`process.type = renderer` is not settable through the WebSDK options. Distinguish the two sides with a renderer-specific `serviceName` instead, per `resources.md`, or stamp it per record with `setAttributes({ 'everr.process.type': 'renderer' })`.
 
-Capture renderer errors with `@everr/auto-otel-errors/browser` (and `/react` for React), emitting through the `LoggerProvider` above. Set the global providers, then call `init()`:
+The `errors()` instrumentation owns the `window` `error`/`unhandledrejection` handlers. Do not also register your own: that double-captures. `captureError(error, attributes)` covers manual capture, and React apps wrap their root with `ErrorBoundary` from `@everr/otel-web/react`.
 
-```ts
-import { init as initErrorTracking } from '@everr/auto-otel-errors/browser';
-
-await initRendererTelemetry();
-initErrorTracking();
-```
-
-`init()` installs the `window` `error`/`unhandledrejection` handlers and exposes `captureError` for manual capture. Do not also register your own `window` error listeners — that double-captures. Wrap React apps with `ErrorBoundary` from `@everr/auto-otel-errors/react`.
+Add `pageviews()`, `interactions()`, `performance()`, or `network()` when the renderer is a real UI and those signals are wanted; each is opt-in.
 
 ## Validation
 
@@ -239,8 +201,8 @@ LIMIT 50
 
 ## Troubleshooting
 
-- No renderer logs: verify `initRendererTelemetry()` runs before capture, the global providers are set before `initErrorTracking()`, the preload exposes `everrTelemetry`, and the `everr:proxy-otlp-logs` handler is registered.
-- Proxy failures: verify the renderer serializes OTLP/JSON and passes it as `body`, and that `everr:proxy-otlp-logs` POSTs to `{endpoint}/v1/logs` with `content-type: application/json` (confirm the collector accepts OTLP/JSON).
+- No renderer logs: verify `initRendererTelemetry()` runs before capture, the preload exposes `everrTelemetry`, and the `everr:proxy-otlp` handler is registered. A WebSDK with neither `send` nor a key is inert by design, so a dropped `send` looks identical to disabled telemetry.
+- Proxy failures: verify the renderer's `send` passes the payload through as `body`, and that `everr:proxy-otlp` POSTs to `{endpoint}/v1/{signal}` with `content-type: application/json` (confirm the collector accepts OTLP/JSON). A throwing `send` is swallowed by design, so failures surface in the main process, not the renderer.
 - Each error captured twice: the library's handlers are running alongside leftover hand-rolled `window`/`process` error handlers. Remove the hand-rolled ones.
 - `everrTelemetry` is undefined in the renderer: the preload script is not wired to the `BrowserWindow` (`webPreferences.preload`), or `contextIsolation` is off.
 

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/error-tracking.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/error-tracking.md
@@ -47,10 +47,7 @@ Keep stack traces as one structured field. Do not emit multiline stack traces as
 
 ## Handled vs Unhandled
 
-Use a low-cardinality handled flag when useful:
-
-- `error.handled=true` for exceptions caught and converted into a controlled failure response.
-- `error.handled=false` for unhandled exceptions, fatal crashes, and process-level failures.
+Do not add a handled flag. How the error reached you is already on the record: `@everr/otel-errors` and `@everr/otel-web` stamp `everr.error.mechanism` (`uncaughtException`, `unhandledrejection`, `onerror`, `react`, `manual`), and a crash carries `FATAL` severity where a caught failure carries `ERROR`. A boolean beside those is a second, weaker spelling of the same fact.
 
 If the codebase already has a project-specific error namespace, follow it. Otherwise keep custom error attributes sparse and documented.
 

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/error-tracking.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/error-tracking.md
@@ -1,5 +1,7 @@
 # Error Tracking
 
+Use this rule when the stack has no `@everr` SDK owning error capture: languages beyond JS (Python, Go, Java, Ruby, ...) and any runtime without a dedicated rule file. The JS runtimes carry their own compact hints (`@everr/otel-errors` on Node, `errors()` in the browser), and `rust.md` has "Errors And Panics"; this rule is the generic contract those hints compress.
+
 Error tracking is the combination of:
 - Span status on the failed operation.
 - Structured exception logs with trace correlation.
@@ -68,46 +70,4 @@ Redact at the source when possible and use collector-side redaction only as a se
 
 ## Validation
 
-Especially when instrumenting errors, it is a MUST to try to throw a syntetic error and see if it is reported correctly.
-
-Use a browser or an API call to trigger the error using a public path.
-
-VALIDATION IS IMPORTANT, don't skip it.
-
-Validate error tracking from multiple sourcers:
-- API handlers
-- UI components in SSR
-- Server functions
-- Middlewares
-- Cron or background tasks
-
-## Validation queries
-
-Recent error spans:
-
-```sql
-SELECT Timestamp, ServiceName, SpanName, StatusMessage, TraceId
-FROM traces
-WHERE Timestamp > now() - INTERVAL 10 MINUTE
-  AND ServiceName = '<service-name>'
-  AND StatusCode = 'Error'
-ORDER BY Timestamp DESC
-LIMIT 20
-```
-
-Recent exception logs:
-
-```sql
-SELECT Timestamp, ServiceName, SeverityText, Body, LogAttributes, TraceId
-FROM logs
-WHERE Timestamp > now() - INTERVAL 10 MINUTE
-  AND ServiceName = '<service-name>'
-  AND SeverityNumber >= 17
-  AND mapContains(ResourceAttributes, 'service.name')
-  AND (
-    mapContains(LogAttributes, 'exception.type')
-    OR mapContains(LogAttributes, 'exception.message')
-  )
-ORDER BY Timestamp DESC
-LIMIT 20
-```
+Throwing a synthetic error and proving it lands exactly once is mandatory: follow the Error Path Gate in `validation.md`, which also holds the queries.

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/nextjs.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/nextjs.md
@@ -4,7 +4,9 @@ Use this rule for Next.js 13+ App Router projects that need server-side
 OpenTelemetry instrumentation.
 
 This rule is intentionally server-only. Keep device-side instrumentation out of
-this setup.
+this setup: the browser half is `browser.md` (`@everr/otel-web`), and joining
+browser and server traces into one trace follows the seam section of
+`vite-ssr.md`, which applies to Next.js unchanged.
 
 ## Prerequisites
 
@@ -136,10 +138,14 @@ function otlpEndpoint(signal: 'traces' | 'metrics' | 'logs') {
   return `${base.replace(/\/+$/, '')}/v1/${signal}`;
 }
 
+// Keyless means `undefined`, never `{}`: under strict TypeScript a
+// conditional `{ Authorization: ... } : {}` infers the union
+// `{ Authorization?: undefined }`, which is not assignable to the exporters'
+// `Record<string, string>` headers and fails `next build`. `undefined` is.
 function otlpHeaders() {
   return process.env.EVERR_INGEST_KEY
     ? { Authorization: `Bearer ${process.env.EVERR_INGEST_KEY}` }
-    : {};
+    : undefined;
 }
 
 function serviceResource() {
@@ -189,15 +195,18 @@ if (!globalThis.__otelSdk) {
   const resource = serviceResource();
   const headers = otlpHeaders();
 
+  // Options-object form: since sdk-logs 0.221 the constructor takes
+  // `{ exporter }`; the older positional-exporter form compiles on some
+  // versions but leaves the exporter undefined and silently drops logs.
   const loggerProvider = new LoggerProvider({
     resource,
     processors: [
-      new BatchLogRecordProcessor(
-        new OTLPLogExporter({
+      new BatchLogRecordProcessor({
+        exporter: new OTLPLogExporter({
           url: otlpEndpoint('logs'),
           headers,
         }),
-      ),
+      }),
     ],
   });
   logs.setGlobalLoggerProvider(loggerProvider);
@@ -328,7 +337,7 @@ For final failures:
 - Preserve framework semantics: rethrow, return the intended error response, or
   let Next.js handle the failure exactly as before.
 
-See [error tracking](./error-tracking.md) and [spans](./spans.md).
+Add `error.handled` (`false` for `onRequestError` and process crashes, `true` for caught-and-converted failures), and record each error exactly once: `onRequestError` already covers handled request failures, so route handlers only emit their own exception log when they swallow the error before Next.js sees it. See [spans](./spans.md).
 
 ## Metrics
 
@@ -373,15 +382,17 @@ addresses, tokens, exception messages, or stacktraces to metric attributes.
 
 After setup:
 
-1. Start the app with a local OTLP endpoint.
-2. Hit a route handler that should produce telemetry.
-3. Verify a server span exists for the route under `service.name`.
-4. Verify an exception path emits an error-severity log with
+1. Run `next build`. The dev server skips strict type checking, so a setup
+   that works under `next dev` can still fail the production build.
+2. Start the app with a local OTLP endpoint.
+3. Hit a route handler that should produce telemetry.
+4. Verify a server span exists for the route under `service.name`.
+5. Verify an exception path emits an error-severity log with
    `exception.type`, `exception.message`, and `exception.stacktrace`.
-5. Verify the error log has `TraceId` and `SpanId` when it happens inside an
+6. Verify the error log has `TraceId` and `SpanId` when it happens inside an
    active span.
-6. Verify metrics arrive with units and low-cardinality attributes.
-7. Stop the process and confirm shutdown flushes traces, logs, and metrics.
+7. Verify metrics arrive with units and low-cardinality attributes.
+8. Stop the process and confirm shutdown flushes traces, logs, and metrics.
 
 ## References
 

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/nextjs.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/nextjs.md
@@ -337,7 +337,7 @@ For final failures:
 - Preserve framework semantics: rethrow, return the intended error response, or
   let Next.js handle the failure exactly as before.
 
-Add `error.handled` (`false` for `onRequestError` and process crashes, `true` for caught-and-converted failures), and record each error exactly once: `onRequestError` already covers handled request failures, so route handlers only emit their own exception log when they swallow the error before Next.js sees it. See [spans](./spans.md).
+Do not add a handled flag: `everr.error.mechanism` and the record's severity already separate a crash from a caught-and-converted failure. Record each error exactly once: `onRequestError` already covers handled request failures, so route handlers only emit their own exception log when they swallow the error before Next.js sees it. See [spans](./spans.md).
 
 ## Metrics
 

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/nodejs.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/nodejs.md
@@ -11,7 +11,7 @@ Use this rule for Node.js services, CLIs, workers, background jobs, and test run
 - Load telemetry before importing HTTP, framework, database, queue, AWS SDK, GraphQL, gRPC, logger, or job-runner modules.
 - Export to OTLP over HTTP for Everr local and hosted ingest unless project constraints require a different protocol.
 - Prefer framework-native OpenTelemetry support or OpenTelemetry contrib instrumentation for common libraries, then add manual spans only for work the library instrumentation cannot see.
-- Use `@everr/auto-otel-errors/node` for error capture: call `init()` after `sdk.start()`. Do not hand-roll process error handlers or exception logging.
+- Use `@everr/otel-errors` for error capture: add `new ErrorsInstrumentation()` to the SDK's `instrumentations`. Do not hand-roll process error handlers or exception logging.
 
 ## Framework-Specific OpenTelemetry First
 
@@ -44,10 +44,10 @@ Use this precedence order:
 
 ## Packages
 
-Follow the package manager already used by the project. For a complete traces, logs, and metrics setup, plus `@everr/auto-otel-errors` for error capture:
+Follow the package manager already used by the project. For a complete traces, logs, and metrics setup, plus `@everr/otel-errors` for error capture:
 
 ```bash
-npm install @everr/auto-otel-errors @opentelemetry/api @opentelemetry/api-logs @opentelemetry/sdk-node @opentelemetry/sdk-trace-node @opentelemetry/sdk-metrics @opentelemetry/sdk-logs @opentelemetry/resources @opentelemetry/auto-instrumentations-node @opentelemetry/exporter-trace-otlp-proto @opentelemetry/exporter-metrics-otlp-proto @opentelemetry/exporter-logs-otlp-proto
+npm install @everr/otel-errors @opentelemetry/instrumentation @opentelemetry/api @opentelemetry/api-logs @opentelemetry/sdk-node @opentelemetry/sdk-trace-node @opentelemetry/sdk-metrics @opentelemetry/sdk-logs @opentelemetry/resources @opentelemetry/auto-instrumentations-node @opentelemetry/exporter-trace-otlp-proto @opentelemetry/exporter-metrics-otlp-proto @opentelemetry/exporter-logs-otlp-proto
 ```
 
 If the app only needs traces at first, install the SDK, auto-instrumentations, resources, trace SDK, and trace exporter. Add metrics and logs packages when those signals are part of the task.
@@ -81,7 +81,7 @@ Latest Node.js versions support .ts files, stick with them if possible.
 
 ```typescript
 // src/telemetry-setup.ts
-import { init as initErrorTracking } from '@everr/auto-otel-errors/node';
+import { ErrorsInstrumentation } from '@everr/otel-errors';
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-proto';
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-proto';
@@ -134,14 +134,21 @@ function startTelemetry() {
       }),
     ],
     logRecordProcessors: [
-      new BatchLogRecordProcessor(
-        new OTLPLogExporter({
+      // Options-object form: since sdk-logs 0.221 the constructor takes
+      // `{ exporter }`; the older positional form silently drops logs.
+      new BatchLogRecordProcessor({
+        exporter: new OTLPLogExporter({
           url: signalUrl(endpoint, 'logs'),
           headers: config.headers,
         }),
-      ),
+      }),
     ],
     instrumentations: [
+      // Error capture. It owns the uncaughtException/unhandledRejection
+      // handlers (flush logs, spans, and metrics, then exit), active-span
+      // ERROR marking, rate limiting, and redaction. Pass
+      // { onFatal: 'continue' } to capture without exiting on a fatal error.
+      new ErrorsInstrumentation(),
       getNodeAutoInstrumentations({
         '@opentelemetry/instrumentation-fs': { enabled: false },
       }),
@@ -150,11 +157,6 @@ function startTelemetry() {
 
   sdk.start();
 
-  // Error capture: install after sdk.start() so the global providers are live.
-  // It owns the uncaughtException/unhandledRejection handlers (flush, then exit),
-  // active-span ERROR marking, rate limiting, and redaction. Pass
-  // { onFatal: 'continue' } to capture without exiting on a fatal error.
-  initErrorTracking();
   installShutdownHandlers(sdk);
 
   return { sdk };
@@ -212,7 +214,7 @@ function installShutdownHandlers(sdk: NodeSDK) {
 
 ```
 
-`@everr/auto-otel-errors` owns crash handling, so there is no `installFatalErrorHandlers` here — the library installs the `uncaughtException`/`unhandledRejection` handlers, flushes, and exits.
+`@everr/otel-errors` owns crash handling, so there is no `installFatalErrorHandlers` here: the instrumentation installs the `uncaughtException`/`unhandledRejection` handlers, flushes, and exits.
 
 If the app has a singleton/hot-reload pattern already, use that pattern instead of the `Symbol.for` guard.
 
@@ -241,7 +243,7 @@ Use low-cardinality span names. Prefer operation names and route templates over 
 
 ```typescript
 import { SpanStatusCode, trace } from '@opentelemetry/api';
-import { captureError } from '@everr/auto-otel-errors/node';
+import { captureError } from '@everr/otel-errors';
 
 const tracer = trace.getTracer('checkout-worker');
 
@@ -276,13 +278,26 @@ For incoming requests, rely on HTTP or framework instrumentation to extract cont
 
 ## Error Tracking
 
-Error capture is `@everr/auto-otel-errors/node`, wired in the setup module above with `init()` after `sdk.start()`. This is the path for Node — do not hand-roll `process.on('uncaughtException')`, `unhandledRejection`, `console` patches, or per-call exception logging.
+Error capture is `@everr/otel-errors`, registered in the setup module above as `new ErrorsInstrumentation()` in the SDK's `instrumentations`. This is the path for Node: do not hand-roll `process.on('uncaughtException')`, `unhandledRejection`, `console` patches, or per-call exception logging.
 
-- It installs the `uncaughtException`/`unhandledRejection` handlers (flush, then exit; pass `onFatal: 'continue'` to capture without exiting), marks the active span `ERROR`, and applies rate limiting and redaction.
+- It installs the `uncaughtException`/`unhandledRejection` handlers (flush logs, spans, and metrics, then exit; pass `onFatal: 'continue'` to capture without exiting), marks the active span `ERROR`, and applies rate limiting and redaction.
+- The SDK injects its own `LoggerProvider`, so records go to the app's log pipeline rather than through a global lookup.
 - Use `captureError(error, attributes)` in catch blocks for manual capture (see Custom Spans above).
-- Framework adapters: `@everr/auto-otel-errors/express` (`errorHandler()` as the last middleware) and `@everr/auto-otel-errors/fastify` (`errorTrackingPlugin`).
+- There are no framework adapters. Express and Fastify errors already reach the `uncaughtException` path or the framework's own error hook; call `captureError` there if the framework swallows them.
 
-See `error-tracking.md` for options (`onFatal`, `rateLimit`, `scrubPatterns`, `beforeSend`).
+Options are `onFatal`, `rateLimit`, `redactPatterns`, `redactKeys`, and `beforeSend`. See `sensitive-data.md` for redaction.
+
+What a captured error must look like: span status `ERROR` only on the span of the failed operation (with a short, non-sensitive message), one exception log in the active span context carrying `exception.type`, `exception.message`, `exception.stacktrace`, and `error.handled` (`true` for caught-and-converted failures, `false` for crashes). Each error is recorded exactly once: check the framework's own error hook before adding capture so the same exception does not land twice.
+
+## Full-Stack Frameworks And Shared Code
+
+When a full-stack framework (Next.js, TanStack Start, Remix) uses `@everr/otel-web` in the browser, shared isomorphic code keeps importing `logger` and `captureError` from `@everr/otel-web`: the package's `node` conditional export resolves a server entry that attaches to the app's registered OpenTelemetry SDK instead of running its own pipeline. Records ride the app's `LoggerProvider` with the active context attached, so they join the request trace, including traces propagated from the browser.
+
+The division of ownership stays as above:
+
+- `instrumentation.ts` (or the setup module) owns the NodeSDK startup and the `@everr/otel-errors` `ErrorsInstrumentation` for crash handlers. The `@everr/otel-web` server entry never installs process handlers and never exports anything itself.
+- `@everr/otel-web` `init()` options are inert on the server: `ingestKey` and `endpoint` are browser concerns, and lifecycle (`forceFlush` before a serverless freeze, shutdown) belongs to the NodeSDK handle.
+- Without a registered SDK the server entry is a structural no-op: nothing is emitted and no request is issued.
 
 ## Troubleshooting
 
@@ -297,6 +312,7 @@ See `error-tracking.md` for options (`onFatal`, `rateLimit`, `scrubPatterns`, `b
 | High cardinality | Span names or metric/log attributes contain IDs, paths, queries, or raw messages |
 | Missing DB spans | Database module imported before setup or unsupported driver version |
 | Missing trace-log correlation | Logger helper not reading active context or logs emitted outside active spans |
-| Each error captured twice | `@everr/auto-otel-errors` running alongside leftover hand-rolled `uncaughtException`/`unhandledRejection` handlers — remove the hand-rolled ones |
+| Logs silently absent with no errors | Two `@opentelemetry/api-logs` versions in the tree (check with the package manager's why/ls command): the global logger registry is per-version, so the SDK registers on one copy and the app emits into the other. Align the direct OTel package versions with what `@everr/otel-errors` resolves |
+| Each error captured twice | `@everr/otel-errors` running alongside leftover hand-rolled `uncaughtException`/`unhandledRejection` handlers: remove the hand-rolled ones |
 
 After changes, run the instrumented path and validate with `everr local query`. Filter by `ServiceName`, a recent time window, and a run/request/test marker when practical.

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/nodejs.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/nodejs.md
@@ -258,7 +258,6 @@ await tracer.startActiveSpan('invoice.send', async (span) => {
     span.setStatus({ code: SpanStatusCode.OK });
   } catch (error) {
     captureError(error, {
-      'error.handled': true,
       'error.source': 'invoice.send',
     });
     throw error;
@@ -287,7 +286,7 @@ Error capture is `@everr/otel-errors`, registered in the setup module above as `
 
 Options are `onFatal`, `rateLimit`, `redactPatterns`, `redactKeys`, and `beforeSend`. See `sensitive-data.md` for redaction.
 
-What a captured error must look like: span status `ERROR` only on the span of the failed operation (with a short, non-sensitive message), one exception log in the active span context carrying `exception.type`, `exception.message`, `exception.stacktrace`, and `error.handled` (`true` for caught-and-converted failures, `false` for crashes). Each error is recorded exactly once: check the framework's own error hook before adding capture so the same exception does not land twice.
+What a captured error must look like: span status `ERROR` only on the span of the failed operation (with a short, non-sensitive message), one exception log in the active span context carrying `exception.type`, `exception.message`, and `exception.stacktrace`. Crashes are distinguished by `FATAL` severity and by `everr.error.mechanism`, both of which the package sets, so do not add a handled flag of your own. Each error is recorded exactly once: check the framework's own error hook before adding capture so the same exception does not land twice.
 
 ## Full-Stack Frameworks And Shared Code
 

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/rust.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/rust.md
@@ -301,9 +301,7 @@ Metric attributes must be bounded and low-cardinality. Do not use request IDs, u
 
 ## Errors And Panics
 
-Use `error-tracking.md` before adding panic hooks or exception-style telemetry.
-
-- Record operation failures on the current span with safe context.
+- Record operation failures on the current span with safe context: status `ERROR` only on the failing operation's span, one structured event carrying the error type and message, and `error.handled` (`false` for panics and fatal failures).
 - Emit one structured error event at the failing boundary.
 - For panic hooks, emit a redacted event, flush providers if possible, then call the previous hook or preserve the normal panic.
 - Do not catch panics or convert fatal failures into successful exits just to keep telemetry alive.

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/rust.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/rust.md
@@ -301,7 +301,7 @@ Metric attributes must be bounded and low-cardinality. Do not use request IDs, u
 
 ## Errors And Panics
 
-- Record operation failures on the current span with safe context: status `ERROR` only on the failing operation's span, one structured event carrying the error type and message, and `error.handled` (`false` for panics and fatal failures).
+- Record operation failures on the current span with safe context: status `ERROR` only on the failing operation's span, and one structured event carrying the error type and message. Do not add a handled flag: mark panics and fatal failures with `FATAL` severity instead.
 - Emit one structured error event at the failing boundary.
 - For panic hooks, emit a redacted event, flush providers if possible, then call the previous hook or preserve the normal panic.
 - Do not catch panics or convert fatal failures into successful exits just to keep telemetry alive.

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/tanstack-start.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/tanstack-start.md
@@ -1,0 +1,84 @@
+# TanStack Start Instrumentation
+
+Use this rule for TanStack Start apps (Vite + Nitro, React). Read `vite-ssr.md` first: it owns the two-halves layout, environment split, and the browser-to-server seam. This rule adds only what TanStack Start changes.
+
+## Browser Half
+
+Follow `browser.md` for the `@everr/otel-web` setup. TanStack Start specifics:
+
+- Put the `WebSDK` construction in a side-effect module and import it at the top of `src/routes/__root.tsx`, so it runs once when the client bundle loads. The WebSDK is inert during SSR, so no environment guard is needed.
+- Register the router with the SDK's route resolver so pageviews and errors carry the route id (`/blog/$slug`) instead of raw paths. Telemetry setup runs before the router exists, so bridge through an app-owned module:
+
+```ts
+// src/telemetry/route-pattern.ts
+import { setRouteResolver } from "@everr/otel-web";
+
+type RouterLike = {
+  matchRoutes(pathname: string): ReadonlyArray<{ routeId: string }>;
+};
+
+/** Call from `getRouter()` right after creating the router. */
+export function registerRouter(router: RouterLike): void {
+  setRouteResolver((url) => {
+    const matches = router.matchRoutes(new URL(url).pathname);
+    return matches[matches.length - 1]?.routeId;
+  });
+}
+```
+
+- Server function calls go over `POST /_serverFn/<id>`. Give `network()` a `resolveRouteTemplate` that parameterizes that path (for example to `/_serverFn/:id`) with the same helper the server uses for `http.route`, per the seam section of `vite-ssr.md`.
+
+## Server Half
+
+Follow `nodejs.md` for the NodeSDK setup module, including the hot-reload guard: `vite dev` runs the server in-process and re-evaluates on reload.
+
+### Request Spans In The Server Entry
+
+The framework entrypoint for server telemetry is a custom `src/server.ts`: import the setup module first, then wrap the Start fetch handler so every request gets a SERVER span.
+
+```ts
+// src/server.ts
+import {
+  createStartHandler,
+  defaultStreamHandler,
+  defineHandlerCallback,
+} from "@tanstack/react-start/server";
+import { instrumentServerFetch } from "@/telemetry/server";
+import "@/telemetry/node";
+
+const startFetch = createStartHandler(defineHandlerCallback(defaultStreamHandler));
+
+export default {
+  fetch: (...args: Parameters<typeof startFetch>) =>
+    instrumentServerFetch(args[0], () => startFetch(...args)),
+};
+```
+
+`instrumentServerFetch` starts a SERVER span named `<METHOD> <route-template>`:
+
+- Extract the parent context from the request headers with `propagation.extract` so browser-injected `traceparent` (and any first-party client's) parents the span. Requests without the header extract to an empty context and root themselves.
+- Parameterize the path before it becomes the span name or `http.route`; raw paths are unbounded cardinality.
+- Set `http.response.status_code` from the response; capture 5xx responses and thrown errors with `captureError` and `error.handled: false`.
+- When wrapping the handler this way, disable the HTTP auto-instrumentation's incoming-request span (`disableIncomingRequestInstrumentation: true`) so each request gets one SERVER span, not two.
+
+### Server Functions
+
+Wrap every server function through global middleware in `src/start.ts` instead of instrumenting call sites:
+
+```ts
+// src/start.ts
+import { createStart } from "@tanstack/react-start";
+import { serverFnTelemetryMiddleware } from "@/telemetry/server-fn";
+
+export const startInstance = createStart(() => ({
+  functionMiddleware: [serverFnTelemetryMiddleware],
+}));
+```
+
+The middleware (`createMiddleware({ type: "function" })`) starts an INTERNAL span per invocation with the function id, name, and filename from `serverFnMeta` as attributes (prefix non-semconv attributes with `everr.`). It nests under the request's SERVER span automatically because the fetch wrapper's context is active.
+
+TanStack Start signals control flow with throwables: `redirect()` and `notFound()` surface as thrown values inside server functions. Filter those out before calling `captureError`, or every redirect becomes a phantom error.
+
+## Validation
+
+Run the seam validation from `vite-ssr.md`. Additionally trigger one server function from the browser and verify its INTERNAL span shares a `TraceId` with the browser request and the SERVER span.

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/tanstack-start.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/tanstack-start.md
@@ -58,7 +58,7 @@ export default {
 
 - Extract the parent context from the request headers with `propagation.extract` so browser-injected `traceparent` (and any first-party client's) parents the span. Requests without the header extract to an empty context and root themselves.
 - Parameterize the path before it becomes the span name or `http.route`; raw paths are unbounded cardinality.
-- Set `http.response.status_code` from the response; capture 5xx responses and thrown errors with `captureError` and `error.handled: false`.
+- Set `http.response.status_code` from the response; capture 5xx responses and thrown errors with `captureError`.
 - When wrapping the handler this way, disable the HTTP auto-instrumentation's incoming-request span (`disableIncomingRequestInstrumentation: true`) so each request gets one SERVER span, not two.
 
 ### Server Functions

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/tauri.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/tauri.md
@@ -265,7 +265,7 @@ Keep `ingest_headers_from_env()` server-side. If exporting to Everr hosted inges
 
 ## Rust Backend Errors
 
-Capture Rust backend failures and panics per `rust.md`'s "Errors And Panics": emit one structured exception event at the failing boundary, and install a panic hook that emits a redacted event with `error.handled=false` before delegating to the previous hook. Do not log Tauri command arguments, auth tokens, request headers, request bodies, local file contents, paths from file dialogs, or user-entered text.
+Capture Rust backend failures and panics per `rust.md`'s "Errors And Panics": emit one structured exception event at the failing boundary, and install a panic hook that emits a redacted event at `FATAL` severity before delegating to the previous hook. Do not log Tauri command arguments, auth tokens, request headers, request bodies, local file contents, paths from file dialogs, or user-entered text.
 
 ## Browser Telemetry
 

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/tauri.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/tauri.md
@@ -4,7 +4,7 @@ Use this rule for Tauri v2 apps that need telemetry from both the Rust backend a
 
 The webview cannot reach the collector directly, so Rust is an **OTLP passthrough proxy**: the browser runs normal OTel providers + exporters, serializes each batch to encoded OTLP, and hands the bytes to a Rust command that forwards them to the collector unchanged. **Rust must not decode, map, or rebuild browser telemetry.** Forwarding the encoded request verbatim preserves the resource, scope, severity, and attributes the renderer produced; reconstructing records on the Rust side loses that fidelity for no benefit.
 
-The Rust backend is itself a Rust process: set up its own telemetry per `rust.md` and error tracking per `error-tracking.md`, and reuse that exporter config (endpoint + headers) to drive the proxy. Only browser telemetry goes through the proxy; Rust's own logs, traces, and metrics export directly through its SDK.
+The Rust backend is itself a Rust process: set up its own telemetry and error capture per `rust.md`, and reuse that exporter config (endpoint + headers) to drive the proxy. Only browser telemetry goes through the proxy; Rust's own logs, traces, and metrics export directly through its SDK.
 
 This rule is app-agnostic. Resolve concrete service names, release version, environment, and endpoint from the app before editing code. Use placeholders in plans until the values are known:
 
@@ -34,10 +34,10 @@ Choose service names from the app, not from this rule. Use a stable backend name
 
 ## Package Setup
 
-Browser dependencies. `@opentelemetry/otlp-transformer` provides the serializers that turn each signal into OTLP the proxy forwards:
+Browser dependencies. `@everr/otel-web` builds OTLP itself, so the webview carries no OpenTelemetry packages:
 
 ```bash
-pnpm add @everr/auto-otel-errors @opentelemetry/api @opentelemetry/api-logs @opentelemetry/core @opentelemetry/otlp-transformer @opentelemetry/resources @opentelemetry/sdk-logs @opentelemetry/sdk-trace-base @opentelemetry/sdk-metrics @opentelemetry/semantic-conventions @tauri-apps/api
+pnpm add @everr/otel-web @tauri-apps/api
 ```
 
 Use equivalent `npm install` or `yarn add` commands when the project does not use pnpm.
@@ -265,43 +265,15 @@ Keep `ingest_headers_from_env()` server-side. If exporting to Everr hosted inges
 
 ## Rust Backend Errors
 
-Capture Rust backend failures and panics per `error-tracking.md` and `rust.md`'s "Errors And Panics": emit one structured exception event at the failing boundary, and install a panic hook that emits a redacted event with `error.handled=false` before delegating to the previous hook. Do not log Tauri command arguments, auth tokens, request headers, request bodies, local file contents, paths from file dialogs, or user-entered text.
+Capture Rust backend failures and panics per `rust.md`'s "Errors And Panics": emit one structured exception event at the failing boundary, and install a panic hook that emits a redacted event with `error.handled=false` before delegating to the previous hook. Do not log Tauri command arguments, auth tokens, request headers, request bodies, local file contents, paths from file dialogs, or user-entered text.
 
-## Browser Exporters
+## Browser Telemetry
 
-Each exporter serializes its batch to OTLP/JSON with `@opentelemetry/otlp-transformer` and hands the bytes to `proxy_otlp`. No body allowlist, no attribute mapping — the encoded request carries the signal's body, severity, and attributes.
+`@everr/otel-web` builds one OTLP/JSON payload per signal and hands it to `proxy_otlp` through `send`. There is no exporter, no provider, and no serializer in the webview: Rust forwards the bytes verbatim, so resource, scope, severity, and trace context survive intact.
 
 ```ts
-import type { ExportResult } from '@opentelemetry/core';
-import { ExportResultCode } from '@opentelemetry/core';
-import {
-  JsonLogsSerializer,
-  JsonMetricsSerializer,
-  JsonTraceSerializer,
-} from '@opentelemetry/otlp-transformer';
-import { resourceFromAttributes } from '@opentelemetry/resources';
-import { logs } from '@opentelemetry/api-logs';
-import { metrics, trace } from '@opentelemetry/api';
-import {
-  BatchLogRecordProcessor,
-  LoggerProvider,
-  type LogRecordExporter,
-  type ReadableLogRecord,
-} from '@opentelemetry/sdk-logs';
-import {
-  BatchSpanProcessor,
-  BasicTracerProvider,
-  type ReadableSpan,
-  type SpanExporter,
-} from '@opentelemetry/sdk-trace-base';
-import {
-  AggregationTemporality,
-  MeterProvider,
-  PeriodicExportingMetricReader,
-  type PushMetricExporter,
-  type ResourceMetrics,
-} from '@opentelemetry/sdk-metrics';
-import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+// src/telemetry.ts, imported once before the app renders
+import { errors, WebSDK } from '@everr/otel-web';
 import { invoke } from '@tauri-apps/api/core';
 
 type TelemetryContext = {
@@ -311,126 +283,48 @@ type TelemetryContext = {
   deploymentEnvironment: string;
 };
 
-type Signal = 'logs' | 'traces' | 'metrics';
+let client: WebSDK | null = null;
 
-const decoder = new TextDecoder();
-
-async function proxyOtlp(
-  signal: Signal,
-  payload: Uint8Array | undefined,
-  done: (result: ExportResult) => void,
-) {
-  if (!payload || payload.length === 0) {
-    done({ code: ExportResultCode.SUCCESS });
-    return;
-  }
-  try {
-    // OTLP/JSON is UTF-8 text; pass it as a string and Rust POSTs it verbatim.
-    await invoke('proxy_otlp', { signal, body: decoder.decode(payload) });
-    done({ code: ExportResultCode.SUCCESS });
-  } catch (error) {
-    done({ code: ExportResultCode.FAILED, error: error as Error });
-  }
-}
-
-class OtlpProxyLogExporter implements LogRecordExporter {
-  export(records: ReadableLogRecord[], done: (result: ExportResult) => void) {
-    void proxyOtlp('logs', JsonLogsSerializer.serializeRequest(records), done);
-  }
-  async shutdown() {}
-  async forceFlush() {}
-}
-
-class OtlpProxySpanExporter implements SpanExporter {
-  export(spans: ReadableSpan[], done: (result: ExportResult) => void) {
-    void proxyOtlp('traces', JsonTraceSerializer.serializeRequest(spans), done);
-  }
-  async shutdown() {}
-}
-
-class OtlpProxyMetricExporter implements PushMetricExporter {
-  export(data: ResourceMetrics, done: (result: ExportResult) => void) {
-    void proxyOtlp('metrics', JsonMetricsSerializer.serializeRequest(data), done);
-  }
-  selectAggregationTemporality() {
-    return AggregationTemporality.DELTA;
-  }
-  async forceFlush() {}
-  async shutdown() {}
-}
-
-let loggerProvider: LoggerProvider | null = null;
-let tracerProvider: BasicTracerProvider | null = null;
-let meterProvider: MeterProvider | null = null;
-
-export async function initBrowserTelemetry() {
+async function initBrowserTelemetry() {
   const context = await invoke<TelemetryContext>('get_telemetry_context');
-  const resource = resourceFromAttributes({
-    [ATTR_SERVICE_NAME]: context.serviceName,
-    'service.version': context.serviceVersion,
-    'service.instance.id': context.serviceInstanceId,
-    'deployment.environment.name': context.deploymentEnvironment,
-  });
-  const batch = {
-    maxQueueSize: 100,
-    maxExportBatchSize: 32,
-    scheduledDelayMillis: 5_000,
-    exportTimeoutMillis: 30_000,
-  };
 
-  loggerProvider = new LoggerProvider({
-    resource,
-    processors: [new BatchLogRecordProcessor(new OtlpProxyLogExporter(), batch)],
+  client = new WebSDK({
+    serviceName: context.serviceName,
+    serviceVersion: context.serviceVersion,
+    serviceInstanceId: context.serviceInstanceId,
+    deploymentEnvironment: context.deploymentEnvironment,
+    // Only Rust reads exporter configuration: ingestKey, endpoint, and dev are
+    // unused, and the SDK issues no request of its own.
+    send: (signal, body) => invoke('proxy_otlp', { signal, body }),
+    // Capture is opt-in. errors() owns the window error/unhandledrejection
+    // handlers; never register your own alongside it, that double-captures.
+    instrumentations: [errors()],
   });
-  logs.setGlobalLoggerProvider(loggerProvider);
-
-  tracerProvider = new BasicTracerProvider({
-    resource,
-    spanProcessors: [new BatchSpanProcessor(new OtlpProxySpanExporter(), batch)],
-  });
-  trace.setGlobalTracerProvider(tracerProvider);
-
-  meterProvider = new MeterProvider({
-    resource,
-    readers: [
-      new PeriodicExportingMetricReader({
-        exporter: new OtlpProxyMetricExporter(),
-        exportIntervalMillis: 30_000,
-      }),
-    ],
-  });
-  metrics.setGlobalMeterProvider(meterProvider);
 }
 
-export async function shutdownBrowserTelemetry() {
-  await Promise.allSettled([
-    loggerProvider?.shutdown(),
-    tracerProvider?.shutdown(),
-    meterProvider?.shutdown(),
-  ]);
-}
-```
+void initBrowserTelemetry();
 
-## Browser Error Capture
-
-Capture renderer errors with `@everr/auto-otel-errors/browser` (and `/react` for React), emitting through the providers above. Set the global providers, then call `init()`:
-
-```ts
-import { init as initErrorTracking } from '@everr/auto-otel-errors/browser';
-
-await initBrowserTelemetry();
-initErrorTracking();
-```
-
-`init()` installs the `window` `error`/`unhandledrejection` handlers and exposes `captureError` for manual capture. Do not also register your own `window` error listeners — that double-captures. Wrap React apps with `ErrorBoundary` from `@everr/auto-otel-errors/react`.
-
-Flush on exit so buffered batches are sent:
-
-```ts
+// The SDK flushes on pagehide and on visibilitychange-hidden. A Tauri window
+// close does not reliably fire either, so flush here too. flush, not shutdown:
+// capture stays alive if the close is aborted.
 window.addEventListener('beforeunload', () => {
-  void shutdownBrowserTelemetry();
+  void client?.flush();
 });
 ```
+
+`captureError(error, attributes)` covers manual capture, and React apps wrap their root with `ErrorBoundary` from `@everr/otel-web/react`. Add `pageviews()`, `interactions()`, `performance()`, or `network()` when those signals are wanted; each is opt-in, and `network()` is what makes the webview emit spans.
+
+### Browser Metrics
+
+`@everr/otel-web` emits logs and spans, not metrics. Browser metrics are rarely worth their bytes in a desktop shell: prefer a counter or histogram on the Rust side, where `rust.md`'s SDK already exports them.
+
+If the webview genuinely needs its own metrics, run an OpenTelemetry `MeterProvider` alongside the SDK (they do not conflict) with a `PushMetricExporter` that calls the same command:
+
+```ts
+void invoke('proxy_otlp', { signal: 'metrics', body });
+```
+
+`proxy_otlp` already accepts `metrics`, so no Rust change is needed.
 
 ## Validation
 
@@ -484,7 +378,7 @@ A Rust-side change (the proxy command, headers, endpoint, backend setup) needs a
 
 ## Troubleshooting
 
-- No browser telemetry: verify `initBrowserTelemetry()` runs before capture, the global providers are set before `initErrorTracking()`, `get_telemetry_context` is registered, and `proxy_otlp` accepts the `signal`.
+- No browser telemetry: verify `initBrowserTelemetry()` runs before capture, `get_telemetry_context` is registered, and `proxy_otlp` accepts the `signal`. A WebSDK with neither `send` nor a key is inert by design, so a dropped `send` looks identical to disabled telemetry.
 - Proxy failures: verify the browser exporter serializes OTLP/JSON and passes it as `body`, and that `proxy_otlp` POSTs to `{endpoint}/v1/{signal}` with `content-type: application/json` (confirm the collector accepts OTLP/JSON).
 - Each error captured twice: the library's handlers are running alongside leftover hand-rolled `window` error handlers. Remove the hand-rolled ones.
 - Missing release version or session id: verify Rust creates one telemetry context at process startup, passes `context.resource()` into the backend setup, and the browser uses `get_telemetry_context`.

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/validation.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/validation.md
@@ -10,6 +10,48 @@ Before querying the backend, verify:
 
 For local Everr runs, use `everr local status` and the returned `otlp:` URL.
 
+## Error Path Gate
+
+When error capture is part of the setup, throwing a synthetic error is a MUST, not optional. Trigger it through a public path (a browser interaction or an API call), then confirm in the collector:
+
+- Exactly one exception record per error, not two (framework hook plus custom capture is the usual double).
+- The error log carries `exception.type`, `exception.message`, `exception.stacktrace`, and `TraceId`/`SpanId` when thrown inside an active span.
+- Span status `ERROR` appears only on the failed operation's span.
+
+Cover each error source the app actually has: API handlers, SSR components, server functions, middlewares, and background tasks.
+
+Recent error spans:
+
+```sql
+SELECT Timestamp, ServiceName, SpanName, StatusMessage, TraceId
+FROM traces
+WHERE Timestamp > now() - INTERVAL 10 MINUTE
+  AND ServiceName = '<service-name>'
+  AND StatusCode = 'Error'
+ORDER BY Timestamp DESC
+LIMIT 20
+```
+
+Recent exception logs:
+
+```sql
+SELECT Timestamp, ServiceName, SeverityText, Body, LogAttributes, TraceId
+FROM logs
+WHERE Timestamp > now() - INTERVAL 10 MINUTE
+  AND ServiceName = '<service-name>'
+  AND SeverityNumber >= 17
+  AND (
+    mapContains(LogAttributes, 'exception.type')
+    OR mapContains(LogAttributes, 'exception.message')
+  )
+ORDER BY Timestamp DESC
+LIMIT 20
+```
+
+## Build Gate
+
+Telemetry setup usually touches build-sensitive files (setup modules, framework entrypoints, TypeScript config edges). Run the project's production build (or at least its typecheck) after the changes and before claiming setup works. Dev servers skip strict type checking, so telemetry that flows in dev can still break the build.
+
 ## Local Validation Gate
 
 1. Pick the expected `service.name`.

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/vite-ssr.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/vite-ssr.md
@@ -1,0 +1,63 @@
+# Full-Stack Vite SSR Instrumentation
+
+Use this rule for full-stack apps built on Vite with server-side rendering on Node.js: a custom SSR server (Express, Hono, plain `node server.js`), a Nitro-based output, or a framework CLI that runs Vite in the middle. For TanStack Start specifics, read `tanstack-start.md` on top of this rule. For Next.js, use `nextjs.md` instead.
+
+Node.js servers only. Edge and worker runtimes (Cloudflare Workers, Deno Deploy) are out of scope: the OpenTelemetry Node SDK does not run there.
+
+## Two Halves, Two Rules
+
+A full-stack Vite app is two services that happen to share a repo:
+
+- **Browser half**: `@everr/otel-web` per `browser.md`. One side-effect module imported before the app renders. Public origin-bound key in production, local collector in dev.
+- **Server half**: `@opentelemetry/sdk-node` per `nodejs.md`. A setup module loaded before framework, HTTP, and database imports.
+
+This rule owns only what neither half covers alone: wiring both into one Vite project and joining their traces.
+
+## Server Setup Placement
+
+- Put the NodeSDK setup in its own module (`src/telemetry/node.ts` or similar) and import it first in the server entry, before the framework or any I/O library.
+- `vite dev` runs the SSR server inside the Vite process and re-evaluates modules on reload. Guard the setup with an idempotent global (`globalThis` key or `Symbol.for`) so hot reload cannot start a second SDK.
+- The production build runs the same module from the built server entry (`.output/server/index.mjs` for Nitro). Confirm the setup module survives the build by checking the built entry imports it, not by assuming.
+- Keep the setup module out of any code path the client bundle imports. Vite will happily bundle Node-only packages into the browser and fail late; the browser half imports only `@everr/otel-web`.
+
+## Environment Split
+
+Vite exposes `import.meta.env.VITE_*` to the client and `process.env` to the server. Keep the two surfaces separate:
+
+| Variable | Side | Purpose |
+| --- | --- | --- |
+| `VITE_EVERR_PUBLIC_INGEST_KEY` | client | Public origin-bound key, production browser export |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | server | Optional local/custom collector override |
+| `EVERR_INGEST_KEY` | server | Secret key, production server export |
+
+Never move `EVERR_INGEST_KEY` into a `VITE_`-prefixed variable: the `VITE_` prefix is exactly the boundary that ships values to every visitor.
+
+## The Seam: Joining Browser And Server Traces
+
+- Give each half its own `service.name` (for example `shop-web` and `shop-server`) so the sides stay separable in queries. Never share one name.
+- `@everr/otel-web`'s `network()` instrumentation injects `traceparent` on same-origin requests by default, so browser-initiated requests parent the server spans with no extra configuration. Cross-origin APIs need the target listed in `network()` options and `traceparent` in the server's CORS `Access-Control-Allow-Headers`.
+- On the server, the HTTP auto-instrumentation extracts incoming W3C context automatically. If incoming-request instrumentation is disabled in favor of a manual SERVER span, extract explicitly with `propagation.extract(context.active(), request.headers, getter)` and pass the result as the span's parent context.
+- Align route templates across the seam: give `network()` a `resolveRouteTemplate` callback that applies the same parameterization the server stamps on `http.route`, so a request's `url.template` matches its server span's route. Share one parameterization helper between both halves.
+
+## CORS In Development
+
+The browser posts OTLP to the collector from the page's origin. The local CLI collector accepts any origin, but if dev telemetry routes through another collector, its CORS allowlist must include the exact dev origin, port included. A disallowed origin fails preflight and the SDK drops batches silently: when browser rows are missing but server rows arrive, check the collector's CORS allowlist against the page origin before touching the app code.
+
+## Validation
+
+Validate the seam, not just each half:
+
+1. Load the app in a real browser and trigger a page that fetches from the server.
+2. `everr local query` for fresh rows under the browser `ServiceName` and separately under the server `ServiceName`.
+3. Prove the join: at least one `TraceId` with spans from both service names.
+
+```sql
+SELECT TraceId, groupUniqArray(ServiceName) AS services
+FROM traces
+WHERE Timestamp > now() - INTERVAL 5 MINUTE
+GROUP BY TraceId
+HAVING length(services) > 1
+LIMIT 5
+```
+
+No joined rows with both halves emitting usually means `network()` is missing, the request was cross-origin without a configured target, or the server span ignored the incoming `traceparent`.

--- a/crates/everr-core/assets/skills/everr-use-telemetry/SKILL.md
+++ b/crates/everr-core/assets/skills/everr-use-telemetry/SKILL.md
@@ -28,6 +28,7 @@ The ONLY query command is `everr cloud query "<SQL>"` or `everr local query "<SQ
 | Production, deployed services, customer reports, cloud CI history | `everr cloud query "<SQL>"` |
 | Local app, dev server, local tests, wrapped command output | `everr local query "<SQL>"` |
 | Current CI run, branch status, failed jobs, workflow logs | Use the `everr-working-with-ci` skill |
+| Browser or web-app behavior: page views, clicks, web vitals, frontend errors | Read `rules/browser-events.md` for the event and attribute catalog, then query as usual |
 | Missing or stale local telemetry | Use the `everr-setup-telemetry` skill |
 
 If an Everr command fails, investigate why: collector stopped, stale app, wrong repo, missing auth, missing import, bad query, or CLI bug. **Follow the error message literally** — if it says run `everr local start`, run that. Do not invent alternative explanations for the error or silently replace real telemetry with guesses.

--- a/crates/everr-core/assets/skills/everr-use-telemetry/rules/browser-events.md
+++ b/crates/everr-core/assets/skills/everr-use-telemetry/rules/browser-events.md
@@ -46,7 +46,7 @@ Semconv names stay bare: `browser.web_vital.name` (`lcp`, `cls`, `ttfb`, `inp`),
 
 ### Exceptions
 
-`exception.type`, `exception.message`, `exception.stacktrace`, `everr.error.mechanism` (`onerror`, `unhandledrejection`, `react`, `manual`), `everr.error.handled` (boolean), `everr.react.component_stack` (React boundaries only). These are error logs (`SeverityNumber >= 17`), so the fingerprint grouping in SKILL.md applies to them unchanged.
+`exception.type`, `exception.message`, `exception.stacktrace`, `everr.error.mechanism` (`onerror`, `unhandledrejection`, `react`, `manual`), `everr.react.component_stack` (React boundaries only). These are error logs (`SeverityNumber >= 17`), so the fingerprint grouping in SKILL.md applies to them unchanged.
 
 ## Spans (in `traces`)
 

--- a/crates/everr-core/assets/skills/everr-use-telemetry/rules/browser-events.md
+++ b/crates/everr-core/assets/skills/everr-use-telemetry/rules/browser-events.md
@@ -1,0 +1,122 @@
+# Browser Events From @everr/otel-web
+
+Use this rule when investigating web-app behavior: page views, clicks, web vitals, frontend errors, or browser-issued requests. It catalogs what the `@everr/otel-web` SDK emits so you can filter by real names instead of guessing.
+
+Names below are curated, not exhaustive, and were verified against the SDK source as of this commit. If a filter returns nothing, sample rows before concluding the data is missing: `SELECT EventName, LogAttributes FROM logs WHERE ... LIMIT 5`.
+
+## Where Browser Data Lands
+
+- Everything except requests is a **log record** in `logs` with the event name in the `EventName` column.
+- Browser `fetch` requests, slow interactions, and page-load capture are **CLIENT spans** in `traces`.
+- Every record (logs and spans) carries the context envelope in its attributes map, so any signal can slice by page and join by session.
+
+## The Context Envelope (on every record)
+
+| Attribute | Meaning |
+| --- | --- |
+| `session.id` | Rotates after 30 idle minutes; groups one visit |
+| `everr.visitor.id` | Stable per browser (localStorage); groups return visits |
+| `everr.page_view.id` | Joins any record to the pageview it happened on |
+| `url.full`, `url.path` | The page the record happened on |
+| `everr.route.pattern` | Low-cardinality route, e.g. `/posts/{id}`; group by this, not `url.path` |
+| `everr.referrer.url` | The page's referrer |
+| `user.id`, `user.*` | Set by `identify()`; flat traits like `user.plan` |
+| ambient `everr.*` keys | Set by the host app via `setAttributes()` |
+
+Resource attributes (in `ResourceAttributes`): `service.name`, `service.version`, `deployment.environment.name`, `everr.landing.url`, `everr.landing.path`, `everr.utm.*` (campaign attribution), `everr.screen.width`/`height`, `everr.timezone`, and `telemetry.distro.name` = `@everr/otel-web` (the reliable "this came from a browser" filter).
+
+## Log Events (`EventName` column)
+
+| EventName | Meaning | Key attributes |
+| --- | --- | --- |
+| `everr.browser.page_view` | One per hard navigation and per SPA navigation | `everr.navigation.type` (`initial` or `history_change`) |
+| `everr.browser.page_leave` | One per pageview, on navigation away or hide | `everr.page_view.duration` (ms), `everr.scroll.depth` (0 to 1) |
+| `everr.browser.interaction.click` | Autocaptured click | element attrs, `everr.browser.click.x`/`y` |
+| `everr.browser.interaction.rage_click` | 3 clicks within 30px in under 1s each | same as click |
+| `everr.browser.interaction.change` | Form-field change (values never captured) | element attrs |
+| `everr.browser.interaction.submit` | Form submit, targeted at the submit button | element attrs |
+| `browser.web_vital` | One per metric (lcp, cls, ttfb, inp) per navigation | see below |
+| `exception` | Frontend error (unhandled, unhandled rejection, React boundary, or manual capture) | see below |
+
+Element attributes, shared by everything that names a DOM element: `everr.element.selector` (stable CSS path, the one spelling across all signals), `everr.element.tag`, `everr.element.text`, `everr.element.href`, `everr.viewport.width`/`height`.
+
+### Web vitals
+
+Semconv names stay bare: `browser.web_vital.name` (`lcp`, `cls`, `ttfb`, `inp`), `browser.web_vital.value` (ms, except cls which is unitless), `browser.web_vital.id`. Everr additions: `everr.browser.web_vital.rating` (`good`, `needs-improvement`, `poor`) and `everr.browser.web_vital.navigation_type`. Per-metric attribution rides under `everr.browser.web_vital.<metric>.*` (for example `lcp.target`, `cls.largest_shift_target`, `ttfb.request_duration`, `inp.*` mirroring the interaction attrs); sample a row to see what a given metric carries.
+
+### Exceptions
+
+`exception.type`, `exception.message`, `exception.stacktrace`, `everr.error.mechanism` (`onerror`, `unhandledrejection`, `react`, `manual`), `everr.error.handled` (boolean), `everr.react.component_stack` (React boundaries only). These are error logs (`SeverityNumber >= 17`), so the fingerprint grouping in SKILL.md applies to them unchanged.
+
+## Spans (in `traces`)
+
+| SpanName | Meaning | Key attributes |
+| --- | --- | --- |
+| `<METHOD> <route>` (e.g. `GET /api/posts/{id}`) | One per browser `fetch`; the browser is the trace root the server spans parent to, so `TraceId` joins frontend to backend | HTTP client semconv: `http.request.method`, `http.response.status_code`, `url.full` (query-stripped request URL), `url.template`, `server.address`; 4xx/5xx set `StatusCode = 'Error'` with `error.type` |
+| `slow_interaction` | Event Timing entry over threshold, from the same observer as INP | `everr.browser.interaction.*` (`id`, `type`, `input_delay`, `processing_duration`, `presentation_delay`, `script.*`) plus element attrs; `everr.browser.interaction.id` joins it to the INP vital |
+| `GET <asset url>` | Static-resource waterfall during page load (sampled per session) | `everr.browser.asset.*` (`initiator_type`, `transfer_size`, `render_blocking`, per-phase durations) |
+| `long_animation_frame` | Main-thread stall during page load | `everr.browser.long_animation_frame.*` (`blocking_duration`, `script_duration`, `script.source_url`) |
+
+## Example Queries
+
+Web-vital p75 by route (one row per metric per route):
+
+```sql
+SELECT LogAttributes['everr.route.pattern'] AS route,
+  LogAttributes['browser.web_vital.name'] AS vital,
+  quantile(0.75)(toFloat64(LogAttributes['browser.web_vital.value'])) AS p75,
+  count() AS samples
+FROM logs
+WHERE Timestamp > now() - INTERVAL 24 HOUR
+  AND EventName = 'browser.web_vital'
+GROUP BY route, vital
+ORDER BY route, vital
+LIMIT 50
+```
+
+Rage clicks by element, to find broken UI:
+
+```sql
+SELECT LogAttributes['everr.route.pattern'] AS route,
+  LogAttributes['everr.element.selector'] AS selector,
+  LogAttributes['everr.element.text'] AS text,
+  count() AS rage_clicks
+FROM logs
+WHERE Timestamp > now() - INTERVAL 24 HOUR
+  AND EventName = 'everr.browser.interaction.rage_click'
+GROUP BY route, selector, text
+ORDER BY rage_clicks DESC
+LIMIT 20
+```
+
+Frontend error rate by page:
+
+```sql
+SELECT LogAttributes['everr.route.pattern'] AS route,
+  countIf(EventName = 'exception') AS errors,
+  countIf(EventName = 'everr.browser.page_view') AS views
+FROM logs
+WHERE Timestamp > now() - INTERVAL 24 HOUR
+  AND EventName IN ('exception', 'everr.browser.page_view')
+GROUP BY route
+ORDER BY errors DESC
+LIMIT 20
+```
+
+What one user session did, in order (events and requests interleaved):
+
+```sql
+SELECT * FROM (
+  SELECT Timestamp, EventName AS what, LogAttributes['url.path'] AS path
+  FROM logs
+  WHERE Timestamp > now() - INTERVAL 24 HOUR
+    AND LogAttributes['session.id'] = '<session-id>'
+  UNION ALL
+  SELECT Timestamp, SpanName, SpanAttributes['url.full']
+  FROM traces
+  WHERE Timestamp > now() - INTERVAL 24 HOUR
+    AND SpanAttributes['session.id'] = '<session-id>'
+)
+ORDER BY Timestamp ASC
+LIMIT 200
+```

--- a/evals/setup-telemetry/README.md
+++ b/evals/setup-telemetry/README.md
@@ -1,0 +1,21 @@
+# everr-setup-telemetry skill evals
+
+Agent-driven, end-to-end: each run scaffolds a fresh project, hands it to a headless Claude Code agent with only the `everr-setup-telemetry` skill and a one-paragraph prompt, then grades the outcome objectively against the local collector.
+
+```bash
+node evals/setup-telemetry/run.mjs --framework tanstack-start
+node evals/setup-telemetry/run.mjs --framework nextjs
+node evals/setup-telemetry/run.mjs --framework vite-ssr
+```
+
+Pass criteria (all required):
+
+1. `npm run build` succeeds after the agent's changes.
+2. The app boots and serves a page.
+3. Fresh rows arrive under the prompted browser service name (`<run-id>-web`).
+4. Fresh rows arrive under the prompted server service name (`<run-id>-server`).
+5. At least one `TraceId` contains spans from both service names (the browser-to-server seam).
+
+The verdict prints as JSON and the exit code is 0 only on pass. Failed runs keep the scaffolded project on disk for inspection; pass `--keep` to keep passing runs too.
+
+Requirements: the `everr-dev` local collector running, the `claude` CLI, and the `agent-browser` CLI. Runs are token-costly and non-deterministic: they exercise the real agent, so run them on demand (before skill changes ship), not in CI.

--- a/evals/setup-telemetry/run.mjs
+++ b/evals/setup-telemetry/run.mjs
@@ -1,0 +1,299 @@
+#!/usr/bin/env node
+// Agent-driven eval for the everr-setup-telemetry skill.
+//
+// For one framework it scaffolds a fresh project in a temp dir, copies the
+// skill into the project's .claude/skills/, lets a headless Claude Code agent
+// instrument the app from the prompt alone, then grades objectively: the
+// production build passes, the app boots, and the local collector holds fresh
+// browser rows, server rows, and at least one trace joining both halves.
+//
+// Usage:
+//   node evals/setup-telemetry/run.mjs --framework tanstack-start|nextjs|vite-ssr [--keep] [--model <model>] [--port <port>]
+//
+// Requires: everr-dev collector running, `claude` CLI, `agent-browser` CLI.
+//
+// The @everr/* packages the skill prescribes are not on public npm yet, so the
+// runner builds them from the monorepo, publishes them to a throwaway local
+// verdaccio registry that proxies everything else to npmjs, and points the
+// scaffold's .npmrc at it. The agent then installs them exactly as a real
+// user would once they are published.
+
+import { execSync, spawn } from "node:child_process";
+import { mkdtempSync, cpSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const SKILL_DIR = join(
+  REPO_ROOT,
+  "crates/everr-core/assets/skills/everr-setup-telemetry",
+);
+const AGENT_TIMEOUT_MS = 30 * 60 * 1000;
+const REGISTRY_PORT = 4873;
+const REGISTRY = `http://localhost:${REGISTRY_PORT}/`;
+const LOCAL_PACKAGES = ["packages/otel-web", "packages/otel-errors"];
+const BOOT_TIMEOUT_MS = 90 * 1000;
+const FLUSH_WAIT_MS = 12 * 1000;
+const DEFAULT_PORT = 4173;
+
+const FRAMEWORKS = {
+  "tanstack-start": {
+    scaffold: (dir) =>
+      run(
+        `npx --yes @tanstack/cli@latest create app --framework React --package-manager npm --no-toolchain --no-examples --deployment nitro`,
+        dir,
+      ),
+    build: "npm run build",
+    serve: "npm run dev",
+  },
+  nextjs: {
+    scaffold: (dir) =>
+      run(
+        `npx --yes create-next-app@latest app --ts --app --eslint --no-tailwind --no-src-dir --use-npm --yes`,
+        dir,
+      ),
+    build: "npm run build",
+    serve: "npm run dev",
+  },
+  "vite-ssr": {
+    scaffold: (dir) =>
+      run(`npm create vite-extra@latest app -- --template ssr-react-ts`, dir),
+    build: "npm run build",
+    serve: "npm run dev",
+  },
+};
+
+function run(cmd, cwd, opts = {}) {
+  return execSync(cmd, {
+    cwd,
+    stdio: opts.capture ? "pipe" : "inherit",
+    encoding: "utf8",
+    env: { ...process.env, ...opts.env, CI: "1" },
+    timeout: opts.timeout ?? 10 * 60 * 1000,
+  });
+}
+
+function localQuery(sql) {
+  // Plain `everr`, not `everr-dev`: the agent under eval runs in a fresh
+  // project with the public CLI, so the grader must read the same collector
+  // store that `everr local status` hands the agent.
+  const out = run(`everr local query ${JSON.stringify(sql)}`, REPO_ROOT, {
+    capture: true,
+  });
+  return out
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+async function registryUp() {
+  try {
+    const res = await fetch(`${REGISTRY}-/ping`);
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+// Idempotent and safe under parallel runs: reuses a live registry, treats
+// version-conflict publishes as success.
+async function ensureLocalRegistry() {
+  if (!(await registryUp())) {
+    const configDir = mkdtempSync(join(tmpdir(), "everr-eval-registry-"));
+    writeFileSync(
+      join(configDir, "config.yaml"),
+      [
+        `storage: ${join(configDir, "storage")}`,
+        "auth:",
+        "  htpasswd:",
+        `    file: ${join(configDir, "htpasswd")}`,
+        "uplinks:",
+        "  npmjs:",
+        "    url: https://registry.npmjs.org/",
+        "packages:",
+        "  '@everr/*':",
+        "    access: $all",
+        "    publish: $anonymous",
+        "  '**':",
+        "    access: $all",
+        "    proxy: npmjs",
+        "log: { type: stdout, level: warn }",
+      ].join("\n"),
+    );
+    spawn(
+      "npx",
+      ["--yes", "verdaccio", "--config", join(configDir, "config.yaml"), "--listen", String(REGISTRY_PORT)],
+      { stdio: "ignore", detached: true },
+    ).unref();
+    const deadline = Date.now() + 60 * 1000;
+    while (!(await registryUp())) {
+      if (Date.now() > deadline) throw new Error("verdaccio did not start");
+      await new Promise((r) => setTimeout(r, 1000));
+    }
+  }
+
+  // npm refuses to publish without a token, and verdaccio accepts any.
+  const env = { [`npm_config_//localhost:${REGISTRY_PORT}/:_authToken`]: "eval" };
+  for (const pkg of LOCAL_PACKAGES) {
+    const dir = join(REPO_ROOT, pkg);
+    run("pnpm build", dir, { capture: true });
+    try {
+      // pnpm, not npm: it rewrites workspace: dependency ranges to real
+      // versions at pack time.
+      run(`pnpm publish --registry ${REGISTRY} --no-git-checks`, dir, {
+        capture: true,
+        env,
+      });
+    } catch (error) {
+      const message = [error.stdout, error.stderr, error.message].join("\n");
+      if (!/conflict|409|already present|previously published/i.test(message)) {
+        throw error;
+      }
+    }
+  }
+}
+
+function prompt(runId) {
+  return [
+    `Set up Everr telemetry for this app using the everr-setup-telemetry skill: browser and server halves, with browser and server traces joined into single traces.`,
+    `Use service.name "${runId}-web" for the browser and "${runId}-server" for the server, exactly.`,
+    `Export to the local collector (no production key exists). Validate your work by exercising the app and querying the collector before finishing.`,
+  ].join("\n");
+}
+
+async function waitForBoot(url) {
+  const deadline = Date.now() + BOOT_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch {}
+    await new Promise((r) => setTimeout(r, 1500));
+  }
+  throw new Error(`app did not boot at ${url}`);
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const framework = args[args.indexOf("--framework") + 1];
+  const keep = args.includes("--keep");
+  const model = args.includes("--model")
+    ? args[args.indexOf("--model") + 1]
+    : undefined;
+  const PORT = args.includes("--port")
+    ? Number(args[args.indexOf("--port") + 1])
+    : DEFAULT_PORT;
+  const fw = FRAMEWORKS[framework];
+  if (!fw) {
+    console.error(`--framework must be one of: ${Object.keys(FRAMEWORKS)}`);
+    process.exit(2);
+  }
+
+  run("everr local status", REPO_ROOT, { capture: true });
+  await ensureLocalRegistry();
+
+  const runId = `eval-${framework}-${Date.now().toString(36)}`;
+  const workDir = mkdtempSync(join(tmpdir(), `everr-eval-`));
+  const appDir = join(workDir, "app");
+  const verdict = {
+    runId,
+    framework,
+    scaffold: false,
+    agent: false,
+    build: false,
+    boot: false,
+    browserRows: 0,
+    serverRows: 0,
+    joinedTraces: 0,
+    pass: false,
+  };
+
+  let server;
+  try {
+    console.log(`[eval] scaffolding ${framework} in ${appDir}`);
+    fw.scaffold(workDir);
+    // Some scaffolders (create-next-app) git-init and commit on their own.
+    run(
+      "git init -q; git add -A; git diff --cached --quiet || git commit -qm scaffold",
+      appDir,
+    );
+    verdict.scaffold = true;
+
+    cpSync(SKILL_DIR, join(appDir, ".claude/skills/everr-setup-telemetry"), {
+      recursive: true,
+    });
+    writeFileSync(join(appDir, ".npmrc"), `registry=${REGISTRY}\n`);
+
+    writeFileSync(join(appDir, "EVAL_PROMPT.md"), prompt(runId));
+
+    console.log(`[eval] running agent (up to 30m)`);
+    // --setting-sources project,local keeps auth working but stops user-level
+    // config from leaking in: without it, a globally installed (possibly
+    // stale) copy of this same skill in ~/.claude/skills shadows the project
+    // copy, along with the user's global CLAUDE.md and memory.
+    run(
+      `claude -p ${JSON.stringify(prompt(runId))} --dangerously-skip-permissions --setting-sources project,local${model ? ` --model ${model}` : ""}`,
+      appDir,
+      { timeout: AGENT_TIMEOUT_MS },
+    );
+    verdict.agent = true;
+
+    console.log(`[eval] building`);
+    run(fw.build, appDir);
+    verdict.build = true;
+
+    console.log(`[eval] booting`);
+    server = spawn("sh", ["-c", fw.serve], {
+      cwd: appDir,
+      env: { ...process.env, PORT: String(PORT) },
+      stdio: "ignore",
+      detached: true,
+    });
+    await waitForBoot(`http://localhost:${PORT}/`);
+    verdict.boot = true;
+
+    console.log(`[eval] driving a real browser`);
+    const session = `--session ${runId}`;
+    run(`agent-browser open http://localhost:${PORT}/ ${session}`, appDir);
+    run(`agent-browser wait --load networkidle ${session}`, appDir);
+    run(`agent-browser reload ${session}`, appDir);
+    await new Promise((r) => setTimeout(r, FLUSH_WAIT_MS));
+    run(`agent-browser close ${session}`, appDir);
+
+    // Browser rows can be logs (pageviews, errors) or spans depending on the
+    // SDK the agent chose, so count both tables.
+    const counts = localQuery(
+      `SELECT ServiceName, sum(c) AS c FROM (SELECT ServiceName, count() AS c FROM traces WHERE Timestamp > now() - INTERVAL 15 MINUTE AND ServiceName IN ('${runId}-web','${runId}-server') GROUP BY ServiceName UNION ALL SELECT ServiceName, count() AS c FROM logs WHERE Timestamp > now() - INTERVAL 15 MINUTE AND ServiceName IN ('${runId}-web','${runId}-server') GROUP BY ServiceName) GROUP BY ServiceName`,
+    );
+    verdict.browserRows =
+      counts.find((r) => r.ServiceName === `${runId}-web`)?.c ?? 0;
+    verdict.serverRows =
+      counts.find((r) => r.ServiceName === `${runId}-server`)?.c ?? 0;
+    verdict.joinedTraces = localQuery(
+      `SELECT count() AS c FROM (SELECT TraceId, groupUniqArray(ServiceName) AS s FROM traces WHERE Timestamp > now() - INTERVAL 15 MINUTE AND ServiceName IN ('${runId}-web','${runId}-server') GROUP BY TraceId HAVING length(s) > 1)`,
+    )[0]?.c ?? 0;
+
+    verdict.pass =
+      verdict.build &&
+      verdict.boot &&
+      verdict.browserRows > 0 &&
+      verdict.serverRows > 0 &&
+      verdict.joinedTraces > 0;
+  } catch (error) {
+    verdict.error = String(error?.message ?? error);
+  } finally {
+    if (server) process.kill(-server.pid, "SIGTERM");
+    if (keep || !verdict.pass) {
+      console.log(`[eval] project kept at ${appDir}`);
+    } else {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  }
+
+  console.log(JSON.stringify(verdict, null, 2));
+  process.exit(verdict.pass ? 0 : 1);
+}
+
+await main();


### PR DESCRIPTION
Part 4/4 of the browser telemetry stack. Stacked on #339. Replaces #335.

## User-facing changes

- **`everr setup-telemetry` now handles full-stack Vite apps**: new `vite-ssr` and `tanstack-start` rules instrument client and server together with `@everr/otel-web`, so one skill run wires the whole app.
- The browser, electron, nextjs, nodejs, rust, and tauri rules are updated for the new WebSDK API.
- Error tracking guidance is back for stacks without an SDK; SDK stacks get error capture from their runtime hints and validation instead of a separate rule.

## What's inside

- New `evals/setup-telemetry` harness: runs the skill against fixture apps with `@everr` packages served from a local registry, grades against the public CLI collector, and counts ingested log rows. Keeps user-level agent config from leaking into eval runs.