### PR TITLE
feat(alerts): journal schema riders and the instance_closed vocabulary

### DIFF
--- a/packages/app/drizzle/0011_robust_cardiac.sql
+++ b/packages/app/drizzle/0011_robust_cardiac.sql
@@ -2,7 +2,8 @@ DROP TABLE "alert_silences";--> statement-breakpoint
 DROP TABLE "alert_definitions";--> statement-breakpoint
 DROP TABLE "alert_settings";--> statement-breakpoint
 CREATE TYPE "public"."alert_delivery_state" AS ENUM('pending', 'sent', 'failed');--> statement-breakpoint
-CREATE TYPE "public"."alert_event_type" AS ENUM('instance_fired', 'instance_resolved', 'delivery', 'rule_health', 'silenced');--> statement-breakpoint
+CREATE TYPE "public"."alert_event_kind" AS ENUM('notifying', 'state');--> statement-breakpoint
+CREATE TYPE "public"."alert_event_type" AS ENUM('instance_pending', 'instance_fired', 'instance_resolved', 'instance_closed', 'delivery', 'rule_health', 'silenced', 'hold_changed', 'evaluation_failed');--> statement-breakpoint
 CREATE TYPE "public"."alert_health" AS ENUM('healthy', 'degraded');--> statement-breakpoint
 CREATE TYPE "public"."alert_instance_state" AS ENUM('inactive', 'pending', 'firing');--> statement-breakpoint
 CREATE TYPE "public"."alert_severity" AS ENUM('info', 'warning', 'critical');--> statement-breakpoint
@@ -83,6 +84,7 @@ CREATE TABLE "alert_deliveries" (
 	"attempts" integer DEFAULT 0 NOT NULL,
 	"last_error" text,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"journaled_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
 	CONSTRAINT "alert_deliveries_attempts_nonnegative" CHECK ("alert_deliveries"."attempts" >= 0)
 );
@@ -102,13 +104,15 @@ CREATE TABLE "alert_evaluations" (
 );
 --> statement-breakpoint
 CREATE TABLE "alert_events" (
-	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
 	"organization_id" text NOT NULL,
 	"repoid" text NOT NULL,
 	"preview_id" uuid,
 	"source_definition_id" uuid NOT NULL,
 	"slug" text NOT NULL,
 	"event_type" "alert_event_type" NOT NULL,
+	"kind" "alert_event_kind" DEFAULT 'notifying' NOT NULL,
+	"episode_id" uuid,
 	"instance_fingerprint" text DEFAULT '' NOT NULL,
 	"instance_labels" jsonb DEFAULT '{}'::jsonb NOT NULL,
 	"severity" "alert_severity" DEFAULT 'info' NOT NULL,
@@ -119,6 +123,7 @@ CREATE TABLE "alert_events" (
 	"inhibited" boolean DEFAULT false NOT NULL,
 	"silence_id" uuid,
 	"occurred_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"journaled_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"processed_at" timestamp with time zone,
 	CONSTRAINT "alert_events_repoid_nonempty" CHECK (length("alert_events"."repoid") > 0)
 );
@@ -143,6 +148,7 @@ CREATE TABLE "alert_instances" (
 	"active_since" timestamp with time zone,
 	"last_seen_at" timestamp with time zone,
 	"absent_count" integer DEFAULT 0 NOT NULL,
+	"episode_id" uuid,
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
 	CONSTRAINT "alert_instances_absent_count_nonnegative" CHECK ("alert_instances"."absent_count" >= 0)
 );

--- a/packages/app/drizzle/meta/0011_snapshot.json
+++ b/packages/app/drizzle/meta/0011_snapshot.json
@@ -607,6 +607,13 @@
           "notNull": true,
           "default": "now()"
         },
+        "journaled_at": {
+          "name": "journaled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
         "updated_at": {
           "name": "updated_at",
           "type": "timestamp with time zone",
@@ -881,7 +888,7 @@
           "type": "uuid",
           "primaryKey": true,
           "notNull": true,
-          "default": "gen_random_uuid()"
+          "default": "uuidv7()"
         },
         "organization_id": {
           "name": "organization_id",
@@ -919,6 +926,20 @@
           "typeSchema": "public",
           "primaryKey": false,
           "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "alert_event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'notifying'"
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
         },
         "instance_fingerprint": {
           "name": "instance_fingerprint",
@@ -985,6 +1006,13 @@
         },
         "occurred_at": {
           "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "journaled_at": {
+          "name": "journaled_at",
           "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
@@ -1299,6 +1327,12 @@
           "primaryKey": false,
           "notNull": true,
           "default": 0
+        },
+        "episode_id": {
+          "name": "episode_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
         },
         "updated_at": {
           "name": "updated_at",
@@ -4838,15 +4872,27 @@
         "failed"
       ]
     },
