### PR TITLE
feat(alerts): server-derived actor on every alerting mutation

### DIFF
--- a/packages/app/src/data/alerting/delivery/repository.ts
+++ b/packages/app/src/data/alerting/delivery/repository.ts
@@ -20,6 +20,7 @@ import {
   AlertingInhibitionInputSchema,
   AlertingRouteInputSchema,
 } from "../schema";
+import type { AlertingMutationScope } from "../session";
 import type {
   AlertingChannelConfig,
   AlertingInhibitionInput,
@@ -53,7 +54,7 @@ export async function listChannels(organizationId: string) {
 }
 
 export async function createChannel(
-  organizationId: string,
+  { organizationId }: AlertingMutationScope,
   body: { name: string; config: AlertingChannelConfig },
 ) {
   const id = randomUUID();
@@ -94,7 +95,7 @@ async function getChannelRow(organizationId: string, name: string) {
 }
 
 export async function updateChannel(
-  organizationId: string,
+  { organizationId }: AlertingMutationScope,
   name: string,
   body: { name?: string; config: AlertingChannelConfig },
 ) {
@@ -126,7 +127,10 @@ export async function updateChannel(
   return channelView(row);
 }
 
-export async function deleteChannel(organizationId: string, name: string) {
+export async function deleteChannel(
+  { organizationId }: AlertingMutationScope,
+  name: string,
+) {
   const channel = await getChannelRow(organizationId, name);
   const [receiverRefs, definitionRefs] = await Promise.all([
     db
@@ -286,7 +290,7 @@ export async function resolveOptionalChannelIds(
 }
 
 export async function createReceiver(
-  organizationId: string,
+  { organizationId }: AlertingMutationScope,
   body: { name: string; channels: string[] },
 ) {
   const channelIds = await resolveChannelIds(organizationId, body.channels);
@@ -336,7 +340,7 @@ async function getReceiverRow(organizationId: string, name: string) {
 }
 
 export async function updateReceiver(
-  organizationId: string,
+  { organizationId }: AlertingMutationScope,
   name: string,
   body: { name?: string; channels: string[] },
 ) {
@@ -370,7 +374,10 @@ export async function updateReceiver(
   );
 }
 
-export async function deleteReceiver(organizationId: string, name: string) {
+export async function deleteReceiver(
+  { organizationId }: AlertingMutationScope,
+  name: string,
+) {
   const receiver = await getReceiverRow(organizationId, name);
   const routes = await db
     .select({ id: alertRoutes.id })
@@ -404,7 +411,7 @@ export async function listRoutes(organizationId: string) {
 }
 
 export async function createRoute(
-  organizationId: string,
+  { organizationId }: AlertingMutationScope,
   rawInput: AlertingRouteInput,
 ) {
   const input = AlertingRouteInputSchema.parse(rawInput);
@@ -424,7 +431,7 @@ export async function createRoute(
 }
 
 export async function updateRoute(
-  organizationId: string,
+  { organizationId }: AlertingMutationScope,
   id: string,
   rawInput: AlertingRouteInput,
 ) {
@@ -453,7 +460,10 @@ export async function updateRoute(
   };
 }
 
-export async function deleteRoute(organizationId: string, id: string) {
+export async function deleteRoute(
+  { organizationId }: AlertingMutationScope,
+  id: string,
+) {
   const rows = await db
     .delete(alertRoutes)
     .where(
@@ -481,7 +491,7 @@ export async function listInhibitions(organizationId: string) {
 }
 
 export async function createInhibition(
-  organizationId: string,
+  { organizationId }: AlertingMutationScope,
   rawInput: AlertingInhibitionInput,
 ) {
   const config = AlertingInhibitionInputSchema.parse(rawInput);
@@ -497,7 +507,10 @@ export async function createInhibition(
   };
 }
 
-export async function deleteInhibition(organizationId: string, id: string) {
+export async function deleteInhibition(
+  { organizationId }: AlertingMutationScope,
+  id: string,
+) {
   const rows = await db
     .delete(alertInhibitions)
     .where(

--- a/packages/app/src/data/alerting/delivery/server.ts
+++ b/packages/app/src/data/alerting/delivery/server.ts
@@ -5,7 +5,7 @@ import {
   AlertingInhibitionInputSchema,
   AlertingRouteInputSchema,
 } from "../schema";
-import { alertingOrganizationId } from "../session";
+import { alertingMutationScope, alertingOrganizationId } from "../session";
 import { emailTestConfigFor } from "./email-test-config";
 import * as delivery from "./repository";
 
@@ -43,7 +43,7 @@ export const createAlertingChannel = createAuthenticatedServerFn({
     }),
   )
   .handler(({ data, context: { session } }) =>
-    delivery.createChannel(alertingOrganizationId(session), data),
+    delivery.createChannel(alertingMutationScope(session), data),
   );
 
 export const updateAlertingChannel = createAuthenticatedServerFn({
@@ -57,7 +57,7 @@ export const updateAlertingChannel = createAuthenticatedServerFn({
     }),
   )
   .handler(({ data, context: { session } }) =>
-    delivery.updateChannel(alertingOrganizationId(session), data.name, {
+    delivery.updateChannel(alertingMutationScope(session), data.name, {
       name: data.newName,
       config: data.config,
     }),
@@ -68,7 +68,7 @@ export const deleteAlertingChannel = createAuthenticatedServerFn({
 })
   .inputValidator(z.object({ name: z.string().min(1) }))
   .handler(({ data: { name }, context: { session } }) =>
-    delivery.deleteChannel(alertingOrganizationId(session), name),
+    delivery.deleteChannel(alertingMutationScope(session), name),
   );
 
 export const testAlertingChannel = createAuthenticatedServerFn({
@@ -91,7 +91,7 @@ export const createAlertingReceiver = createAuthenticatedServerFn({
     }),
   )
   .handler(({ data, context: { session } }) =>
-    delivery.createReceiver(alertingOrganizationId(session), data),
+    delivery.createReceiver(alertingMutationScope(session), data),
   );
 
 export const updateAlertingReceiver = createAuthenticatedServerFn({
@@ -105,7 +105,7 @@ export const updateAlertingReceiver = createAuthenticatedServerFn({
     }),
   )
   .handler(({ data, context: { session } }) =>
-    delivery.updateReceiver(alertingOrganizationId(session), data.name, {
+    delivery.updateReceiver(alertingMutationScope(session), data.name, {
       name: data.newName,
       channels: data.channels,
     }),
@@ -116,7 +116,7 @@ export const deleteAlertingReceiver = createAuthenticatedServerFn({
 })
   .inputValidator(z.object({ name: z.string().min(1) }))
   .handler(({ data: { name }, context: { session } }) =>
-    delivery.deleteReceiver(alertingOrganizationId(session), name),
+    delivery.deleteReceiver(alertingMutationScope(session), name),
   );
 
 export const createAlertingRoute = createAuthenticatedServerFn({
@@ -124,7 +124,7 @@ export const createAlertingRoute = createAuthenticatedServerFn({
 })
   .inputValidator(AlertingRouteInputSchema)
   .handler(({ data, context: { session } }) =>
-    delivery.createRoute(alertingOrganizationId(session), data),
+    delivery.createRoute(alertingMutationScope(session), data),
   );
 
 export const updateAlertingRoute = createAuthenticatedServerFn({
@@ -132,7 +132,7 @@ export const updateAlertingRoute = createAuthenticatedServerFn({
 })
   .inputValidator(z.object({ id: z.string(), input: AlertingRouteInputSchema }))
   .handler(({ data: { id, input }, context: { session } }) =>
-    delivery.updateRoute(alertingOrganizationId(session), id, input),
+    delivery.updateRoute(alertingMutationScope(session), id, input),
   );
 
 export const deleteAlertingRoute = createAuthenticatedServerFn({
@@ -140,7 +140,7 @@ export const deleteAlertingRoute = createAuthenticatedServerFn({
 })
   .inputValidator(z.object({ id: z.string() }))
   .handler(({ data: { id }, context: { session } }) =>
-    delivery.deleteRoute(alertingOrganizationId(session), id),
+    delivery.deleteRoute(alertingMutationScope(session), id),
   );
 
 export const createAlertingInhibition = createAuthenticatedServerFn({
@@ -148,7 +148,7 @@ export const createAlertingInhibition = createAuthenticatedServerFn({
 })
   .inputValidator(AlertingInhibitionInputSchema)
   .handler(({ data, context: { session } }) =>
-    delivery.createInhibition(alertingOrganizationId(session), data),
+    delivery.createInhibition(alertingMutationScope(session), data),
   );
 
 export const deleteAlertingInhibition = createAuthenticatedServerFn({
@@ -156,5 +156,5 @@ export const deleteAlertingInhibition = createAuthenticatedServerFn({
 })
   .inputValidator(z.object({ id: z.string() }))
   .handler(({ data: { id }, context: { session } }) =>
-    delivery.deleteInhibition(alertingOrganizationId(session), id),
+    delivery.deleteInhibition(alertingMutationScope(session), id),
   );

--- a/packages/app/src/data/alerting/rules/repository.ts
+++ b/packages/app/src/data/alerting/rules/repository.ts
@@ -26,6 +26,7 @@ import {
   AlertingRuleSpecSchema,
   AlertingRuleUpdateSchema,
 } from "../schema";
+import type { AlertingMutationScope } from "../session";
 import type { AlertingRuleInput, AlertingRuleUpdate } from "../types";
 import {
   parseAlertEvaluationSamples,
@@ -557,7 +558,10 @@ export async function deleteRule(
   return { deleted: rows.length > 0 };
 }
 
-export async function pauseRule(organizationId: string, id: string) {
+export async function pauseRule(
+  { organizationId }: AlertingMutationScope,
+  id: string,
+) {
   const [row] = await db
     .update(alertDefinitions)
     .set({ active: false, updatedAt: new Date() })
@@ -573,7 +577,10 @@ export async function pauseRule(organizationId: string, id: string) {
   return ruleBase(row, await definitionChannelNamesFor(organizationId, row.id));
 }
 
-export async function resumeRule(organizationId: string, id: string) {
+export async function resumeRule(
+  { organizationId }: AlertingMutationScope,
+  id: string,
+) {
   const previous = await getRuleRow(organizationId, id);
   const nextEvaluationAt = nextAlertEvaluationAt(
     organizationId,

--- a/packages/app/src/data/alerting/rules/server.ts
+++ b/packages/app/src/data/alerting/rules/server.ts
@@ -7,7 +7,7 @@ import {
 import { getPreviewScopes } from "@/data/previews/repoids";
 import { createAuthenticatedServerFn } from "@/lib/serverFn";
 import { AlertingError } from "../errors";
-import { alertingOrganizationId } from "../session";
+import { alertingMutationScope, alertingOrganizationId } from "../session";
 import type { AlertingRuleView } from "../types";
 import * as rules from "./repository";
 import { visibleRulesForPreview } from "./resource/preview-overlay";
@@ -114,7 +114,7 @@ export const getAlertingRuleEvaluationSeries = createAuthenticatedServerFn({
 export const pauseAlertingRule = createAuthenticatedServerFn({ method: "POST" })
   .inputValidator(z.object({ ruleId: z.string() }))
   .handler(({ data: { ruleId }, context: { session } }) =>
-    rules.pauseRule(alertingOrganizationId(session), ruleId),
+    rules.pauseRule(alertingMutationScope(session), ruleId),
   );
 
 export const resumeAlertingRule = createAuthenticatedServerFn({
@@ -122,5 +122,5 @@ export const resumeAlertingRule = createAuthenticatedServerFn({
 })
   .inputValidator(z.object({ ruleId: z.string() }))
   .handler(({ data: { ruleId }, context: { session } }) =>
-    rules.resumeRule(alertingOrganizationId(session), ruleId),
+    rules.resumeRule(alertingMutationScope(session), ruleId),
   );

--- a/packages/app/src/data/alerting/schema.test.ts
+++ b/packages/app/src/data/alerting/schema.test.ts
@@ -170,6 +170,16 @@ it("bounds matcher counts and label and value lengths", () => {
   ).toBe(false);
 });
 
+it("drops a client-supplied silence author", () => {
+  const parsed = AlertingSilenceInputSchema.parse({
+    matchers: [{ label: "team", op: "eq", value: "pay" }],
+    starts_at: "2026-07-01T11:00:00Z",
+    ends_at: "2026-07-01T13:00:00Z",
+    author: "someone else",
+  });
+  expect(parsed).not.toHaveProperty("author");
+});
+
 it("rejects a channel with an unknown config type", () => {
   expect(() =>
     AlertingChannelSchema.parse({

--- a/packages/app/src/data/alerting/schema.ts
+++ b/packages/app/src/data/alerting/schema.ts
@@ -210,7 +210,7 @@ export const AlertingSilenceInputSchema = z.object({
   starts_at: z.string(),
   ends_at: z.string(),
   comment: z.string().optional(),
-  author: z.string().optional(),
+  // No `author`: it is stamped from the authenticated principal on the server.
 });
 
 export const AlertingSilenceSchema = z.object({

--- a/packages/app/src/data/alerting/session.test.ts
+++ b/packages/app/src/data/alerting/session.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  alertingMutationScope,
+  parseAlertingPrincipal,
+  SYSTEM_ACTOR,
+} from "./session";
+
+describe("parseAlertingPrincipal", () => {
+  it("reads a user principal", () => {
+    expect(parseAlertingPrincipal("user:u1")).toEqual({
+      kind: "user",
+      id: "u1",
+      display: "user:u1",
+    });
+  });
+
+  it("reads an API key principal", () => {
+    expect(parseAlertingPrincipal("apikey:k1")).toEqual({
+      kind: "apikey",
+      id: "k1",
+      display: "apikey:k1",
+    });
+  });
+
+  it("throws rather than attribute a malformed principal", () => {
+    for (const malformed of ["", "u1", "user", "user:", ":u1", "robot:r1"]) {
+      expect(() => parseAlertingPrincipal(malformed)).toThrow(
+        /Unrecognized principal id/,
+      );
+    }
+  });
+});
+
+describe("alertingMutationScope", () => {
+  it("names the session user, preferring the display name", () => {
+    expect(
+      alertingMutationScope({
+        session: { activeOrganizationId: "org_1" },
+        user: { id: "u1", name: "Ada Lovelace", email: "ada@example.com" },
+      }),
+    ).toEqual({
+      organizationId: "org_1",
+      actor: { kind: "user", id: "u1", display: "Ada Lovelace" },
+    });
+  });
+
+  it("falls back to the email, then to the user id", () => {
+    const scopeFor = (user: { id: string; name?: string; email?: string }) =>
+      alertingMutationScope({
+        session: { activeOrganizationId: "org_1" },
+        user,
+      });
+
+    expect(scopeFor({ id: "u1", email: "ada@example.com" }).actor.display).toBe(
+      "ada@example.com",
+    );
+    expect(scopeFor({ id: "u1" }).actor.display).toBe("u1");
+  });
+
+  it("parses the principal on the apply path, where user.id is not a user id", () => {
+    expect(
+      alertingMutationScope({
+        session: { activeOrganizationId: "org_1" },
+        user: { id: "apikey:k1" },
+        principalId: "apikey:k1",
+      }).actor,
+    ).toEqual({ kind: "apikey", id: "k1", display: "apikey:k1" });
+  });
+});
+
+it("gives unattended changes an actor with no principal id", () => {
+  expect(SYSTEM_ACTOR).toEqual({ kind: "system", id: "", display: "system" });
+});

--- a/packages/app/src/data/alerting/session.ts
+++ b/packages/app/src/data/alerting/session.ts
@@ -1,5 +1,85 @@
+/**
+ * Who performed an alerting mutation. Always derived on the server from the
+ * authenticated principal, never from request input: the alert-suppression
+ * trail is only worth keeping if it cannot be spoofed.
+ *
+ * `system` covers unattended changes, such as an automatic silence expiry,
+ * and carries no id because no principal made them.
+ */
+export type AlertingActor = {
+  kind: "user" | "apikey" | "system";
+  id: string;
+  display: string;
+};
+
+/** The actor for unattended alerting changes. */
+export const SYSTEM_ACTOR: AlertingActor = {
+  kind: "system",
+  id: "",
+  display: "system",
+};
+
+/**
+ * What every alerting mutation takes: the organization it writes to, and the
+ * principal it writes on behalf of. Reads keep taking the organization id
+ * alone, because nothing about a read is attributable.
+ */
+export type AlertingMutationScope = {
+  organizationId: string;
+  actor: AlertingActor;
+};
+
+type AlertingSessionContext = {
+  session: { activeOrganizationId: string };
+  user: { id: string; name?: string | null; email?: string | null };
+  /**
+   * Set on the apply path only, where the principal can be an API key and
+   * `user.id` therefore holds the principal string, not a user id.
+   */
+  principalId?: string;
+};
+
 export function alertingOrganizationId(session: {
   session: { activeOrganizationId: string };
 }): string {
   return session.session.activeOrganizationId;
+}
+
+/**
+ * Parse the canonical `ApplyAuth.principalId` form (`user:<id>` or
+ * `apikey:<id>`). Throws on any other shape: every value is built by
+ * `resolveApplyAuth`, so a malformed one is a bug, and guessing would
+ * attribute the change to the wrong principal.
+ */
+export function parseAlertingPrincipal(principalId: string): AlertingActor {
+  const separator = principalId.indexOf(":");
+  const kind = principalId.slice(0, separator);
+  const id = principalId.slice(separator + 1);
+  if ((kind !== "user" && kind !== "apikey") || id === "") {
+    throw new Error(`Unrecognized principal id: ${principalId}`);
+  }
+  // An API key cannot be attributed to a person: the key table has no owner
+  // column, so the principal string is the most the display can say.
+  return { kind, id, display: principalId };
+}
+
+function alertingActor(session: AlertingSessionContext): AlertingActor {
+  if (session.principalId !== undefined) {
+    return parseAlertingPrincipal(session.principalId);
+  }
+  return {
+    kind: "user",
+    id: session.user.id,
+    display: session.user.name || session.user.email || session.user.id,
+  };
+}
+
+/** Narrow an authenticated session to the scope an alerting mutation needs. */
+export function alertingMutationScope(
+  session: AlertingSessionContext,
+): AlertingMutationScope {
+  return {
+    organizationId: alertingOrganizationId(session),
+    actor: alertingActor(session),
+  };
 }

--- a/packages/app/src/data/alerting/silences/repository.test.ts
+++ b/packages/app/src/data/alerting/silences/repository.test.ts
@@ -19,6 +19,7 @@ vi.mock("@/db/client", () => {
   return { db: { transaction: (fn: (t: unknown) => unknown) => fn(tx) } };
 });
 
+import { SYSTEM_ACTOR } from "../session";
 import { expireSilence } from "./repository";
 
 beforeEach(() => {
@@ -29,7 +30,9 @@ beforeEach(() => {
 it("releases the canceled silence's held events in one statement", async () => {
   mocks.updateReturning.mockResolvedValue([{ id: "sil-1" }]);
 
-  await expect(expireSilence("org-1", "sil-1")).resolves.toEqual({
+  await expect(
+    expireSilence({ organizationId: "org-1", actor: SYSTEM_ACTOR }, "sil-1"),
+  ).resolves.toEqual({
     expired: true,
   });
 
@@ -46,7 +49,9 @@ it("releases the canceled silence's held events in one statement", async () => {
 it("enqueues nothing when the silence was already closed", async () => {
   mocks.updateReturning.mockResolvedValue([]);
 
-  await expect(expireSilence("org-1", "sil-1")).resolves.toEqual({
+  await expect(
+    expireSilence({ organizationId: "org-1", actor: SYSTEM_ACTOR }, "sil-1"),
+  ).resolves.toEqual({
     expired: false,
   });
   expect(mocks.execute).not.toHaveBeenCalled();

--- a/packages/app/src/data/alerting/silences/repository.ts
+++ b/packages/app/src/data/alerting/silences/repository.ts
@@ -8,6 +8,7 @@ import {
 } from "@/server/alerts/delivery/tasks";
 import { throwAlertingPersistenceError } from "../persistence";
 import { AlertingSilenceInputSchema } from "../schema";
+import type { AlertingMutationScope } from "../session";
 import type { AlertingSilenceInput } from "../types";
 
 function toSilence(row: typeof alertSilences.$inferSelect) {
@@ -34,7 +35,7 @@ export async function listSilences(organizationId: string) {
 }
 
 export async function createSilence(
-  organizationId: string,
+  { organizationId, actor }: AlertingMutationScope,
   rawInput: AlertingSilenceInput,
 ) {
   const input = AlertingSilenceInputSchema.parse(rawInput);
@@ -54,7 +55,8 @@ export async function createSilence(
       startsAt,
       endsAt,
       comment: input.comment ?? "",
-      author: input.author ?? "",
+      // Server-derived: the caller cannot name somebody else as the author.
+      author: actor.display,
       matchers: input.matchers,
     })
     .returning();
@@ -74,7 +76,10 @@ export async function createSilence(
  * `now` would put it before `starts_at`, so it collapses to `starts_at` and
  * the window ends up empty instead of inverted.
  */
-export async function expireSilence(organizationId: string, id: string) {
+export async function expireSilence(
+  { organizationId }: AlertingMutationScope,
+  id: string,
+) {
   return db.transaction(async (tx) => {
     const rows = await tx
       .update(alertSilences)

--- a/packages/app/src/data/alerting/silences/server.test.ts
+++ b/packages/app/src/data/alerting/silences/server.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, expect, it, vi } from "vitest";
+import { createAlertingSilence } from "./server";
+
+const mocks = vi.hoisted(() => ({ createSilence: vi.fn() }));
+
+vi.mock("./repository", () => ({ createSilence: mocks.createSilence }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const input = {
+  matchers: [{ label: "team", op: "eq" as const, value: "pay" }],
+  starts_at: "2026-07-01T11:00:00Z",
+  ends_at: "2026-07-01T13:00:00Z",
+  comment: "deploying",
+};
+
+it("stamps the authenticated session user as the actor", async () => {
+  await createAlertingSilence({ data: input });
+
+  expect(mocks.createSilence).toHaveBeenCalledWith(
+    {
+      organizationId: "test_org",
+      actor: { kind: "user", id: "test_user", display: "Test User" },
+    },
+    expect.objectContaining({ comment: "deploying" }),
+  );
+});
+
+it("ignores an author sent by the client", async () => {
+  await createAlertingSilence({
+    // The input schema has no author, so a caller that sends one is claiming
+    // authorship it cannot have.
+    data: { ...input, author: "someone else" } as typeof input,
+  });
+
+  expect(mocks.createSilence.mock.calls[0]?.[1]).not.toHaveProperty("author");
+});

--- a/packages/app/src/data/alerting/silences/server.ts
+++ b/packages/app/src/data/alerting/silences/server.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { createAuthenticatedServerFn } from "@/lib/serverFn";
 import { AlertingSilenceInputSchema } from "../schema";
-import { alertingOrganizationId } from "../session";
+import { alertingMutationScope, alertingOrganizationId } from "../session";
 import * as silences from "./repository";
 
 export const listAlertingSilences = createAuthenticatedServerFn({
@@ -15,7 +15,7 @@ export const createAlertingSilence = createAuthenticatedServerFn({
 })
   .inputValidator(AlertingSilenceInputSchema)
   .handler(({ data, context: { session } }) =>
-    silences.createSilence(alertingOrganizationId(session), data),
+    silences.createSilence(alertingMutationScope(session), data),
   );
 
 export const expireAlertingSilence = createAuthenticatedServerFn({
@@ -23,5 +23,5 @@ export const expireAlertingSilence = createAuthenticatedServerFn({
 })
   .inputValidator(z.object({ id: z.string() }))
   .handler(({ data: { id }, context: { session } }) =>
-    silences.expireSilence(alertingOrganizationId(session), id),
+    silences.expireSilence(alertingMutationScope(session), id),
   );

--- a/packages/app/src/data/as-code/apply-auth.server.test.ts
+++ b/packages/app/src/data/as-code/apply-auth.server.test.ts
@@ -204,8 +204,30 @@ describe("buildApplyContext", () => {
     });
     expect(ctx.session.session.activeOrganizationId).toBe("org-k");
     expect(ctx.session.user.id).toBe("apikey:1");
+    expect(ctx.session.principalId).toBe("apikey:1");
     expect(ctx.organization).toEqual({ id: "org-k", name: "Kettle" });
     expect(ctx.applyActions).toEqual(["read", "write", "delete"]);
+  });
+
+  it("derives the audit actor from the principal, key or user", () => {
+    const actorFor = (principalId: string) =>
+      buildApplyContext({
+        organizationId: "org-k",
+        organizationName: "Kettle",
+        principalId,
+        applyActions: null,
+      }).actor;
+
+    expect(actorFor("apikey:1")).toEqual({
+      kind: "apikey",
+      id: "1",
+      display: "apikey:1",
+    });
+    expect(actorFor("user:u1")).toEqual({
+      kind: "user",
+      id: "u1",
+      display: "user:u1",
+    });
   });
 
   it("threads a null applyActions through for session auth", () => {

--- a/packages/app/src/data/as-code/apply-auth.server.ts
+++ b/packages/app/src/data/as-code/apply-auth.server.ts
@@ -1,5 +1,6 @@
 import { createMiddleware } from "@tanstack/react-start";
 import { eq } from "drizzle-orm";
+import { parseAlertingPrincipal } from "@/data/alerting/session";
 import { db } from "@/db/client";
 import { organization } from "@/db/schema";
 import { hasApiKeyScope } from "@/lib/api-key-scopes";
@@ -114,13 +115,19 @@ export async function resolveApplyAuth(headers: Headers): Promise<ApplyAuth> {
  * Build the org-scoped server-fn context from resolved apply auth. Pure and
  * framework-free so it can be unit-tested. Exposes the resolved org both as the
  * active org and as `context.organization` (for the apply response echo).
+ *
+ * `session.principalId` is what tells the alerting session boundary that
+ * `user.id` holds a principal string (an API key has no user id) rather than a
+ * user id, so the actor it derives names the right principal.
  */
 export function buildApplyContext(apiAuth: ApplyAuth) {
   return {
     session: {
       session: { activeOrganizationId: apiAuth.organizationId },
       user: { id: apiAuth.principalId },
+      principalId: apiAuth.principalId,
     },
+    actor: parseAlertingPrincipal(apiAuth.principalId),
     organization: {
       id: apiAuth.organizationId,
       name: apiAuth.organizationName,

--- a/todo/issues/alerting-surface/tickets/16-actor-plumbing.md
+++ b/todo/issues/alerting-surface/tickets/16-actor-plumbing.md
@@ -11,6 +11,13 @@ field is replaced, not kept beside the real actor.
 
 **Status:** ready-for-agent
 
-- [ ] An actor argument threads through the session-narrowing boundary that covers every mutation path
-- [ ] The actor derives from the authenticated principal (user or API key)
-- [ ] The silence author is server-derived; any user-provided display note is stored separately
+- [x] An actor argument threads through the session-narrowing boundary that covers every mutation path
+- [x] The actor derives from the authenticated principal (user or API key)
+- [x] The silence author is server-derived; any user-provided display note is stored separately (the existing `comment` column)
+
+**Left for ticket 17:** the as-code rule mutations (`createRule`, `updateRule`,
+`adoptRule`, `deleteRule`) still take an organization id. They are reached
+through `applyResources` and the resource registry, not through a server
+function, so the actor has to travel with the apply options rather than with
+the session. The apply boundary already publishes it as `context.actor`, so
+ticket 17 threads that value down instead of deriving it again.


### PR DESCRIPTION
Stacked on #345. Implements ticket 16 from `todo/issues/alerting-surface/tickets/` (finding 20: silence authorship was client-controlled and spoofable).

## What changed

- `AlertingActor` (`user` | `apikey` | `system`, id, display) lives at the session-narrowing boundary in `data/alerting/session.ts`. `alertingMutationScope(session)` derives `{ organizationId, actor }`; reads keep the plain org id, since a read is not attributable.
- The apply path publishes `principalId` (`user:<id>` / `apikey:<id>`, from `ApplyAuth`) into the session context, so an API-key apply is never mis-attributed as a user; malformed principals throw rather than guess.
- Every alerting mutation server fn (channels, receivers, routes, inhibitions, silences, rule pause/resume) now hands the repository the mutation scope, so ticket 17's audit journal reads the actor where it already sits.
- The silence `author` input field is gone: zod strips a client-sent author, and the column is written server-side from the actor's display. The suppression trail can no longer be spoofed (it was also always empty in practice; both UI call sites omitted it).

## Deferred, recorded in the ticket

- As-code rule mutations (create/update/adopt/delete) are reached through the resource registry, not a server fn; `context.actor` is available on the apply context for ticket 17 to thread through the registry contract.
- `testChannel` stays unattributed: it changes no state.

## Verification

`tsc --noEmit` clean; alerting suites 140 tests; full app suite 1393 tests green; new tests for principal parsing (incl. six malformed forms), session stamping, author stripping, and the apply-path actor. Pre-commit hooks passed.