### PR TITLE
feat(alerts): SQL caller reads alert history, with a skill file to guide it

### DIFF
--- a/clickhouse/init/15-create-sql-api-role.sql
+++ b/clickhouse/init/15-create-sql-api-role.sql
@@ -48,7 +48,7 @@ CREATE SETTINGS PROFILE IF NOT EXISTS sql_api_profile SETTINGS
   allow_ddl = 0 READONLY,                              -- no CREATE/ALTER/DROP
   allow_introspection_functions = 0 READONLY;          -- no addressToLine/demangle/etc.
 
--- Role: SELECT only on the four tenant-scoped read tables. We deliberately
+-- Role: SELECT only on the tenant-scoped read tables. We deliberately
 -- avoid `app.*` so future internal tables (and app.tenant_retention_source,
 -- which is cross-tenant and has no RLS) don't auto-expand the surface area.
 -- Per-org users `sql_api_org_<id>` are granted this role at provision time.
@@ -60,6 +60,19 @@ GRANT SELECT ON app.metrics_sum       TO sql_api_role;
 GRANT SELECT ON app.metrics_histogram              TO sql_api_role;
 GRANT SELECT ON app.metrics_exponential_histogram TO sql_api_role;
 GRANT SELECT ON app.metrics_summary              TO sql_api_role;
+-- Tenancy template, copy all three parts for every future alerting object: the
+-- SELECT grant here, the default-deny row policy at the bottom of this file,
+-- and the table name in SQL_API_TENANT_TABLES
+-- (packages/app/src/lib/sql-api-tables.ts), which provisions the per-
+-- organization row policy and advertises the table to callers. If any one of
+-- the three is missing, the table is either unreachable or readable across
+-- tenants. Organizations provisioned before the new entry also need a policy
+-- backfill; see clickhouse/migrate-alert-events-sql-api-access.sql.
+-- app.alert_events_logs_mv needs no grant or policy of its own: row policies
+-- apply when the destination table (app.logs) is read, and a MV body runs
+-- with the inserting user's privileges, so projected alert rows are already
+-- covered by the logs policies above and below.
+GRANT SELECT ON app.alert_events  TO sql_api_role;
 
 -- Clean up accidental/manual system grants. SHOW TABLES handles schema
 -- discovery without exposing storage counters from system.tables or the
@@ -109,3 +122,5 @@ CREATE ROW POLICY IF NOT EXISTS sql_api_default_deny_metrics_exponential_histogr
   ON app.metrics_exponential_histogram FOR SELECT USING 0 TO sql_api_role;
 CREATE ROW POLICY IF NOT EXISTS sql_api_default_deny_metrics_summary
   ON app.metrics_summary               FOR SELECT USING 0 TO sql_api_role;
+CREATE ROW POLICY IF NOT EXISTS sql_api_default_deny_alert_events
+  ON app.alert_events  FOR SELECT USING 0 TO sql_api_role;

--- a/clickhouse/init/15-create-sql-api-role.sql
+++ b/clickhouse/init/15-create-sql-api-role.sql
@@ -68,10 +68,6 @@ GRANT SELECT ON app.metrics_summary              TO sql_api_role;
 -- the three is missing, the table is either unreachable or readable across
 -- tenants. Organizations provisioned before the new entry also need a policy
 -- backfill; see clickhouse/migrate-alert-events-sql-api-access.sql.
--- app.alert_events_logs_mv needs no grant or policy of its own: row policies
--- apply when the destination table (app.logs) is read, and a MV body runs
--- with the inserting user's privileges, so projected alert rows are already
--- covered by the logs policies above and below.
 GRANT SELECT ON app.alert_events  TO sql_api_role;
 
 -- Clean up accidental/manual system grants. SHOW TABLES handles schema

