### PR TITLE
feat(alerts): pending, pause and delete complete the instance lifecycle

### DIFF
--- a/packages/app/drizzle/0011_robust_cardiac.sql
+++ b/packages/app/drizzle/0011_robust_cardiac.sql
@@ -1,6 +1,7 @@
 DROP TABLE "alert_silences";--> statement-breakpoint
 DROP TABLE "alert_definitions";--> statement-breakpoint
 DROP TABLE "alert_settings";--> statement-breakpoint
+ALTER TYPE "public"."alert_state" ADD VALUE 'pending' BEFORE 'firing';--> statement-breakpoint
 CREATE TYPE "public"."alert_delivery_state" AS ENUM('pending', 'sent', 'failed');--> statement-breakpoint
 CREATE TYPE "public"."alert_event_kind" AS ENUM('notifying', 'state');--> statement-breakpoint
 CREATE TYPE "public"."alert_event_type" AS ENUM('instance_pending', 'instance_fired', 'instance_resolved', 'instance_closed', 'delivery', 'rule_health', 'silenced', 'hold_changed', 'evaluation_failed');--> statement-breakpoint
@@ -113,6 +114,7 @@ CREATE TABLE "alert_events" (
 	"event_type" "alert_event_type" NOT NULL,
 	"kind" "alert_event_kind" DEFAULT 'notifying' NOT NULL,
 	"episode_id" uuid,
+	"reason" text DEFAULT '' NOT NULL,
 	"instance_fingerprint" text DEFAULT '' NOT NULL,
 	"instance_labels" jsonb DEFAULT '{}'::jsonb NOT NULL,
 	"severity" "alert_severity" DEFAULT 'info' NOT NULL,

--- a/packages/app/drizzle/meta/0011_snapshot.json
+++ b/packages/app/drizzle/meta/0011_snapshot.json
@@ -941,6 +941,13 @@
           "primaryKey": false,
           "notNull": false
         },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
         "instance_fingerprint": {
           "name": "instance_fingerprint",
           "type": "text",
@@ -4927,6 +4934,7 @@
       "values": [
         "unknown",
         "resolved",
+        "pending",
         "firing"
       ]
     },