+    "public.alert_event_kind": {
+      "name": "alert_event_kind",
+      "schema": "public",
+      "values": [
+        "notifying",
+        "state"
+      ]
+    },
     "public.alert_event_type": {
       "name": "alert_event_type",
       "schema": "public",
       "values": [
+        "instance_pending",
         "instance_fired",
         "instance_resolved",
+        "instance_closed",
         "delivery",
         "rule_health",
-        "silenced"
+        "silenced",
+        "hold_changed",
+        "evaluation_failed"
       ]
     },
     "public.alert_health": {

--- a/packages/app/src/data/alerting/history/event-types.ts
+++ b/packages/app/src/data/alerting/history/event-types.ts
@@ -6,6 +6,7 @@ export type AlertEventType = (typeof ALERTING_EVENT_TYPES)[number];
 const ALERT_TRANSITION_EVENT_TYPES = [
   "instance_fired",
   "instance_resolved",
+  "instance_closed",
 ] as const;
 
 /**
@@ -30,12 +31,20 @@ export const ALERT_OUTCOME_EVENT_TYPES_SQL = sqlStringList(
   ALERT_OUTCOME_EVENT_TYPES,
 );
 
+// `instance_closed` gets its own neutral status: it ends the instance without
+// notifying, so rendering it as "resolved" would claim a recovery that nobody
+// observed.
 export function alertingEventStatus(
   eventType: string,
-): "firing" | "resolved" | null {
-  return eventType === "instance_fired"
-    ? "firing"
-    : eventType === "instance_resolved"
-      ? "resolved"
-      : null;
+): "firing" | "resolved" | "closed" | null {
+  switch (eventType) {
+    case "instance_fired":
+      return "firing";
+    case "instance_resolved":
+      return "resolved";
+    case "instance_closed":
+      return "closed";
+    default:
+      return null;
+  }
 }

--- a/packages/app/src/data/alerting/history/repository.server.test.ts
+++ b/packages/app/src/data/alerting/history/repository.server.test.ts
@@ -35,7 +35,7 @@ describe("queryClickHouseAlertEventLog", () => {
     const [sql, organizationId, params] = mocks.query.mock.calls[0];
     expect(sql).toContain("FROM app.alert_events");
     expect(sql).toContain(
-      "event_type IN ('instance_fired', 'instance_resolved')",
+      "event_type IN ('instance_fired', 'instance_resolved', 'instance_closed')",
     );
     expect(sql).toContain(
       "preview_id = toUUID('00000000-0000-0000-0000-000000000000')",

--- a/packages/app/src/data/alerting/vocabulary.ts
+++ b/packages/app/src/data/alerting/vocabulary.ts
@@ -8,10 +8,18 @@ export const ALERTING_INSTANCE_STATUSES = [
 
 export const ALERTING_HEALTH_STATUSES = ["healthy", "degraded"] as const;
 
+// `instance_closed` is the terminal that ends an instance without notifying
+// anybody (pending cleared, rule paused, rule deleted, preview deleted).
+// `instance_resolved` stays the notifying resolve, so closing must never
+// borrow its name or its display status.
 export const ALERTING_EVENT_TYPES = [
+  "instance_pending",
   "instance_fired",
   "instance_resolved",
+  "instance_closed",
   "delivery",
   "rule_health",
   "silenced",
+  "hold_changed",
+  "evaluation_failed",
 ] as const;

--- a/packages/app/src/db/schema/alerts.ts
+++ b/packages/app/src/db/schema/alerts.ts
@@ -54,6 +54,14 @@ export const alertEventTypeEnum = pgEnum(
   ALERTING_EVENT_TYPES,
 );
 
+// State-only rows (pending, closed, hold decisions, failed evaluations) are
+// born processed and exist only to be projected; they must never be
+// deliverable, whatever their event type says.
+export const alertEventKindEnum = pgEnum("alert_event_kind", [
+  "notifying",
+  "state",
+]);
+
 export const alertSeverityEnum = pgEnum("alert_severity", ALERTING_SEVERITIES);
 
 export const alertDefinitions = pgTable(
@@ -154,6 +162,10 @@ export const alertInstances = pgTable(
     activeSince: timestamp("active_since", { withTimezone: true }),
     lastSeenAt: timestamp("last_seen_at", { withTimezone: true }),
     absentCount: integer("absent_count").notNull().default(0),
+    // The open episode, so the evaluator can stamp every lifecycle row of one
+    // incident with the same id. Null while the instance is inactive, and null
+    // on rows written before the writers exist, so no foreign key.
+    episodeId: uuid("episode_id"),
     updatedAt: timestamp("updated_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -202,13 +214,20 @@ export const alertEvaluations = pgTable(
 export const alertEvents = pgTable(
   "alert_events",
   {
-    id: uuid("id").primaryKey().defaultRandom(),
+    // UUIDv7, not drizzle's `defaultRandom()`: the id sorts by creation time,
+    // which is what makes an id range a time bound on the projected history.
+    // Postgres 18 has `uuidv7()` natively.
+    id: uuid("id").primaryKey().default(sql`uuidv7()`),
     organizationId: text("organization_id").notNull(),
     repoid: text("repoid").notNull(),
     previewId: uuid("preview_id"),
     sourceDefinitionId: uuid("source_definition_id").notNull(),
     slug: text("slug").notNull(),
     eventType: alertEventTypeEnum("event_type").notNull(),
+    kind: alertEventKindEnum("kind").notNull().default("notifying"),
+    // The episode this lifecycle row belongs to: the id of the row that opened
+    // it. Null on rows that belong to no episode (evaluation and hold rows).
+    episodeId: uuid("episode_id"),
     instanceFingerprint: text("instance_fingerprint").notNull().default(""),
     instanceLabels: jsonb("instance_labels")
       .notNull()
@@ -224,6 +243,11 @@ export const alertEvents = pgTable(
     inhibited: boolean("inhibited").notNull().default(false),
     silenceId: uuid("silence_id"),
     occurredAt: timestamp("occurred_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    // Commit-side time, stamped by PostgreSQL. The reconciliation diff filters
+    // on this; `occurred_at` is domain time and can be backdated by the caller.
+    journaledAt: timestamp("journaled_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
     processedAt: timestamp("processed_at", { withTimezone: true }),
@@ -553,6 +577,11 @@ export const alertDeliveries = pgTable(
     attempts: integer("attempts").notNull().default(0),
     lastError: text("last_error"),
     createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    // Commit-side time, stamped by PostgreSQL, for the reconciliation diff.
+    // `created_at` and `updated_at` follow the delivery's own lifecycle.
+    journaledAt: timestamp("journaled_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true })

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/-components/rules/history.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/-components/rules/history.tsx
@@ -28,11 +28,17 @@ import { AlertingStatusLabel } from "../shared/status";
 import { AlertRuleEvaluationHistoryTable } from "./evaluation-details";
 
 const EVENT_META: Record<AlertEventType, { label: string; tone: Tone }> = {
+  instance_pending: { label: "Pending", tone: "warning" },
   instance_fired: { label: "Fired", tone: "danger" },
   instance_resolved: { label: "Resolved", tone: "healthy" },
+  // Closed ends the instance without a recovery, so it stays neutral rather
+  // than borrowing the healthy tone of a resolve.
+  instance_closed: { label: "Closed", tone: "muted" },
   delivery: { label: "Delivery", tone: "info" },
   rule_health: { label: "Rule health", tone: "warning" },
   silenced: { label: "Silenced", tone: "muted" },
+  hold_changed: { label: "Hold changed", tone: "muted" },
+  evaluation_failed: { label: "Evaluation failed", tone: "warning" },
 };
 
 function EventTypeLabel({ eventType }: { eventType: AlertEventType }) {

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/-components/rules/signal-chart.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/-components/rules/signal-chart.tsx
@@ -70,6 +70,12 @@ function createAlertTimeTickFormatter(domain: [number, number]) {
   return (timestamp: number) => formatter.format(new Date(timestamp));
 }
 
+const TRANSITION_LABELS = {
+  firing: "Fired",
+  resolved: "Resolved",
+  closed: "Closed",
+} as const;
+
 function transitionEvents(events: readonly AlertEventLogRow[]) {
   const seen = new Set<string>();
   return events.flatMap((event) => {
@@ -358,8 +364,7 @@ export function AlertRuleSignalChart({
       <ul className="sr-only" aria-label="Alert transitions in range">
         {visibleTransitions.map((event) => (
           <li key={`accessible-${event.key}`}>
-            {event.type === "firing" ? "Fired" : "Resolved"} at{" "}
-            {alertingFormatTs(event.t)}
+            {TRANSITION_LABELS[event.type]} at {alertingFormatTs(event.t)}
           </li>
         ))}
       </ul>

--- a/todo/issues/alerting-surface/02-alerting-clickhouse-surface.md
+++ b/todo/issues/alerting-surface/02-alerting-clickhouse-surface.md
@@ -174,7 +174,10 @@ Second, hold decisions stop mutating the work item. Today, processing freezes
 `silenced`, `inhibited` and `silence_id` onto the event row, then clears them
 before dispatch. That destroys the only durable copy of the hold. Instead,
 each change to that triple journals its own decision row that references the
-event. Queue state and decision history stop sharing columns. The deferral
+event. The journal type for those rows is `hold_changed` (state kind, born
+processed); at projection time one `hold_changed` row becomes a
+`notification_deferred` or `notification_suppressed` ClickHouse row,
+depending on the decision it records. Queue state and decision history stop sharing columns. The deferral
 record becomes repairable. The freeze-then-clear sequence disappears. The
 frozen comment and matchers on the ClickHouse row are written at projection
 time. A repaired row recovers them with a join to `alert_silences`, which

--- a/todo/issues/alerting-surface/tickets/01-name-terminal-event-type.md
+++ b/todo/issues/alerting-surface/tickets/01-name-terminal-event-type.md
@@ -16,4 +16,4 @@ processed, discriminated by the existing `reason` column
 
 - [x] The name appears in the design doc's event-type table and Reference
 - [x] The event-type arithmetic in the design doc is corrected
-- [ ] The alerting vocabulary constants include the new type
+- [x] The alerting vocabulary constants include the new type

--- a/todo/issues/alerting-surface/tickets/03-migration-0011-riders.md
+++ b/todo/issues/alerting-surface/tickets/03-migration-0011-riders.md
@@ -12,10 +12,10 @@ generate`).
 
 **Status:** ready-for-agent
 
-- [ ] The `kind` discriminator on the journal table
-- [ ] The event-type enum extended with pending, terminal and hold decision values, and `evaluation_failed` as a journaled state kind
-- [ ] The id default is a `uuidv7()` expression, not `defaultRandom()`
-- [ ] The episode id column on the journal tables, per Episodes and chain membership in the design doc
-- [ ] A PostgreSQL-stamped commit-side timestamp column on the journal tables
-- [ ] Folded into migration 0011 with the snapshot patched; applied to the dev database
-- [ ] Engine unit tests stay green
+- [x] The `kind` discriminator on the journal table
+- [x] The event-type enum extended with pending, terminal and hold decision values, and `evaluation_failed` as a journaled state kind
+- [x] The id default is a `uuidv7()` expression, not `defaultRandom()`
+- [x] The episode id column on the journal tables, per Episodes and chain membership in the design doc
+- [x] A PostgreSQL-stamped commit-side timestamp column on the journal tables
+- [x] Folded into migration 0011 with the snapshot patched; applied to the dev database
+- [x] Engine unit tests stay green


### PR DESCRIPTION
Stacked on #344. Implements tickets 01 (code half) and 03 from `todo/issues/alerting-surface/tickets/` (both in the merge gate).

## Ticket 01: the terminal event type

`instance_closed` joins the alerting vocabulary as the non-notifying terminal (pending cleared, rule paused, rule deleted, preview deleted). `alertingEventStatus` gives it its own neutral `closed` status, the history UI's event metadata labels it "Closed"/muted, and the signal chart's transition labels cover it, so a closure can never render as "resolved". The transition-type list includes it so closed rows appear in history once the writers land (tickets 12/13).

## Ticket 03: migration 0011 riders (schema only)

While 0011 is unshipped, the journal reaches its final shape in one fold:

- `alert_event_kind` enum (`notifying` | `state`), `kind` NOT NULL DEFAULT `'notifying'` on `alert_events`. State rows are born processed; the delivery-pipeline gate lands with ticket 11.
- `alert_event_type` gains `instance_pending`, `instance_closed`, `hold_changed`, `evaluation_failed` (bare snake_case, matching the existing values). `hold_changed` and its projection to `notification_deferred`/`notification_suppressed` are now pinned in the design doc.
- `alert_events.id` defaults to native `uuidv7()` (dev Postgres is 18.3), replacing `gen_random_uuid()`. Only the journal id qualifies; config/state ids stay v4 per the design doc.
- `journaled_at timestamptz NOT NULL DEFAULT now()` on `alert_events` and `alert_deliveries`: the PostgreSQL-stamped commit-side clock the reconciler diff will filter on (`occurred_at` stays domain time).
- Nullable `episode_id uuid` on `alert_events` and `alert_instances`; writers come with the lifecycle tickets.

Migration mechanics per the design doc's "Changing the schema": no `drizzle-kit generate`; 0011 and `meta/0011_snapshot.json` edited by hand (snapshot round-trip verified byte-identical before patching); the dev database altered to match, with enum value order pinned via `BEFORE`/`AFTER` so it matches the schema array.

## Verification

- `tsc --noEmit` clean, biome clean.
- Full app suite green (1382 tests); alerting suites 191 tests.
- Dev DB `\d` verification: new columns/defaults present on `alert_events`, `alert_instances`, `alert_deliveries`; `\dT+ alert_event_type` shows the nine values in vocabulary order.
- Two-axis review ran; accepted findings applied (comment accuracy fixes, `instance_closed` in the transition list, `hold_changed` pinned in the doc). No engine writer emits the new values yet, by design.