--- a/clickhouse/migrate-alert-events-sql-api-access.sql
+++ b/clickhouse/migrate-alert-events-sql-api-access.sql
@@ -1,0 +1,39 @@
+-- One-shot migration for an existing cloud ClickHouse: gives the /sql API role
+-- read access to app.alert_events, matching init/15-create-sql-api-role.sql.
+-- Run after clickhouse/migrate-alert-events-final-shape.sql, which creates the
+-- table this grants on.
+--
+-- Apply with an admin user, e.g.:
+--   clickhouse-client --user default --password '<ADMIN_PASSWORD>' --multiquery \
+--     < clickhouse/migrate-alert-events-sql-api-access.sql
+--
+-- Every statement is self-contained: the settings a statement needs ride on
+-- its own SETTINGS clause rather than a session-level SET, so this also
+-- applies cleanly through a runner that sends one query per request. Nothing
+-- here needs a setting.
+--
+-- The per-organization row policies are the third part of the tenancy
+-- template. New organizations get theirs from provisionSqlApiOrgUser in
+-- packages/app/src/lib/clickhouse.ts. Organizations provisioned before this
+-- migration have none, and the default-deny policy below means they read zero
+-- rows (a wrong answer, not an error), so the backfill at the bottom is not
+-- optional.
+
+GRANT SELECT ON app.alert_events TO sql_api_role;
+
+CREATE ROW POLICY IF NOT EXISTS sql_api_default_deny_alert_events
+  ON app.alert_events FOR SELECT USING 0 TO sql_api_role;
+
+-- Backfill for organizations that already have a /sql API user. This prints
+-- one CREATE ROW POLICY statement per existing user; run the output with the
+-- same admin client. The statements match provisionSqlApiOrgUser exactly, and
+-- they are IF NOT EXISTS, so re-running is harmless.
+SELECT concat(
+    'CREATE ROW POLICY IF NOT EXISTS `', name, '_alert_events` ',
+    'ON app.`alert_events` FOR SELECT USING tenant_id = ''',
+    substring(name, length('sql_api_org_') + 1), ''' TO `', name, '`;'
+  ) AS statement
+FROM system.users
+WHERE name LIKE 'sql\_api\_org\_%'
+ORDER BY name
+FORMAT TSVRaw;

--- a/crates/everr-core/assets/skills/everr-use-telemetry/SKILL.md
+++ b/crates/everr-core/assets/skills/everr-use-telemetry/SKILL.md
@@ -27,6 +27,7 @@ The ONLY query command is `everr cloud query "<SQL>"` or `everr local query "<SQ
 | --- | --- |
 | Production, deployed services, customer reports, cloud CI history | `everr cloud query "<SQL>"` |
 | Local app, dev server, local tests, wrapped command output | `everr local query "<SQL>"` |
+| What alerts fired, why, and whether the notification went out | Read `rules/alert-history.md`, then `everr cloud query "<SQL>"` |
 | Current CI run, branch status, failed jobs, workflow logs | Use the `everr-working-with-ci` skill |
 | Missing or stale local telemetry | Use the `everr-setup-telemetry` skill |
 
@@ -61,6 +62,12 @@ SQL starts with the same query-facing table names for local and cloud:
 - `metrics_histogram`
 - `metrics_exponential_histogram`
 - `metrics_summary`
+
+Cloud has one more table, `alert_events`, holding alert history:
+evaluations, state transitions, withheld notifications, and delivery
+attempts. Read `rules/alert-history.md` before querying it, and never guess
+its columns from this section. It is cloud only, because alerting does not
+run locally.
 
 Useful trace columns: `Timestamp`, `TraceId`, `SpanId`, `ParentSpanId`, `ServiceName`, `ScopeName`, `SpanName`, `SpanKind`, `Duration`, `StatusCode`, `StatusMessage`, `SpanAttributes`, `ResourceAttributes`.
 

--- a/crates/everr-core/assets/skills/everr-use-telemetry/rules/alert-history.md
+++ b/crates/everr-core/assets/skills/everr-use-telemetry/rules/alert-history.md
@@ -1,0 +1,230 @@
+# Alert History (`alert_events`)
+
+> Maintainers: this file mirrors the Reference section of the alerting
+> ClickHouse surface design doc
+> (`todo/issues/alerting-surface/02-alerting-clickhouse-surface.md`).
+> The two move in lockstep: a column added, renamed, or re-explained in one
+> is changed in the other in the same commit.
+
+Alert history is cloud only. `everr cloud query` reads it; `everr local query`
+has no such table, because alerting does not run locally.
+
+One row per thing that happened to an alert: an evaluation, a state
+transition, a withheld notification, a delivery attempt. All event types live
+in one table, discriminated by `event_type`, so one query reads a whole
+incident in timestamp order with no join.
+
+## Query Rules
+
+1. **Filter `is_live`** in every query. Preview alerts write to the same
+   table. Drop the predicate only when the question is about a preview.
+2. **Always carry a `LIMIT`.** The cloud profile throws at 1000 result rows,
+   so a query without a limit fails instead of truncating.
+3. **Never filter `tenant_id`.** A row policy already scopes every read to
+   your organization. Adding the predicate cannot widen a result, and getting
+   the value wrong empties it.
+4. **Always carry a time bound.** `event_time` is the partition key's time
+   dimension, so a bound on it prunes whole months of data.
+5. `silenced`, `inhibited`, `silence_id` and `silence_comment` are decided
+   after the transition is written, so they carry meaning **only on
+   `notification_deferred` and `notification_suppressed` rows**.
+   `WHERE event_type = 'instance_fired' AND silenced` returns nothing, however
+   many alerts were silenced.
+6. **An absent row means unknown, not "it did not happen".** History writes
+   are best effort and delivery reconciliation does not exist yet, so a
+   missing delivery row is equally consistent with a lost write and a
+   notification that never went out. Say which of the two you cannot tell
+   apart rather than reporting the stronger claim.
+
+## Event Types
+
+| `event_type` | Meaning |
+| --- | --- |
+| `evaluation_succeeded` | The rule query ran. One row per rule per interval, so these outnumber everything else by roughly 100 to 1 |
+| `evaluation_failed` | The rule query threw. `error` holds the reason |
+| `instance_pending` | An instance started breaching but is inside its `for` window |
+| `instance_fired` | An instance started alerting |
+| `instance_resolved` | The condition cleared |
+| `instance_closed` | The instance stopped for a reason other than clearing: pending cleared, rule paused, rule deleted, preview deleted. `reason` says which |
+| `notification_deferred` | A silence or an inhibition held the notification; it goes out later |
+| `notification_suppressed` | The notification was withheld for good |
+| `delivery_succeeded` | A channel accepted the notification |
+| `delivery_failed` | One send attempt failed. `error` holds the sanitized reason |
+
+Not every type has a writer yet: `instance_pending`, `instance_closed` and
+`notification_deferred` are part of the shape but nothing writes them today,
+so queries about pending instances or held notifications return nothing.
+
+## Columns
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `event_id` | `UUID` | Unique per row. UUIDv7 on non-delivery rows, so `UUIDv7ToDateTime(event_id)` recovers its creation time. Delivery rows are the exception: their id is deterministic so repair stays idempotent, and it carries no embedded time |
+| `notification_event_id` | `UUID` | Links a transition to the suppression and delivery rows that follow it. A transition sets it to its own `event_id`. Zero on evaluation rows. UUIDv7, so its embedded time is the chain start |
+| `episode_id` | `UUID` | The opening event's id: one continuous breach, from leaving inactive to resolved or closed. Set on `instance_pending`, `instance_fired`, `instance_resolved` and `instance_closed`; zero elsewhere. `GROUP BY episode_id` reads an incident whole |
+| `tenant_id` | `LowCardinality(String)` | Enforced by row policy. Never filter on it |
+| `alert_definition_id` | `UUID` | The rule's id |
+| `repoid`, `slug` | `LowCardinality(String)` | Sort key prefix: filtering on both is significantly faster. `slug` alone merges same-named rules across repositories |
+| `preview_id` | `UUID` | Zero UUID means live |
+| `is_live` | `Bool` | True when `preview_id` is zero. Filter on this, never on the zero sentinel |
+| `event_type` | `LowCardinality(String)` | See the table above. Second partition dimension: evaluation rows sit in their own partitions, so every non-evaluation query skips them whole |
+| `write_source` | `LowCardinality(String)` | `'live'` or `'reconciled'` |
+| `evaluation_scheduled_at`, `event_time` | `DateTime64(3)` | `event_time` is when it happened, and the column every query bounds. `evaluation_scheduled_at` is when the evaluation was due; it is the epoch (1970) off evaluation rows, so never `dateDiff` against it there. Delivery `event_time` is send time, not evaluation time |
+| `row_count` | `UInt64` | Rows the rule query returned |
+| `evidence_json`, `samples_json` | `String` | Opaque JSON: the query-wide evidence and the captured sample rows |
+| `evidence_truncated`, `samples_truncated` | `Bool` | Set when the JSON beside them was cut short |
+| `error` | `String` | Set on `evaluation_failed` and `delivery_failed`. Sanitized: never a URL or a token |
+| `instance_fingerprint` | `String` | Stable identity of one alerting instance |
+| `instance_labels` | `Map(LowCardinality(String), String)` | Read a key with `instance_labels['service']` |
+| `service_name` | `LowCardinality(String)` | The service the alert concerns, resolved when the row was written; `'alert'` when none |
+| `severity` | `LowCardinality(String)` | `info`, `warning` or `critical`. The rule's severity at write time: editing a rule changes later rows, not past ones |
+| `rule_muted` | `Bool` | The rule never notifies at all (`spec.suppressed`, or a preview). Set on every row. Unrelated to `silenced`, which is about one notification |
+| `reason` | `LowCardinality(String)` | `condition_cleared` on `instance_resolved`; `pending_cleared`, `rule_paused`, `rule_deleted` or `preview_deleted` on `instance_closed`; the matching value on a terminal `notification_suppressed` |
+| `silenced`, `inhibited` | `Bool` | Frozen when the notification was decided. Meaningful only on `notification_deferred` and `notification_suppressed` rows; always false on a transition |
+| `silence_id` | `UUID` | The matched silence, zero if none |
+| `silence_comment`, `silence_matchers_json` | `String` | Copied from the silence, so the row explains itself |
+| `inhibition_comment`, `inhibition_source_json` | `String` | Reserved for inhibitions, which have no writer yet; always empty today |
+| `context_json` | `String` | Opaque JSON frozen on lifecycle rows, keys `{summary, description, links: {runbook, alert}, condition}`. `condition` is what makes "at what value" readable; `links` is the pivot to the runbook and the alert page |
+| `delivery_targets` | `Map(String, Array(String))` | Channel type to channel name. Never an address. A channel whose config failed to decrypt is recorded under type `unknown` |
+| `delivery_dedup_key` | `String` | The delivery key. Empty off delivery rows |
+
+## Worked Queries
+
+What fired in the last day. `notification_event_id` is selected so the chain
+query below is reachable from this result:
+
+```sql
+SELECT event_time, slug, instance_fingerprint, severity, instance_labels,
+       notification_event_id
+FROM alert_events
+WHERE event_type = 'instance_fired'
+  AND is_live
+  AND event_time >= now() - INTERVAL 1 DAY
+ORDER BY event_time DESC
+LIMIT 100
+```
+
+How long each incident ran and how it ended. `episode_id` groups one
+continuous breach, so duration needs no self-join:
+
+```sql
+SELECT episode_id, any(slug) AS slug,
+       min(event_time) AS opened_at,
+       dateDiff('minute', min(event_time), max(event_time)) AS duration_minutes,
+       argMax(event_type, (event_time, event_id)) AS last_event_type,
+       argMax(reason, (event_time, event_id)) AS last_reason
+FROM alert_events
+WHERE event_type IN ('instance_pending', 'instance_fired',
+                     'instance_resolved', 'instance_closed')
+  AND is_live
+  AND event_time >= now() - INTERVAL 7 DAY
+GROUP BY episode_id
+ORDER BY opened_at DESC
+LIMIT 100
+```
+
+Every row for one notification: the transition, what was decided about it,
+and every delivery attempt. The time bound is not optional, and it is
+derived, never guessed: `notification_event_id` is UUIDv7, so
+`UUIDv7ToDateTime` reads the chain's start out of the id, minus a day of
+slack for clock skew. Without it the query scans every partition in the
+retention range. Read the sequence from `event_type`, never from id order:
+chain rows come from different jobs on different hosts, and the trailing
+`event_id` only makes ties stable. Substitute the same id in both places:
+
+```sql
+SELECT event_time, event_type, silenced, inhibited, silence_id,
+       delivery_targets, error
+FROM alert_events
+WHERE notification_event_id = toUUID('...')
+  AND event_time >= UUIDv7ToDateTime(toUUID('...')) - INTERVAL 1 DAY
+ORDER BY event_time, event_id
+LIMIT 100
+```
+
+Withheld and held notifications for one alert. `silence_comment` is on the
+row, so nothing has to resolve the id. Deferrals have no writer yet, so today
+only `notification_suppressed` rows appear:
+
+```sql
+SELECT event_time, event_type, instance_fingerprint,
+       silenced, inhibited, silence_id, silence_comment
+FROM alert_events
+WHERE repoid = '...' AND slug = 'default/high-5xx'
+  AND event_type IN ('notification_suppressed', 'notification_deferred')
+  AND is_live
+  AND event_time >= now() - INTERVAL 7 DAY
+ORDER BY event_time DESC
+LIMIT 100
+```
+
+Delivery outcomes by channel type:
+
+```sql
+SELECT arrayJoin(mapKeys(delivery_targets)) AS channel_type,
+       countIf(event_type = 'delivery_succeeded') AS sent,
+       countIf(event_type = 'delivery_failed') AS failed
+FROM alert_events
+WHERE event_type IN ('delivery_succeeded', 'delivery_failed')
+  AND is_live
+  AND event_time >= now() - INTERVAL 7 DAY
+GROUP BY channel_type
+LIMIT 100
+```
+
+Rules failing to evaluate. Group by `repoid` and `slug` together, because
+`slug` alone merges same-named rules across repositories:
+
+```sql
+SELECT repoid, slug, count() AS failures,
+       max(event_time) AS last_failure, any(error) AS example
+FROM alert_events
+WHERE event_type = 'evaluation_failed'
+  AND is_live
+  AND event_time >= now() - INTERVAL 1 DAY
+GROUP BY repoid, slug
+ORDER BY failures DESC
+LIMIT 100
+```
+
+Critical alerts with no successful delivery. Read the result with rule 6:
+until delivery reconciliation exists, a lost history write and a broken
+delivery look the same. `NOT rule_muted` excludes rules that never notify by
+design. The 15 minute maturity offset keeps fires still inside the
+group-flush wait from showing as undelivered. `held` separates two stories: a
+held notification was withheld by a silence or an inhibition, which is not a
+delivery incident. One scan and a `HAVING` keep the query correct under any
+session setting:
+
+```sql
+SELECT notification_event_id,
+       anyIf(event_time, event_type = 'instance_fired') AS fired_at,
+       anyIf(slug, event_type = 'instance_fired') AS slug,
+       anyIf(instance_fingerprint,
+             event_type = 'instance_fired') AS instance_fingerprint,
+       countIf(event_type IN ('notification_suppressed',
+                              'notification_deferred')) > 0 AS held
+FROM alert_events
+WHERE event_time >= now() - INTERVAL 7 DAY
+  AND is_live
+  AND event_type IN ('instance_fired', 'delivery_succeeded',
+                     'notification_suppressed', 'notification_deferred')
+GROUP BY notification_event_id
+HAVING countIf(event_type = 'instance_fired'
+               AND severity = 'critical'
+               AND NOT rule_muted
+               AND event_time <= now() - INTERVAL 15 MINUTE) > 0
+   AND countIf(event_type = 'delivery_succeeded') = 0
+ORDER BY fired_at DESC
+LIMIT 100
+```
+
+## Alert Rows In `logs`
+
+Fired and resolved transitions are also projected into `logs`, so an engineer
+reading application output around an incident sees the alert inline. Those
+rows carry `ScopeName = 'everr.alerting'`, the alerted service in
+`ServiceName`, `ResourceAttributes['everr.signal'] = 'alert'`, and the ids in
+`LogAttributes` (`alert.event_id`, `alert.notification_event_id`,
+`alert.slug`, `alert.event_type`). The projection carries identity only: for
+evidence, samples, context, silences or delivery, query `alert_events`.

--- a/crates/everr-core/assets/skills/everr-use-telemetry/rules/alert-history.md
+++ b/crates/everr-core/assets/skills/everr-use-telemetry/rules/alert-history.md
@@ -218,13 +218,3 @@ HAVING countIf(event_type = 'instance_fired'
 ORDER BY fired_at DESC
 LIMIT 100
 ```
-
-## Alert Rows In `logs`
-
-Fired and resolved transitions are also projected into `logs`, so an engineer
-reading application output around an incident sees the alert inline. Those
-rows carry `ScopeName = 'everr.alerting'`, the alerted service in
-`ServiceName`, `ResourceAttributes['everr.signal'] = 'alert'`, and the ids in
-`LogAttributes` (`alert.event_id`, `alert.notification_event_id`,
-`alert.slug`, `alert.event_type`). The projection carries identity only: for
-evidence, samples, context, silences or delivery, query `alert_events`.

--- a/packages/app/src/lib/clickhouse.test.ts
+++ b/packages/app/src/lib/clickhouse.test.ts
@@ -208,6 +208,7 @@ describe("provisionSqlApiOrgUser", () => {
       `CREATE ROW POLICY IF NOT EXISTS \`${ORG_USER}_metrics_histogram\` ON app.\`metrics_histogram\` FOR SELECT USING tenant_id = '${ORG}' TO \`${ORG_USER}\``,
       `CREATE ROW POLICY IF NOT EXISTS \`${ORG_USER}_metrics_exponential_histogram\` ON app.\`metrics_exponential_histogram\` FOR SELECT USING tenant_id = '${ORG}' TO \`${ORG_USER}\``,
       `CREATE ROW POLICY IF NOT EXISTS \`${ORG_USER}_metrics_summary\` ON app.\`metrics_summary\` FOR SELECT USING tenant_id = '${ORG}' TO \`${ORG_USER}\``,
+      `CREATE ROW POLICY IF NOT EXISTS \`${ORG_USER}_alert_events\` ON app.\`alert_events\` FOR SELECT USING tenant_id = '${ORG}' TO \`${ORG_USER}\``,
     ]);
 
     const setRoleCall = mockCommand.mock.calls[1][0];
@@ -236,6 +237,7 @@ describe("deprovisionSqlApiOrgUser", () => {
       `DROP ROW POLICY IF EXISTS \`${ORG_USER}_metrics_histogram\` ON app.\`metrics_histogram\``,
       `DROP ROW POLICY IF EXISTS \`${ORG_USER}_metrics_exponential_histogram\` ON app.\`metrics_exponential_histogram\``,
       `DROP ROW POLICY IF EXISTS \`${ORG_USER}_metrics_summary\` ON app.\`metrics_summary\``,
+      `DROP ROW POLICY IF EXISTS \`${ORG_USER}_alert_events\` ON app.\`alert_events\``,
       `DROP USER IF EXISTS \`${ORG_USER}\``,
     ]);
   });

--- a/packages/app/src/lib/clickhouse.ts
+++ b/packages/app/src/lib/clickhouse.ts
@@ -1,6 +1,7 @@
 import { createHmac, randomUUID } from "node:crypto";
 import { env } from "@/env";
 import { createClient } from "@/lib/clickhouse-client";
+import { SQL_API_TENANT_TABLES } from "@/lib/sql-api-tables";
 import { instrumentClickhouseOperation } from "@/telemetry/clickhouse";
 
 // The client default of 2500ms forces a fresh TLS handshake on most queries
@@ -45,20 +46,6 @@ export async function query<T>(
 
   return result.json<T>();
 }
-
-// Tables that get a per-org row policy provisioned. Must match the read tables
-// granted to sql_api_role in clickhouse/init/15-create-sql-api-role.sql. The
-// canonical readable-table list — exported so callers (e.g. the MCP tool
-// description) advertise exactly these instead of hand-syncing copies.
-export const SQL_API_TENANT_TABLES = [
-  "traces",
-  "logs",
-  "metrics_gauge",
-  "metrics_sum",
-  "metrics_histogram",
-  "metrics_exponential_histogram",
-  "metrics_summary",
-] as const;
 
 function sqlApiOrgUserName(organizationId: string): string {
   return `sql_api_org_${organizationId}`;

--- a/packages/app/src/lib/sql-api-error.ts
+++ b/packages/app/src/lib/sql-api-error.ts
@@ -1,4 +1,5 @@
 import { ClickHouseError } from "@clickhouse/client";
+import { SQL_API_TENANT_TABLES } from "@/lib/sql-api-tables";
 
 // ClickHouse spells out exact table/column names in access-denied errors and
 // returns distinct errors for "exists but no read grant" vs "doesn't exist".
@@ -13,8 +14,7 @@ const SCHEMA_PROBE_ERROR_CODES = new Set(["497", "60", "81"]);
 
 export const SCHEMA_PROBE_MESSAGE =
   "Query references a table that doesn't exist or isn't available to you. " +
-  "Readable tables: traces, logs, metrics_gauge, metrics_sum, " +
-  "metrics_histogram, metrics_exponential_histogram, metrics_summary.";
+  `Readable tables: ${SQL_API_TENANT_TABLES.join(", ")}.`;
 
 export function sanitizeSqlApiError(error: unknown): string {
   if (

--- a/packages/app/src/lib/sql-api-tables.ts
+++ b/packages/app/src/lib/sql-api-tables.ts
@@ -1,0 +1,16 @@
+// Tables that get a per-org row policy provisioned. Must match the read tables
+// granted to sql_api_role in clickhouse/init/15-create-sql-api-role.sql. The
+// canonical readable-table list: exported so callers (the MCP tool
+// description, the schema-probe error) advertise exactly these instead of
+// hand-syncing copies. Lives apart from the ClickHouse client so consumers of
+// the list alone don't import node:crypto or the server env.
+export const SQL_API_TENANT_TABLES = [
+  "traces",
+  "logs",
+  "metrics_gauge",
+  "metrics_sum",
+  "metrics_histogram",
+  "metrics_exponential_histogram",
+  "metrics_summary",
+  "alert_events",
+] as const;

--- a/packages/app/src/routes/api/cli/sql.test.ts
+++ b/packages/app/src/routes/api/cli/sql.test.ts
@@ -6,6 +6,7 @@ vi.mock("@/lib/clickhouse", () => ({
 }));
 
 import { querySqlApi } from "@/lib/clickhouse";
+import { SCHEMA_PROBE_MESSAGE } from "@/lib/sql-api-error";
 import { Route } from "./sql";
 
 const mockedQuerySqlApi = vi.mocked(querySqlApi);
@@ -108,11 +109,6 @@ describe("/api/cli/sql", () => {
       error: "Syntax error near nope",
     });
   });
-
-  const SCHEMA_PROBE_MESSAGE =
-    "Query references a table that doesn't exist or isn't available to you. " +
-    "Readable tables: traces, logs, metrics_gauge, metrics_sum, " +
-    "metrics_histogram, metrics_exponential_histogram, metrics_summary.";
 
   async function postSql(body: string) {
     return getHandler()({

--- a/packages/app/src/routes/mcp/$.ts
+++ b/packages/app/src/routes/mcp/$.ts
@@ -4,9 +4,9 @@ import { z } from "zod";
 import { getMcpIdentity } from "@/data/mcp/identity";
 import { assertCurrentMember } from "@/data/mcp/membership";
 import { runSqlForConnection } from "@/data/mcp/run-sql";
-import { SQL_API_TENANT_TABLES } from "@/lib/clickhouse";
 import { AUTH_ISSUER, MCP_RESOURCE } from "@/lib/mcp-resource";
 import { mcpResourceClient } from "@/lib/mcp-resource-client";
+import { SQL_API_TENANT_TABLES } from "@/lib/sql-api-tables";
 
 // Single source of truth: the tables the per-org ClickHouse role can read.
 const READABLE_TABLES = SQL_API_TENANT_TABLES.join(", ");

--- a/todo/issues/alerting-surface/02-alerting-clickhouse-surface.md
+++ b/todo/issues/alerting-surface/02-alerting-clickhouse-surface.md
@@ -771,6 +771,7 @@ queries must not add a `tenant_id` predicate.
 | `silenced`, `inhibited` | `Bool` | Frozen at write time. Meaningful only on `notification_deferred` and `notification_suppressed` rows; always false on a transition |
 | `silence_id` | `UUID` | The matched silence, zero if none |
 | `silence_comment`, `silence_matchers_json` | `String` | Frozen from the silence, so the row reads without PostgreSQL |
+| `inhibition_comment`, `inhibition_source_json` | `String` | Reserved for inhibitions, mirroring the silence freeze columns; no writer yet, always empty today |
 | `delivery_targets` | `Map(String, Array(String))` | Channel type to channel name; never an address |
 | `delivery_dedup_key` | `String` | The PostgreSQL delivery key; the reconciliation diff joins on it. Empty off delivery rows |
 
@@ -1786,6 +1787,8 @@ These are free at recreation time and expensive after, so they ride it:
   claim is currently false in code. Proper fix: sanitize at the write
   boundary (strip URLs and tokens before insert), enforced by the same
   type-level boundary the redaction open question already calls for.
+  Resolved by ticket 02: `sanitizeAlertError` in `history/content.ts` strips
+  URLs, bare webhook hosts and bot tokens before every insert.
 - **"At what value" is unanswerable, and audit snapshots no longer arrive to
   fix it.** Scope question 1 promises the value, but no row carries the
   rule's condition or threshold, so `row_count = 3` is uninterpretable.


### PR DESCRIPTION
Stacked on #347. Implements tickets 04 and 05 of the merge gate: the `/sql` caller (CLI and MCP) can read `app.alert_events` under the same tenancy model as the telemetry tables, and the `everr-use-telemetry` skill documents how.

## Access (ticket 04)

- `GRANT SELECT ON app.alert_events TO sql_api_role` plus the `sql_api_default_deny_alert_events` row policy in `init/15-create-sql-api-role.sql`, with a comment that names all three parts of the tenancy template and what breaks when any one is missing.
- Per-organization policies come from `provisionSqlApiOrgUser` looping over `SQL_API_TENANT_TABLES`. The constant moves to `lib/sql-api-tables.ts` so the schema-probe error message and the MCP tool description derive the readable-table list from it instead of hand-syncing copies (the route test now imports the constant too).
- `clickhouse/migrate-alert-events-sql-api-access.sql` mirrors the final-shape migration's header contract and ends with a generator that prints the per-organization `CREATE ROW POLICY` backfill from `system.users`; pre-existing organizations would otherwise read zero rows silently.

## Skill file (ticket 05)

`crates/everr-core/assets/skills/everr-use-telemetry/rules/alert-history.md`, linked from SKILL.md's source table and table list. Six query rules (filter `is_live`, mandatory `LIMIT`, never filter `tenant_id`, always bound `event_time`, where `silenced`/`inhibited` carry meaning, absent row means unknown), the event-type table with an explicit note on which types have no writer yet, the 28-column reference, and seven worked queries. Queries use the bare `alert_events` name like every other table the skill advertises. The hold-duration join and the state view stay out until their writers exist; the withheld-notifications and undelivered-criticals queries are in, each carrying its honesty caveat.

Lockstep kept in both directions: the design doc's Reference gains the reserved `inhibition_comment`/`inhibition_source_json` rows the DDL already carries, and its stale error-column blocker now records the sanitizer ticket 02 shipped.

## Verification

- Permission transcript: before the grant the caller got the uniform schema-probe error, and the raw ClickHouse user got `ACCESS_DENIED`; after the grant but before the per-organization policy, `count()` returned 0 (default deny proves itself); after the backfill, 584 own rows visible, another tenant's probe rows invisible, `SELECT DISTINCT tenant_id` returns only the caller's organization.
- All seven documented queries ran verbatim through the SQL API profile; none hit `max_result_rows`, `max_execution_time`, or `min_execution_speed`. The chain query returned a full fire-plus-four-delivery-attempts chain with the derived UUIDv7 time bound. The undelivered-criticals query returns empty on dev because every recent fire is `info` severity, confirmed against the admin view.
- `tsc --noEmit` clean, biome clean, full app suite 181 files / 1419 tests green, `cargo test -p everr-core skills` green.

## Design signals

- The reference does not fit "roughly a page": 28 columns drive the file to about three pages even before the deferred queries return. The column count is the driver; recorded here per ticket 05 rather than papered over.
- Legacy v4 notification ids exist on dev from the pre-recreation writers; `UUIDv7ToDateTime` on them returns epoch 1970 and the derived-bound query degrades to a profile-killed full scan, exactly the failure mode the skill file warns about.
