### PR TITLE
fix(collector): truncate over-long log lines instead of aborting the scan

### DIFF
--- a/collector/receiver/githubactionsreceiver/log_event_handling.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling.go
@@ -10,6 +10,7 @@ import (
 	"archive/zip"
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -254,6 +255,36 @@ type parsedLine struct {
 	body string
 }
 
+// A single step-output line can be arbitrarily long (a minified bundle, a
+// one-line JSON dump); lines are truncated at this cap instead of aborting
+// the scan, which would silently drop every remaining line of the run.
+const maxLogLineBytes = 1024 * 1024 // 1 MiB
+
+// readLogLine reads one line, truncated at maxLogLineBytes. The rest of an
+// over-long line is consumed and discarded. A non-nil error means no line
+// was read.
+func readLogLine(r *bufio.Reader) (string, error) {
+	var buf []byte
+	for {
+		frag, isPrefix, err := r.ReadLine()
+		if err != nil {
+			if len(buf) > 0 {
+				return string(buf), nil
+			}
+			return "", err
+		}
+		if remaining := maxLogLineBytes - len(buf); remaining > 0 {
+			if len(frag) > remaining {
+				frag = frag[:remaining]
+			}
+			buf = append(buf, frag...)
+		}
+		if !isPrefix {
+			return string(buf), nil
+		}
+	}
+}
+
 // scanLogFile reads a zip log file and calls emit for each parsed line.
 func scanLogFile(f *zip.File, logger *zap.Logger, emit func(parsedLine)) {
 	ff, err := f.Open()
@@ -263,11 +294,17 @@ func scanLogFile(f *zip.File, logger *zap.Logger, emit func(parsedLine)) {
 	}
 	defer ff.Close()
 
-	scanner := bufio.NewScanner(ff)
+	reader := bufio.NewReader(ff)
 	firstLine := true
 	var lastTime time.Time
-	for scanner.Scan() {
-		lineText := scanner.Text()
+	for {
+		lineText, err := readLogLine(reader)
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				logger.Error("Error reading file", zap.Error(err))
+			}
+			break
+		}
 		if firstLine {
 			lineText = strings.TrimPrefix(lineText, "\xEF\xBB\xBF")
 			firstLine = false
@@ -288,10 +325,6 @@ func scanLogFile(f *zip.File, logger *zap.Logger, emit func(parsedLine)) {
 		// output, not an error. Keep the full text and attribute it to the
 		// previous line's timestamp (zero if it's the very first line).
 		emit(parsedLine{time: lastTime, body: lineText})
-	}
-
-	if err := scanner.Err(); err != nil {
-		logger.Error("Error reading file", zap.Error(err))
 	}
 }
 

--- a/collector/receiver/githubactionsreceiver/log_event_handling_test.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -617,6 +618,31 @@ func TestScanLogFileContinuationLines(t *testing.T) {
 		require.Equal(t, "line one", lines[1].body)
 
 		require.Equal(t, 0, observed.Len(), "lines without timestamps must not log at error level")
+	})
+
+	t.Run("over-long line is truncated, not fatal", func(t *testing.T) {
+		huge := strings.Repeat("x", maxLogLineBytes+512)
+		lines, observed := scan(t, ""+
+			"2023-10-13T10:11:33Z line one\n"+
+			"2023-10-13T10:11:34Z "+huge+"\n"+
+			"2023-10-13T10:11:35Z line after\n")
+
+		require.Len(t, lines, 3, "lines after the over-long one must still be emitted")
+		require.Equal(t, "line one", lines[0].body)
+		require.Len(t, lines[1].body, maxLogLineBytes-len("2023-10-13T10:11:34Z "))
+		require.Equal(t, "line after", lines[2].body)
+
+		require.Equal(t, 0, observed.Len(), "an over-long line must not log at error level")
+	})
+
+	t.Run("final line without trailing newline", func(t *testing.T) {
+		lines, observed := scan(t, ""+
+			"2023-10-13T10:11:33Z line one\n"+
+			"2023-10-13T10:11:34Z last line no newline")
+
+		require.Len(t, lines, 2)
+		require.Equal(t, "last line no newline", lines[1].body)
+		require.Equal(t, 0, observed.Len())
 	})
 }
 


### PR DESCRIPTION
## Problem

The production collector was silently dropping most log lines for some CI runs. `scanLogFile` used `bufio.Scanner`, and a single step-output line larger than the scanner's max token size (a minified bundle, a one-line JSON dump) aborted the whole file scan with `bufio.Scanner: token too long`. Everything after that line was lost, while the webhook still returned success so nothing retried. Observed today in production: an affected repo's "PR CI" runs kept their traces but lost their logs on every run.

## Fix

Read lines with `bufio.Reader.ReadLine` via a new `readLogLine` helper: each line is capped at 1 MiB, the rest of an over-long line is consumed and discarded, and the scan continues with the next line. Timestamp and continuation-line parsing are unchanged.

## Tests

- Over-long line is truncated, later lines still emitted, no error-level log
- Final line without trailing newline is still emitted
- Full `githubactionsreceiver` suite and `golangci-lint` pass