### PR TITLE
style(app): ten-color dashboard series palette

### DIFF
--- a/packages/app/src/components/dashboards/visualizations/data-utils.ts
+++ b/packages/app/src/components/dashboards/visualizations/data-utils.ts
@@ -7,12 +7,16 @@ export { toNumber };
 /** Shared series palette. Index 0 doubles as the accent color for brush
  * selections and sparklines. */
 export const SERIES_COLORS = [
-  "hsl(217, 91%, 60%)",
-  "hsl(142, 71%, 45%)",
-  "hsl(0, 84%, 60%)",
-  "hsl(280, 68%, 60%)",
-  "hsl(35, 92%, 50%)",
-  "hsl(190, 90%, 50%)",
+  "hsl(263, 90%, 65%)",
+  "hsl(56, 90%, 65%)",
+  "hsl(195, 90%, 65%)",
+  "hsl(27, 90%, 65%)",
+  "hsl(215, 90%, 65%)",
+  "hsl(126, 90%, 65%)",
+  "hsl(167, 90%, 65%)",
+  "hsl(356, 90%, 65%)",
+  "hsl(185, 90%, 65%)",
+  "hsl(311, 90%, 65%)",
 ];
 
 /** Clean clock intervals a time axis may tick at, ascending. */


### PR DESCRIPTION
Stacked on #341.

Replaces the six-color series palette with a ten-color set at uniform `hsl(H, 90%, 65%)`. Hues are ordered so perceptually similar colors never sit in adjacent slots, and adjacent-pair separation was checked under colorblind simulation (worst pair well above the legibility floor) along with 3:1 contrast against the dark card surface. Index 0 (purple) is the brush/sparkline accent.

## Palette

![palette](https://raw.githubusercontent.com/everr-labs/everr/assets/dashboard-series-palette/pr-assets/palette.png)

## Screenshots

Bar chart demo dashboard:

![bar charts](https://raw.githubusercontent.com/everr-labs/everr/assets/dashboard-series-palette/pr-assets/demo-bar-chart.png)

Time series demo dashboard:

![time series](https://raw.githubusercontent.com/everr-labs/everr/assets/dashboard-series-palette/pr-assets/series.png)

Images are served from the `assets/dashboard-series-palette` branch; delete it after merge.