### PR TITLE
fix(alerts): transactional applies, org deletion with direct channels, regex matcher removal

### DIFF
--- a/packages/app/src/data/alerting/delivery/repository.ts
+++ b/packages/app/src/data/alerting/delivery/repository.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { and, asc, desc, eq, inArray } from "drizzle-orm";
-import { db } from "@/db/client";
+import { type DbExecutor, db } from "@/db/client";
 import {
   alertChannels,
   alertDefinitionChannels,
@@ -245,6 +245,7 @@ export async function listReceivers(organizationId: string) {
 async function resolveChannelIds(
   organizationId: string,
   names: string[],
+  executor: DbExecutor = db,
 ): Promise<string[]> {
   if (names.length === 0) {
     throwAlertingPersistenceError(
@@ -253,7 +254,7 @@ async function resolveChannelIds(
       "receiver needs a channel",
     );
   }
-  const rows = await db
+  const rows = await executor
     .select({ id: alertChannels.id, name: alertChannels.name })
     .from(alertChannels)
     .where(
@@ -277,8 +278,11 @@ async function resolveChannelIds(
 export async function resolveOptionalChannelIds(
   organizationId: string,
   names: string[],
+  executor: DbExecutor = db,
 ): Promise<string[]> {
-  return names.length === 0 ? [] : resolveChannelIds(organizationId, names);
+  return names.length === 0
+    ? []
+    : resolveChannelIds(organizationId, names, executor);
 }
 
 export async function createReceiver(

--- a/packages/app/src/data/alerting/routing/resolution.test.ts
+++ b/packages/app/src/data/alerting/routing/resolution.test.ts
@@ -37,27 +37,35 @@ function route(
 }
 
 describe("alertingMatcherMatches", () => {
-  // A missing label reads as the empty string, so `ne` and `notregex` match it
-  // and a permissive pattern does too. An invalid pattern never matches, which
-  // notregex negates into a match.
+  // A missing label reads as the empty string, so `ne` matches it.
   it.each<[AlertingMatcher["op"], string, Record<string, string>, boolean]>([
     ["eq", "pay", { team: "pay" }, true],
     ["eq", "pay", { team: "core" }, false],
     ["eq", "pay", {}, false],
+    ["eq", "", {}, true],
     ["ne", "pay", { team: "core" }, true],
     ["ne", "pay", {}, true],
     ["ne", "pay", { team: "pay" }, false],
-    ["regex", "^pay.*", { team: "payments" }, true],
-    ["regex", "^pay.*", { team: "core" }, false],
-    ["regex", ".*", {}, true],
-    ["regex", "pay", {}, false],
-    ["regex", "(", { team: "pay" }, false],
-    ["notregex", "^pay.*", { team: "core" }, true],
-    ["notregex", "^pay.*", {}, true],
-    ["notregex", "^pay.*", { team: "payments" }, false],
-    ["notregex", "(", { team: "pay" }, true],
   ])("team %s %s against %j is %s", (op, value, labels, expected) => {
     expect(alertingMatcherMatches(matcher(op, value), labels)).toBe(expected);
+  });
+
+  // Matching is exact: a value that reads as a pattern is compared literally.
+  it("compares pattern-looking values literally", () => {
+    expect(
+      alertingMatcherMatches(matcher("eq", "^pay.*"), { team: "pay" }),
+    ).toBe(false);
+    expect(
+      alertingMatcherMatches(matcher("eq", "^pay.*"), { team: "^pay.*" }),
+    ).toBe(true);
+  });
+
+  // Rows persisted before the regex ops were removed must not match.
+  it("never matches a removed op left in stored data", () => {
+    const stale = { label: "team", op: "regex", value: ".*" } as unknown;
+    expect(
+      alertingMatcherMatches(stale as AlertingMatcher, { team: "pay" }),
+    ).toBe(false);
   });
 });
 
@@ -141,7 +149,7 @@ describe("alertingSelectRoutes", () => {
 describe("alertingIsCatchAll", () => {
   it("recognizes only an explicit route without matchers", () => {
     expect(alertingIsCatchAll([])).toBe(true);
-    expect(alertingIsCatchAll([matcher("regex", ".*")])).toBe(false);
+    expect(alertingIsCatchAll([matcher("ne", "")])).toBe(false);
   });
 });
 

--- a/packages/app/src/data/alerting/routing/resolution.ts
+++ b/packages/app/src/data/alerting/routing/resolution.ts
@@ -5,35 +5,24 @@ import type {
   AlertingRuleView,
 } from "../types";
 
-const OP_SYMBOL: Record<AlertingMatcher["op"], string> = {
-  eq: "=",
-  ne: "≠",
-  regex: "=~",
-  notregex: "!~",
-};
+const OP_SYMBOL = { eq: "=", ne: "≠" } satisfies Record<
+  AlertingMatcher["op"],
+  string
+>;
 
 export function alertingOpSymbol(op: AlertingMatcher["op"]): string {
-  return OP_SYMBOL[op];
+  // A row persisted before an op was retired renders its raw op name, never
+  // the string "undefined".
+  return (OP_SYMBOL as Record<string, string | undefined>)[op] ?? op;
 }
 
-// Invalid patterns are cached as null. Configuration bounds the cache size.
-const REGEX_CACHE = new Map<string, RegExp | null>();
-
-/** Full-string regex match. Invalid patterns never match. */
-function alertingRegexFullMatch(pattern: string, value: string): boolean {
-  let re = REGEX_CACHE.get(pattern);
-  if (re === undefined) {
-    try {
-      re = new RegExp(`^(?:${pattern})$`);
-    } catch {
-      re = null;
-    }
-    REGEX_CACHE.set(pattern, re);
-  }
-  return re?.test(value) ?? false;
+// Rows written before the regex ops were removed never match. The `never`
+// parameter forces a new enum op to add its case before this compiles.
+function staleMatcherOpNeverMatches(_op: never): boolean {
+  return false;
 }
 
-/** Missing labels match as empty strings. */
+/** Missing labels match as empty strings. Matching is exact only. */
 export function alertingMatcherMatches(
   m: AlertingMatcher,
   labels: Record<string, string>,
@@ -44,10 +33,8 @@ export function alertingMatcherMatches(
       return v === m.value;
     case "ne":
       return v !== m.value;
-    case "regex":
-      return alertingRegexFullMatch(m.value, v);
-    case "notregex":
-      return !alertingRegexFullMatch(m.value, v);
+    default:
+      return staleMatcherOpNeverMatches(m.op);
   }
 }
 
@@ -58,8 +45,7 @@ export function alertingRouteMatches(
   return matchers.every((m) => alertingMatcherMatches(m, labels));
 }
 
-/** No matchers = matches every alert. (A `.*` regex also would, but the UI
- * only treats the explicit no-conditions form as a catch-all.) */
+/** No matchers = matches every alert. */
 export function alertingIsCatchAll(matchers: AlertingMatcher[]): boolean {
   return matchers.length === 0;
 }

--- a/packages/app/src/data/alerting/rules/repository.ts
+++ b/packages/app/src/data/alerting/rules/repository.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { toClickHouseDateTime } from "@everr/ui/lib/time-range";
 import { and, asc, desc, eq, inArray, isNull } from "drizzle-orm";
 import { parseResourceName } from "@/data/as-code/identity";
-import { db, type Transaction } from "@/db/client";
+import { type DbExecutor, db, type Transaction } from "@/db/client";
 import {
   alertChannels,
   alertDefinitionChannels,
@@ -18,6 +18,7 @@ import {
 } from "../persistence";
 import {
   enqueueAlertEvaluation,
+  enqueueAlertEvaluationInTransaction,
   nextAlertEvaluationAt,
 } from "../scheduling/evaluation-jobs.server";
 import {
@@ -80,9 +81,10 @@ function ruleView(row: RuleRow, notificationChannels: string[]) {
 async function definitionChannelNames(
   organizationId: string,
   definitionIds: string[],
+  executor: DbExecutor = db,
 ): Promise<Map<string, string[]>> {
   if (definitionIds.length === 0) return new Map();
-  const rows = await db
+  const rows = await executor
     .select({
       alertDefinitionId: alertDefinitionChannels.alertDefinitionId,
       channelName: alertChannels.name,
@@ -121,11 +123,12 @@ async function definitionChannelNames(
 async function definitionChannelNamesFor(
   organizationId: string,
   definitionId: string,
+  executor: DbExecutor = db,
 ): Promise<string[]> {
   return (
-    (await definitionChannelNames(organizationId, [definitionId])).get(
-      definitionId,
-    ) ?? []
+    (
+      await definitionChannelNames(organizationId, [definitionId], executor)
+    ).get(definitionId) ?? []
   );
 }
 
@@ -229,8 +232,9 @@ export async function listAllRules(
 async function getRuleRow(
   organizationId: string,
   id: string,
+  executor: DbExecutor = db,
 ): Promise<RuleRow> {
-  const [row] = await db
+  const [row] = await executor
     .select()
     .from(alertDefinitions)
     .where(
@@ -325,18 +329,33 @@ function definitionValues(
   };
 }
 
+// In-transaction so the evaluation job cannot outlive a rolled-back rule,
+// and a mutated rule is never left unscheduled by a crash.
+function scheduleEvaluation(tx: Transaction, row: RuleRow): Promise<void> {
+  return enqueueAlertEvaluationInTransaction(tx, {
+    alertDefinitionId: row.id,
+    scheduledFor:
+      row.nextEvaluationAt?.toISOString() ?? new Date().toISOString(),
+    ruleVersion: row.version,
+  });
+}
+
+// The executor is required on every mutation: a defaulted `db` would let a
+// missed call site silently escape the caller's transaction.
 export async function createRule(
   organizationId: string,
   rawInput: AlertingRuleInput,
+  executor: DbExecutor,
 ) {
   const input = AlertingRuleInputSchema.parse(rawInput);
   const channelIds = await resolveOptionalChannelIds(
     organizationId,
     input.notification_channels,
+    executor,
   );
   const id = randomUUID();
   const row = await translateAlertingConflict(() =>
-    db.transaction(async (tx) => {
+    executor.transaction(async (tx) => {
       const [created] = await tx
         .insert(alertDefinitions)
         .values(definitionValues(id, organizationId, input))
@@ -347,15 +366,10 @@ export async function createRule(
         created.id,
         channelIds,
       );
+      await scheduleEvaluation(tx, created);
       return created;
     }),
   );
-  await enqueueAlertEvaluation({
-    alertDefinitionId: row.id,
-    scheduledFor:
-      row.nextEvaluationAt?.toISOString() ?? new Date().toISOString(),
-    ruleVersion: row.version,
-  });
   return ruleBase(row, input.notification_channels);
 }
 
@@ -363,7 +377,8 @@ export async function updateRule(
   organizationId: string,
   id: string,
   rawSpec: AlertingRuleUpdate,
-  version?: number,
+  version: number | undefined,
+  executor: DbExecutor,
 ) {
   const input = AlertingRuleUpdateSchema.parse(rawSpec);
   const { notification_channels: notificationChannels, ...rawRuleSpec } = input;
@@ -371,8 +386,9 @@ export async function updateRule(
   const channelIds = await resolveOptionalChannelIds(
     organizationId,
     notificationChannels,
+    executor,
   );
-  const previous = await getRuleRow(organizationId, id);
+  const previous = await getRuleRow(organizationId, id, executor);
   if (version !== undefined && previous.version !== version) {
     throwAlertingPersistenceError(
       409,
@@ -389,7 +405,7 @@ export async function updateRule(
     spec.interval_secs,
   );
   const updated = await translateAlertingConflict(() =>
-    db.transaction(async (tx) => {
+    executor.transaction(async (tx) => {
       const [row] = await tx
         .update(alertDefinitions)
         .set({
@@ -418,15 +434,10 @@ export async function updateRule(
           .where(eq(alertInstances.alertDefinitionId, id));
       }
       await replaceDefinitionChannels(tx, organizationId, id, channelIds);
+      await scheduleEvaluation(tx, row);
       return row;
     }),
   );
-  await enqueueAlertEvaluation({
-    alertDefinitionId: updated.id,
-    scheduledFor:
-      updated.nextEvaluationAt?.toISOString() ?? new Date().toISOString(),
-    ruleVersion: updated.version,
-  });
   return ruleBase(updated, notificationChannels);
 }
 
@@ -435,11 +446,12 @@ export async function adoptRule(
   id: string,
   repoid: string,
   version: number,
-  rawSpec?: AlertingRuleUpdate,
+  rawSpec: AlertingRuleUpdate | undefined,
+  executor: DbExecutor,
 ) {
   if (repoid.length === 0)
     throwAlertingPersistenceError(422, "validation", "repoid is required");
-  const previous = await getRuleRow(organizationId, id);
+  const previous = await getRuleRow(organizationId, id, executor);
   if (previous.version !== version || previous.previewId !== null) {
     throwAlertingPersistenceError(
       409,
@@ -459,14 +471,18 @@ export async function adoptRule(
       )
     : null;
   const channelIds = notificationChannels
-    ? await resolveOptionalChannelIds(organizationId, notificationChannels)
+    ? await resolveOptionalChannelIds(
+        organizationId,
+        notificationChannels,
+        executor,
+      )
     : null;
   const labelsChanged =
     spec !== null &&
     JSON.stringify(previous.spec.label_columns) !==
       JSON.stringify(spec.label_columns);
   const row = await translateAlertingConflict(() =>
-    db.transaction(async (tx) => {
+    executor.transaction(async (tx) => {
       const [updated] = await tx
         .update(alertDefinitions)
         .set({
@@ -507,6 +523,7 @@ export async function adoptRule(
       if (channelIds) {
         await replaceDefinitionChannels(tx, organizationId, id, channelIds);
       }
+      if (spec) await scheduleEvaluation(tx, updated);
       return updated;
     }),
   );
@@ -516,23 +533,19 @@ export async function adoptRule(
       "conflict",
       `Rule version changed: ${id}`,
     );
-  if (spec) {
-    await enqueueAlertEvaluation({
-      alertDefinitionId: row.id,
-      scheduledFor:
-        row.nextEvaluationAt?.toISOString() ?? new Date().toISOString(),
-      ruleVersion: row.version,
-    });
-  }
   return ruleBase(
     row,
     notificationChannels ??
-      (await definitionChannelNamesFor(organizationId, row.id)),
+      (await definitionChannelNamesFor(organizationId, row.id, executor)),
   );
 }
 
-export async function deleteRule(organizationId: string, id: string) {
-  const rows = await db
+export async function deleteRule(
+  organizationId: string,
+  id: string,
+  executor: DbExecutor,
+) {
+  const rows = await executor
     .delete(alertDefinitions)
     .where(
       and(

--- a/packages/app/src/data/alerting/rules/resource/apply.server.test.ts
+++ b/packages/app/src/data/alerting/rules/resource/apply.server.test.ts
@@ -28,7 +28,8 @@ import type { DbExecutor } from "@/db/client";
 import { querySqlApiWithMeta } from "@/lib/clickhouse";
 import { applyAlertSpecs } from "./apply.server";
 
-// These tests mock the repository, so the reconciler executor is unused.
+// The repository is mocked, so the executor's identity is all that matters:
+// the reconciler must hand this exact object to every mutation.
 const db = {} as unknown as DbExecutor;
 
 const ch = vi.mocked(querySqlApiWithMeta);
@@ -155,6 +156,47 @@ describe("applyAlertSpecs", () => {
     expect(mockedDeleteRule).not.toHaveBeenCalled();
   });
 
+  it("passes the registry executor to every mutation, so apply commits or rolls back whole", async () => {
+    mockedListRules.mockResolvedValue([
+      managedRule("changed", { sql: CHANGED_SQL }),
+      managedRule("stale"),
+      managedRule("foreign", { repoid: "other-repo" }),
+    ]);
+
+    await applyAlertSpecs({
+      namespace: live,
+      db,
+      adopt: true,
+      resources: [
+        { path: "new.yaml", resource: alert("brand-new") },
+        { path: "changed.yaml", resource: alert("changed") },
+        { path: "foreign.yaml", resource: alert("foreign") },
+      ],
+    });
+
+    expect(mockedCreateRule).toHaveBeenCalledTimes(1);
+    expect(mockedCreateRule).toHaveBeenCalledWith("o", expect.anything(), db);
+    expect(mockedUpdateRule).toHaveBeenCalledTimes(1);
+    expect(mockedUpdateRule).toHaveBeenCalledWith(
+      "o",
+      "rule-changed",
+      expect.anything(),
+      3,
+      db,
+    );
+    expect(mockedAdoptRule).toHaveBeenCalledTimes(1);
+    expect(mockedAdoptRule).toHaveBeenCalledWith(
+      "o",
+      "rule-foreign",
+      "repo-1",
+      3,
+      expect.anything(),
+      db,
+    );
+    expect(mockedDeleteRule).toHaveBeenCalledTimes(1);
+    expect(mockedDeleteRule).toHaveBeenCalledWith("o", "rule-stale", db);
+  });
+
   it("resolves explicit notification channels before creating the rule", async () => {
     mockedListChannels.mockResolvedValue([
       { id: "channel-1", tenant: "o", name: "team-slack", config: {} },
@@ -176,6 +218,7 @@ describe("applyAlertSpecs", () => {
     expect(mockedCreateRule).toHaveBeenCalledWith(
       "o",
       expect.objectContaining({ notification_channels: ["team-slack"] }),
+      db,
     );
   });
 
@@ -263,7 +306,7 @@ describe("applyAlertSpecs", () => {
 
     expect(res.deleted).toEqual(["default/stale"]);
     expect(mockedDeleteRule).toHaveBeenCalledTimes(1);
-    expect(mockedDeleteRule).toHaveBeenCalledWith("o", "prev-rule-stale");
+    expect(mockedDeleteRule).toHaveBeenCalledWith("o", "prev-rule-stale", db);
   });
 
   it("a live apply updates and prunes only the live copy when a preview copy of the same name coexists", async () => {
@@ -297,7 +340,7 @@ describe("applyAlertSpecs", () => {
 
     expect(pruned.deleted).toEqual(["default/high-errors"]);
     expect(mockedDeleteRule).toHaveBeenCalledTimes(1);
-    expect(mockedDeleteRule).toHaveBeenCalledWith("o", "rule-high-errors");
+    expect(mockedDeleteRule).toHaveBeenCalledWith("o", "rule-high-errors", db);
   });
 
   it("leaves an unchanged preview rule alone and updates a changed one in place", async () => {
@@ -610,7 +653,7 @@ describe("applyAlertSpecs", () => {
 
     expect(res.deleted).toEqual(["default/gone"]);
     expect(mockedDeleteRule).toHaveBeenCalledTimes(1);
-    expect(mockedDeleteRule).toHaveBeenCalledWith("o", "x");
+    expect(mockedDeleteRule).toHaveBeenCalledWith("o", "x", db);
   });
 
   it("reports cross-repo name collisions as ownership conflicts (no writes)", async () => {

--- a/packages/app/src/data/alerting/rules/resource/apply.server.ts
+++ b/packages/app/src/data/alerting/rules/resource/apply.server.ts
@@ -167,10 +167,7 @@ async function validateAlertRuleQuery(
   return { instanceLabelColumns, ...(warning ? { warning } : {}) };
 }
 
-// Bound ClickHouse validation and database mutations independently.
 const VALIDATION_QUERY_CONCURRENCY = 8;
-
-const ALERTING_MUTATION_CONCURRENCY = 8;
 
 function specFingerprint(spec: Record<string, unknown>): string {
   return stableStringify(spec);
@@ -186,6 +183,7 @@ export const applyAlertSpecs: Reconciler = async ({
   resources,
   dryRun,
   adopt,
+  db: executor,
 }): Promise<ApplyAlertsResult> => {
   const { orgId, repoid } = namespace;
   // A missing first-apply preview id scopes to no existing rules.
@@ -321,15 +319,18 @@ export const applyAlertSpecs: Reconciler = async ({
       });
   const adopted = adopt ? taken.map(({ d }) => d.input.name) : [];
 
-  // 5. Converge in a bounded pool, preserving deterministic errors.
-  const runMutation = createLimiter(ALERTING_MUTATION_CONCURRENCY);
+  // 5. Converge sequentially on the registry executor: mutations run as
+  // savepoints on its single connection, and savepoints must nest strictly,
+  // so a concurrent pool here would interleave them. allSettled still
+  // preserves deterministic error reporting.
+  const runMutation = createLimiter(1);
   const writes = await Promise.allSettled([
     ...fresh.map((d) =>
       runMutation(undefined, async () => {
         if (dryRun) return;
         // Translate a create race into the same ownership error as the plan.
         try {
-          await alerting.createRule(orgId, d.input);
+          await alerting.createRule(orgId, d.input, executor);
         } catch (error) {
           if (isAlertingVersionConflict(error)) {
             throw new ApplyValidationError(
@@ -356,6 +357,7 @@ export const applyAlertSpecs: Reconciler = async ({
               repoid,
               foreign.version,
               spec,
+              executor,
             );
           }),
         )
@@ -371,7 +373,7 @@ export const applyAlertSpecs: Reconciler = async ({
           ...spec
         } = d.input;
         try {
-          await alerting.updateRule(orgId, cur.id, spec, cur.version);
+          await alerting.updateRule(orgId, cur.id, spec, cur.version, executor);
         } catch (error) {
           if (isAlertingVersionConflict(error)) {
             throw new ApplyValidationError(
@@ -394,7 +396,7 @@ export const applyAlertSpecs: Reconciler = async ({
   const deletions = await Promise.allSettled(
     stale.map(([, cur]) =>
       runMutation(undefined, async () => {
-        if (!dryRun) await alerting.deleteRule(orgId, cur.id);
+        if (!dryRun) await alerting.deleteRule(orgId, cur.id, executor);
       }),
     ),
   );

--- a/packages/app/src/data/alerting/scheduling/evaluation-jobs.server.ts
+++ b/packages/app/src/data/alerting/scheduling/evaluation-jobs.server.ts
@@ -1,5 +1,7 @@
 import { createHash } from "node:crypto";
-import { addWorkerJob } from "@/server/worker/jobs";
+import type { TaskSpec } from "graphile-worker";
+import type { Transaction } from "@/db/client";
+import { addWorkerJob, addWorkerJobInTransaction } from "@/server/worker/jobs";
 
 export const ALERT_EVALUATE_TASK = "alerts/evaluate";
 
@@ -87,11 +89,8 @@ export function alertEvaluationJobKey(
   return `${ALERT_EVALUATE_TASK}:${id}:${scheduledFor}`;
 }
 
-export function enqueueAlertEvaluation(
-  payload: EvaluatePayload,
-  runAt = new Date(payload.scheduledFor),
-): Promise<void> {
-  return addWorkerJob(ALERT_EVALUATE_TASK, payload, {
+function evaluationTaskSpec(payload: EvaluatePayload, runAt: Date): TaskSpec {
+  return {
     jobKey: alertEvaluationJobKey(
       payload.alertDefinitionId,
       payload.scheduledFor,
@@ -100,5 +99,31 @@ export function enqueueAlertEvaluation(
     maxAttempts: EVALUATE_MAX_ATTEMPTS,
     queueName: alertingPartitionQueue("alert", payload.alertDefinitionId),
     runAt,
-  });
+  };
+}
+
+export function enqueueAlertEvaluation(
+  payload: EvaluatePayload,
+  runAt = new Date(payload.scheduledFor),
+): Promise<void> {
+  return addWorkerJob(
+    ALERT_EVALUATE_TASK,
+    payload,
+    evaluationTaskSpec(payload, runAt),
+  );
+}
+
+// Enqueued through graphile's SQL function so the job commits or rolls back
+// with the mutation that scheduled it.
+export function enqueueAlertEvaluationInTransaction(
+  tx: Transaction,
+  payload: EvaluatePayload,
+  runAt = new Date(payload.scheduledFor),
+): Promise<void> {
+  return addWorkerJobInTransaction(
+    tx,
+    ALERT_EVALUATE_TASK,
+    payload,
+    evaluationTaskSpec(payload, runAt),
+  );
 }

--- a/packages/app/src/data/alerting/schema.test.ts
+++ b/packages/app/src/data/alerting/schema.test.ts
@@ -1,8 +1,13 @@
 import { expect, it } from "vitest";
 import {
+  ALERTING_MATCHER_LABEL_MAX,
+  ALERTING_MATCHER_VALUE_MAX,
+  ALERTING_MATCHERS_MAX,
   AlertingChannelSchema,
   AlertingReceiverSchema,
+  AlertingRouteInputSchema,
   AlertingRuleViewSchema,
+  AlertingSilenceInputSchema,
 } from "./schema";
 
 const ruleView = {
@@ -84,6 +89,85 @@ it("rejects receiver channels that are not a non-empty list of names", () => {
   expect(() =>
     AlertingReceiverSchema.parse(receiver([{ type: "slack", url: "***" }])),
   ).toThrow();
+});
+
+const routeInput = (matchers: unknown) => ({
+  matchers,
+  receiver: "oncall",
+  continue: false,
+  priority: 1,
+  group_by: null,
+  group_wait_secs: null,
+  group_interval_secs: null,
+  repeat_interval_secs: null,
+});
+
+it("rejects the removed regex ops and names them in the error", () => {
+  for (const op of ["regex", "notregex"] as const) {
+    const result = AlertingRouteInputSchema.safeParse(
+      routeInput([{ label: "team", op, value: "^pay.*" }]),
+    );
+    expect(result.success).toBe(false);
+    const message = result.error?.issues[0]?.message ?? "";
+    expect(message).toContain(op);
+    expect(message).toContain("removed");
+    expect(message).toContain("eq");
+  }
+
+  const unknown = AlertingRouteInputSchema.safeParse(
+    routeInput([{ label: "team", op: "glob", value: "pay*" }]),
+  );
+  expect(unknown.success).toBe(false);
+  expect(unknown.error?.issues[0]?.message).toContain("eq");
+});
+
+it("bounds matcher counts and label and value lengths", () => {
+  const matchers = (count: number, value = "pay") =>
+    Array.from({ length: count }, () => ({ label: "team", op: "eq", value }));
+
+  expect(
+    AlertingRouteInputSchema.safeParse(
+      routeInput([
+        {
+          label: "x".repeat(ALERTING_MATCHER_LABEL_MAX + 1),
+          op: "eq",
+          value: "pay",
+        },
+      ]),
+    ).success,
+  ).toBe(false);
+
+  expect(
+    AlertingRouteInputSchema.safeParse(
+      routeInput(matchers(ALERTING_MATCHERS_MAX)),
+    ).success,
+  ).toBe(true);
+  expect(
+    AlertingRouteInputSchema.safeParse(
+      routeInput(matchers(ALERTING_MATCHERS_MAX + 1)),
+    ).success,
+  ).toBe(false);
+
+  const silence = (matchers: unknown) => ({
+    matchers,
+    starts_at: "2026-07-01T11:00:00Z",
+    ends_at: "2026-07-01T13:00:00Z",
+  });
+  expect(
+    AlertingSilenceInputSchema.safeParse(
+      silence(matchers(1, "x".repeat(ALERTING_MATCHER_VALUE_MAX))),
+    ).success,
+  ).toBe(true);
+  expect(
+    AlertingSilenceInputSchema.safeParse(
+      silence(matchers(1, "x".repeat(ALERTING_MATCHER_VALUE_MAX + 1))),
+    ).success,
+  ).toBe(false);
+  expect(
+    AlertingSilenceInputSchema.safeParse(
+      silence(matchers(ALERTING_MATCHERS_MAX + 1)),
+    ).success,
+  ).toBe(false);
 });
 
 it("rejects a channel with an unknown config type", () => {

--- a/packages/app/src/data/alerting/schema.ts
+++ b/packages/app/src/data/alerting/schema.ts
@@ -10,7 +10,19 @@ import {
 } from "./vocabulary";
 
 export const AlertingSeveritySchema = z.enum(ALERTING_SEVERITIES);
-export const AlertingMatchOpSchema = z.enum(["eq", "ne", "regex", "notregex"]);
+
+// Matching is exact only. `regex`/`notregex` were removed: user patterns
+// reached the native RegExp engine, where catastrophic backtracking and an
+// unbounded pattern cache were a denial-of-service path.
+const ALERTING_REMOVED_MATCH_OPS = ["regex", "notregex"];
+
+export const AlertingMatchOpSchema = z.enum(["eq", "ne"], {
+  error: (issue) =>
+    typeof issue.input === "string" &&
+    ALERTING_REMOVED_MATCH_OPS.includes(issue.input)
+      ? `matcher op "${issue.input}" was removed: matchers are exact match only, use "eq" or "ne"`
+      : `matcher op must be "eq" or "ne"`,
+});
 const AlertingRuleConditionOperatorSchema = z.enum([
   "gt",
   "gte",
@@ -31,11 +43,20 @@ const AlertingTimestampSchema = z.string().datetime();
 const AlertingTimestampNullable = AlertingTimestampSchema.nullable();
 const AlertingChannelNamesSchema = alertingChannelNamesSchema();
 
+// Generous bounds that keep a matcher set bounded in memory and in the
+// dispatcher's per-alert work. They are not a UX policy.
+export const ALERTING_MATCHERS_MAX = 64;
+export const ALERTING_MATCHER_LABEL_MAX = 256;
+export const ALERTING_MATCHER_VALUE_MAX = 1024;
+
 export const AlertingMatcherSchema = z.object({
-  label: z.string(),
+  label: z.string().max(ALERTING_MATCHER_LABEL_MAX),
   op: AlertingMatchOpSchema,
-  value: z.string(),
+  value: z.string().max(ALERTING_MATCHER_VALUE_MAX),
 });
+
+const alertingMatchersSchema = <T extends z.ZodType>(matcher: T) =>
+  z.array(matcher).max(ALERTING_MATCHERS_MAX);
 
 export const AlertingRuleSpecSchema = z.object({
   sql: z.string(),
@@ -141,7 +162,7 @@ export const AlertingReceiverSchema = z.object({
 export const AlertingRouteSchema = z.object({
   id: z.string(),
   tenant: z.string(),
-  matchers: z.array(AlertingMatcherSchema),
+  matchers: alertingMatchersSchema(AlertingMatcherSchema),
   receiver: z.string(),
   continue: z.boolean(),
   priority: z.number().int(),
@@ -152,7 +173,7 @@ export const AlertingRouteSchema = z.object({
 });
 
 export const AlertingRouteInputSchema = z.object({
-  matchers: z.array(AlertingMatcherSchema),
+  matchers: alertingMatchersSchema(AlertingMatcherSchema),
   receiver: z.string().min(1),
   continue: z.boolean(),
   priority: z.number().int(),
@@ -174,20 +195,18 @@ export const AlertingRuleUpdateSchema = AlertingRuleSpecSchema.extend({
 });
 
 export const AlertingInhibitionInputSchema = z.object({
-  source_matchers: z.array(AlertingMatcherSchema),
-  target_matchers: z.array(AlertingMatcherSchema),
+  source_matchers: alertingMatchersSchema(AlertingMatcherSchema),
+  target_matchers: alertingMatchersSchema(AlertingMatcherSchema),
   equal: z.array(z.string()),
 });
 
 export const AlertingSilenceInputSchema = z.object({
   // Empty label names would turn missing labels into a global match.
-  matchers: z
-    .array(
-      AlertingMatcherSchema.refine((m) => m.label.trim() !== "", {
-        message: "matcher label is required",
-      }),
-    )
-    .min(1),
+  matchers: alertingMatchersSchema(
+    AlertingMatcherSchema.refine((m) => m.label.trim() !== "", {
+      message: "matcher label is required",
+    }),
+  ).min(1),
   starts_at: z.string(),
   ends_at: z.string(),
   comment: z.string().optional(),
@@ -197,7 +216,7 @@ export const AlertingSilenceInputSchema = z.object({
 export const AlertingSilenceSchema = z.object({
   id: z.string(),
   tenant: z.string(),
-  matchers: z.array(AlertingMatcherSchema),
+  matchers: alertingMatchersSchema(AlertingMatcherSchema),
   starts_at: AlertingTimestampSchema,
   ends_at: AlertingTimestampSchema,
   comment: z.string().nullable().optional(),
@@ -209,8 +228,8 @@ export const AlertingSilenceSchema = z.object({
 export const AlertingInhibitionSchema = z.object({
   id: z.string(),
   tenant: z.string(),
-  source_matchers: z.array(AlertingMatcherSchema),
-  target_matchers: z.array(AlertingMatcherSchema),
+  source_matchers: alertingMatchersSchema(AlertingMatcherSchema),
+  target_matchers: alertingMatchersSchema(AlertingMatcherSchema),
   equal: z.array(z.string()).nullable().optional(),
   created_at: AlertingTimestampSchema,
 });

--- a/packages/app/src/data/as-code/registry.test.ts
+++ b/packages/app/src/data/as-code/registry.test.ts
@@ -99,6 +99,17 @@ describe("applyResources", () => {
     expect(alertReconciler).toHaveBeenCalledWith(
       expect.objectContaining({ namespace: liveNs, resources: [alert] }),
     );
+    // The write pass (the last call; the first is validation) hands every
+    // reconciler the shared transaction executor, so a failing kind rolls
+    // back the others' mutations (the rejection path is covered by the
+    // mid-apply failure test below).
+    for (const reconciler of [
+      dashboardReconciler,
+      runbookReconciler,
+      alertReconciler,
+    ]) {
+      expect(reconciler.mock.lastCall?.[0].db).toEqual({ tx: true });
+    }
     expect(validateRunbookLinks).toHaveBeenCalledWith({
       namespace: liveNs,
       alerts: [alert],
@@ -343,7 +354,8 @@ describe("applyResources", () => {
       }),
     ).rejects.toThrow("alert repository unavailable");
 
-    // The registered namespace keeps partial preview resources recoverable.
+    // The preview row commits outside the reconcile transaction, so the next
+    // apply upserts the same namespace instead of re-registering.
     expect(upsertPreview).toHaveBeenCalledTimes(1);
     expect(upsertPreview).toHaveBeenCalledWith(db, {
       orgId: "org-1",

--- a/packages/app/src/data/as-code/registry.ts
+++ b/packages/app/src/data/as-code/registry.ts
@@ -215,18 +215,16 @@ export async function applyResources(opts: {
 
   if (dryRun) return { dryRun: true, results: withOrphanWarnings(validated) };
 
-  // Real apply. The preview registration commits first on the base executor.
-  // Alert reconciliation currently performs its own database writes outside
-  // the transaction below, and every preview-owned definition has a
-  // foreign key to this row. A registered-but-partially-applied preview is the
-  // safe failure mode: the next apply upserts the same row and every reconciler
-  // converges. Live is not registered.
+  // Real apply. The preview registration commits first on the base executor:
+  // every preview-owned definition has a foreign key to this row, and a
+  // registered-but-empty preview is the safe failure mode (the next apply
+  // upserts the same row). Live is not registered.
   const applied = await resolveNamespace((name) =>
     upsertPreview(db, { orgId, repoid, name }),
   );
-  // One transaction for the reconcile loop. Reconcilers that use the supplied
-  // executor commit or roll back together; alerting reconcilers currently use
-  // their own database operations and recover by convergence on re-apply.
+  // One transaction for the reconcile loop: every reconciler writes through
+  // the supplied executor, so a later kind's failure rolls back earlier
+  // kinds' mutations and apply never half-changes live state.
   const results: KindResult[] = [];
   await db.transaction(async (tx) => {
     for (const { key, kind, reconcile } of REGISTRY) {

--- a/packages/app/src/data/as-code/resource-admin.server.ts
+++ b/packages/app/src/data/as-code/resource-admin.server.ts
@@ -191,7 +191,7 @@ const alertBackend: KindBackend = {
   async delete(orgId, project, slug) {
     const rule = await findAlertRule(orgId, project, slug);
     if (!rule) return false;
-    await alertRules.deleteRule(orgId, rule.id);
+    await alertRules.deleteRule(orgId, rule.id, db);
     return true;
   },
   async adopt(orgId, project, slug, destRepoid) {
@@ -200,7 +200,14 @@ const alertBackend: KindBackend = {
     if (fromAlertingRule(rule).repoid === destRepoid) {
       return { found: true, alreadyOwned: true };
     }
-    await alertRules.adoptRule(orgId, rule.id, destRepoid, rule.version);
+    await alertRules.adoptRule(
+      orgId,
+      rule.id,
+      destRepoid,
+      rule.version,
+      undefined,
+      db,
+    );
     return { found: true, alreadyOwned: false };
   },
 };

--- a/packages/app/src/lib/organization-data-cleanup.server.test.ts
+++ b/packages/app/src/lib/organization-data-cleanup.server.test.ts
@@ -31,6 +31,7 @@ vi.mock("drizzle-orm", async (importOriginal) => {
 
 import {
   alertChannels,
+  alertDefinitionChannels,
   alertDefinitions,
   alertDeliveries,
   alertEvents,
@@ -74,6 +75,7 @@ describe("deletePostgresOrganizationData", () => {
       alertDeliveries,
       alertNotificationGroups,
       alertReceiverChannels,
+      alertDefinitionChannels,
       alertRoutes,
       alertChannels,
       alertReceivers,
@@ -91,6 +93,7 @@ describe("deletePostgresOrganizationData", () => {
       alertDeliveries,
       alertNotificationGroups,
       alertReceiverChannels,
+      alertDefinitionChannels,
       alertRoutes,
       alertChannels,
       alertReceivers,

--- a/packages/app/src/lib/organization-data-cleanup.server.ts
+++ b/packages/app/src/lib/organization-data-cleanup.server.ts
@@ -2,6 +2,7 @@ import { and, eq } from "drizzle-orm";
 import { db } from "@/db/client";
 import {
   alertChannels,
+  alertDefinitionChannels,
   alertDefinitions,
   alertDeliveries,
   alertEvents,
@@ -35,6 +36,11 @@ export async function deletePostgresOrganizationData(
     await tx
       .delete(alertReceiverChannels)
       .where(eq(alertReceiverChannels.organizationId, organizationId));
+    // The direct rule-to-channel mapping's channel FK does not cascade, so
+    // it must clear before alertChannels or the delete below is rejected.
+    await tx
+      .delete(alertDefinitionChannels)
+      .where(eq(alertDefinitionChannels.organizationId, organizationId));
     await tx
       .delete(alertRoutes)
       .where(eq(alertRoutes.organizationId, organizationId));

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/-components/delivery/matchers-editor.test.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/-components/delivery/matchers-editor.test.tsx
@@ -91,16 +91,16 @@ describe("MatchersEditor comboboxes", () => {
     ]);
   });
 
-  it("falls back to a free-text input for regex operators", async () => {
+  // Matching is exact only, so the operator menu offers no pattern ops.
+  it("offers only the exact-match operators", async () => {
     const user = userEvent.setup();
-    const latest = renderEditor([{ label: "svc", op: "regex", value: "" }]);
+    renderEditor([{ label: "svc", op: "eq", value: "" }]);
 
-    const field = screen.getByLabelText("Matcher value");
-    await user.type(field, "^web-.*$");
+    await user.click(
+      screen.getByRole("combobox", { name: "Matcher operator" }),
+    );
 
-    expect(latest.matchers).toEqual([
-      { label: "svc", op: "regex", value: "^web-.*$" },
-    ]);
-    expect(mocks.listAlertingLabelValues).not.toHaveBeenCalled();
+    const options = await screen.findAllByRole("option");
+    expect(options.map((o) => o.textContent)).toEqual(["=", "≠"]);
   });
 });

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/-components/delivery/matchers-editor.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/-components/delivery/matchers-editor.tsx
@@ -1,5 +1,4 @@
 import { Button } from "@everr/ui/components/button";
-import { Input } from "@everr/ui/components/input";
 import { OptionCombobox } from "@everr/ui/components/option-combobox";
 import {
   SuggestCombobox,
@@ -19,19 +18,12 @@ import {
 import { AlertingMatchOpSchema } from "@/data/alerting/schema";
 import type { AlertingMatcher } from "@/data/alerting/types";
 
-const OP_PHRASE: Record<AlertingMatcher["op"], string> = {
-  eq: "=",
-  ne: "≠",
-  regex: "matches",
-  notregex: "doesn't match",
-};
-
 /** Plain-language preview of a matcher set, e.g. "severity = critical and team = pay". */
 export function matchersPhrase(m: AlertingMatcher[]): string {
   const real = m.filter((x) => x.label.trim() !== "");
   if (alertingIsCatchAll(real)) return "any alert";
   return real
-    .map((x) => `${x.label} ${OP_PHRASE[x.op]} ${x.value || "…"}`)
+    .map((x) => `${x.label} ${alertingOpSymbol(x.op)} ${x.value || "…"}`)
     .join(" and ");
 }
 
@@ -159,31 +151,17 @@ export function MatchersEditor({
                 ),
               }))}
             />
-            {row.op === "regex" || row.op === "notregex" ? (
-              <Input
-                placeholder="pattern"
-                aria-label="Matcher value"
-                className="min-w-0 flex-1 font-mono"
-                value={row.value}
-                disabled={locked}
-                onChange={(e) =>
-                  onChange(updateMatcher(value, i, { value: e.target.value }))
-                }
-              />
-            ) : (
-              <SuggestCombobox
-                label="Matcher value"
-                placeholder="value"
-                className="min-w-0 flex-1"
-                value={row.value}
-                disabled={locked}
-                displayValue={locked ? lockedValueLabels[i] : undefined}
-                onChange={(v) =>
-                  onChange(updateMatcher(value, i, { value: v }))
-                }
-                options={alertingLabelValueOptions(row.label)}
-              />
-            )}
+            <SuggestCombobox
+              label="Matcher value"
+              placeholder="value"
+              className="min-w-0 flex-1"
+              value={row.value}
+              disabled={locked}
+              displayValue={locked ? lockedValueLabels[i] : undefined}
+              onChange={(v) => onChange(updateMatcher(value, i, { value: v }))}
+              options={alertingLabelValueOptions(row.label)}
+            />
+
             {locked ? (
               <span
                 className="inline-flex size-8 items-center justify-center justify-self-end text-muted-foreground"


### PR DESCRIPTION
Stacked on #343. Implements tickets 20, 21, and 22 from `todo/issues/alerting-surface/tickets/` (all three in the merge gate).

## Ticket 20: failed applies do not half-change alerting

The alert reconciler now writes through the transaction executor the resource registry supplies. Rule mutations nest as savepoints, run serially (savepoints on one connection must nest strictly), and enqueue evaluation jobs via `graphile_worker.add_job` inside the same transaction. A later reconciler failure rolls back alerting mutations, and a rolled-back apply leaves no orphan evaluation jobs. The executor parameter is required on the four mutations so a missed call site fails to compile instead of silently escaping the transaction.

Note: the ticket's literal test scenario (a later kind failing after alerting mutations) is unreachable because alerts reconcile last; the registry test asserts the executor reaches every reconciler and that a mid-apply failure rejects the transaction, which is the reachable equivalent.

## Ticket 21: organization deletion with direct rule channels

Cleanup deletes `alert_definition_channels` rows before `alert_channels`, mirroring the receiver-channels treatment. All three non-cascading FKs into `alert_channels` (definition mappings, receiver mappings, deliveries) are now cleared before the channel delete. The ordering is pinned by the cleanup unit test; no real-database harness exists in this package, so that plus FK-graph inspection is the honest local proof.

## Ticket 22: regex matchers removed

`regex`/`notregex` are gone from the shared matcher op enum, so route, silence, and inhibition matchers are exact match only. The rejection message names the removal ("matchers are exact match only"). The regex evaluation path and its unbounded process-wide cache are deleted; no user pattern reaches `RegExp` anywhere in the alerting tree. Bounds added: 64 matchers per list, 256-char labels, 1024-char values. Rows persisted with retired ops never match (fails toward delivering, enforced exhaustively at compile time) and render their raw op name instead of "undefined". Follow-up for safe pattern matching lives in `todo/ideas/alerting-matcher-patterns.md`.

## Verification

- `tsc --noEmit` clean, `biome check` clean, pre-commit dead-code check clean.
- Full app suite: 1382 tests, 177 files, green (plus the new bounds/executor tests).
- Two-axis review (standards + spec) ran; all accepted findings applied (shared enqueue helper, required executor, exhaustive matcher switch, stale-op rendering fallback, registry executor assertions).