--- a/packages/app/src/data/alerting/history/event-types.ts
+++ b/packages/app/src/data/alerting/history/event-types.ts
@@ -4,6 +4,7 @@ export type AlertEventType = (typeof ALERTING_EVENT_TYPES)[number];
 
 /** `app.alert_events` types that are instance state changes. */
 const ALERT_TRANSITION_EVENT_TYPES = [
+  "instance_pending",
   "instance_fired",
   "instance_resolved",
   "instance_closed",
@@ -36,8 +37,10 @@ export const ALERT_OUTCOME_EVENT_TYPES_SQL = sqlStringList(
 // observed.
 export function alertingEventStatus(
   eventType: string,
-): "firing" | "resolved" | "closed" | null {
+): "pending" | "firing" | "resolved" | "closed" | null {
   switch (eventType) {
+    case "instance_pending":
+      return "pending";
     case "instance_fired":
       return "firing";
     case "instance_resolved":

--- a/packages/app/src/data/alerting/history/repository.server.test.ts
+++ b/packages/app/src/data/alerting/history/repository.server.test.ts
@@ -35,7 +35,7 @@ describe("queryClickHouseAlertEventLog", () => {
     const [sql, organizationId, params] = mocks.query.mock.calls[0];
     expect(sql).toContain("FROM app.alert_events");
     expect(sql).toContain(
-      "event_type IN ('instance_fired', 'instance_resolved', 'instance_closed')",
+      "event_type IN ('instance_pending', 'instance_fired', 'instance_resolved', 'instance_closed')",
     );
     expect(sql).toContain(
       "preview_id = toUUID('00000000-0000-0000-0000-000000000000')",

--- a/packages/app/src/data/alerting/history/repository.server.ts
+++ b/packages/app/src/data/alerting/history/repository.server.ts
@@ -27,6 +27,8 @@ export type AlertEventLogRow = {
   suppressed: boolean;
   silenced: boolean;
   inhibited: boolean;
+  /** Why a terminal row ended its instance; empty off terminals. */
+  reason: string;
   deliveryTargets: string[];
   evidence: AlertEvidence | null;
   evidenceTruncated: boolean;
@@ -41,6 +43,7 @@ type ClickHouseAlertEventRow = {
   labelsJson: string;
   severity: string;
   suppressed: boolean;
+  reason: string;
   evidenceJson: string;
   evidenceTruncated: boolean;
 };
@@ -181,6 +184,7 @@ export async function queryClickHouseAlertEventLog(
         toJSONString(instance_labels) AS labelsJson,
         severity,
         rule_muted AS suppressed,
+        reason,
         evidence_json AS evidenceJson,
         evidence_truncated AS evidenceTruncated
       FROM app.alert_events
@@ -222,6 +226,7 @@ export async function queryClickHouseAlertEventLog(
       suppressed: Boolean(row.suppressed),
       silenced: outcome?.silenced ?? false,
       inhibited: outcome?.inhibited ?? false,
+      reason: row.reason,
       deliveryTargets: outcome?.deliveryTargets ?? [],
       evidence: parseJsonObject(row.evidenceJson),
       evidenceTruncated: Boolean(row.evidenceTruncated),

--- a/packages/app/src/data/alerting/rules/lifecycle.server.test.ts
+++ b/packages/app/src/data/alerting/rules/lifecycle.server.test.ts
@@ -1,3 +1,4 @@
+import { QueryBuilder } from "drizzle-orm/pg-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -13,8 +14,10 @@ vi.mock("@/server/worker/jobs", () => ({
 }));
 
 import type { Transaction } from "@/db/client";
+import { alertEvents } from "@/db/schema";
 import { ALERT_PROJECT_LIFECYCLE_TASK } from "@/server/alerts/history/tasks";
 import {
+  cancelableNotifyingEventsFilter,
   closeRuleLifecycle,
   instanceClosedJournalRow,
 } from "./lifecycle.server";
@@ -113,7 +116,7 @@ describe("closeRuleLifecycle", () => {
 
     const result = await closeRuleLifecycle(
       recordingTx(state),
-      def as never,
+      def,
       "rule_paused",
       at,
     );
@@ -135,6 +138,24 @@ describe("closeRuleLifecycle", () => {
     ]);
   });
 
+  // The recording tx above cannot see predicates, so the cancel's WHERE is
+  // pinned on real rendered SQL: without every one of these four conditions
+  // the update cancels another tenant's, another rule's, a state-kind, or an
+  // already-claimed event.
+  it("cancels only the rule's own unclaimed notifying events", () => {
+    const { sql, params } = new QueryBuilder()
+      .select()
+      .from(alertEvents)
+      .where(cancelableNotifyingEventsFilter(def))
+      .toSQL();
+
+    expect(sql).toContain('"organization_id" = ');
+    expect(sql).toContain('"source_definition_id" = ');
+    expect(sql).toContain('"kind" = ');
+    expect(sql).toContain('"processed_at" is null');
+    expect(params).toEqual([def.organizationId, def.id, "notifying"]);
+  });
+
   it("enqueues nothing when the rule has no open instances and no in-flight events", async () => {
     const state = {
       openInstances: [],
@@ -145,7 +166,7 @@ describe("closeRuleLifecycle", () => {
 
     const result = await closeRuleLifecycle(
       recordingTx(state),
-      def as never,
+      def,
       "rule_deleted",
       at,
     );

--- a/packages/app/src/data/alerting/rules/lifecycle.server.test.ts
+++ b/packages/app/src/data/alerting/rules/lifecycle.server.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  jobs: [] as { task: string; payload: unknown }[],
+}));
+
+vi.mock("@/db/client", () => ({ db: {}, pool: {} }));
+vi.mock("@/server/worker/jobs", () => ({
+  addWorkerJobInTransaction: (_tx: unknown, task: string, payload: unknown) => {
+    mocks.jobs.push({ task, payload });
+    return Promise.resolve();
+  },
+}));
+
+import type { Transaction } from "@/db/client";
+import { ALERT_PROJECT_LIFECYCLE_TASK } from "@/server/alerts/history/tasks";
+import {
+  closeRuleLifecycle,
+  instanceClosedJournalRow,
+} from "./lifecycle.server";
+
+const def = {
+  id: "6f1c9d20-3b7a-4c11-9f2e-8a5d4c3b2a10",
+  organizationId: "org-1",
+  repoid: "host/owner/repo",
+  previewId: null,
+  project: "default",
+  slug: "high-5xx",
+  spec: {
+    severity: "critical",
+    suppressed: false,
+    annotations: {},
+  },
+} as unknown as Parameters<typeof instanceClosedJournalRow>[0];
+
+const openInstance = {
+  fingerprint: "api",
+  labels: { service: "api" },
+  episodeId: "019c3aba-29f8-7d6e-9e55-301cf47fa80d",
+};
+
+const at = new Date("2026-08-09T10:00:00Z");
+
+describe("instanceClosedJournalRow", () => {
+  it("is born processed, state kind, and carries reason and episode", () => {
+    const row = instanceClosedJournalRow(def, openInstance, "rule_paused", at);
+    expect(row).toMatchObject({
+      eventType: "instance_closed",
+      kind: "state",
+      reason: "rule_paused",
+      episodeId: openInstance.episodeId,
+      instanceFingerprint: "api",
+      slug: "default/high-5xx",
+      occurredAt: at,
+      processedAt: at,
+      suppressed: false,
+    });
+  });
+
+  it("marks preview copies muted", () => {
+    const row = instanceClosedJournalRow(
+      { ...def, previewId: "0f1c9d20-3b7a-4c11-9f2e-8a5d4c3b2a10" },
+      openInstance,
+      "rule_deleted",
+      at,
+    );
+    expect(row.suppressed).toBe(true);
+  });
+});
+
+/** Records what the lifecycle close writes, without a database behind it. */
+function recordingTx(state: {
+  openInstances: unknown[];
+  canceledIds: string[];
+  insertedJournalRows: unknown[][];
+  eventUpdates: Record<string, unknown>[];
+}) {
+  return {
+    select: () => ({
+      from: () => ({ where: () => Promise.resolve(state.openInstances) }),
+    }),
+    insert: () => ({
+      values: (rows: unknown[]) => {
+        state.insertedJournalRows.push(rows);
+        return Promise.resolve();
+      },
+    }),
+    update: () => ({
+      set: (values: Record<string, unknown>) => ({
+        where: () => ({
+          returning: () => {
+            state.eventUpdates.push(values);
+            return Promise.resolve(state.canceledIds.map((id) => ({ id })));
+          },
+        }),
+      }),
+    }),
+  } as unknown as Transaction;
+}
+
+describe("closeRuleLifecycle", () => {
+  beforeEach(() => {
+    mocks.jobs = [];
+  });
+
+  it("journals one terminal per open instance, cancels in-flight events, and enqueues the projection", async () => {
+    const state = {
+      openInstances: [openInstance, { ...openInstance, fingerprint: "web" }],
+      canceledIds: ["11111111-1111-7111-8111-111111111111"],
+      insertedJournalRows: [] as unknown[][],
+      eventUpdates: [] as Record<string, unknown>[],
+    };
+
+    const result = await closeRuleLifecycle(
+      recordingTx(state),
+      def as never,
+      "rule_paused",
+      at,
+    );
+
+    expect(state.insertedJournalRows).toHaveLength(1);
+    expect(state.insertedJournalRows[0]).toHaveLength(2);
+    expect(state.eventUpdates).toContainEqual({ processedAt: at });
+    expect(result.closedEventIds).toHaveLength(2);
+    expect(result.suppressedEventIds).toEqual(state.canceledIds);
+    expect(mocks.jobs).toEqual([
+      {
+        task: ALERT_PROJECT_LIFECYCLE_TASK,
+        payload: {
+          closedEventIds: result.closedEventIds,
+          suppressedEventIds: result.suppressedEventIds,
+          reason: "rule_paused",
+        },
+      },
+    ]);
+  });
+
+  it("enqueues nothing when the rule has no open instances and no in-flight events", async () => {
+    const state = {
+      openInstances: [],
+      canceledIds: [],
+      insertedJournalRows: [] as unknown[][],
+      eventUpdates: [] as Record<string, unknown>[],
+    };
+
+    const result = await closeRuleLifecycle(
+      recordingTx(state),
+      def as never,
+      "rule_deleted",
+      at,
+    );
+
+    expect(result).toEqual({ closedEventIds: [], suppressedEventIds: [] });
+    expect(state.insertedJournalRows).toEqual([]);
+    expect(mocks.jobs).toEqual([]);
+  });
+});

--- a/packages/app/src/data/alerting/rules/lifecycle.server.ts
+++ b/packages/app/src/data/alerting/rules/lifecycle.server.ts
@@ -1,4 +1,5 @@
 import { and, eq, isNull, ne } from "drizzle-orm";
+import type { AlertingLifecycleReason } from "@/data/alerting/vocabulary";
 import type { Transaction } from "@/db/client";
 import {
   type alertDefinitions,
@@ -11,7 +12,10 @@ import { addWorkerJobInTransaction } from "@/server/worker/jobs";
 
 type RuleRow = typeof alertDefinitions.$inferSelect;
 type InstanceRow = typeof alertInstances.$inferSelect;
-type LifecycleReason = "rule_paused" | "rule_deleted";
+type LifecycleReason = Extract<
+  AlertingLifecycleReason,
+  "rule_paused" | "rule_deleted"
+>;
 
 /**
  * The journal terminal for an instance a mutation ends. Born processed and
@@ -23,7 +27,7 @@ export function instanceClosedJournalRow(
   instance: Pick<InstanceRow, "fingerprint" | "labels" | "episodeId">,
   reason: LifecycleReason,
   at: Date,
-): typeof alertEvents.$inferInsert {
+): typeof alertEvents.$inferInsert & { id: string } {
   return {
     id: uuidv7(at),
     organizationId: def.organizationId,
@@ -75,16 +79,9 @@ export async function closeRuleLifecycle(
   const canceled = await tx
     .update(alertEvents)
     .set({ processedAt: at })
-    .where(
-      and(
-        eq(alertEvents.organizationId, def.organizationId),
-        eq(alertEvents.sourceDefinitionId, def.id),
-        eq(alertEvents.kind, "notifying"),
-        isNull(alertEvents.processedAt),
-      ),
-    )
+    .where(cancelableNotifyingEventsFilter(def))
     .returning({ id: alertEvents.id });
-  const closedEventIds = closedRows.flatMap((row) => (row.id ? [row.id] : []));
+  const closedEventIds = closedRows.map((row) => row.id);
   const suppressedEventIds = canceled.map((row) => row.id);
   if (closedEventIds.length > 0 || suppressedEventIds.length > 0) {
     await addWorkerJobInTransaction(
@@ -95,4 +92,22 @@ export async function closeRuleLifecycle(
     );
   }
   return { closedEventIds, suppressedEventIds };
+}
+
+/**
+ * What a mutation may cancel: the rule's own not-yet-processed notifying
+ * events, nothing else. Scoped by organization and definition so no other
+ * tenant's or rule's in-flight work is touched, to `kind = 'notifying'` so
+ * born-processed state rows stay out, and to `processed_at IS NULL` so an
+ * event a worker already claimed keeps exactly one owner.
+ */
+export function cancelableNotifyingEventsFilter(
+  def: Pick<RuleRow, "id" | "organizationId">,
+) {
+  return and(
+    eq(alertEvents.organizationId, def.organizationId),
+    eq(alertEvents.sourceDefinitionId, def.id),
+    eq(alertEvents.kind, "notifying"),
+    isNull(alertEvents.processedAt),
+  );
 }

--- a/packages/app/src/data/alerting/rules/lifecycle.server.ts
+++ b/packages/app/src/data/alerting/rules/lifecycle.server.ts
@@ -1,0 +1,98 @@
+import { and, eq, isNull, ne } from "drizzle-orm";
+import type { Transaction } from "@/db/client";
+import {
+  type alertDefinitions,
+  alertEvents,
+  alertInstances,
+} from "@/db/schema";
+import { uuidv7 } from "@/server/alerts/history/ids";
+import { ALERT_PROJECT_LIFECYCLE_TASK } from "@/server/alerts/history/tasks";
+import { addWorkerJobInTransaction } from "@/server/worker/jobs";
+
+type RuleRow = typeof alertDefinitions.$inferSelect;
+type InstanceRow = typeof alertInstances.$inferSelect;
+type LifecycleReason = "rule_paused" | "rule_deleted";
+
+/**
+ * The journal terminal for an instance a mutation ends. Born processed and
+ * state kind: it exists only to be projected, and the delivery pipeline's
+ * notifying-kind boundary can never select it.
+ */
+export function instanceClosedJournalRow(
+  def: RuleRow,
+  instance: Pick<InstanceRow, "fingerprint" | "labels" | "episodeId">,
+  reason: LifecycleReason,
+  at: Date,
+): typeof alertEvents.$inferInsert {
+  return {
+    id: uuidv7(at),
+    organizationId: def.organizationId,
+    repoid: def.repoid,
+    previewId: def.previewId,
+    sourceDefinitionId: def.id,
+    slug: `${def.project}/${def.slug}`,
+    eventType: "instance_closed",
+    kind: "state",
+    episodeId: instance.episodeId,
+    reason,
+    instanceFingerprint: instance.fingerprint,
+    instanceLabels: instance.labels,
+    severity: def.spec.severity,
+    suppressed: def.spec.suppressed || def.previewId !== null,
+    occurredAt: at,
+    processedAt: at,
+  };
+}
+
+/**
+ * Close a rule's open instances in the mutation's own transaction: journal one
+ * `instance_closed` terminal per open instance, cancel every not-yet-processed
+ * notifying event so nothing sends after the mutation commits, and enqueue the
+ * projection of both. The instance reset (pause) or cascade (delete) happens
+ * at the call site, after this has read the open set.
+ */
+export async function closeRuleLifecycle(
+  tx: Transaction,
+  def: RuleRow,
+  reason: LifecycleReason,
+  at: Date,
+): Promise<{ closedEventIds: string[]; suppressedEventIds: string[] }> {
+  const openInstances = await tx
+    .select()
+    .from(alertInstances)
+    .where(
+      and(
+        eq(alertInstances.alertDefinitionId, def.id),
+        ne(alertInstances.status, "inactive"),
+      ),
+    );
+  const closedRows = openInstances.map((instance) =>
+    instanceClosedJournalRow(def, instance, reason, at),
+  );
+  if (closedRows.length > 0) {
+    await tx.insert(alertEvents).values(closedRows);
+  }
+  const canceled = await tx
+    .update(alertEvents)
+    .set({ processedAt: at })
+    .where(
+      and(
+        eq(alertEvents.organizationId, def.organizationId),
+        eq(alertEvents.sourceDefinitionId, def.id),
+        eq(alertEvents.kind, "notifying"),
+        isNull(alertEvents.processedAt),
+      ),
+    )
+    .returning({ id: alertEvents.id });
+  const closedEventIds = closedRows.flatMap((row) => (row.id ? [row.id] : []));
+  const suppressedEventIds = canceled.map((row) => row.id);
+  if (closedEventIds.length > 0 || suppressedEventIds.length > 0) {
+    await addWorkerJobInTransaction(
+      tx,
+      ALERT_PROJECT_LIFECYCLE_TASK,
+      { closedEventIds, suppressedEventIds, reason },
+      { maxAttempts: 5 },
+    );
+  }
+  return { closedEventIds, suppressedEventIds };
+}

--- a/packages/app/src/data/alerting/rules/repository.test.ts
+++ b/packages/app/src/data/alerting/rules/repository.test.ts
@@ -4,8 +4,8 @@ vi.mock("@/db/client", () => ({ db: {}, pool: {} }));
 
 import { rollupAlertState } from "./repository";
 
-// Finding 11: everything except firing used to collapse to inactive, which
-// made the Pending state unreachable in every list and detail view.
+// The rollup must pass `pending` through: collapsing everything but firing to
+// inactive makes the Pending state unreachable in every list and detail view.
 describe("rollupAlertState", () => {
   it("covers inactive, pending, firing, and resolved", () => {
     expect(rollupAlertState("unknown")).toBe("inactive");

--- a/packages/app/src/data/alerting/rules/repository.test.ts
+++ b/packages/app/src/data/alerting/rules/repository.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/db/client", () => ({ db: {}, pool: {} }));
+
+import { rollupAlertState } from "./repository";
+
+// Finding 11: everything except firing used to collapse to inactive, which
+// made the Pending state unreachable in every list and detail view.
+describe("rollupAlertState", () => {
+  it("covers inactive, pending, firing, and resolved", () => {
+    expect(rollupAlertState("unknown")).toBe("inactive");
+    expect(rollupAlertState("resolved")).toBe("inactive");
+    expect(rollupAlertState("pending")).toBe("pending");
+    expect(rollupAlertState("firing")).toBe("firing");
+  });
+});

--- a/packages/app/src/data/alerting/rules/repository.ts
+++ b/packages/app/src/data/alerting/rules/repository.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { toClickHouseDateTime } from "@everr/ui/lib/time-range";
-import { and, asc, desc, eq, inArray, isNull } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNull, ne } from "drizzle-orm";
 import { parseResourceName } from "@/data/as-code/identity";
 import { type DbExecutor, db, type Transaction } from "@/db/client";
 import {
@@ -32,6 +32,7 @@ import {
   parseAlertEvaluationSamples,
   shapeAlertEvaluationSeries,
 } from "./evaluation-series";
+import { closeRuleLifecycle } from "./lifecycle.server";
 
 type RuleRow = typeof alertDefinitions.$inferSelect;
 
@@ -53,6 +54,24 @@ function ruleBase(row: RuleRow, notificationChannels: string[]) {
   };
 }
 
+/**
+ * The rollup state a stored definition state renders as. `pending` is a
+ * breach inside its for-duration and must stay distinguishable from OK;
+ * `unknown` and `resolved` both read as inactive.
+ */
+export function rollupAlertState(
+  currentState: RuleRow["currentState"],
+): "inactive" | "pending" | "firing" {
+  switch (currentState) {
+    case "firing":
+      return "firing";
+    case "pending":
+      return "pending";
+    default:
+      return "inactive";
+  }
+}
+
 function ruleView(row: RuleRow, notificationChannels: string[]) {
   return {
     ...ruleBase(row, notificationChannels),
@@ -65,10 +84,7 @@ function ruleView(row: RuleRow, notificationChannels: string[]) {
       last_error_at: row.lastErrorAt?.toISOString() ?? null,
     },
     rollup: {
-      alert_state:
-        row.currentState === "firing"
-          ? ("firing" as const)
-          : ("inactive" as const),
+      alert_state: rollupAlertState(row.currentState),
       firing_instance_count: row.firingInstanceCount,
       last_fired_at: row.lastFiredAt?.toISOString() ?? null,
       last_resolved_at: row.lastResolvedAt?.toISOString() ?? null,
@@ -546,34 +562,81 @@ export async function deleteRule(
   id: string,
   executor: DbExecutor,
 ) {
-  const rows = await executor
-    .delete(alertDefinitions)
-    .where(
-      and(
-        eq(alertDefinitions.organizationId, organizationId),
-        eq(alertDefinitions.id, id),
-      ),
-    )
-    .returning({ id: alertDefinitions.id });
-  return { deleted: rows.length > 0 };
+  const now = new Date();
+  return await executor.transaction(async (tx) => {
+    const [def] = await tx
+      .select()
+      .from(alertDefinitions)
+      .where(
+        and(
+          eq(alertDefinitions.organizationId, organizationId),
+          eq(alertDefinitions.id, id),
+        ),
+      )
+      .limit(1);
+    if (!def) return { deleted: false };
+    // The terminals must be journaled before the cascade forgets the open
+    // instances; the journal rows themselves have no FK to the definition,
+    // so they outlive it.
+    await closeRuleLifecycle(tx, def, "rule_deleted", now);
+    await tx
+      .delete(alertDefinitions)
+      .where(
+        and(
+          eq(alertDefinitions.organizationId, organizationId),
+          eq(alertDefinitions.id, id),
+        ),
+      );
+    return { deleted: true };
+  });
 }
 
 export async function pauseRule(
   { organizationId }: AlertingMutationScope,
   id: string,
 ) {
-  const [row] = await db
-    .update(alertDefinitions)
-    .set({ active: false, updatedAt: new Date() })
-    .where(
-      and(
-        eq(alertDefinitions.organizationId, organizationId),
-        eq(alertDefinitions.id, id),
-      ),
-    )
-    .returning();
-  if (!row)
-    throwAlertingPersistenceError(404, "not_found", `Rule not found: ${id}`);
+  const now = new Date();
+  const row = await db.transaction(async (tx) => {
+    const [updated] = await tx
+      .update(alertDefinitions)
+      .set({
+        active: false,
+        // The rollup must not keep reporting a firing state the pause just
+        // closed; resume re-derives it from scratch.
+        currentState: "unknown",
+        firingInstanceCount: 0,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(alertDefinitions.organizationId, organizationId),
+          eq(alertDefinitions.id, id),
+        ),
+      )
+      .returning();
+    if (!updated)
+      throwAlertingPersistenceError(404, "not_found", `Rule not found: ${id}`);
+    await closeRuleLifecycle(tx, updated, "rule_paused", now);
+    // Reset after the close read the open set, so resume starts from scratch:
+    // re-pending, re-firing, re-notifying.
+    await tx
+      .update(alertInstances)
+      .set({
+        status: "inactive",
+        pendingSince: null,
+        activeSince: null,
+        absentCount: 0,
+        episodeId: null,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(alertInstances.alertDefinitionId, id),
+          ne(alertInstances.status, "inactive"),
+        ),
+      );
+    return updated;
+  });
   return ruleBase(row, await definitionChannelNamesFor(organizationId, row.id));
 }
 

--- a/packages/app/src/data/alerting/vocabulary.ts
+++ b/packages/app/src/data/alerting/vocabulary.ts
@@ -23,3 +23,23 @@ export const ALERTING_EVENT_TYPES = [
   "hold_changed",
   "evaluation_failed",
 ] as const;
+
+// The closed vocabulary of reasons a terminal row can carry. History rows are
+// append-only, so a typo here would be an unlabelled reason forever; every
+// writer must pick from this list, not from a bare string.
+const ALERTING_LIFECYCLE_REASONS = [
+  "condition_cleared",
+  "pending_cleared",
+  "rule_paused",
+  "rule_deleted",
+  "preview_deleted",
+] as const;
+
+export type AlertingLifecycleReason =
+  (typeof ALERTING_LIFECYCLE_REASONS)[number];
+
+export function isAlertingLifecycleReason(
+  value: string,
+): value is AlertingLifecycleReason {
+  return (ALERTING_LIFECYCLE_REASONS as readonly string[]).includes(value);
+}

--- a/packages/app/src/data/previews/apply.server.ts
+++ b/packages/app/src/data/previews/apply.server.ts
@@ -110,7 +110,7 @@ export async function deleteStalePreviews(
   });
   if (closures.length > 0) {
     await recordAlertHistory(
-      closures[0].def.id,
+      null,
       closures.map(({ instance, def }) =>
         instanceHistoryRow({
           def: {

--- a/packages/app/src/data/previews/apply.server.ts
+++ b/packages/app/src/data/previews/apply.server.ts
@@ -1,6 +1,13 @@
-import { and, eq, lt } from "drizzle-orm";
+import { and, eq, lt, ne } from "drizzle-orm";
 import { type DbExecutor, db } from "@/db/client";
-import { previews } from "@/db/schema";
+import { alertDefinitions, alertInstances, previews } from "@/db/schema";
+import {
+  instanceHistoryRow,
+  recordAlertHistory,
+  ZERO_UUID,
+} from "@/server/alerts/history/clickhouse";
+import { alertServiceFallback } from "@/server/alerts/history/content";
+import { uuidv7 } from "@/server/alerts/history/ids";
 
 /**
  * Record that a preview was applied for (org, repoid) and return its id: the
@@ -67,9 +74,68 @@ export async function deleteStalePreviews(
   retentionDays: number,
 ): Promise<number> {
   const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
-  const deleted = await db
-    .delete(previews)
-    .where(lt(previews.lastAppliedAt, cutoff))
-    .returning({ id: previews.id });
-  return deleted.length;
+  const now = new Date();
+  // Preview alert terminals are projections only, declared ephemeral: the
+  // cascade removes the preview's journal rows in this same transaction, so
+  // journaling them would leave nothing to repair from. The open set is read
+  // under the delete's own transaction and filtered to the previews the
+  // predicated delete actually removed, so a concurrent re-apply that rescues
+  // a preview never gets a closed row.
+  const { deletedIds, closures } = await db.transaction(async (tx) => {
+    const open = await tx
+      .select({ instance: alertInstances, def: alertDefinitions })
+      .from(alertInstances)
+      .innerJoin(
+        alertDefinitions,
+        eq(alertInstances.alertDefinitionId, alertDefinitions.id),
+      )
+      .innerJoin(previews, eq(alertDefinitions.previewId, previews.id))
+      .where(
+        and(
+          lt(previews.lastAppliedAt, cutoff),
+          ne(alertInstances.status, "inactive"),
+        ),
+      );
+    const deleted = await tx
+      .delete(previews)
+      .where(lt(previews.lastAppliedAt, cutoff))
+      .returning({ id: previews.id });
+    const removed = new Set(deleted.map((row) => row.id));
+    return {
+      deletedIds: deleted.map((row) => row.id),
+      closures: open.filter(
+        ({ def }) => def.previewId !== null && removed.has(def.previewId),
+      ),
+    };
+  });
+  if (closures.length > 0) {
+    await recordAlertHistory(
+      closures[0].def.id,
+      closures.map(({ instance, def }) =>
+        instanceHistoryRow({
+          def: {
+            id: def.id,
+            organizationId: def.organizationId,
+            repoid: def.repoid,
+            slug: `${def.project}/${def.slug}`,
+            previewId: def.previewId,
+            severity: def.spec.severity,
+            ruleMuted: true,
+            serviceFallback: alertServiceFallback(def.spec.annotations),
+          },
+          eventId: uuidv7(now),
+          eventType: "instance_closed",
+          occurredAt: now,
+          episodeId: instance.episodeId ?? ZERO_UUID,
+          fingerprint: instance.fingerprint,
+          labels: instance.labels,
+          evidence: {},
+          evidenceTruncated: false,
+          contextJson: "{}",
+          reason: "preview_deleted",
+        }),
+      ),
+    );
+  }
+  return deletedIds.length;
 }

--- a/packages/app/src/data/previews/apply.server.ts
+++ b/packages/app/src/data/previews/apply.server.ts
@@ -6,7 +6,6 @@ import {
   recordAlertHistory,
   ZERO_UUID,
 } from "@/server/alerts/history/clickhouse";
-import { alertServiceFallback } from "@/server/alerts/history/content";
 import { uuidv7 } from "@/server/alerts/history/ids";
 
 /**
@@ -121,7 +120,6 @@ export async function deleteStalePreviews(
             previewId: def.previewId,
             severity: def.spec.severity,
             ruleMuted: true,
-            serviceFallback: alertServiceFallback(def.spec.annotations),
           },
           eventId: uuidv7(now),
           eventType: "instance_closed",

--- a/packages/app/src/db/schema/alerts.ts
+++ b/packages/app/src/db/schema/alerts.ts
@@ -22,6 +22,7 @@ import type {
   AlertingRouteInput,
   AlertingRuleSpec,
 } from "@/data/alerting/types";
+import type { AlertingLifecycleReason } from "@/data/alerting/vocabulary";
 import {
   ALERTING_EVENT_TYPES,
   ALERTING_HEALTH_STATUSES,
@@ -231,8 +232,12 @@ export const alertEvents = pgTable(
     episodeId: uuid("episode_id"),
     // Why a terminal row ended its instance: condition_cleared on a resolve;
     // pending_cleared, rule_paused or rule_deleted on instance_closed. The
-    // journal carries it so a repaired projection recovers it.
-    reason: text("reason").notNull().default(""),
+    // journal carries it so a repaired projection recovers it. Branded to the
+    // closed vocabulary so a writer cannot journal a reason no reader labels.
+    reason: text("reason")
+      .notNull()
+      .default("")
+      .$type<AlertingLifecycleReason | "">(),
     instanceFingerprint: text("instance_fingerprint").notNull().default(""),
     instanceLabels: jsonb("instance_labels")
       .notNull()

--- a/packages/app/src/db/schema/alerts.ts
+++ b/packages/app/src/db/schema/alerts.ts
@@ -33,6 +33,7 @@ import { previews } from "./app";
 export const alertStateEnum = pgEnum("alert_state", [
   "unknown",
   "resolved",
+  "pending",
   "firing",
 ]);
 
@@ -228,6 +229,10 @@ export const alertEvents = pgTable(
     // The episode this lifecycle row belongs to: the id of the row that opened
     // it. Null on rows that belong to no episode (evaluation and hold rows).
     episodeId: uuid("episode_id"),
+    // Why a terminal row ended its instance: condition_cleared on a resolve;
+    // pending_cleared, rule_paused or rule_deleted on instance_closed. The
+    // journal carries it so a repaired projection recovers it.
+    reason: text("reason").notNull().default(""),
     instanceFingerprint: text("instance_fingerprint").notNull().default(""),
     instanceLabels: jsonb("instance_labels")
       .notNull()

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/-components/rules/chart-data.test.ts
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/-components/rules/chart-data.test.ts
@@ -195,6 +195,7 @@ describe("alert rule evaluation states", () => {
       suppressed: false,
       silenced: false,
       inhibited: false,
+      reason: "",
       deliveryTargets: [],
       evidence: null,
       evidenceTruncated: false,

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/-components/rules/history.test.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/-components/rules/history.test.tsx
@@ -42,6 +42,7 @@ function eventRow(overrides: Partial<AlertEventLogRow> = {}): AlertEventLogRow {
     suppressed: false,
     silenced: false,
     inhibited: false,
+    reason: "",
     deliveryTargets: [],
     evidence: { value: 2 },
     evidenceTruncated: false,

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/-components/rules/history.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/-components/rules/history.tsx
@@ -46,8 +46,19 @@ function EventTypeLabel({ eventType }: { eventType: AlertEventType }) {
   return <AlertingStatusLabel tone={tone}>{label}</AlertingStatusLabel>;
 }
 
+// The closing reasons a terminal row can carry. `condition_cleared` is not
+// here on purpose: that is a plain resolve and the event label already says
+// Resolved.
+const CLOSE_REASON_LABELS: Record<string, string> = {
+  pending_cleared: "Pending cleared",
+  rule_paused: "Rule paused",
+  rule_deleted: "Rule deleted",
+  preview_deleted: "Preview deleted",
+};
+
 function EventDetails({ event }: { event: AlertEventLogRow }) {
   const flags = [
+    CLOSE_REASON_LABELS[event.reason] ?? null,
     event.suppressed ? "Suppressed" : null,
     event.silenced ? "Silenced" : null,
     event.inhibited ? "Inhibited" : null,

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/-components/rules/history.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/-components/rules/history.tsx
@@ -19,6 +19,10 @@ import type {
   AlertingRuleEvaluationSeries,
 } from "@/data/alerting/types";
 import {
+  type AlertingLifecycleReason,
+  isAlertingLifecycleReason,
+} from "@/data/alerting/vocabulary";
+import {
   AlertingTableSkeleton,
   alertingErrorMessage,
   alertingFormatTs,
@@ -48,17 +52,28 @@ function EventTypeLabel({ eventType }: { eventType: AlertEventType }) {
 
 // The closing reasons a terminal row can carry. `condition_cleared` is not
 // here on purpose: that is a plain resolve and the event label already says
-// Resolved.
-const CLOSE_REASON_LABELS: Record<string, string> = {
+// Resolved. Keyed over the closed vocabulary so a new reason cannot ship
+// without a label.
+const CLOSE_REASON_LABELS: Record<
+  Exclude<AlertingLifecycleReason, "condition_cleared">,
+  string
+> = {
   pending_cleared: "Pending cleared",
   rule_paused: "Rule paused",
   rule_deleted: "Rule deleted",
   preview_deleted: "Preview deleted",
 };
 
+function closeReasonLabel(reason: string): string | null {
+  if (!isAlertingLifecycleReason(reason) || reason === "condition_cleared") {
+    return null;
+  }
+  return CLOSE_REASON_LABELS[reason];
+}
+
 function EventDetails({ event }: { event: AlertEventLogRow }) {
   const flags = [
-    CLOSE_REASON_LABELS[event.reason] ?? null,
+    closeReasonLabel(event.reason),
     event.suppressed ? "Suppressed" : null,
     event.silenced ? "Silenced" : null,
     event.inhibited ? "Inhibited" : null,

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/-components/rules/signal-chart.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/-components/rules/signal-chart.tsx
@@ -71,6 +71,7 @@ function createAlertTimeTickFormatter(domain: [number, number]) {
 }
 
 const TRANSITION_LABELS = {
+  pending: "Pending",
   firing: "Fired",
   resolved: "Resolved",
   closed: "Closed",

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/index.test.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/index.test.tsx
@@ -152,6 +152,7 @@ function eventRow(overrides: Partial<AlertEventLogRow> = {}): AlertEventLogRow {
     suppressed: false,
     silenced: false,
     inhibited: false,
+    reason: "",
     deliveryTargets: [],
     evidence: { status_code: 500 },
     evidenceTruncated: false,

--- a/packages/app/src/server/alerts/delivery/flush-group.ts
+++ b/packages/app/src/server/alerts/delivery/flush-group.ts
@@ -17,7 +17,6 @@ import {
   recordAlertHistory,
   suppressionHistoryRow,
 } from "../history/clickhouse";
-import { alertServiceFallback } from "../history/content";
 import { ALERT_DELIVERY_MAX_ATTEMPTS } from "./config";
 import {
   type GroupMember,
@@ -327,7 +326,7 @@ export async function flushAlertGroup(rawPayload: unknown): Promise<void> {
     const decidedAt = new Date();
     await recordAlertHistory(
       null,
-      droppedRows.map(({ event, ruleActive, ruleSpec }) =>
+      droppedRows.map(({ event, ruleActive }) =>
         suppressionHistoryRow({
           def: {
             id: event.sourceDefinitionId,
@@ -337,7 +336,6 @@ export async function flushAlertGroup(rawPayload: unknown): Promise<void> {
             previewId: event.previewId,
             severity: event.severity,
             ruleMuted: event.suppressed,
-            serviceFallback: alertServiceFallback(ruleSpec?.annotations ?? {}),
           },
           notificationEventId: event.id,
           occurredAt: decidedAt,

--- a/packages/app/src/server/alerts/delivery/flush-group.ts
+++ b/packages/app/src/server/alerts/delivery/flush-group.ts
@@ -13,12 +13,19 @@ import {
 } from "@/db/schema";
 import { CHANNEL_TEXT_MAX } from "@/lib/channel-text-limits";
 import { addWorkerJobInTransaction } from "@/server/worker/jobs";
+import {
+  recordAlertHistory,
+  suppressionHistoryRow,
+} from "../history/clickhouse";
+import { alertServiceFallback } from "../history/content";
 import { ALERT_DELIVERY_MAX_ATTEMPTS } from "./config";
 import {
   type GroupMember,
   groupNotificationPlan,
+  memberLiveness,
   nextGroupFlushState,
 } from "./grouping";
+import { deliverableGroupMemberQuery } from "./journal-reader";
 import {
   deferSuppressedEvent,
   isInhibited,
@@ -104,23 +111,7 @@ export async function flushAlertGroup(rawPayload: unknown): Promise<void> {
       .for("update")
       .limit(1);
     if (!group || group.nextFlushAt > new Date()) return null;
-    const rows = await tx
-      .select({
-        event: alertEvents,
-        flushedAt: alertNotificationGroupEvents.flushedAt,
-      })
-      .from(alertNotificationGroupEvents)
-      .innerJoin(
-        alertEvents,
-        and(
-          eq(
-            alertNotificationGroupEvents.organizationId,
-            alertEvents.organizationId,
-          ),
-          eq(alertNotificationGroupEvents.eventId, alertEvents.id),
-        ),
-      )
-      .where(eq(alertNotificationGroupEvents.groupId, group.id));
+    const rows = await deliverableGroupMemberQuery(tx, group.id);
     return rows.length === 0 ? null : { group, rows };
   });
   if (!claimed) return;
@@ -129,7 +120,17 @@ export async function flushAlertGroup(rawPayload: unknown): Promise<void> {
   // suppression is evaluated below belongs to the next flush.
   const claimedEventIds = new Set(rows.map(({ event }) => event.id));
   const members: GroupMember<(typeof rows)[number]["event"]>[] = [];
-  for (const { event, flushedAt } of rows) {
+  // A member whose rule was paused or deleted after it joined the group must
+  // not notify. Its membership stays in the claimed set, so the committing
+  // delete below removes it; a member that never made a notification also
+  // gets its terminal suppression row so its chain does not dangle.
+  const droppedRows = rows.filter(
+    ({ event, flushedAt, ruleActive }) =>
+      memberLiveness(ruleActive, flushedAt) === "dropped_unnotified" &&
+      !event.suppressed,
+  );
+  for (const { event, flushedAt, ruleActive } of rows) {
+    if (memberLiveness(ruleActive, flushedAt) !== "deliverable") continue;
     if (event.suppressed) continue;
     const now = new Date();
     const silence = await matchingSilence(event, now);
@@ -322,4 +323,32 @@ export async function flushAlertGroup(rawPayload: unknown): Promise<void> {
       );
     }
   });
+  if (droppedRows.length > 0) {
+    const decidedAt = new Date();
+    await recordAlertHistory(
+      droppedRows[0].event.sourceDefinitionId,
+      droppedRows.map(({ event, ruleActive, ruleSpec }) =>
+        suppressionHistoryRow({
+          def: {
+            id: event.sourceDefinitionId,
+            organizationId: event.organizationId,
+            repoid: event.repoid,
+            slug: event.slug,
+            previewId: event.previewId,
+            severity: event.severity,
+            ruleMuted: event.suppressed,
+            serviceFallback: alertServiceFallback(ruleSpec?.annotations ?? {}),
+          },
+          notificationEventId: event.id,
+          occurredAt: decidedAt,
+          fingerprint: event.instanceFingerprint,
+          labels: event.instanceLabels,
+          silenced: false,
+          inhibited: false,
+          silenceId: null,
+          reason: ruleActive === null ? "rule_deleted" : "rule_paused",
+        }),
+      ),
+    );
+  }
 }

--- a/packages/app/src/server/alerts/delivery/flush-group.ts
+++ b/packages/app/src/server/alerts/delivery/flush-group.ts
@@ -326,7 +326,7 @@ export async function flushAlertGroup(rawPayload: unknown): Promise<void> {
   if (droppedRows.length > 0) {
     const decidedAt = new Date();
     await recordAlertHistory(
-      droppedRows[0].event.sourceDefinitionId,
+      null,
       droppedRows.map(({ event, ruleActive, ruleSpec }) =>
         suppressionHistoryRow({
           def: {

--- a/packages/app/src/server/alerts/delivery/grouping.test.ts
+++ b/packages/app/src/server/alerts/delivery/grouping.test.ts
@@ -7,6 +7,7 @@ vi.mock("@/db/client", () => ({ db: {}, pool: {} }));
 import {
   type GroupMember,
   groupNotificationPlan,
+  memberLiveness,
   nextGroupFlushAt,
   nextGroupFlushState,
 } from "./grouping";
@@ -217,5 +218,24 @@ describe("nextGroupFlushState", () => {
         now,
       }),
     ).toEqual({ nextFlushAt: repeatAt, enqueue: true });
+  });
+});
+
+describe("memberLiveness", () => {
+  const flushed = new Date("2026-08-06T09:55:00Z");
+
+  it("delivers only for a live rule", () => {
+    expect(memberLiveness(true, null)).toBe("deliverable");
+    expect(memberLiveness(true, flushed)).toBe("deliverable");
+  });
+
+  it("drops paused and deleted rules, recording never-notified chains", () => {
+    // false = paused, null = the definition row is gone (deleted).
+    expect(memberLiveness(false, null)).toBe("dropped_unnotified");
+    expect(memberLiveness(null, null)).toBe("dropped_unnotified");
+    // Already carried into a notification once: drop without a terminal row,
+    // the withheld thing is only the repeat.
+    expect(memberLiveness(false, flushed)).toBe("dropped");
+    expect(memberLiveness(null, flushed)).toBe("dropped");
   });
 });

--- a/packages/app/src/server/alerts/delivery/grouping.ts
+++ b/packages/app/src/server/alerts/delivery/grouping.ts
@@ -54,6 +54,24 @@ export function groupNotificationPlan<E extends GroupedEvent>(
   return { active, notify: hasUnflushed ? latest : active };
 }
 
+export type MemberLiveness = "deliverable" | "dropped" | "dropped_unnotified";
+
+/**
+ * What a flush does with a claimed membership, given the owning rule's
+ * liveness. A paused (`ruleActive` false) or deleted (`ruleActive` null) rule
+ * must not notify, so its members are dropped at claim time. A dropped member
+ * that was never carried into a notification also gets a terminal
+ * `notification_suppressed` row; without it, its chain would read as still in
+ * flight forever.
+ */
+export function memberLiveness(
+  ruleActive: boolean | null,
+  flushedAt: Date | null,
+): MemberLiveness {
+  if (ruleActive) return "deliverable";
+  return flushedAt === null ? "dropped_unnotified" : "dropped";
+}
+
 /**
  * When the group should next flush, given a membership may have been added
  * while this flush was evaluating suppression.

--- a/packages/app/src/server/alerts/delivery/grouping.ts
+++ b/packages/app/src/server/alerts/delivery/grouping.ts
@@ -54,7 +54,7 @@ export function groupNotificationPlan<E extends GroupedEvent>(
   return { active, notify: hasUnflushed ? latest : active };
 }
 
-export type MemberLiveness = "deliverable" | "dropped" | "dropped_unnotified";
+type MemberLiveness = "deliverable" | "dropped" | "dropped_unnotified";
 
 /**
  * What a flush does with a claimed membership, given the owning rule's

--- a/packages/app/src/server/alerts/delivery/journal-reader.test.ts
+++ b/packages/app/src/server/alerts/delivery/journal-reader.test.ts
@@ -1,0 +1,46 @@
+import { QueryBuilder } from "drizzle-orm/pg-core";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/db/client", () => ({ db: {}, pool: {} }));
+
+import type { DbExecutor } from "@/db/client";
+import {
+  deliverableEventQuery,
+  deliverableGroupMemberQuery,
+} from "./journal-reader";
+
+// A detached builder renders the exact SQL the reader would execute, so these
+// tests pin the boundary itself: the WHERE clause, not a mock's behavior.
+const builder = () => new QueryBuilder() as unknown as DbExecutor;
+
+describe("the delivery pipeline's journal boundary", () => {
+  it("selects an event for processing only when its kind is notifying", () => {
+    const { sql, params } = deliverableEventQuery(
+      builder(),
+      "0ee52a7c-c9d7-4bca-9c67-a21db2096acf",
+    ).toSQL();
+
+    expect(sql).toContain('"alert_events"."kind" = ');
+    expect(params).toContain("notifying");
+  });
+
+  it("joins group memberships to notifying events only", () => {
+    const { sql, params } = deliverableGroupMemberQuery(
+      builder(),
+      "1af52a7c-c9d7-4bca-9c67-a21db2096acf",
+    ).toSQL();
+
+    expect(sql).toContain('"kind" = ');
+    expect(params).toContain("notifying");
+  });
+
+  it("reads the owning rule's liveness in the same claim", () => {
+    const { sql } = deliverableGroupMemberQuery(
+      builder(),
+      "1af52a7c-c9d7-4bca-9c67-a21db2096acf",
+    ).toSQL();
+
+    expect(sql).toContain('left join "alert_definitions"');
+    expect(sql).toContain('"active"');
+  });
+});

--- a/packages/app/src/server/alerts/delivery/journal-reader.test.ts
+++ b/packages/app/src/server/alerts/delivery/journal-reader.test.ts
@@ -7,6 +7,7 @@ import type { DbExecutor } from "@/db/client";
 import {
   deliverableEventQuery,
   deliverableGroupMemberQuery,
+  liveRuleForDeliveryQuery,
 } from "./journal-reader";
 
 // A detached builder renders the exact SQL the reader would execute, so these
@@ -42,5 +43,16 @@ describe("the delivery pipeline's journal boundary", () => {
 
     expect(sql).toContain('left join "alert_definitions"');
     expect(sql).toContain('"active"');
+  });
+
+  it("counts a delivery's rules as live only when notifying and active", () => {
+    const { sql, params } = liveRuleForDeliveryQuery(builder(), "dk-1").toSQL();
+
+    expect(sql).toContain('"alert_delivery_events"');
+    expect(sql).toContain('"kind" = ');
+    expect(sql).toContain('"active" = ');
+    expect(params).toContain("notifying");
+    expect(params).toContain(true);
+    expect(params).toContain("dk-1");
   });
 });

--- a/packages/app/src/server/alerts/delivery/journal-reader.ts
+++ b/packages/app/src/server/alerts/delivery/journal-reader.ts
@@ -1,0 +1,66 @@
+import { and, eq } from "drizzle-orm";
+import { type DbExecutor, db } from "@/db/client";
+import {
+  alertDefinitions,
+  alertEvents,
+  alertNotificationGroupEvents,
+} from "@/db/schema";
+
+/**
+ * The delivery pipeline's only reads of the journal. Every query here
+ * hard-codes `kind = 'notifying'`, so a state-only row (pending, closed, hold
+ * decisions) can never be selected for delivery, whatever its event type
+ * says. Nothing outside this module may query `alert_events` for deliverable
+ * work.
+ */
+export function deliverableEventQuery(executor: DbExecutor, eventId: string) {
+  return executor
+    .select()
+    .from(alertEvents)
+    .where(and(eq(alertEvents.id, eventId), eq(alertEvents.kind, "notifying")))
+    .limit(1);
+}
+
+export async function claimDeliverableEvent(eventId: string) {
+  const [event] = await deliverableEventQuery(db, eventId);
+  return event ?? null;
+}
+
+/**
+ * A group's claimed memberships, with the owning rule's liveness read in the
+ * same statement. `ruleActive` is null when the definition is gone (the rule
+ * was deleted; its journal rows outlive it), false when it is paused. The
+ * flush drops both instead of notifying.
+ */
+export function deliverableGroupMemberQuery(
+  executor: DbExecutor,
+  groupId: string,
+) {
+  return executor
+    .select({
+      event: alertEvents,
+      flushedAt: alertNotificationGroupEvents.flushedAt,
+      ruleActive: alertDefinitions.active,
+      ruleSpec: alertDefinitions.spec,
+    })
+    .from(alertNotificationGroupEvents)
+    .innerJoin(
+      alertEvents,
+      and(
+        eq(
+          alertNotificationGroupEvents.organizationId,
+          alertEvents.organizationId,
+        ),
+        eq(alertNotificationGroupEvents.eventId, alertEvents.id),
+        eq(alertEvents.kind, "notifying"),
+      ),
+    )
+    .leftJoin(
+      alertDefinitions,
+      and(
+        eq(alertEvents.organizationId, alertDefinitions.organizationId),
+        eq(alertEvents.sourceDefinitionId, alertDefinitions.id),
+      ),
+    )
+    .where(eq(alertNotificationGroupEvents.groupId, groupId));
+}

--- a/packages/app/src/server/alerts/delivery/journal-reader.ts
+++ b/packages/app/src/server/alerts/delivery/journal-reader.ts
@@ -42,7 +42,6 @@ export function deliverableGroupMemberQuery(
       event: alertEvents,
       flushedAt: alertNotificationGroupEvents.flushedAt,
       ruleActive: alertDefinitions.active,
-      ruleSpec: alertDefinitions.spec,
     })
     .from(alertNotificationGroupEvents)
     .innerJoin(

--- a/packages/app/src/server/alerts/delivery/journal-reader.ts
+++ b/packages/app/src/server/alerts/delivery/journal-reader.ts
@@ -2,6 +2,7 @@ import { and, eq } from "drizzle-orm";
 import { type DbExecutor, db } from "@/db/client";
 import {
   alertDefinitions,
+  alertDeliveryEvents,
   alertEvents,
   alertNotificationGroupEvents,
 } from "@/db/schema";
@@ -63,4 +64,38 @@ export function deliverableGroupMemberQuery(
       ),
     )
     .where(eq(alertNotificationGroupEvents.groupId, groupId));
+}
+
+/**
+ * At least one still-active rule behind a composed notification. A send job
+ * can outlive a pause or a delete that committed after its delivery row was
+ * written; a notification whose every source rule is gone must not send. One
+ * live rule is enough: dropping the whole send would lose that rule's only
+ * notification.
+ */
+export function liveRuleForDeliveryQuery(
+  executor: DbExecutor,
+  dedupKey: string,
+) {
+  return executor
+    .select({ eventId: alertDeliveryEvents.eventId })
+    .from(alertDeliveryEvents)
+    .innerJoin(
+      alertEvents,
+      and(
+        eq(alertDeliveryEvents.organizationId, alertEvents.organizationId),
+        eq(alertDeliveryEvents.eventId, alertEvents.id),
+        eq(alertEvents.kind, "notifying"),
+      ),
+    )
+    .innerJoin(
+      alertDefinitions,
+      and(
+        eq(alertEvents.organizationId, alertDefinitions.organizationId),
+        eq(alertEvents.sourceDefinitionId, alertDefinitions.id),
+        eq(alertDefinitions.active, true),
+      ),
+    )
+    .where(eq(alertDeliveryEvents.deliveryDedupKey, dedupKey))
+    .limit(1);
 }

--- a/packages/app/src/server/alerts/delivery/process-event.test.ts
+++ b/packages/app/src/server/alerts/delivery/process-event.test.ts
@@ -21,7 +21,9 @@ vi.mock("@/db/client", () => ({
   pool: {},
 }));
 
-import { processAlertEvent } from "./process-event";
+import { QueryBuilder } from "drizzle-orm/pg-core";
+import { alertEvents } from "@/db/schema";
+import { processAlertEvent, processedStampGuard } from "./process-event";
 import { selectDispatchTargets } from "./targeting";
 
 describe("notification destination precedence", () => {
@@ -82,5 +84,22 @@ describe("processAlertEvent retention lifecycle", () => {
     });
 
     expect(mocks.update).not.toHaveBeenCalled();
+  });
+});
+
+// The stamp is the dispatch's claim against a concurrent lifecycle cancel;
+// without the null guard both sides own the event and its chain gets two
+// terminals.
+describe("processedStampGuard", () => {
+  it("claims the event only while it is unprocessed", () => {
+    const { sql, params } = new QueryBuilder()
+      .select()
+      .from(alertEvents)
+      .where(processedStampGuard("0ee52a7c-c9d7-4bca-9c67-a21db2096acf"))
+      .toSQL();
+
+    expect(sql).toContain('"id" = ');
+    expect(sql).toContain('"processed_at" is null');
+    expect(params).toEqual(["0ee52a7c-c9d7-4bca-9c67-a21db2096acf"]);
   });
 });

--- a/packages/app/src/server/alerts/delivery/process-event.ts
+++ b/packages/app/src/server/alerts/delivery/process-event.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull, TransactionRollbackError } from "drizzle-orm";
 import { alertingPartitionQueue } from "@/data/alerting/scheduling/evaluation-jobs.server";
 import { db } from "@/db/client";
 import {
@@ -54,76 +54,104 @@ export async function processAlertEvent(rawPayload: unknown): Promise<void> {
   }
 
   const targets = await dispatchTargetsForEvent(event);
-  for (const target of targets) {
+  // One transaction for every membership plus the processed stamp. The stamp
+  // is the claim: a concurrent pause or delete cancels events through
+  // `processed_at IS NULL`, so either the cancel wins and this rolls back
+  // (no membership, the cancel's terminal is the only record), or this
+  // commits first and the cancel skips the event (the flush drops the
+  // membership and writes the only terminal). Split transactions left a
+  // window where both wrote one. Targets are locked in group-key order so
+  // two events dispatching to overlapping groups cannot deadlock.
+  try {
     await db.transaction(async (tx) => {
-      const [existing] = await tx
-        .select()
-        .from(alertNotificationGroups)
-        .where(
-          and(
-            eq(alertNotificationGroups.organizationId, event.organizationId),
-            eq(alertNotificationGroups.groupKey, target.groupKey),
-          ),
-        )
-        .for("update")
-        .limit(1);
-      const nextFlushAt = nextGroupFlushAt(
-        existing
-          ? {
-              nextFlushAt: existing.nextFlushAt,
-              lastFlushedAt: existing.lastFlushedAt,
-            }
-          : null,
-        now,
-        target.groupWaitSeconds,
-        target.groupIntervalSeconds,
+      const ordered = [...targets].sort((a, b) =>
+        a.groupKey.localeCompare(b.groupKey),
       );
-      const [group] = existing
-        ? await tx
-            .update(alertNotificationGroups)
-            .set({
-              nextFlushAt,
-              repeatIntervalSeconds: target.repeatIntervalSeconds,
-              updatedAt: now,
-            })
-            .where(eq(alertNotificationGroups.id, existing.id))
-            .returning()
-        : await tx
-            .insert(alertNotificationGroups)
-            .values({
-              organizationId: event.organizationId,
-              groupKey: target.groupKey,
-              receiverId: target.receiverId,
-              directAlertDefinitionId: target.directAlertDefinitionId,
-              labels: target.groupLabels,
-              nextFlushAt,
-              repeatIntervalSeconds: target.repeatIntervalSeconds,
-            })
-            .returning();
-      await tx
-        .insert(alertNotificationGroupEvents)
-        .values({
-          organizationId: event.organizationId,
-          groupId: group.id,
-          eventId: event.id,
-        })
-        .onConflictDoNothing();
-      await addWorkerJobInTransaction(
-        tx,
-        ALERT_FLUSH_GROUP_TASK,
-        { groupId: group.id },
-        {
-          jobKey: `${ALERT_FLUSH_GROUP_TASK}:${group.id}:${nextFlushAt.toISOString()}:${event.id}`,
-          jobKeyMode: "replace",
-          maxAttempts: 5,
-          queueName: alertingPartitionQueue("group", group.id),
-          runAt: nextFlushAt,
-        },
-      );
+      for (const target of ordered) {
+        const [existing] = await tx
+          .select()
+          .from(alertNotificationGroups)
+          .where(
+            and(
+              eq(alertNotificationGroups.organizationId, event.organizationId),
+              eq(alertNotificationGroups.groupKey, target.groupKey),
+            ),
+          )
+          .for("update")
+          .limit(1);
+        const nextFlushAt = nextGroupFlushAt(
+          existing
+            ? {
+                nextFlushAt: existing.nextFlushAt,
+                lastFlushedAt: existing.lastFlushedAt,
+              }
+            : null,
+          now,
+          target.groupWaitSeconds,
+          target.groupIntervalSeconds,
+        );
+        const [group] = existing
+          ? await tx
+              .update(alertNotificationGroups)
+              .set({
+                nextFlushAt,
+                repeatIntervalSeconds: target.repeatIntervalSeconds,
+                updatedAt: now,
+              })
+              .where(eq(alertNotificationGroups.id, existing.id))
+              .returning()
+          : await tx
+              .insert(alertNotificationGroups)
+              .values({
+                organizationId: event.organizationId,
+                groupKey: target.groupKey,
+                receiverId: target.receiverId,
+                directAlertDefinitionId: target.directAlertDefinitionId,
+                labels: target.groupLabels,
+                nextFlushAt,
+                repeatIntervalSeconds: target.repeatIntervalSeconds,
+              })
+              .returning();
+        await tx
+          .insert(alertNotificationGroupEvents)
+          .values({
+            organizationId: event.organizationId,
+            groupId: group.id,
+            eventId: event.id,
+          })
+          .onConflictDoNothing();
+        await addWorkerJobInTransaction(
+          tx,
+          ALERT_FLUSH_GROUP_TASK,
+          { groupId: group.id },
+          {
+            jobKey: `${ALERT_FLUSH_GROUP_TASK}:${group.id}:${nextFlushAt.toISOString()}:${event.id}`,
+            jobKeyMode: "replace",
+            maxAttempts: 5,
+            queueName: alertingPartitionQueue("group", group.id),
+            runAt: nextFlushAt,
+          },
+        );
+      }
+      const stamped = await tx
+        .update(alertEvents)
+        .set({ processedAt: now })
+        .where(processedStampGuard(event.id))
+        .returning({ id: alertEvents.id });
+      if (stamped.length === 0) tx.rollback();
     });
+  } catch (error) {
+    // The claim was lost to a concurrent cancel; its projection owns the
+    // terminal, and the rolled-back memberships never existed.
+    if (error instanceof TransactionRollbackError) return;
+    throw error;
   }
-  await db
-    .update(alertEvents)
-    .set({ processedAt: now })
-    .where(eq(alertEvents.id, event.id));
+}
+
+/**
+ * The claim under which memberships commit. Guarded on `processed_at IS NULL`
+ * so a lifecycle cancel and this dispatch cannot both own the event.
+ */
+export function processedStampGuard(eventId: string) {
+  return and(eq(alertEvents.id, eventId), isNull(alertEvents.processedAt));
 }

--- a/packages/app/src/server/alerts/delivery/process-event.ts
+++ b/packages/app/src/server/alerts/delivery/process-event.ts
@@ -8,6 +8,7 @@ import {
 } from "@/db/schema";
 import { addWorkerJobInTransaction } from "@/server/worker/jobs";
 import { nextGroupFlushAt } from "./grouping";
+import { claimDeliverableEvent } from "./journal-reader";
 import {
   deferSuppressedEvent,
   eventStillFiring,
@@ -19,11 +20,7 @@ import { ALERT_FLUSH_GROUP_TASK, AlertEventTaskPayloadSchema } from "./tasks";
 
 export async function processAlertEvent(rawPayload: unknown): Promise<void> {
   const { eventId } = AlertEventTaskPayloadSchema.parse(rawPayload);
-  const [event] = await db
-    .select()
-    .from(alertEvents)
-    .where(eq(alertEvents.id, eventId))
-    .limit(1);
+  const event = await claimDeliverableEvent(eventId);
   if (!event || event.processedAt) return;
   const now = new Date();
   if (event.suppressed) {

--- a/packages/app/src/server/alerts/delivery/send-delivery.test.ts
+++ b/packages/app/src/server/alerts/delivery/send-delivery.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  deliveryRows: [] as unknown[],
+  liveRules: [] as unknown[],
+  set: vi.fn(),
+  update: vi.fn(),
+  where: vi.fn(),
+  send: vi.fn(),
+  outcome: vi.fn(),
+}));
+
+vi.mock("@/db/client", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        innerJoin: () => ({
+          where: () => ({
+            limit: () => Promise.resolve(mocks.deliveryRows),
+          }),
+        }),
+      }),
+    }),
+    update: mocks.update,
+  },
+  pool: {},
+}));
+vi.mock("./journal-reader", () => ({
+  liveRuleForDeliveryQuery: () => Promise.resolve(mocks.liveRules),
+}));
+vi.mock("@/data/alerting/delivery/channel-secrets.server", () => ({
+  decryptChannelConfig: () => ({ type: "webhook", url: "https://hook" }),
+}));
+vi.mock("@/data/alerting/delivery/channel-sender.server", () => ({
+  sendChannelNotification: mocks.send,
+}));
+vi.mock("./history", () => ({ recordDeliveryOutcome: mocks.outcome }));
+
+import { sendAlertDelivery } from "./send-delivery";
+
+const deliveryRow = {
+  delivery: {
+    dedupKey: "dk-1",
+    organizationId: "org-1",
+    channelId: "ch-1",
+    channelName: "on-call",
+    status: "pending",
+    attempts: 0,
+    notification: { title: "t", body: "b" },
+  },
+  channel: { id: "ch-1", encryptedConfig: "enc" },
+};
+
+describe("sendAlertDelivery rule liveness", () => {
+  beforeEach(() => {
+    mocks.deliveryRows = [deliveryRow];
+    mocks.liveRules = [{ eventId: "e-1" }];
+    mocks.send.mockReset().mockResolvedValue(undefined);
+    mocks.outcome.mockReset().mockResolvedValue(undefined);
+    mocks.where.mockReset().mockResolvedValue(undefined);
+    mocks.set.mockReset().mockReturnValue({ where: mocks.where });
+    mocks.update.mockReset().mockReturnValue({ set: mocks.set });
+  });
+
+  it("does not send when every rule behind the notification is paused or deleted", async () => {
+    mocks.liveRules = [];
+
+    await sendAlertDelivery({ dedupKey: "dk-1" });
+
+    expect(mocks.send).not.toHaveBeenCalled();
+    // Failed permanently, not thrown: a retry can never revive the rule.
+    expect(mocks.set).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "failed" }),
+    );
+    expect(mocks.outcome).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.stringContaining("paused") }),
+    );
+  });
+
+  it("sends while at least one rule behind the notification is active", async () => {
+    await sendAlertDelivery({ dedupKey: "dk-1" });
+
+    expect(mocks.send).toHaveBeenCalledOnce();
+    expect(mocks.set).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "sent" }),
+    );
+  });
+});

--- a/packages/app/src/server/alerts/delivery/send-delivery.ts
+++ b/packages/app/src/server/alerts/delivery/send-delivery.ts
@@ -5,6 +5,7 @@ import { db } from "@/db/client";
 import { alertChannels, alertDeliveries } from "@/db/schema";
 import { errorMessage } from "@/telemetry/logger";
 import { recordDeliveryOutcome } from "./history";
+import { liveRuleForDeliveryQuery } from "./journal-reader";
 import { AlertDeliveryTaskPayloadSchema } from "./tasks";
 
 export async function sendAlertDelivery(rawPayload: unknown): Promise<void> {
@@ -22,6 +23,32 @@ export async function sendAlertDelivery(rawPayload: unknown): Promise<void> {
     .where(eq(alertDeliveries.dedupKey, dedupKey))
     .limit(1);
   if (!row || row.delivery.status === "sent") return;
+  const [liveRule] = await liveRuleForDeliveryQuery(db, dedupKey);
+  if (!liveRule) {
+    // A pause or delete that committed after the flush wrote this delivery.
+    // Fail the delivery permanently instead of throwing: a retry can never
+    // make a rule active again, and the trail must say why nothing arrived.
+    const error =
+      "Withheld: every rule behind this notification was paused or deleted before the send ran";
+    await db
+      .update(alertDeliveries)
+      .set({
+        status: "failed",
+        attempts: row.delivery.attempts + 1,
+        lastError: error,
+        updatedAt: new Date(),
+      })
+      .where(eq(alertDeliveries.dedupKey, dedupKey));
+    await recordDeliveryOutcome({
+      organizationId: row.delivery.organizationId,
+      dedupKey,
+      channelType: "unknown",
+      channelName: row.delivery.channelName,
+      occurredAt: new Date(),
+      error,
+    });
+    return;
+  }
   // Unresolvable until the config decrypts, and the failure path still needs a
   // channel type for the trail.
   let channelType = "unknown";

--- a/packages/app/src/server/alerts/evaluation/rule.test.ts
+++ b/packages/app/src/server/alerts/evaluation/rule.test.ts
@@ -179,16 +179,21 @@ describe("transitionEventRows episode stamping", () => {
   };
 
   function transition(
-    event: "firing" | "resolved" | null,
+    event: AlertInstanceTransition["event"],
   ): AlertInstanceTransition {
     return {
       next: {
         fingerprint: "api",
-        status: event === "firing" ? "firing" : "inactive",
+        status:
+          event === "firing"
+            ? "firing"
+            : event === "pending"
+              ? "pending"
+              : "inactive",
         labels: { service: "api" },
         evidence: { value: 1 },
         value: 1,
-        pendingSince: null,
+        pendingSince: event === "pending" ? evaluatedAt : null,
         activeSince: event === "firing" ? evaluatedAt : null,
         lastSeenAt: evaluatedAt,
         absentCount: 0,
@@ -260,5 +265,80 @@ describe("transitionEventRows episode stamping", () => {
         storedEpisodeId: null,
       }),
     ).toEqual([]);
+  });
+
+  it("opens the episode at pending and lets the fire inherit it", () => {
+    const [pending] = transitionEventRows({
+      def: episodeDef,
+      historyDef,
+      transition: transition("pending"),
+      evaluatedAt,
+      storedEpisodeId: null,
+    });
+    expect(pending?.outbox.eventType).toBe("instance_pending");
+    expect(pending?.outbox.episodeId).toBe(pending?.outbox.id);
+    expect(pending?.episodeUpdate).toBe(pending?.outbox.id);
+
+    const [fired] = transitionEventRows({
+      def: episodeDef,
+      historyDef,
+      transition: transition("firing"),
+      evaluatedAt,
+      storedEpisodeId: pending?.outbox.id ?? null,
+    });
+    expect(fired?.outbox.episodeId).toBe(pending?.outbox.id);
+    expect(fired?.history.episode_id).toBe(pending?.outbox.id);
+    expect(fired?.episodeUpdate).toBe(pending?.outbox.id);
+  });
+
+  it("journals pending born processed, state kind, and outside any chain", () => {
+    const [pending] = transitionEventRows({
+      def: episodeDef,
+      historyDef,
+      transition: transition("pending"),
+      evaluatedAt,
+      storedEpisodeId: null,
+    });
+    expect(pending?.outbox.kind).toBe("state");
+    expect(pending?.outbox.processedAt).toEqual(evaluatedAt);
+    expect(pending?.history.notification_event_id).toBe(
+      "00000000-0000-0000-0000-000000000000",
+    );
+  });
+
+  it("closes a cleared pending with instance_closed and its reason", () => {
+    const episodeId = "019c3ab6-54d6-7e26-bc76-8cadd67542fb";
+    const [closed] = transitionEventRows({
+      def: episodeDef,
+      historyDef,
+      transition: transition("pending_cleared"),
+      evaluatedAt,
+      storedEpisodeId: episodeId,
+    });
+    expect(closed?.outbox.eventType).toBe("instance_closed");
+    expect(closed?.outbox.kind).toBe("state");
+    expect(closed?.outbox.processedAt).toEqual(evaluatedAt);
+    expect(closed?.outbox.reason).toBe("pending_cleared");
+    expect(closed?.outbox.episodeId).toBe(episodeId);
+    expect(closed?.history.episode_id).toBe(episodeId);
+    expect(closed?.history.reason).toBe("pending_cleared");
+    expect(closed?.history.notification_event_id).toBe(
+      "00000000-0000-0000-0000-000000000000",
+    );
+    // The terminal closes the episode: the instance's open episode clears.
+    expect(closed?.episodeUpdate).toBeNull();
+  });
+
+  it("stamps condition_cleared on a resolve", () => {
+    const [resolved] = transitionEventRows({
+      def: episodeDef,
+      historyDef,
+      transition: transition("resolved"),
+      evaluatedAt,
+      storedEpisodeId: null,
+    });
+    expect(resolved?.outbox.reason).toBe("condition_cleared");
+    expect(resolved?.outbox.kind).toBe("notifying");
+    expect(resolved?.history.reason).toBe("condition_cleared");
   });
 });

--- a/packages/app/src/server/alerts/evaluation/rule.test.ts
+++ b/packages/app/src/server/alerts/evaluation/rule.test.ts
@@ -362,7 +362,6 @@ describe("shouldEnqueueProcessEvent", () => {
       previewId: null,
       severity: "critical",
       ruleMuted: false,
-      serviceFallback: "alert",
     },
     transition: {
       next: {

--- a/packages/app/src/server/alerts/evaluation/rule.test.ts
+++ b/packages/app/src/server/alerts/evaluation/rule.test.ts
@@ -41,7 +41,11 @@ vi.mock("../history/clickhouse", async (importOriginal) => ({
 }));
 
 import { ALERT_EVALUATE_TASK } from "@/data/alerting/scheduling/evaluation-jobs.server";
-import { evaluateAlert, transitionEventRows } from "./rule";
+import {
+  evaluateAlert,
+  shouldEnqueueProcessEvent,
+  transitionEventRows,
+} from "./rule";
 import type { AlertInstanceTransition } from "./state-machine";
 
 /** Records what the failure path writes, without a database behind it. */
@@ -340,5 +344,53 @@ describe("transitionEventRows episode stamping", () => {
     expect(resolved?.outbox.reason).toBe("condition_cleared");
     expect(resolved?.outbox.kind).toBe("notifying");
     expect(resolved?.history.reason).toBe("condition_cleared");
+  });
+});
+
+describe("shouldEnqueueProcessEvent", () => {
+  const evaluatedAt = new Date("2026-08-06T10:00:00Z");
+  const args = (status: "pending" | "firing") => ({
+    def: {
+      ...definition,
+      spec: { ...definition.spec, condition: { operator: "gt", threshold: 0 } },
+    } as unknown as Parameters<typeof transitionEventRows>[0]["def"],
+    historyDef: {
+      id: RULE_ID,
+      organizationId: "org-1",
+      repoid: "host/owner/repo",
+      slug: "default/high-5xx",
+      previewId: null,
+      severity: "critical",
+      ruleMuted: false,
+      serviceFallback: "alert",
+    },
+    transition: {
+      next: {
+        fingerprint: "api",
+        status,
+        labels: { service: "api" },
+        evidence: { value: 1 },
+        value: 1,
+        pendingSince: status === "pending" ? evaluatedAt : null,
+        activeSince: status === "firing" ? evaluatedAt : null,
+        lastSeenAt: evaluatedAt,
+        absentCount: 0,
+      },
+      event: status,
+    } as AlertInstanceTransition,
+    evaluatedAt,
+    storedEpisodeId: null,
+  });
+
+  it("never enqueues a process job for a born-processed state row", () => {
+    const [pending] = transitionEventRows(args("pending"));
+    expect(pending?.outbox.kind).toBe("state");
+    expect(shouldEnqueueProcessEvent(pending?.outbox ?? {})).toBe(false);
+  });
+
+  it("enqueues for notifying transitions", () => {
+    const [fired] = transitionEventRows(args("firing"));
+    expect(fired?.outbox.kind).not.toBe("state");
+    expect(shouldEnqueueProcessEvent(fired?.outbox ?? {})).toBe(true);
   });
 });

--- a/packages/app/src/server/alerts/evaluation/rule.ts
+++ b/packages/app/src/server/alerts/evaluation/rule.ts
@@ -106,6 +106,17 @@ const TRANSITION_EVENT_TYPES = {
   pending_cleared: "instance_closed",
 } as const;
 
+/**
+ * State-only rows are born processed: they exist to be projected, and the
+ * delivery pipeline must never see them, so no process job may be enqueued
+ * for them.
+ */
+export function shouldEnqueueProcessEvent(
+  outbox: Pick<typeof alertEvents.$inferInsert, "kind">,
+): boolean {
+  return outbox.kind !== "state";
+}
+
 export function transitionEventRows(opts: {
   def: typeof alertDefinitions.$inferSelect;
   historyDef: AlertHistoryDefinition;
@@ -142,10 +153,10 @@ export function transitionEventRows(opts: {
     eventType === "instance_pending" || eventType === "instance_closed";
   const reason =
     eventType === "instance_resolved"
-      ? "condition_cleared"
+      ? ("condition_cleared" as const)
       : eventType === "instance_closed"
-        ? "pending_cleared"
-        : "";
+        ? ("pending_cleared" as const)
+        : undefined;
   const notificationTitle = renderMessage(def.spec.annotations.summary ?? "", {
     firstRow,
   });
@@ -503,10 +514,7 @@ async function evaluateAlertRule(
     const eventRows = transitionEvents.map(({ outbox }) => outbox);
     if (eventRows.length > 0) {
       await tx.insert(alertEvents).values(eventRows);
-      // State-only rows are born processed: they exist to be projected, and
-      // the delivery pipeline must never see them, so no job is enqueued.
-      for (const { outbox } of transitionEvents) {
-        if (outbox.kind === "state") continue;
+      for (const outbox of eventRows.filter(shouldEnqueueProcessEvent)) {
         await enqueueProcessAlertEvent(tx, outbox.id);
       }
     }

--- a/packages/app/src/server/alerts/evaluation/rule.ts
+++ b/packages/app/src/server/alerts/evaluation/rule.ts
@@ -93,10 +93,18 @@ type TransitionEvent = {
   fingerprint: string;
   /**
    * The value `alert_instances.episode_id` takes with this transition: the
-   * fired event's id opens the episode, a resolve closes it. `null` clears.
+   * event that leaves inactive opens the episode, a terminal closes it.
+   * `null` clears.
    */
   episodeUpdate: string | null;
 };
+
+const TRANSITION_EVENT_TYPES = {
+  pending: "instance_pending",
+  firing: "instance_fired",
+  resolved: "instance_resolved",
+  pending_cleared: "instance_closed",
+} as const;
 
 export function transitionEventRows(opts: {
   def: typeof alertDefinitions.$inferSelect;
@@ -118,14 +126,26 @@ export function transitionEventRows(opts: {
   // The journal row and its projection share this id, and the surface
   // promises a time-decodable id, so it must be v7.
   const id = uuidv7(evaluatedAt);
-  const eventType =
-    transition.event === "firing"
-      ? ("instance_fired" as const)
-      : ("instance_resolved" as const);
-  // No pending phase exists yet, so the fired event opens its own episode;
-  // the resolved row carries the episode it closes. Pending and closed rows
-  // extend this when they land.
-  const episodeId = eventType === "instance_fired" ? id : opts.storedEpisodeId;
+  const eventType = TRANSITION_EVENT_TYPES[transition.event];
+  // The event that leaves inactive opens the episode with its own id: the
+  // pending row when a for-duration exists, else the fired row. A fire that
+  // follows a pending phase inherits the open episode, and the terminals
+  // carry the episode they close.
+  const opens =
+    eventType === "instance_pending" ||
+    (eventType === "instance_fired" && opts.storedEpisodeId === null);
+  const episodeId = opens ? id : opts.storedEpisodeId;
+  const terminal =
+    eventType === "instance_resolved" || eventType === "instance_closed";
+  // Pending and closed rows are state-only: born processed, never delivered.
+  const stateOnly =
+    eventType === "instance_pending" || eventType === "instance_closed";
+  const reason =
+    eventType === "instance_resolved"
+      ? "condition_cleared"
+      : eventType === "instance_closed"
+        ? "pending_cleared"
+        : "";
   const notificationTitle = renderMessage(def.spec.annotations.summary ?? "", {
     firstRow,
   });
@@ -143,7 +163,9 @@ export function transitionEventRows(opts: {
         sourceDefinitionId: def.id,
         slug: historyDef.slug,
         eventType,
+        kind: stateOnly ? ("state" as const) : ("notifying" as const),
         episodeId,
+        reason,
         instanceFingerprint: next.fingerprint,
         instanceLabels: next.labels,
         severity: def.spec.severity,
@@ -151,6 +173,7 @@ export function transitionEventRows(opts: {
         notificationDescription,
         suppressed: historyDef.ruleMuted,
         occurredAt: evaluatedAt,
+        ...(stateOnly ? { processedAt: evaluatedAt } : {}),
       } satisfies typeof alertEvents.$inferInsert,
       history: instanceHistoryRow({
         def: historyDef,
@@ -162,6 +185,7 @@ export function transitionEventRows(opts: {
         labels: next.labels,
         evidence: bounded.evidence,
         evidenceTruncated: bounded.truncated,
+        reason,
         contextJson: buildAlertContextJson({
           summary: notificationTitle,
           description: notificationDescription,
@@ -175,7 +199,7 @@ export function transitionEventRows(opts: {
         }),
       }),
       fingerprint: next.fingerprint,
-      episodeUpdate: eventType === "instance_fired" ? id : null,
+      episodeUpdate: terminal ? null : episodeId,
     },
   ];
 }
@@ -449,6 +473,9 @@ async function evaluateAlertRule(
     }
 
     const firing = transitions.filter((item) => item.next.status === "firing");
+    const pending = transitions.filter(
+      (item) => item.next.status === "pending",
+    );
     const fired = transitions.filter((item) => item.event === "firing");
     const resolved = transitions.filter((item) => item.event === "resolved");
     await tx
@@ -462,7 +489,12 @@ async function evaluateAlertRule(
         lastSeenAt: present.length > 0 ? evaluatedAt : def.lastSeenAt,
         lastRowCount: evidence.rowCount,
         firingInstanceCount: firing.length,
-        currentState: firing.length > 0 ? "firing" : "resolved",
+        currentState:
+          firing.length > 0
+            ? "firing"
+            : pending.length > 0
+              ? "pending"
+              : "resolved",
         lastFiredAt: fired.length > 0 ? evaluatedAt : def.lastFiredAt,
         lastResolvedAt: resolved.length > 0 ? evaluatedAt : def.lastResolvedAt,
       })
@@ -470,12 +502,12 @@ async function evaluateAlertRule(
 
     const eventRows = transitionEvents.map(({ outbox }) => outbox);
     if (eventRows.length > 0) {
-      const events = await tx
-        .insert(alertEvents)
-        .values(eventRows)
-        .returning({ id: alertEvents.id });
-      for (const event of events) {
-        await enqueueProcessAlertEvent(tx, event.id);
+      await tx.insert(alertEvents).values(eventRows);
+      // State-only rows are born processed: they exist to be projected, and
+      // the delivery pipeline must never see them, so no job is enqueued.
+      for (const { outbox } of transitionEvents) {
+        if (outbox.kind === "state") continue;
+        await enqueueProcessAlertEvent(tx, outbox.id);
       }
     }
     await scheduleAlertAtInTransaction(

--- a/packages/app/src/server/alerts/evaluation/rule.ts
+++ b/packages/app/src/server/alerts/evaluation/rule.ts
@@ -88,7 +88,9 @@ function historyDefinition(
 }
 
 type TransitionEvent = {
-  outbox: typeof alertEvents.$inferInsert;
+  // The id is minted here, never left to the column default: the episode
+  // logic and the enqueue need it before the insert returns.
+  outbox: typeof alertEvents.$inferInsert & { id: string };
   history: AlertHistoryRow;
   fingerprint: string;
   /**

--- a/packages/app/src/server/alerts/evaluation/state-machine.test.ts
+++ b/packages/app/src/server/alerts/evaluation/state-machine.test.ts
@@ -100,4 +100,79 @@ describe("advanceAlertInstance", () => {
     expect(two.next.status).toBe("inactive");
     expect(two.event).toBe("resolved");
   });
+
+  it("emits a pending event on entry to pending, and only then", () => {
+    const entered = advanceAlertInstance({
+      previous: newInactiveInstance(present),
+      present,
+      evaluatedAt: at(0),
+      forSeconds: 60,
+      resolveAfter: 1,
+    });
+    const stillPending = advanceAlertInstance({
+      previous: entered.next,
+      present,
+      evaluatedAt: at(30),
+      forSeconds: 60,
+      resolveAfter: 1,
+    });
+    expect(entered.event).toBe("pending");
+    expect(stillPending.event).toBeNull();
+  });
+
+  it("does not emit a pending event when the fire is immediate", () => {
+    const result = advanceAlertInstance({
+      previous: newInactiveInstance(present),
+      present,
+      evaluatedAt: at(0),
+      forSeconds: 0,
+      resolveAfter: 1,
+    });
+    expect(result.event).toBe("firing");
+  });
+
+  it("clears a pending instance with a pending_cleared event, not a resolve", () => {
+    const entered = advanceAlertInstance({
+      previous: newInactiveInstance(present),
+      present,
+      evaluatedAt: at(0),
+      forSeconds: 60,
+      resolveAfter: 1,
+    });
+    const cleared = advanceAlertInstance({
+      previous: entered.next,
+      present: undefined,
+      evaluatedAt: at(30),
+      forSeconds: 60,
+      resolveAfter: 1,
+    });
+    expect(cleared.next.status).toBe("inactive");
+    expect(cleared.event).toBe("pending_cleared");
+  });
+
+  it("keeps a reappearance inside the pending phase silent", () => {
+    const entered = advanceAlertInstance({
+      previous: newInactiveInstance(present),
+      present,
+      evaluatedAt: at(0),
+      forSeconds: 120,
+      resolveAfter: 2,
+    });
+    const absent = advanceAlertInstance({
+      previous: entered.next,
+      present: undefined,
+      evaluatedAt: at(30),
+      forSeconds: 120,
+      resolveAfter: 2,
+    });
+    const reappeared = advanceAlertInstance({
+      previous: absent.next,
+      present,
+      evaluatedAt: at(60),
+      forSeconds: 120,
+      resolveAfter: 2,
+    });
+    expect(reappeared.next.status).toBe("pending");
+    expect(reappeared.event).toBeNull();
+  });
 });

--- a/packages/app/src/server/alerts/evaluation/state-machine.ts
+++ b/packages/app/src/server/alerts/evaluation/state-machine.ts
@@ -21,7 +21,12 @@ export interface PresentAlertInstance {
 
 export interface AlertInstanceTransition {
   next: StoredAlertInstance;
-  event: "firing" | "resolved" | null;
+  /**
+   * `pending` and `pending_cleared` are state-only: they are journaled born
+   * processed and never notify. `firing` and `resolved` enter the delivery
+   * pipeline.
+   */
+  event: "pending" | "firing" | "resolved" | "pending_cleared" | null;
 }
 
 function inactive(previous: StoredAlertInstance): StoredAlertInstance {
@@ -72,7 +77,12 @@ export function advanceAlertInstance(input: {
         event: "firing",
       };
     }
-    return { next, event: null };
+    // Entering pending is an event; staying pending (or reappearing while
+    // still pending) is not.
+    return {
+      next,
+      event: previous.status === "inactive" ? "pending" : null,
+    };
   }
 
   if (previous.status === "inactive") return { next: previous, event: null };
@@ -82,7 +92,7 @@ export function advanceAlertInstance(input: {
   }
   return {
     next: inactive({ ...previous, absentCount }),
-    event: previous.status === "firing" ? "resolved" : null,
+    event: previous.status === "firing" ? "resolved" : "pending_cleared",
   };
 }
 

--- a/packages/app/src/server/alerts/history/clickhouse.test.ts
+++ b/packages/app/src/server/alerts/history/clickhouse.test.ts
@@ -165,6 +165,56 @@ describe("ClickHouse alert history", () => {
     ).toBe(ZERO_UUID);
   });
 
+  it("keeps pending and closed rows outside any notification chain", () => {
+    const pending = instanceHistoryRow({
+      def,
+      eventId: "019c3aba-29f8-7d6e-9e55-301cf47fa80d",
+      eventType: "instance_pending",
+      occurredAt,
+      episodeId: "019c3aba-29f8-7d6e-9e55-301cf47fa80d",
+      fingerprint: "api",
+      labels: { service: "api" },
+      evidence: {},
+      evidenceTruncated: false,
+      contextJson: "{}",
+    });
+    const closed = instanceHistoryRow({
+      def,
+      eventId: "019c3aba-4444-7d6e-9e55-301cf47fa80d",
+      eventType: "instance_closed",
+      occurredAt,
+      episodeId: "019c3aba-29f8-7d6e-9e55-301cf47fa80d",
+      fingerprint: "api",
+      labels: { service: "api" },
+      evidence: {},
+      evidenceTruncated: false,
+      contextJson: "{}",
+      reason: "rule_paused",
+    });
+
+    expect(pending.notification_event_id).toBe(ZERO_UUID);
+    expect(pending.episode_id).toBe("019c3aba-29f8-7d6e-9e55-301cf47fa80d");
+    expect(closed.notification_event_id).toBe(ZERO_UUID);
+    expect(closed.episode_id).toBe("019c3aba-29f8-7d6e-9e55-301cf47fa80d");
+    expect(closed.reason).toBe("rule_paused");
+  });
+
+  it("carries a lifecycle reason on a terminal suppression", () => {
+    const row = suppressionHistoryRow({
+      def,
+      notificationEventId: "019c3aba-29f8-7d6e-9e55-301cf47fa80d",
+      occurredAt,
+      fingerprint: "api",
+      labels: { service: "api" },
+      silenced: false,
+      inhibited: false,
+      silenceId: null,
+      reason: "rule_paused",
+    });
+    expect(row.reason).toBe("rule_paused");
+    expect(row.silenced).toBe(false);
+  });
+
   it("freezes the suppression decision against the transition it withheld", () => {
     const row = suppressionHistoryRow({
       def,

--- a/packages/app/src/server/alerts/history/clickhouse.ts
+++ b/packages/app/src/server/alerts/history/clickhouse.ts
@@ -1,4 +1,5 @@
 import type { AlertingEvaluationSample } from "@/data/alerting/types";
+import type { AlertingLifecycleReason } from "@/data/alerting/vocabulary";
 import { insertAdminRows } from "@/lib/clickhouse";
 import { exceptionAttributes, serverLogger } from "@/telemetry/logger";
 import {
@@ -204,7 +205,7 @@ export function instanceHistoryRow(opts: {
   evidenceTruncated: boolean;
   contextJson: string;
   /** `condition_cleared` on a resolve; the closing reason on `instance_closed`. */
-  reason?: string;
+  reason?: AlertingLifecycleReason;
 }): AlertHistoryRow {
   // Only the notifying transitions head a notification chain: the suppression
   // and delivery rows written by later jobs point back here. Pending and
@@ -246,7 +247,7 @@ export function suppressionHistoryRow(opts: {
   silenceId: string | null;
   /** Set on lifecycle terminals (`rule_paused`, `rule_deleted`); empty when a
    * silence or inhibition made the decision. */
-  reason?: string;
+  reason?: AlertingLifecycleReason;
 }): AlertHistoryRow {
   return {
     ...baseHistoryRow({
@@ -302,7 +303,9 @@ export function deliveryHistoryRow(opts: {
 }
 
 export async function recordAlertHistory(
-  definitionId: string,
+  // Null when one batch spans many definitions; a single arbitrary id would
+  // misattribute the whole failure to one rule.
+  definitionId: string | null,
   rows: AlertHistoryRow[],
 ): Promise<void> {
   if (rows.length === 0) return;
@@ -315,7 +318,7 @@ export async function recordAlertHistory(
   } catch (error) {
     serverLogger.error("alerts.history.insert_failed", {
       ...exceptionAttributes(error),
-      "alert.definition_id": definitionId,
+      ...(definitionId ? { "alert.definition_id": definitionId } : {}),
       "alert.event_count": rows.length,
       "error.handled": true,
     });

--- a/packages/app/src/server/alerts/history/clickhouse.ts
+++ b/packages/app/src/server/alerts/history/clickhouse.ts
@@ -17,11 +17,19 @@ const EPOCH_ISO = "1970-01-01T00:00:00.000Z";
 type AlertHistoryEventType =
   | "evaluation_succeeded"
   | "evaluation_failed"
+  | "instance_pending"
   | "instance_fired"
   | "instance_resolved"
+  | "instance_closed"
   | "notification_suppressed"
   | "delivery_succeeded"
   | "delivery_failed";
+
+type AlertInstanceEventType =
+  | "instance_pending"
+  | "instance_fired"
+  | "instance_resolved"
+  | "instance_closed";
 
 /**
  * Channel name to the targets it reached. Never a URL, token, or address: the
@@ -185,24 +193,30 @@ export function evaluationFailureHistoryRow(opts: {
 export function instanceHistoryRow(opts: {
   def: AlertHistoryDefinition;
   eventId: string;
-  eventType: "instance_fired" | "instance_resolved";
+  eventType: AlertInstanceEventType;
   occurredAt: Date;
-  /** The episode's opening event id: the fired event's own id until a pending
-   * phase exists. */
+  /** The episode's opening event id: the pending event's own id, or the fired
+   * event's own id when there is no pending phase. */
   episodeId: string;
   fingerprint: string;
   labels: Record<string, string>;
   evidence: Record<string, unknown>;
   evidenceTruncated: boolean;
   contextJson: string;
+  /** `condition_cleared` on a resolve; the closing reason on `instance_closed`. */
+  reason?: string;
 }): AlertHistoryRow {
+  // Only the notifying transitions head a notification chain: the suppression
+  // and delivery rows written by later jobs point back here. Pending and
+  // closed rows never notify, so their chain id stays zero.
+  const notifies =
+    opts.eventType === "instance_fired" ||
+    opts.eventType === "instance_resolved";
   return {
     ...baseHistoryRow({
       def: opts.def,
       eventId: opts.eventId,
-      // A transition is the head of its own notification chain: the
-      // suppression and delivery rows written by later jobs point back here.
-      notificationEventId: opts.eventId,
+      ...(notifies ? { notificationEventId: opts.eventId } : {}),
       eventType: opts.eventType,
       occurredAt: opts.occurredAt,
     }),
@@ -212,6 +226,7 @@ export function instanceHistoryRow(opts: {
     evidence_json: JSON.stringify(opts.evidence),
     evidence_truncated: opts.evidenceTruncated,
     context_json: opts.contextJson,
+    reason: opts.reason ?? "",
   };
 }
 
@@ -229,6 +244,9 @@ export function suppressionHistoryRow(opts: {
   silenced: boolean;
   inhibited: boolean;
   silenceId: string | null;
+  /** Set on lifecycle terminals (`rule_paused`, `rule_deleted`); empty when a
+   * silence or inhibition made the decision. */
+  reason?: string;
 }): AlertHistoryRow {
   return {
     ...baseHistoryRow({
@@ -241,6 +259,7 @@ export function suppressionHistoryRow(opts: {
     silenced: opts.silenced,
     inhibited: opts.inhibited,
     silence_id: opts.silenceId ?? ZERO_UUID,
+    reason: opts.reason ?? "",
   };
 }
 

--- a/packages/app/src/server/alerts/history/project-lifecycle.test.ts
+++ b/packages/app/src/server/alerts/history/project-lifecycle.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  // First select resolves the journal rows, second the surviving definitions.
+  selects: [] as unknown[][],
+  history: vi.fn(),
+}));
+
+vi.mock("@/db/client", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => Promise.resolve(mocks.selects.shift() ?? []),
+      }),
+    }),
+  },
+  pool: {},
+}));
+
+vi.mock("./clickhouse", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  recordAlertHistory: mocks.history,
+}));
+
+import { projectAlertLifecycle } from "./project-lifecycle";
+
+const CLOSED_ID = "019c3aba-29f8-7d6e-9e55-301cf47fa80d";
+const CANCELED_ID = "019c3aba-4444-7d6e-9e55-301cf47fa80d";
+const EPISODE_ID = "019c3ab6-54d6-7e26-bc76-8cadd67542fb";
+
+const journalRow = (overrides: Record<string, unknown>) => ({
+  organizationId: "org-1",
+  repoid: "host/owner/repo",
+  previewId: null,
+  sourceDefinitionId: "6f1c9d20-3b7a-4c11-9f2e-8a5d4c3b2a10",
+  slug: "default/high-5xx",
+  instanceFingerprint: "api",
+  instanceLabels: { service: "api" },
+  severity: "critical",
+  suppressed: false,
+  occurredAt: new Date("2026-08-09T10:00:00Z"),
+  processedAt: new Date("2026-08-09T10:00:00Z"),
+  episodeId: EPISODE_ID,
+  reason: "",
+  ...overrides,
+});
+
+describe("projectAlertLifecycle", () => {
+  beforeEach(() => {
+    mocks.selects = [];
+    mocks.history.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("projects closed terminals and canceled-notification suppressions from the journal", async () => {
+    mocks.selects = [
+      [
+        journalRow({
+          id: CLOSED_ID,
+          eventType: "instance_closed",
+          kind: "state",
+          reason: "rule_paused",
+        }),
+        journalRow({
+          id: CANCELED_ID,
+          eventType: "instance_fired",
+          kind: "notifying",
+        }),
+      ],
+      // The definition is already gone, as it is after a delete.
+      [],
+    ];
+
+    await projectAlertLifecycle({
+      closedEventIds: [CLOSED_ID],
+      suppressedEventIds: [CANCELED_ID],
+      reason: "rule_paused",
+    });
+
+    const rows = mocks.history.mock.calls[0][1];
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      event_id: CLOSED_ID,
+      event_type: "instance_closed",
+      episode_id: EPISODE_ID,
+      reason: "rule_paused",
+      notification_event_id: "00000000-0000-0000-0000-000000000000",
+    });
+    expect(rows[1]).toMatchObject({
+      event_type: "notification_suppressed",
+      notification_event_id: CANCELED_ID,
+      reason: "rule_paused",
+      silenced: false,
+      inhibited: false,
+    });
+  });
+
+  it("writes nothing for ids the journal no longer has", async () => {
+    mocks.selects = [[], []];
+
+    await projectAlertLifecycle({
+      closedEventIds: [CLOSED_ID],
+      suppressedEventIds: [],
+      reason: "rule_deleted",
+    });
+
+    expect(mocks.history).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/server/alerts/history/project-lifecycle.ts
+++ b/packages/app/src/server/alerts/history/project-lifecycle.ts
@@ -1,6 +1,6 @@
 import { inArray } from "drizzle-orm";
 import { db } from "@/db/client";
-import { alertDefinitions, alertEvents } from "@/db/schema";
+import { alertEvents } from "@/db/schema";
 import {
   type AlertHistoryDefinition,
   instanceHistoryRow,
@@ -8,7 +8,6 @@ import {
   suppressionHistoryRow,
   ZERO_UUID,
 } from "./clickhouse";
-import { alertServiceFallback } from "./content";
 import { AlertLifecycleProjectionPayloadSchema } from "./tasks";
 
 /**
@@ -30,12 +29,6 @@ export async function projectAlertLifecycle(
     .where(inArray(alertEvents.id, ids));
   if (rows.length === 0) return;
   const rowById = new Map(rows.map((row) => [row.id, row]));
-  const definitionIds = [...new Set(rows.map((row) => row.sourceDefinitionId))];
-  const definitions = await db
-    .select({ id: alertDefinitions.id, spec: alertDefinitions.spec })
-    .from(alertDefinitions)
-    .where(inArray(alertDefinitions.id, definitionIds));
-  const specById = new Map(definitions.map((def) => [def.id, def.spec]));
 
   const historyDef = (
     row: typeof alertEvents.$inferSelect,
@@ -47,9 +40,6 @@ export async function projectAlertLifecycle(
     previewId: row.previewId,
     severity: row.severity,
     ruleMuted: row.suppressed,
-    serviceFallback: alertServiceFallback(
-      specById.get(row.sourceDefinitionId)?.annotations ?? {},
-    ),
   });
 
   const historyRows = [

--- a/packages/app/src/server/alerts/history/project-lifecycle.ts
+++ b/packages/app/src/server/alerts/history/project-lifecycle.ts
@@ -68,7 +68,7 @@ export async function projectAlertLifecycle(
           evidence: {},
           evidenceTruncated: false,
           contextJson: "{}",
-          reason: row.reason,
+          reason: row.reason || undefined,
         }),
       ];
     }),
@@ -90,5 +90,5 @@ export async function projectAlertLifecycle(
       ];
     }),
   ];
-  await recordAlertHistory(rows[0].sourceDefinitionId, historyRows);
+  await recordAlertHistory(null, historyRows);
 }

--- a/packages/app/src/server/alerts/history/project-lifecycle.ts
+++ b/packages/app/src/server/alerts/history/project-lifecycle.ts
@@ -1,0 +1,94 @@
+import { inArray } from "drizzle-orm";
+import { db } from "@/db/client";
+import { alertDefinitions, alertEvents } from "@/db/schema";
+import {
+  type AlertHistoryDefinition,
+  instanceHistoryRow,
+  recordAlertHistory,
+  suppressionHistoryRow,
+  ZERO_UUID,
+} from "./clickhouse";
+import { alertServiceFallback } from "./content";
+import { AlertLifecycleProjectionPayloadSchema } from "./tasks";
+
+/**
+ * Project the lifecycle terminals a pause or delete journaled. Runs after the
+ * mutation's commit; the journal rows are self-sufficient, so a definition
+ * that is already gone (delete) only costs the service-name fallback.
+ */
+export async function projectAlertLifecycle(
+  rawPayload: unknown,
+): Promise<void> {
+  const payload = AlertLifecycleProjectionPayloadSchema.parse(rawPayload);
+  const ids = [
+    ...new Set([...payload.closedEventIds, ...payload.suppressedEventIds]),
+  ];
+  if (ids.length === 0) return;
+  const rows = await db
+    .select()
+    .from(alertEvents)
+    .where(inArray(alertEvents.id, ids));
+  if (rows.length === 0) return;
+  const rowById = new Map(rows.map((row) => [row.id, row]));
+  const definitionIds = [...new Set(rows.map((row) => row.sourceDefinitionId))];
+  const definitions = await db
+    .select({ id: alertDefinitions.id, spec: alertDefinitions.spec })
+    .from(alertDefinitions)
+    .where(inArray(alertDefinitions.id, definitionIds));
+  const specById = new Map(definitions.map((def) => [def.id, def.spec]));
+
+  const historyDef = (
+    row: typeof alertEvents.$inferSelect,
+  ): AlertHistoryDefinition => ({
+    id: row.sourceDefinitionId,
+    organizationId: row.organizationId,
+    repoid: row.repoid,
+    slug: row.slug,
+    previewId: row.previewId,
+    severity: row.severity,
+    ruleMuted: row.suppressed,
+    serviceFallback: alertServiceFallback(
+      specById.get(row.sourceDefinitionId)?.annotations ?? {},
+    ),
+  });
+
+  const historyRows = [
+    ...payload.closedEventIds.flatMap((id) => {
+      const row = rowById.get(id);
+      if (!row) return [];
+      return [
+        instanceHistoryRow({
+          def: historyDef(row),
+          eventId: row.id,
+          eventType: "instance_closed" as const,
+          occurredAt: row.occurredAt,
+          episodeId: row.episodeId ?? ZERO_UUID,
+          fingerprint: row.instanceFingerprint,
+          labels: row.instanceLabels,
+          evidence: {},
+          evidenceTruncated: false,
+          contextJson: "{}",
+          reason: row.reason,
+        }),
+      ];
+    }),
+    ...payload.suppressedEventIds.flatMap((id) => {
+      const row = rowById.get(id);
+      if (!row) return [];
+      return [
+        suppressionHistoryRow({
+          def: historyDef(row),
+          notificationEventId: row.id,
+          occurredAt: row.processedAt ?? new Date(),
+          fingerprint: row.instanceFingerprint,
+          labels: row.instanceLabels,
+          silenced: false,
+          inhibited: false,
+          silenceId: null,
+          reason: payload.reason,
+        }),
+      ];
+    }),
+  ];
+  await recordAlertHistory(rows[0].sourceDefinitionId, historyRows);
+}

--- a/packages/app/src/server/alerts/history/tasks.ts
+++ b/packages/app/src/server/alerts/history/tasks.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const ALERT_PROJECT_LIFECYCLE_TASK = "alerts/project-lifecycle";
+
+/**
+ * Enqueued by pause and delete in the mutation's own transaction, so the
+ * projection of the journal rows it wrote runs exactly when the mutation
+ * committed. `closedEventIds` are `instance_closed` journal rows;
+ * `suppressedEventIds` are the notifying journal rows the mutation canceled,
+ * each of which gets a terminal `notification_suppressed` projection.
+ */
+export const AlertLifecycleProjectionPayloadSchema = z.object({
+  closedEventIds: z.array(z.string().uuid()),
+  suppressedEventIds: z.array(z.string().uuid()),
+  reason: z.enum(["rule_paused", "rule_deleted"]),
+});

--- a/packages/app/src/server/alerts/runtime.ts
+++ b/packages/app/src/server/alerts/runtime.ts
@@ -18,6 +18,8 @@ import {
   ALERT_SEND_DELIVERY_TASK,
 } from "./delivery/tasks";
 import { evaluateAlert } from "./evaluation/rule";
+import { projectAlertLifecycle } from "./history/project-lifecycle";
+import { ALERT_PROJECT_LIFECYCLE_TASK } from "./history/tasks";
 import { cleanupAlertingHistory } from "./maintenance/cleanup";
 import { scanDueAlerts } from "./scheduling/scanner";
 
@@ -40,6 +42,12 @@ export const alertTaskList: TaskList = {
   [ALERT_SEND_DELIVERY_TASK]: context.bind(ROOT_CONTEXT, async (payload) => {
     await sendAlertDelivery(payload);
   }),
+  [ALERT_PROJECT_LIFECYCLE_TASK]: context.bind(
+    ROOT_CONTEXT,
+    async (payload) => {
+      await projectAlertLifecycle(payload);
+    },
+  ),
   [ALERT_RETENTION_TASK]: context.bind(ROOT_CONTEXT, async () => {
     const counts = await cleanupAlertingHistory();
     const deleted = Object.values(counts).reduce(

--- a/packages/app/src/server/worker/runtime.test.ts
+++ b/packages/app/src/server/worker/runtime.test.ts
@@ -109,6 +109,7 @@ describe("worker runtime", () => {
       "alerts/evaluate",
       "alerts/flush-group",
       "alerts/process-event",
+      "alerts/project-lifecycle",
       "alerts/retention",
       "alerts/scan",
       "alerts/send-delivery",

--- a/todo/issues/alerting-surface/02-alerting-clickhouse-surface.md
+++ b/todo/issues/alerting-surface/02-alerting-clickhouse-surface.md
@@ -469,8 +469,11 @@ Pause also cancels the delivery side, in the same transaction (decided
 2026-08-09): the rule's unprocessed and deferred events are marked terminal
 with a `notification_suppressed` row carrying `reason = 'rule_paused'`,
 which also closes their held chains, and group flush re-checks rule
-liveness at claim time. Nothing sends after a pause. The same shape covers
-delete with its own reason.
+liveness at claim time, and the send job re-checks it once more before the
+provider call. Nothing sends after a pause. A chain that already notified is
+not suppressed retroactively: the terminal `notification_suppressed` marks
+only chains that never notified. The same shape covers delete with its own
+reason.
 
 The state view stays a pure fold over transitions and never needs rule
 liveness. The investigator also gets a useful fact: "stopped because someone

--- a/todo/issues/alerting-surface/tickets/11-born-processed-boundary.md
+++ b/todo/issues/alerting-surface/tickets/11-born-processed-boundary.md
@@ -11,6 +11,6 @@ queries the journal for deliverable events.
 
 **Status:** ready-for-agent
 
-- [ ] One reader function selects only notifying events
-- [ ] No other code path queries the journal for deliverable events
-- [ ] A test proves a state-only event never reaches delivery
+- [x] One reader function selects only notifying events (`delivery/journal-reader.ts`, 2026-08-09)
+- [x] No other code path queries the journal for deliverable events (process-event and flush-group both read through the module)
+- [x] A test proves a state-only event never reaches delivery (`journal-reader.test.ts` pins the `kind = 'notifying'` WHERE clause on both reads)

--- a/todo/issues/alerting-surface/tickets/12-pending-end-to-end.md
+++ b/todo/issues/alerting-surface/tickets/12-pending-end-to-end.md
@@ -14,7 +14,7 @@ Firing, and the history explains both.
 **Status:** ready-for-agent
 
 - [x] Chain membership for pending and terminal rows is specified in the design doc before the rows are written (Episodes and chain membership, 2026-08-09: pending and closed rows carry a zero `notification_event_id` and the `episode_id`)
-- [ ] Pending rows on entry to pending, and a pending-cleared terminal when the condition clears before firing, both journaled and born processed
-- [ ] The definition state distinguishes pending from inactive
-- [ ] Rule lists, detail pages, triage, and API vocabulary stay consistent
-- [ ] Rollup coverage for inactive, pending, firing, and resolved
+- [x] Pending rows on entry to pending, and a pending-cleared terminal when the condition clears before firing, both journaled and born processed (state-machine `pending`/`pending_cleared` events; `transitionEventRows` writes them state-kind with `processed_at` set; the episode opens at pending and the fire inherits it)
+- [x] The definition state distinguishes pending from inactive (`alert_state` enum gains `pending`; the evaluator stores it when instances are pending and none fire)
+- [x] Rule lists, detail pages, triage, and API vocabulary stay consistent (rollup emits `pending`; both pages already render the badge; history, chart and instance detail label pending events)
+- [x] Rollup coverage for inactive, pending, firing, and resolved (`rollupAlertState` + test)

--- a/todo/issues/alerting-surface/tickets/13-pause-and-delete-end-to-end.md
+++ b/todo/issues/alerting-surface/tickets/13-pause-and-delete-end-to-end.md
@@ -14,8 +14,8 @@ recreated table), 03, 11.
 
 **Status:** ready-for-agent
 
-- [ ] Pause and delete journal one terminal row per open instance, with the reason, in the mutation's own transaction
-- [ ] Pause resets its instances so resume re-pends, re-fires, re-notifies
-- [ ] Delivery checks respect the paused state; repeat delivery stops; pending notifications are canceled, per the decision (2026-08-09): unprocessed and deferred events go terminal (`notification_suppressed`, matching reason), held chains close, and group flush re-checks rule liveness at claim time
-- [ ] Preview deletion writes its terminals as projections only
-- [ ] Whether the logs projection carries pending rows is decided
+- [x] Pause and delete journal one terminal row per open instance, with the reason, in the mutation's own transaction (`closeRuleLifecycle`; the projection runs from a job enqueued in the same transaction)
+- [x] Pause resets its instances so resume re-pends, re-fires, re-notifies (reset to inactive with `episode_id` cleared, after the close reads the open set)
+- [x] Delivery checks respect the paused state; repeat delivery stops; pending notifications are canceled, per the decision (2026-08-09): unprocessed and deferred events go terminal (`notification_suppressed`, matching reason), held chains close, and group flush re-checks rule liveness at claim time (the mutation marks unprocessed and deferred events processed and projects their terminals; flush reads liveness in the claim join and drops paused or deleted members, writing the terminal for never-notified chains)
+- [x] Preview deletion writes its terminals as projections only (`deleteStalePreviews` collects the open set in the delete transaction and projects `instance_closed` with `reason = 'preview_deleted'` for the previews it actually removed)
+- [x] Whether the logs projection carries pending rows is decided (it does not; recorded in the design doc under The app.logs projection)


### PR DESCRIPTION
Stacked on #349. Implements tickets 11, 12 and 13, the last of the merge gate: the born-processed journal boundary, pending end to end, and pause/delete as first-class terminals.

## Born-processed boundary (ticket 11)

- `delivery/journal-reader.ts` is the delivery pipeline's only way to read the journal; both reads (`claimDeliverableEvent`, `deliverableGroupMemberQuery`) hard-code `kind = 'notifying'`, pinned by tests that render the real SQL. State rows are journaled with `kind = 'state'` and `processed_at` set at insert, so they can never be selected for delivery.
- Second fence: the evaluator never enqueues process jobs for state rows (`shouldEnqueueProcessEvent`, tested against real `transitionEventRows` output).

## Pending end to end (ticket 12)

- The state machine emits `instance_pending` on entry to the for-duration and `instance_closed` with `reason = 'pending_cleared'` when the condition clears early; a resolve carries `reason = 'condition_cleared'`.
- The episode opens at pending: the pending row's UUIDv7 id becomes `episode_id`, stamped onto `alert_instances`, inherited by the later fire; no for-duration means the fire opens its own; terminals clear it.
- The PG `alert_state` enum gains `pending` (rider folded into unshipped 0011 by hand, snapshot patched, dev DB altered), `rollupAlertState` passes pending/firing through and maps unknown/resolved to inactive, and the already-built Pending badges become reachable in list, detail, history, signal chart and triage.

## Pause and delete (ticket 13)

- `closeRuleLifecycle` runs inside the mutation's transaction: journals one born-processed `instance_closed` per open instance (with reason and episode), cancels every unprocessed notifying event, and enqueues the `alerts/project-lifecycle` job transactionally, so the ClickHouse projection (closed terminals plus one terminal `notification_suppressed` per canceled chain) runs exactly when the mutation commits. This is what makes `deleteRule` correct under the registry's apply transaction too.
- Pause cancels everything: unprocessed and deferred events (one guarded update), group members at flush time (the claim left-joins the definition and drops paused or deleted rules, writing the terminal for chains that never notified), and the send job itself: `send-delivery` re-checks rule liveness and permanently fails the delivery instead of sending when every rule behind the notification is paused or gone. Resume starts fresh: instances reset to inactive with episodes cleared, so a still-breaching rule re-pends, re-fires, re-notifies.
- The pause race is closed by construction: group membership and the `processed_at` stamp commit in one transaction with the stamp guarded by `processed_at IS NULL`; whichever of dispatch and cancel commits first, exactly one terminal per chain results (the loser either rolls back its memberships or skips the already-stamped event).
- An already-notified chain is not suppressed retroactively; recorded in the design doc.
- The PG journal gains a `reason` column (0011 rider) beyond the ticket text: reconciliation (ticket 06) cannot rebuild ClickHouse terminals without it.

## Review

Two-axis review ran; all accepted findings applied (send-job liveness re-check, atomic claim stamp for the pause race, evaluator skip coverage, rendered-SQL pin on the cancel predicate, `AlertingLifecycleReason` union typing the writers while the read side stays tolerant, batch logs no longer name one arbitrary rule). Declined by judgement: collapsing the three event-label maps (different tones per surface), structurally enforcing `closeRuleLifecycle` call ordering (documented instead), reverting the deliberate rollup reset on pause.

## Verification

- `tsc --noEmit` clean, biome clean, full app suite 187 files / 1448 tests green (both before and after rebasing onto #349; alerting suites re-run post-rebase, 256 tests).
- 14 new tests from the implementation plus the review-fix tests across state machine, row builders, journal reader, liveness, `closeRuleLifecycle`, projection handler and rollup.
- Live dev verification is deferred: the long-running dev server still holds pre-fix worker runtimes that compete for jobs and write stale-shape rows. After a `pnpm dev` restart on this branch: watch a for-duration rule show Pending then Firing with a shared episode id, pause a firing rule and confirm nothing sends, history reads "Rule paused", and resume re-fires. The dev database already carries the 0011 riders, so the current runtime is unaffected.
