### PR TITLE
fix(alerts): close out the engine, store, and contract review findings

### DIFF
--- a/clickhouse/init/12-create-alert-events.sql
+++ b/clickhouse/init/12-create-alert-events.sql
@@ -27,8 +27,10 @@ CREATE TABLE IF NOT EXISTS app.alert_events
   -- 'live' or 'reconciled'. The app.logs projection copies live rows only,
   -- which is what lets the reconciler re-drive rows without duplicating logs.
   write_source LowCardinality(String) DEFAULT 'live',
-  -- Zero (epoch) off evaluation rows; never dateDiff against it there.
-  evaluation_scheduled_at DateTime64(3) CODEC(Delta, ZSTD(1)),
+  -- Zero (epoch) off evaluation rows; never dateDiff against it there. Every
+  -- writer sends this explicitly; the DEFAULT documents the sentinel in
+  -- SHOW CREATE rather than changing what gets written.
+  evaluation_scheduled_at DateTime64(3) DEFAULT toDateTime64(0, 3) CODEC(Delta, ZSTD(1)),
   event_time DateTime64(3) DEFAULT now64(3) CODEC(Delta, ZSTD(1)),
   row_count UInt64 DEFAULT 0,
   evidence_truncated Bool DEFAULT false,

--- a/clickhouse/init/12-create-alert-events.sql
+++ b/clickhouse/init/12-create-alert-events.sql
@@ -53,8 +53,11 @@ CREATE TABLE IF NOT EXISTS app.alert_events
   -- on every row; unrelated to `silenced`, which is per notification.
   rule_muted Bool DEFAULT false,
   -- On terminal instance rows: condition_cleared on instance_resolved;
-  -- pending_cleared, rule_paused, rule_deleted or preview_deleted on
-  -- instance_closed; the matching value on a terminal notification_suppressed.
+  -- pending_cleared, labels_changed, rule_paused, rule_deleted or
+  -- preview_deleted on instance_closed; rule_paused, rule_deleted,
+  -- no_longer_firing or no_channels on a terminal notification_suppressed.
+  -- The closed vocabulary lives in ALERTING_LIFECYCLE_REASONS
+  -- (src/data/alerting/vocabulary.ts).
   reason LowCardinality(String) DEFAULT '',
   -- Notification outcome, frozen at the moment it was decided. A silence
   -- created later never rewrites what these say happened. Meaningful only on

--- a/clickhouse/init/12-create-alert-events.sql
+++ b/clickhouse/init/12-create-alert-events.sql
@@ -100,9 +100,11 @@ ORDER BY (tenant_id, repoid, slug, event_type, event_time, event_id)
 -- else lives at the tenant retention.
 TTL toDateTime(event_time) + INTERVAL least(toUInt32(30), dictGetOrDefault('app.tenant_retention', 'logs_days', tenant_id, toUInt32(3650))) DAY DELETE WHERE event_type IN ('evaluation_succeeded', 'evaluation_failed'),
     toDateTime(event_time) + INTERVAL dictGetOrDefault('app.tenant_retention', 'logs_days', tenant_id, toUInt32(3650)) DAY DELETE WHERE event_type NOT IN ('evaluation_succeeded', 'evaluation_failed')
--- The deduplication window is sized now, at recreation time, so the
--- reconciler's insert_deduplication_token scheme has it when it lands with
--- the reconciliation ticket; nothing sets tokens yet.
+-- The deduplication window is sized now, at recreation time. recordAlertHistoryStrict
+-- (server/alerts/history/clickhouse.ts) sets insert_deduplication_token today,
+-- synchronously, for the lifecycle projection's Graphile retries; the live
+-- best-effort path and the reconciler (when it lands) still need their own
+-- token scheme.
 -- allow_suspicious_ttl_expressions rides the statement, not the session, so
 -- SHOW CREATE matches migrated deployments.
 SETTINGS index_granularity = 8192, non_replicated_deduplication_window = 10000, allow_suspicious_ttl_expressions = 1;

--- a/clickhouse/migrate-alert-events-final-shape.sql
+++ b/clickhouse/migrate-alert-events-final-shape.sql
@@ -5,6 +5,12 @@
 -- accepted for this release stage (04-alerting-branch-review.md, "Breaking
 -- Postgres migration" applies the same stance to alerting data).
 --
+-- DO NOT RE-RUN once this has been applied and
+-- migrate-alert-events-sql-api-access.sql's backfill has run: DROP TABLE
+-- below discards every row collected since the last run, including from
+-- organizations the backfill just gave read access to. The statements are
+-- IF EXISTS / IF NOT EXISTS for a clean first apply, not for safe repetition.
+--
 -- Apply with an admin user, e.g.:
 --   clickhouse-client --user default --password '<ADMIN_PASSWORD>' --multiquery \
 --     < clickhouse/migrate-alert-events-final-shape.sql

--- a/clickhouse/migrate-alert-events-final-shape.sql
+++ b/clickhouse/migrate-alert-events-final-shape.sql
@@ -40,7 +40,7 @@ CREATE TABLE app.alert_events
   is_live Bool DEFAULT preview_id = toUUID('00000000-0000-0000-0000-000000000000'),
   event_type LowCardinality(String),
   write_source LowCardinality(String) DEFAULT 'live',
-  evaluation_scheduled_at DateTime64(3) CODEC(Delta, ZSTD(1)),
+  evaluation_scheduled_at DateTime64(3) DEFAULT toDateTime64(0, 3) CODEC(Delta, ZSTD(1)),
   event_time DateTime64(3) DEFAULT now64(3) CODEC(Delta, ZSTD(1)),
   row_count UInt64 DEFAULT 0,
   evidence_truncated Bool DEFAULT false,

--- a/clickhouse/migrate-alert-events-sql-api-access.sql
+++ b/clickhouse/migrate-alert-events-sql-api-access.sql
@@ -24,6 +24,16 @@ GRANT SELECT ON app.alert_events TO sql_api_role;
 CREATE ROW POLICY IF NOT EXISTS sql_api_default_deny_alert_events
   ON app.alert_events FOR SELECT USING 0 TO sql_api_role;
 
+-- MANDATORY SECOND STEP, not documentation: the query below is a SELECT that
+-- GENERATES CREATE ROW POLICY statements as text; it does not run them. A
+-- one-query-per-request runner (this migration's own stated audience) will
+-- execute the SELECT and discard its output, leaving every pre-existing org
+-- on the default-deny policy above: they will read zero rows from
+-- app.alert_events, silently, not an error. Copy the `statement` column from
+-- this query's output and execute it, statement by statement, with the same
+-- admin client, before considering this migration done. The verification
+-- query further down confirms whether that step happened.
+--
 -- Backfill for organizations that already have a /sql API user. This prints
 -- one CREATE ROW POLICY statement per existing user; run the output with the
 -- same admin client. The statements match provisionSqlApiOrgUser exactly, and
@@ -37,3 +47,16 @@ FROM system.users
 WHERE name LIKE 'sql\_api\_org\_%'
 ORDER BY name
 FORMAT TSVRaw;
+
+-- Verification: run this after executing the backfill statements above.
+-- Every sql_api_org_% user should have exactly one row policy on
+-- app.alert_events, so org_alert_events_policies should equal org_users.
+-- A lower count means the backfill step was skipped or only partially run;
+-- re-run the SELECT above and execute the statements for the missing users.
+SELECT
+    (SELECT count() FROM system.users WHERE name LIKE 'sql\_api\_org\_%') AS org_users,
+    (SELECT count() FROM system.row_policies
+       WHERE database = 'app' AND table = 'alert_events'
+         AND name LIKE 'sql\_api\_org\_%\_alert\_events') AS org_alert_events_policies
+FORMAT TSVRaw;
+-- Expected result: org_alert_events_policies = org_users.

--- a/packages/app/src/data/alerting/delivery/channel-sender.server.test.ts
+++ b/packages/app/src/data/alerting/delivery/channel-sender.server.test.ts
@@ -7,7 +7,10 @@ vi.mock("@/lib/slack.server", () => ({
   sendSlackMessage: mocks.sendSlackMessage,
 }));
 
-import { sendChannelNotification } from "./channel-sender.server";
+import {
+  ChannelSendError,
+  sendChannelNotification,
+} from "./channel-sender.server";
 
 // A public IP so validateOutboundUrl passes without a DNS lookup.
 const HOOK_URL = "https://8.8.8.8/hook";
@@ -63,4 +66,41 @@ it("leaves an in-limit message untouched", async () => {
   await sendChannelNotification({ type: "discord", url: HOOK_URL }, small);
 
   expect(sentDiscordContent()).toBe(`${small.title}\n\n${small.body}`);
+});
+
+it("marks a 400 permanent: retrying an identical malformed request cannot help", async () => {
+  fetchMock.mockResolvedValueOnce(new Response("bad payload", { status: 400 }));
+
+  const error = await sendChannelNotification(
+    { type: "webhook", url: HOOK_URL },
+    { title: "t", body: "b" },
+  ).catch((caught: unknown) => caught);
+
+  expect(error).toBeInstanceOf(ChannelSendError);
+  expect((error as ChannelSendError).permanent).toBe(true);
+});
+
+it("marks a 500 transient: worth retrying", async () => {
+  fetchMock.mockResolvedValueOnce(new Response("", { status: 500 }));
+
+  const error = await sendChannelNotification(
+    { type: "webhook", url: HOOK_URL },
+    { title: "t", body: "b" },
+  ).catch((caught: unknown) => caught);
+
+  expect(error).toBeInstanceOf(ChannelSendError);
+  expect((error as ChannelSendError).permanent).toBe(false);
+});
+
+it.each([
+  408, 429,
+])("keeps %d retryable even though it is a 4xx", async (status) => {
+  fetchMock.mockResolvedValueOnce(new Response("", { status }));
+
+  const error = await sendChannelNotification(
+    { type: "webhook", url: HOOK_URL },
+    { title: "t", body: "b" },
+  ).catch((caught: unknown) => caught);
+
+  expect((error as ChannelSendError).permanent).toBe(false);
 });

--- a/packages/app/src/data/alerting/delivery/channel-sender.server.ts
+++ b/packages/app/src/data/alerting/delivery/channel-sender.server.ts
@@ -14,6 +14,30 @@ export interface ChannelNotification {
   url?: string;
 }
 
+// A 4xx from the provider means retrying the identical request cannot
+// succeed (a revoked webhook, a malformed payload), except 408 and 429,
+// which mean "try again". Everything else (5xx, network failure, timeout) is
+// transient and worth Graphile's retry budget.
+const RETRYABLE_CLIENT_ERROR_STATUSES = new Set([408, 429]);
+
+export class ChannelSendError extends Error {
+  readonly permanent: boolean;
+
+  constructor(message: string, opts: { permanent: boolean }) {
+    super(message);
+    this.name = "ChannelSendError";
+    this.permanent = opts.permanent;
+  }
+}
+
+function isPermanentStatus(status: number): boolean {
+  return (
+    status >= 400 &&
+    status < 500 &&
+    !RETRYABLE_CLIENT_ERROR_STATUSES.has(status)
+  );
+}
+
 function blockedIpv4(address: string): boolean {
   const octets = address.split(".").map(Number);
   if (octets.length !== 4 || octets.some((value) => !Number.isInteger(value)))
@@ -96,8 +120,9 @@ async function postJson(urlRaw: string, body: unknown): Promise<void> {
   });
   if (!response.ok) {
     const detail = await response.text().catch(() => "");
-    throw new Error(
+    throw new ChannelSendError(
       `notification webhook failed: ${response.status} ${detail}`,
+      { permanent: isPermanentStatus(response.status) },
     );
   }
 }

--- a/packages/app/src/data/alerting/history/event-types.ts
+++ b/packages/app/src/data/alerting/history/event-types.ts
@@ -1,6 +1,9 @@
-import type { ALERTING_EVENT_TYPES } from "../vocabulary";
-
-export type AlertEventType = (typeof ALERTING_EVENT_TYPES)[number];
+// Type-only: the writer module (server/alerts/history/clickhouse.ts) pulls in
+// server-only dependencies (ClickHouse admin credentials, node:crypto), but
+// this file is imported by client-bundled route components. A type-only
+// import is erased at build time, so the real ClickHouse event-type union can
+// anchor these arrays without shipping the writer into the browser.
+import type { AlertHistoryEventType } from "@/server/alerts/history/clickhouse";
 
 /** `app.alert_events` types that are instance state changes. */
 const ALERT_TRANSITION_EVENT_TYPES = [
@@ -8,7 +11,10 @@ const ALERT_TRANSITION_EVENT_TYPES = [
   "instance_fired",
   "instance_resolved",
   "instance_closed",
-] as const;
+] as const satisfies readonly AlertHistoryEventType[];
+
+export type AlertTransitionEventType =
+  (typeof ALERT_TRANSITION_EVENT_TYPES)[number];
 
 /**
  * The outcome rows a transition produces in later jobs, correlated back to it
@@ -19,7 +25,7 @@ const ALERT_OUTCOME_EVENT_TYPES = [
   "notification_suppressed",
   "delivery_succeeded",
   "delivery_failed",
-] as const;
+] as const satisfies readonly AlertHistoryEventType[];
 
 function sqlStringList(values: readonly string[]): string {
   return values.map((value) => `'${value}'`).join(", ");
@@ -37,7 +43,7 @@ export const ALERT_OUTCOME_EVENT_TYPES_SQL = sqlStringList(
 // observed. Keyed over the closed transition list, so a new transition type
 // cannot ship without a status.
 const ALERT_TRANSITION_STATUS: Record<
-  (typeof ALERT_TRANSITION_EVENT_TYPES)[number],
+  AlertTransitionEventType,
   "pending" | "firing" | "resolved" | "closed"
 > = {
   instance_pending: "pending",
@@ -56,7 +62,7 @@ export function alertingEventStatus(
 
 function isAlertTransitionEventType(
   eventType: string,
-): eventType is (typeof ALERT_TRANSITION_EVENT_TYPES)[number] {
+): eventType is AlertTransitionEventType {
   return (ALERT_TRANSITION_EVENT_TYPES as readonly string[]).includes(
     eventType,
   );

--- a/packages/app/src/data/alerting/history/queries.ts
+++ b/packages/app/src/data/alerting/history/queries.ts
@@ -13,6 +13,8 @@ export const alertHistoryQueries = {
       fingerprint?: string;
       sourceId?: string;
       slugs?: readonly string[];
+      /** The rule's own repoid; only a genuinely per-rule caller should set this. */
+      repoid?: string;
       preview?: string;
     } = {},
   ) => {
@@ -29,6 +31,7 @@ export const alertHistoryQueries = {
           fingerprint: opts.fingerprint ?? null,
           sourceId: opts.sourceId ?? null,
           slugs,
+          repoid: opts.repoid ?? null,
           preview,
         },
       ] as const,
@@ -42,6 +45,7 @@ export const alertHistoryQueries = {
               : {}),
             ...(opts.sourceId !== undefined ? { sourceId: opts.sourceId } : {}),
             ...(slugs === null ? {} : { slugs }),
+            ...(opts.repoid !== undefined ? { repoid: opts.repoid } : {}),
             ...(preview === null ? {} : { preview }),
           },
         }),

--- a/packages/app/src/data/alerting/history/repository.server.test.ts
+++ b/packages/app/src/data/alerting/history/repository.server.test.ts
@@ -52,6 +52,8 @@ describe("queryClickHouseAlertEventLog", () => {
       from: "2026-06-01 00:00:00.000",
       to: "2026-06-16 00:00:00.000",
     });
+    const settings = mocks.query.mock.calls[0]?.[3];
+    expect(settings).toMatchObject({ max_execution_time: 30 });
   });
 
   it("does not filter out a muted live rule's own history", async () => {
@@ -166,6 +168,9 @@ describe("observed label suggestions", () => {
     expect(sql).toContain("LIMIT {limit:UInt32}");
     expect(organizationId).toBe("org-1");
     expect(params).toMatchObject({ organizationId: "org-1", limit: 2 });
+    expect(mocks.query.mock.calls[0]?.[3]).toMatchObject({
+      max_execution_time: 30,
+    });
   });
 
   it("ranks values for one key via Map access, excluding rows missing it", async () => {

--- a/packages/app/src/data/alerting/history/repository.server.test.ts
+++ b/packages/app/src/data/alerting/history/repository.server.test.ts
@@ -38,6 +38,9 @@ describe("queryClickHouseAlertEventLog", () => {
       "event_type IN ('instance_pending', 'instance_fired', 'instance_resolved', 'instance_closed')",
     );
     expect(sql).toContain("is_live");
+    // JSONEachRow renders a Map column natively; no toJSONString round-trip.
+    expect(sql).toContain("instance_labels AS labels");
+    expect(sql).not.toContain("toJSONString");
     expect(sql).toContain("alert_definition_id = {sourceId:UUID}");
     expect(sql).toContain("instance_fingerprint = {fingerprint:String}");
     expect(organizationId).toBe("org-1");
@@ -94,7 +97,7 @@ describe("queryClickHouseAlertEventLog", () => {
           eventType: "instance_fired",
           slug: "default/high-5xx",
           instanceFingerprint: "fp-1",
-          labelsJson: '{"host":"web-1"}',
+          labels: { host: "web-1" },
           severity: "critical",
           suppressed: 0,
           reason: "",

--- a/packages/app/src/data/alerting/history/repository.server.test.ts
+++ b/packages/app/src/data/alerting/history/repository.server.test.ts
@@ -24,7 +24,7 @@ beforeEach(() => {
 });
 
 describe("queryClickHouseAlertEventLog", () => {
-  it("selects live, unsuppressed transition history", async () => {
+  it("selects live transition history", async () => {
     await queryClickHouseAlertEventLog("org-1", {
       ...range,
       previewIds: null,
@@ -40,7 +40,6 @@ describe("queryClickHouseAlertEventLog", () => {
     expect(sql).toContain(
       "preview_id = toUUID('00000000-0000-0000-0000-000000000000')",
     );
-    expect(sql).toContain("rule_muted = false");
     expect(sql).toContain("alert_definition_id = {sourceId:UUID}");
     expect(sql).toContain("instance_fingerprint = {fingerprint:String}");
     expect(organizationId).toBe("org-1");
@@ -52,6 +51,22 @@ describe("queryClickHouseAlertEventLog", () => {
       from: "2026-06-01 00:00:00.000",
       to: "2026-06-16 00:00:00.000",
     });
+  });
+
+  it("does not filter out a muted live rule's own history", async () => {
+    // rule_muted marks a rule that never notifies; it must not also hide
+    // that rule's history from its own detail page (rule_muted AS
+    // suppressed is returned for the UI to render, not to filter on).
+    await queryClickHouseAlertEventLog("org-1", { ...range, previewIds: null });
+    const [liveSql] = mocks.query.mock.calls[0];
+    expect(liveSql).not.toContain("rule_muted = false");
+
+    mocks.query.mockClear();
+    await queryClickHouseAlertEventLog("org-1", { ...range, previewIds: [] });
+    const [emptyPreviewSql] = mocks.query.mock.calls[0];
+    // The null and empty-array preview branches both mean "live only" and
+    // must filter identically.
+    expect(emptyPreviewSql).toBe(liveSql);
   });
 
   it("overlays selected Preview ids on live history", async () => {

--- a/packages/app/src/data/alerting/history/repository.server.test.ts
+++ b/packages/app/src/data/alerting/history/repository.server.test.ts
@@ -148,21 +148,41 @@ describe("queryClickHouseAlertEventLog", () => {
 });
 
 describe("observed label suggestions", () => {
-  it("ranks keys and values from ClickHouse transition labels", async () => {
-    mocks.query.mockResolvedValue([
-      { labelsJson: '{"service":"api","region":"eu"}' },
-      { labelsJson: '{"service":"api"}' },
-      { labelsJson: '{"service":"web"}' },
-    ]);
+  // The rank is computed in ClickHouse (GROUP BY + count()), not in Node, so
+  // these assert the pushed-down shape and the row-to-result mapping, not a
+  // ranking algorithm that no longer lives here.
+
+  it("ranks keys in ClickHouse via arrayJoin(mapKeys(...))", async () => {
+    mocks.query.mockResolvedValue([{ key: "service" }, { key: "region" }]);
 
     await expect(
       queryClickHouseObservedLabelKeys("org-1", { ...range, limit: 2 }),
     ).resolves.toEqual(["service", "region"]);
+
+    const [sql, organizationId, params] = mocks.query.mock.calls[0];
+    expect(sql).toContain("arrayJoin(mapKeys(instance_labels)) AS key");
+    expect(sql).toContain("GROUP BY key");
+    expect(sql).toContain("ORDER BY count() DESC, key ASC");
+    expect(sql).toContain("LIMIT {limit:UInt32}");
+    expect(organizationId).toBe("org-1");
+    expect(params).toMatchObject({ organizationId: "org-1", limit: 2 });
+  });
+
+  it("ranks values for one key via Map access, excluding rows missing it", async () => {
+    mocks.query.mockResolvedValue([{ value: "api" }, { value: "web" }]);
+
     await expect(
       queryClickHouseObservedLabelValues("org-1", "service", {
         ...range,
         limit: 2,
       }),
     ).resolves.toEqual(["api", "web"]);
+
+    const [sql, , params] = mocks.query.mock.calls[0];
+    expect(sql).toContain("instance_labels[{key:String}] AS value");
+    expect(sql).toContain("has(instance_labels, {key:String})");
+    expect(sql).toContain("GROUP BY value");
+    expect(sql).toContain("ORDER BY count() DESC, value ASC");
+    expect(params).toMatchObject({ key: "service", limit: 2 });
   });
 });

--- a/packages/app/src/data/alerting/history/repository.server.test.ts
+++ b/packages/app/src/data/alerting/history/repository.server.test.ts
@@ -37,9 +37,7 @@ describe("queryClickHouseAlertEventLog", () => {
     expect(sql).toContain(
       "event_type IN ('instance_pending', 'instance_fired', 'instance_resolved', 'instance_closed')",
     );
-    expect(sql).toContain(
-      "preview_id = toUUID('00000000-0000-0000-0000-000000000000')",
-    );
+    expect(sql).toContain("is_live");
     expect(sql).toContain("alert_definition_id = {sourceId:UUID}");
     expect(sql).toContain("instance_fingerprint = {fingerprint:String}");
     expect(organizationId).toBe("org-1");
@@ -78,7 +76,7 @@ describe("queryClickHouseAlertEventLog", () => {
 
     const [sql, , params] = mocks.query.mock.calls[0];
     expect(sql).toContain(
-      "(preview_id = toUUID('00000000-0000-0000-0000-000000000000') OR preview_id IN {previewIds:Array(UUID)})",
+      "(is_live OR preview_id IN {previewIds:Array(UUID)})",
     );
     expect(sql).toContain("slug IN {slugs:Array(String)}");
     expect(params).toMatchObject({

--- a/packages/app/src/data/alerting/history/repository.server.test.ts
+++ b/packages/app/src/data/alerting/history/repository.server.test.ts
@@ -72,6 +72,27 @@ describe("queryClickHouseAlertEventLog", () => {
     expect(emptyPreviewSql).toBe(liveSql);
   });
 
+  it("filters on repoid for a per-rule read, hitting the sort-key prefix", async () => {
+    await queryClickHouseAlertEventLog("org-1", {
+      ...range,
+      previewIds: null,
+      slugs: ["default/high-5xx"],
+      repoid: "repo-1",
+    });
+
+    const [sql, , params] = mocks.query.mock.calls[0];
+    expect(sql).toContain("repoid = {repoid:String}");
+    expect(params).toMatchObject({ repoid: "repo-1" });
+  });
+
+  it("leaves repoid unfiltered for an org-wide read", async () => {
+    await queryClickHouseAlertEventLog("org-1", { ...range, previewIds: null });
+
+    const [sql, , params] = mocks.query.mock.calls[0];
+    expect(sql).not.toContain("repoid = {repoid:String}");
+    expect(params).not.toHaveProperty("repoid");
+  });
+
   it("overlays selected Preview ids on live history", async () => {
     await queryClickHouseAlertEventLog("org-1", {
       ...range,

--- a/packages/app/src/data/alerting/history/repository.server.ts
+++ b/packages/app/src/data/alerting/history/repository.server.ts
@@ -11,6 +11,12 @@ import {
   type AlertEventType,
 } from "./event-types";
 
+// Per-query, not a client default (@/lib/clickhouse.query is shared with
+// dashboards, where a global cap could break a long-running scan): every
+// query in this file is a bounded alerting history read, so 30s is a bug, not
+// a legitimate slow query.
+const ALERTING_QUERY_SETTINGS = { max_execution_time: 30 };
+
 export type JsonValue =
   | string
   | number
@@ -115,6 +121,7 @@ async function queryNotificationOutcomes(
       from: toClickHouseDateTime(from),
       eventIds: [...eventIds],
     },
+    ALERTING_QUERY_SETTINGS,
   );
   return new Map(
     rows.map((row) => [
@@ -196,6 +203,7 @@ export async function queryClickHouseAlertEventLog(
       ...(opts.sourceId !== undefined ? { sourceId: opts.sourceId } : {}),
       ...(opts.slugs !== undefined ? { slugs: [...opts.slugs] } : {}),
     },
+    ALERTING_QUERY_SETTINGS,
   );
 
   if (rows.length === 0) return [];
@@ -260,6 +268,7 @@ export async function queryClickHouseObservedLabelKeys(
       to: toClickHouseDateTime(opts.to),
       limit: opts.limit,
     },
+    ALERTING_QUERY_SETTINGS,
   );
   return rows.map((row) => row.key);
 }
@@ -287,6 +296,7 @@ export async function queryClickHouseObservedLabelValues(
       to: toClickHouseDateTime(opts.to),
       limit: opts.limit,
     },
+    ALERTING_QUERY_SETTINGS,
   );
   return rows.map((row) => row.value);
 }

--- a/packages/app/src/data/alerting/history/repository.server.ts
+++ b/packages/app/src/data/alerting/history/repository.server.ts
@@ -8,7 +8,7 @@ import { clickhouseIsoMillis } from "./clickhouse";
 import {
   ALERT_OUTCOME_EVENT_TYPES_SQL,
   ALERT_TRANSITION_EVENT_TYPES_SQL,
-  type AlertEventType,
+  type AlertTransitionEventType,
 } from "./event-types";
 
 // Per-query, not a client default (@/lib/clickhouse.query is shared with
@@ -29,7 +29,7 @@ export type AlertEvidence = { [key: string]: JsonValue };
 
 export type AlertEventLogRow = {
   timestamp: string;
-  eventType: AlertEventType;
+  eventType: AlertTransitionEventType;
   slug: string;
   instanceFingerprint: string;
   labels: Record<string, string>;
@@ -47,7 +47,7 @@ export type AlertEventLogRow = {
 type ClickHouseAlertEventRow = {
   eventId: string;
   timestamp: string;
-  eventType: AlertEventType;
+  eventType: AlertTransitionEventType;
   slug: string;
   instanceFingerprint: string;
   labels: Record<string, string>;

--- a/packages/app/src/data/alerting/history/repository.server.ts
+++ b/packages/app/src/data/alerting/history/repository.server.ts
@@ -64,14 +64,6 @@ function parseJsonObject(json: string): Record<string, JsonValue> {
   return {};
 }
 
-function parseLabels(json: string): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(parseJsonObject(json)).flatMap(([key, value]) =>
-      typeof value === "string" ? [[key, value]] : [],
-    ),
-  );
-}
-
 type NotificationOutcome = {
   silenced: boolean;
   inhibited: boolean;
@@ -233,48 +225,43 @@ export async function queryClickHouseAlertEventLog(
   });
 }
 
-async function recentClickHouseLabels(
-  organizationId: string,
-  opts: { from: Date; to: Date },
-) {
-  return query<{ labelsJson: string }>(
-    `
-      SELECT toJSONString(instance_labels) AS labelsJson
-      FROM app.alert_events
-      WHERE tenant_id = {organizationId:String}
+// Shared by both label-suggestion queries: recent, unmuted instance labels,
+// the population the suggestion ranks over.
+const OBSERVED_LABEL_FILTERS = `
+        tenant_id = {organizationId:String}
         AND event_type IN ('instance_fired', 'instance_resolved')
         AND rule_muted = false
         AND event_time >= {from:DateTime64(3)}
-        AND event_time <= {to:DateTime64(3)}
-      ORDER BY event_time DESC
-      LIMIT 10000
+        AND event_time <= {to:DateTime64(3)}`;
+
+/**
+ * Rank observed label keys (or, given `key`, values for that key) by
+ * frequency in ClickHouse rather than pulling up to 10,000 label blobs into
+ * Node to count there. `arrayJoin` explodes each row's keys before the
+ * `GROUP BY`, so `count()` ranks over rows, not blobs.
+ */
+export async function queryClickHouseObservedLabelKeys(
+  organizationId: string,
+  opts: { limit: number; from: Date; to: Date },
+): Promise<string[]> {
+  const rows = await query<{ key: string }>(
+    `
+      SELECT arrayJoin(mapKeys(instance_labels)) AS key
+      FROM app.alert_events
+      WHERE ${OBSERVED_LABEL_FILTERS}
+      GROUP BY key
+      ORDER BY count() DESC, key ASC
+      LIMIT {limit:UInt32}
     `,
     organizationId,
     {
       organizationId,
       from: toClickHouseDateTime(opts.from),
       to: toClickHouseDateTime(opts.to),
+      limit: opts.limit,
     },
   );
-}
-
-export async function queryClickHouseObservedLabelKeys(
-  organizationId: string,
-  opts: { limit: number; from: Date; to: Date },
-): Promise<string[]> {
-  const counts = new Map<string, number>();
-  for (const row of await recentClickHouseLabels(organizationId, opts)) {
-    for (const key of Object.keys(parseLabels(row.labelsJson))) {
-      counts.set(key, (counts.get(key) ?? 0) + 1);
-    }
-  }
-  return [...counts]
-    .sort(
-      ([keyA, countA], [keyB, countB]) =>
-        countB - countA || keyA.localeCompare(keyB),
-    )
-    .slice(0, opts.limit)
-    .map(([key]) => key);
+  return rows.map((row) => row.key);
 }
 
 export async function queryClickHouseObservedLabelValues(
@@ -282,16 +269,24 @@ export async function queryClickHouseObservedLabelValues(
   key: string,
   opts: { limit: number; from: Date; to: Date },
 ): Promise<string[]> {
-  const counts = new Map<string, number>();
-  for (const row of await recentClickHouseLabels(organizationId, opts)) {
-    const value = parseLabels(row.labelsJson)[key];
-    if (value) counts.set(value, (counts.get(value) ?? 0) + 1);
-  }
-  return [...counts]
-    .sort(
-      ([valueA, countA], [valueB, countB]) =>
-        countB - countA || valueA.localeCompare(valueB),
-    )
-    .slice(0, opts.limit)
-    .map(([value]) => value);
+  const rows = await query<{ value: string }>(
+    `
+      SELECT instance_labels[{key:String}] AS value
+      FROM app.alert_events
+      WHERE ${OBSERVED_LABEL_FILTERS}
+        AND has(instance_labels, {key:String})
+      GROUP BY value
+      ORDER BY count() DESC, value ASC
+      LIMIT {limit:UInt32}
+    `,
+    organizationId,
+    {
+      organizationId,
+      key,
+      from: toClickHouseDateTime(opts.from),
+      to: toClickHouseDateTime(opts.to),
+      limit: opts.limit,
+    },
+  );
+  return rows.map((row) => row.value);
 }

--- a/packages/app/src/data/alerting/history/repository.server.ts
+++ b/packages/app/src/data/alerting/history/repository.server.ts
@@ -44,7 +44,7 @@ type ClickHouseAlertEventRow = {
   eventType: AlertEventType;
   slug: string;
   instanceFingerprint: string;
-  labelsJson: string;
+  labels: Record<string, string>;
   severity: string;
   suppressed: boolean;
   reason: string;
@@ -180,7 +180,7 @@ export async function queryClickHouseAlertEventLog(
         event_type AS eventType,
         slug,
         instance_fingerprint AS instanceFingerprint,
-        toJSONString(instance_labels) AS labelsJson,
+        instance_labels AS labels,
         severity,
         rule_muted AS suppressed,
         reason,
@@ -220,7 +220,7 @@ export async function queryClickHouseAlertEventLog(
       eventType: row.eventType,
       slug: row.slug,
       instanceFingerprint: row.instanceFingerprint,
-      labels: parseLabels(row.labelsJson),
+      labels: row.labels,
       severity: row.severity,
       suppressed: Boolean(row.suppressed),
       silenced: outcome?.silenced ?? false,

--- a/packages/app/src/data/alerting/history/repository.server.ts
+++ b/packages/app/src/data/alerting/history/repository.server.ts
@@ -156,10 +156,7 @@ export async function queryClickHouseAlertEventLog(
     "event_time <= {to:DateTime64(3)}",
   ];
   if (opts.previewIds === null) {
-    filters.push(
-      "preview_id = toUUID('00000000-0000-0000-0000-000000000000')",
-      "rule_muted = false",
-    );
+    filters.push("preview_id = toUUID('00000000-0000-0000-0000-000000000000')");
   } else if (opts.previewIds.length === 0) {
     filters.push("preview_id = toUUID('00000000-0000-0000-0000-000000000000')");
   } else {

--- a/packages/app/src/data/alerting/history/repository.server.ts
+++ b/packages/app/src/data/alerting/history/repository.server.ts
@@ -144,6 +144,13 @@ export async function queryClickHouseAlertEventLog(
     fingerprint?: string;
     sourceId?: string;
     slugs?: readonly string[];
+    /**
+     * The sort key is (tenant_id, repoid, slug, ...), so a per-rule read
+     * (one known repoid) should always supply this: without it, the read
+     * falls back to a generic exclusion search past the repoid prefix. Leave
+     * unset only for a caller that genuinely spans repos (org-wide history).
+     */
+    repoid?: string;
     /** null selects live events; an array overlays those Preview ids on live. */
     previewIds: readonly string[] | null;
   },
@@ -160,6 +167,9 @@ export async function queryClickHouseAlertEventLog(
     filters.push("is_live");
   } else {
     filters.push("(is_live OR preview_id IN {previewIds:Array(UUID)})");
+  }
+  if (opts.repoid !== undefined) {
+    filters.push("repoid = {repoid:String}");
   }
   if (opts.fingerprint !== undefined) {
     filters.push("instance_fingerprint = {fingerprint:String}");
@@ -197,6 +207,7 @@ export async function queryClickHouseAlertEventLog(
       to: toClickHouseDateTime(opts.to),
       limit: opts.limit,
       ...(opts.previewIds?.length ? { previewIds: [...opts.previewIds] } : {}),
+      ...(opts.repoid !== undefined ? { repoid: opts.repoid } : {}),
       ...(opts.fingerprint !== undefined
         ? { fingerprint: opts.fingerprint }
         : {}),

--- a/packages/app/src/data/alerting/history/repository.server.ts
+++ b/packages/app/src/data/alerting/history/repository.server.ts
@@ -156,13 +156,11 @@ export async function queryClickHouseAlertEventLog(
     "event_time <= {to:DateTime64(3)}",
   ];
   if (opts.previewIds === null) {
-    filters.push("preview_id = toUUID('00000000-0000-0000-0000-000000000000')");
+    filters.push("is_live");
   } else if (opts.previewIds.length === 0) {
-    filters.push("preview_id = toUUID('00000000-0000-0000-0000-000000000000')");
+    filters.push("is_live");
   } else {
-    filters.push(
-      "(preview_id = toUUID('00000000-0000-0000-0000-000000000000') OR preview_id IN {previewIds:Array(UUID)})",
-    );
+    filters.push("(is_live OR preview_id IN {previewIds:Array(UUID)})");
   }
   if (opts.fingerprint !== undefined) {
     filters.push("instance_fingerprint = {fingerprint:String}");

--- a/packages/app/src/data/alerting/history/server.ts
+++ b/packages/app/src/data/alerting/history/server.ts
@@ -15,12 +15,16 @@ export const listAlertingEventHistory = createAuthenticatedServerFn({
       fingerprint: z.string().min(1).optional(),
       sourceId: z.string().min(1).optional(),
       slugs: z.array(z.string().min(1)).min(1).optional(),
+      // Per-rule callers pass the rule's own repoid, so the read hits the
+      // sort key's (tenant_id, repoid, slug, ...) prefix; org-wide history
+      // leaves it unset on purpose.
+      repoid: z.string().min(1).optional(),
       preview: z.string().optional(),
     }),
   )
   .handler(
     async ({
-      data: { limit, timeRange, fingerprint, sourceId, slugs, preview },
+      data: { limit, timeRange, fingerprint, sourceId, slugs, repoid, preview },
       context: { session },
     }) => {
       const { fromDate, toDate } = resolveTimeRange(timeRange);
@@ -38,6 +42,7 @@ export const listAlertingEventHistory = createAuthenticatedServerFn({
         ...(fingerprint !== undefined ? { fingerprint } : {}),
         ...(sourceId !== undefined ? { sourceId } : {}),
         ...(slugs !== undefined ? { slugs } : {}),
+        ...(repoid !== undefined ? { repoid } : {}),
       });
     },
   );

--- a/packages/app/src/data/alerting/resource/runbook-ref.ts
+++ b/packages/app/src/data/alerting/resource/runbook-ref.ts
@@ -56,6 +56,10 @@ export function refIdentityKey(project: string, slug: string): string {
   return `${project}\0${slug}`;
 }
 
+// Always qualified: the writer only knows the runbook's own project, never
+// the alert's, so omitting it for "default" made the stored ref ambiguous
+// (parseRunbookRef's bare-slug fallback resolves against the READER's own
+// alert project, which may not be "default").
 export function formatRunbookRef(project: string, slug: string): string {
-  return project === "default" ? slug : `${project}/${slug}`;
+  return `${project}/${slug}`;
 }

--- a/packages/app/src/data/alerting/resource/schema.test.ts
+++ b/packages/app/src/data/alerting/resource/schema.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  alertingResourceMetadataSchema,
+  alertingResourceNameSchema,
+} from "./schema";
+
+// "." and ".." satisfy the character class but collapse away when a link
+// resolves the slug against a URL (walking up a path segment instead of
+// naming a resource), so both must fail validation even though the regex
+// alone would admit them.
+describe("alertingResourceMetadataSchema", () => {
+  it('rejects a slug of exactly "." or ".."', () => {
+    expect(
+      alertingResourceMetadataSchema.safeParse({ name: "." }).success,
+    ).toBe(false);
+    expect(
+      alertingResourceMetadataSchema.safeParse({ name: ".." }).success,
+    ).toBe(false);
+  });
+
+  it("still accepts a slug that merely contains dots", () => {
+    expect(
+      alertingResourceMetadataSchema.safeParse({ name: "v1.2.oom" }).success,
+    ).toBe(true);
+  });
+});
+
+describe("alertingResourceNameSchema", () => {
+  it('rejects a qualified name whose slug is "." or ".."', () => {
+    expect(alertingResourceNameSchema.safeParse("default/.").success).toBe(
+      false,
+    );
+    expect(alertingResourceNameSchema.safeParse("default/..").success).toBe(
+      false,
+    );
+  });
+});

--- a/packages/app/src/data/alerting/resource/schema.ts
+++ b/packages/app/src/data/alerting/resource/schema.ts
@@ -4,12 +4,18 @@ import { isReservedAnnotationKey } from "../resource-annotations";
 
 export const alertingNonEmptyStringSchema = z.string().min(1);
 
+// "." and ".." rejected on top of the character class: both are valid
+// matches for it but collapse away when a caller resolves the slug against a
+// URL (`new URL("/alerts/rules/default/..", base)` walks up a level).
 const alertingResourceSlugSchema = z
   .string()
   .regex(
     /^[A-Za-z0-9_.-]{1,128}$/,
     "name must be 1-128 chars of [A-Za-z0-9_.-]",
-  );
+  )
+  .refine((value) => value !== "." && value !== "..", {
+    message: 'name must not be "." or ".."',
+  });
 
 export const alertingResourceNameSchema = z
   .string()

--- a/packages/app/src/data/alerting/rules/evaluation-series.test.ts
+++ b/packages/app/src/data/alerting/rules/evaluation-series.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it } from "vitest";
+import type { AlertingRuleCondition } from "../types";
 import {
   parseAlertEvaluationSamples,
   type StoredAlertEvaluationPoint,
   shapeAlertEvaluationSeries,
 } from "./evaluation-series";
+
+const CONDITION: AlertingRuleCondition = { operator: "gt", threshold: 100 };
+// Comfortably above every default sample value used below (minute indexes,
+// at most a few hundred), so only rows that opt in via `breach` cross it.
+const BREACH_VALUE = 100_000;
 
 const row = (
   minute: number,
@@ -16,11 +22,25 @@ const row = (
   samplesTruncated,
 });
 
+// A GROUP BY-shaped point: several label sets in one evaluation, only one of
+// which crosses the condition.
+const breach = (
+  point: StoredAlertEvaluationPoint,
+): StoredAlertEvaluationPoint => ({
+  ...point,
+  rowCount: 3,
+  samples: [
+    { fingerprint: "eu", labels: { region: "eu" }, value: 1 },
+    { fingerprint: "us", labels: { region: "us" }, value: BREACH_VALUE },
+  ],
+});
+
 describe("shapeAlertEvaluationSeries", () => {
   it("preserves the first and newest point while downsampling", () => {
     const result = shapeAlertEvaluationSeries(
       Array.from({ length: 10 }, (_, i) => row(i)),
       4,
+      CONDITION,
     );
 
     expect(result.points.map((point) => point.t)).toEqual([
@@ -31,11 +51,11 @@ describe("shapeAlertEvaluationSeries", () => {
     ]);
   });
 
-  it("keeps a breaching evaluation sitting between sampled indexes", () => {
+  it("keeps a breaching evaluation sitting between sampled indexes, from a matching sample in the group", () => {
     const rows = Array.from({ length: 10 }, (_, i) => row(i));
-    rows[5] = { ...rows[5], rowCount: 3 };
+    rows[5] = breach(rows[5]);
 
-    const result = shapeAlertEvaluationSeries(rows, 4);
+    const result = shapeAlertEvaluationSeries(rows, 4, CONDITION);
 
     // The even grid alone would pick 0, 3, 6, 9 and drop the breach at
     // minute 5; the recovery point at minute 6 is kept too since the state
@@ -48,15 +68,39 @@ describe("shapeAlertEvaluationSeries", () => {
     ]);
   });
 
+  // The regression: row_count is the unfiltered query's row count, not the
+  // count that matched the condition, so a GROUP BY rule with a lot of
+  // healthy rows and none breaching must not read as breaching.
+  it("ignores a high unfiltered row_count when no sample in the group matches", () => {
+    const rows = Array.from({ length: 10 }, (_, i) => row(i));
+    rows[5] = {
+      ...rows[5],
+      rowCount: 50,
+      samples: [
+        { fingerprint: "eu", labels: { region: "eu" }, value: 1 },
+        { fingerprint: "us", labels: { region: "us" }, value: 2 },
+      ],
+    };
+
+    const result = shapeAlertEvaluationSeries(rows, 4, CONDITION);
+
+    expect(result.points.map((point) => point.t)).toEqual([
+      "2026-08-06T12:00:00.000Z",
+      "2026-08-06T12:03:00.000Z",
+      "2026-08-06T12:06:00.000Z",
+      "2026-08-06T12:09:00.000Z",
+    ]);
+  });
+
   // A required cluster at the window start must not consume the filler grid:
   // walked to a budget cutoff, every filler point lands left of the cutoff
   // and the newest part of the window renders required points only.
   it("spreads the leftover budget across the whole window", () => {
     const rows = Array.from({ length: 100 }, (_, i) =>
-      i >= 1 && i <= 4 ? { ...row(i), rowCount: 3 } : row(i),
+      i >= 1 && i <= 4 ? breach(row(i)) : row(i),
     );
 
-    const result = shapeAlertEvaluationSeries(rows, 10);
+    const result = shapeAlertEvaluationSeries(rows, 10, CONDITION);
 
     const times = result.points.map((point) => Date.parse(point.t));
     const midWindow = times.filter(
@@ -70,12 +114,9 @@ describe("shapeAlertEvaluationSeries", () => {
   // A rule breaching for the whole window makes every point required; without
   // a cap the chart response carries the full row set, samples included.
   it("bounds a whole-window incident to the display budget, edges intact", () => {
-    const rows = Array.from({ length: 1000 }, (_, i) => ({
-      ...row(i),
-      rowCount: 3,
-    }));
+    const rows = Array.from({ length: 1000 }, (_, i) => breach(row(i)));
 
-    const result = shapeAlertEvaluationSeries(rows, 300);
+    const result = shapeAlertEvaluationSeries(rows, 300, CONDITION);
 
     expect(result.points.length).toBeLessThanOrEqual(300);
     expect(result.points[0].t).toBe(rows[0].scheduledFor.toISOString());
@@ -85,7 +126,9 @@ describe("shapeAlertEvaluationSeries", () => {
 
   it("reports truncation even when the truncated evaluation is downsampled out", () => {
     const rows = Array.from({ length: 10 }, (_, i) => row(i, i === 1));
-    expect(shapeAlertEvaluationSeries(rows, 2).samples_truncated).toBe(true);
+    expect(
+      shapeAlertEvaluationSeries(rows, 2, CONDITION).samples_truncated,
+    ).toBe(true);
   });
 
   it("keeps exact recent checks and summarizes display errors", () => {
@@ -97,7 +140,7 @@ describe("shapeAlertEvaluationSeries", () => {
       samples: [],
     };
 
-    const result = shapeAlertEvaluationSeries(rows, 4);
+    const result = shapeAlertEvaluationSeries(rows, 4, CONDITION);
 
     expect(result.evaluation_count).toBe(30);
     expect(result.recent_points).toHaveLength(25);

--- a/packages/app/src/data/alerting/rules/evaluation-series.ts
+++ b/packages/app/src/data/alerting/rules/evaluation-series.ts
@@ -1,7 +1,9 @@
 import type {
   AlertingEvaluationSample,
+  AlertingRuleCondition,
   AlertingRuleEvaluationSeries,
 } from "../types";
+import { alertingConditionMatches } from "./condition";
 
 export type StoredAlertEvaluationPoint = {
   scheduledFor: Date;
@@ -64,14 +66,22 @@ function evaluationPoint(
 
 type EvaluationState = "ok" | "breaching" | "failed";
 
-// `rowCount` is the count of rows the alert query matched at that
-// evaluation, so a positive count is the breach signal itself; a failed
-// evaluation carries no row count (see repository.ts), so error takes
-// priority.
-function evaluationState(row: StoredAlertEvaluationPoint): EvaluationState {
+// `rowCount` is the count of rows the unfiltered alert query returned, not
+// the count that matched the condition (a GROUP BY rule's row_count can be
+// entirely healthy rows), so it cannot stand in for the breach signal. The
+// condition has to be re-applied to the stored samples, the same way the
+// chart's own outcome computation already does (chart-data.ts).
+function evaluationState(
+  row: StoredAlertEvaluationPoint,
+  condition: AlertingRuleCondition,
+): EvaluationState {
   if (row.error !== null) return "failed";
-  if (row.rowCount !== null && row.rowCount > 0) return "breaching";
-  return "ok";
+  const breaching = row.samples.some(
+    (sample) =>
+      sample.value !== null &&
+      alertingConditionMatches({ value: sample.value }, condition),
+  );
+  return breaching ? "breaching" : "ok";
 }
 
 // Indexes a downsampled chart must never drop: both range edges, every
@@ -80,11 +90,12 @@ function evaluationState(row: StoredAlertEvaluationPoint): EvaluationState {
 // itself "ok".
 function requiredEvaluationIndexes(
   rows: readonly StoredAlertEvaluationPoint[],
+  condition: AlertingRuleCondition,
 ): Set<number> {
   const required = new Set<number>([0, rows.length - 1]);
-  let previousState = evaluationState(rows[0]);
+  let previousState = evaluationState(rows[0], condition);
   for (let index = 1; index < rows.length; index++) {
-    const state = evaluationState(rows[index]);
+    const state = evaluationState(rows[index], condition);
     if (state !== "ok") required.add(index);
     if (state !== previousState) required.add(index);
     previousState = state;
@@ -101,11 +112,12 @@ function requiredEvaluationIndexes(
 export function shapeAlertEvaluationSeries(
   rows: readonly StoredAlertEvaluationPoint[],
   targetPoints: number,
+  condition: AlertingRuleCondition,
 ): AlertingRuleEvaluationSeries {
   const count = Math.max(2, targetPoints);
   let selected: readonly StoredAlertEvaluationPoint[] = rows;
   if (rows.length > count) {
-    let indexes = requiredEvaluationIndexes(rows);
+    let indexes = requiredEvaluationIndexes(rows, condition);
     if (indexes.size > count) {
       // A whole-window incident (or constant flapping) makes every point
       // required, which would ship the full row set to the browser. Grid the

--- a/packages/app/src/data/alerting/rules/repository.test.ts
+++ b/packages/app/src/data/alerting/rules/repository.test.ts
@@ -2,10 +2,22 @@ import { describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   steps: [] as string[],
+  dbTransaction: vi.fn(),
 }));
 
 vi.mock("@/db/client", () => ({
-  db: {},
+  db: {
+    transaction: mocks.dbTransaction,
+    // definitionChannelNamesFor's chain, run against `db` after the
+    // transaction commits: no channels attached in these fixtures.
+    select: () => ({
+      from: () => ({
+        innerJoin: () => ({
+          where: () => ({ orderBy: () => Promise.resolve([]) }),
+        }),
+      }),
+    }),
+  },
   pool: {},
   runInTransaction: (
     executor: { transaction: (fn: unknown) => Promise<unknown> },
@@ -23,7 +35,8 @@ vi.mock("./lifecycle.server", () => ({
 }));
 
 import { alertInstances } from "@/db/schema";
-import { rollupAlertState, updateRule } from "./repository";
+import { SYSTEM_ACTOR } from "../session";
+import { pauseRule, rollupAlertState, updateRule } from "./repository";
 
 // The rollup must pass `pending` through: collapsing everything but firing to
 // inactive makes the Pending state unreachable in every list and detail view.
@@ -118,5 +131,50 @@ describe("updateRule", () => {
     );
 
     expect(mocks.steps).toEqual([]);
+  });
+});
+
+// A rule paused mid-degradation must read healthy again: a stale degraded
+// status (or a consecutiveFailures streak that never gets to run) would
+// otherwise survive the pause and greet resume near the retry-backoff
+// ceiling.
+describe("pauseRule", () => {
+  it("resets health alongside the rollup state", async () => {
+    const degraded = {
+      ...previous,
+      healthStatus: "degraded" as const,
+      consecutiveFailures: 4,
+      degradedSince: new Date("2024-01-01T00:00:00Z"),
+    };
+    let definitionsUpdatePayload: Record<string, unknown> | undefined;
+    const tx = {
+      update: (table: unknown) => ({
+        set: (payload: Record<string, unknown>) => {
+          if (table !== alertInstances) definitionsUpdatePayload = payload;
+          return {
+            where: () => ({
+              returning: () =>
+                table === alertInstances
+                  ? Promise.resolve([])
+                  : Promise.resolve([{ ...degraded, ...payload }]),
+            }),
+          };
+        },
+      }),
+    };
+    mocks.dbTransaction.mockImplementation(
+      (fn: (tx: unknown) => Promise<unknown>) => fn(tx),
+    );
+
+    await pauseRule(
+      { organizationId: "org-1", actor: SYSTEM_ACTOR },
+      degraded.id,
+    );
+
+    expect(definitionsUpdatePayload).toMatchObject({
+      healthStatus: "healthy",
+      consecutiveFailures: 0,
+      degradedSince: null,
+    });
   });
 });

--- a/packages/app/src/data/alerting/rules/repository.test.ts
+++ b/packages/app/src/data/alerting/rules/repository.test.ts
@@ -74,12 +74,14 @@ const previous = {
   nextEvaluationAt: null,
 };
 
-function fakeExecutor() {
+function fakeExecutor(storedSpec: typeof spec = spec) {
+  const stored = { ...previous, spec: storedSpec };
   const tx = {
     update: () => ({
       set: () => ({
         where: () => ({
-          returning: () => Promise.resolve([{ ...previous, version: 2, spec }]),
+          returning: () =>
+            Promise.resolve([{ ...stored, version: 2, spec: storedSpec }]),
         }),
       }),
     }),
@@ -94,7 +96,7 @@ function fakeExecutor() {
   return {
     select: () => ({
       from: () => ({
-        where: () => ({ limit: () => Promise.resolve([previous]) }),
+        where: () => ({ limit: () => Promise.resolve([stored]) }),
       }),
     }),
     transaction: (fn: (tx: unknown) => Promise<unknown>) => fn(tx),
@@ -128,6 +130,25 @@ describe("updateRule", () => {
       { ...spec, notification_channels: [] },
       1,
       fakeExecutor(),
+    );
+
+    expect(mocks.steps).toEqual([]);
+  });
+
+  it("leaves instances alone when the label columns are only reordered", async () => {
+    mocks.steps = [];
+    const storedSpec = { ...spec, label_columns: ["host", "region"] };
+
+    await updateRule(
+      "org-1",
+      previous.id,
+      {
+        ...storedSpec,
+        label_columns: ["region", "host"],
+        notification_channels: [],
+      },
+      1,
+      fakeExecutor(storedSpec),
     );
 
     expect(mocks.steps).toEqual([]);

--- a/packages/app/src/data/alerting/rules/repository.ts
+++ b/packages/app/src/data/alerting/rules/repository.ts
@@ -294,7 +294,7 @@ export async function getRuleEvaluationSeries(
   id: string,
   opts: { from: Date; to: Date; points: number },
 ) {
-  await getRuleRow(organizationId, id);
+  const def = await getRuleRow(organizationId, id);
   const rows = await query<{
     scheduledFor: string;
     eventType: "evaluation_succeeded" | "evaluation_failed";
@@ -340,6 +340,7 @@ export async function getRuleEvaluationSeries(
       samplesTruncated: Boolean(row.samplesTruncated),
     })),
     opts.points,
+    def.spec.condition,
   );
 }
 

--- a/packages/app/src/data/alerting/rules/repository.ts
+++ b/packages/app/src/data/alerting/rules/repository.ts
@@ -344,6 +344,19 @@ export async function getRuleEvaluationSeries(
   );
 }
 
+// instanceFingerprint sorts label keys before hashing, so a reorder of
+// label_columns with the same membership is a no-op for every open
+// instance. Comparing the raw arrays would close and re-fire them on a
+// reorder alone.
+function labelColumnsChanged(
+  previous: readonly string[],
+  next: readonly string[],
+): boolean {
+  return (
+    JSON.stringify([...previous].sort()) !== JSON.stringify([...next].sort())
+  );
+}
+
 function definitionValues(
   id: string,
   organizationId: string,
@@ -435,9 +448,10 @@ export async function updateRule(
       `Rule version changed: ${id}`,
     );
   }
-  const labelsChanged =
-    JSON.stringify(previous.spec.label_columns) !==
-    JSON.stringify(spec.label_columns);
+  const labelsChanged = labelColumnsChanged(
+    previous.spec.label_columns,
+    spec.label_columns,
+  );
   const nextEvaluationAt = nextAlertEvaluationAt(
     organizationId,
     id,
@@ -524,8 +538,7 @@ export async function adoptRule(
     : null;
   const labelsChanged =
     spec !== null &&
-    JSON.stringify(previous.spec.label_columns) !==
-      JSON.stringify(spec.label_columns);
+    labelColumnsChanged(previous.spec.label_columns, spec.label_columns);
   const row = await translateAlertingConflict(() =>
     runInTransaction(executor, async (tx) => {
       const [updated] = await tx

--- a/packages/app/src/data/alerting/rules/repository.ts
+++ b/packages/app/src/data/alerting/rules/repository.ts
@@ -632,9 +632,15 @@ export async function pauseRule(
       .set({
         active: false,
         // The rollup must not keep reporting a firing state the pause just
-        // closed; resume re-derives it from scratch.
+        // closed; resume re-derives it from scratch. Health resets the same
+        // way: a rule paused mid-degradation must not read degraded forever,
+        // or resume near the retry-backoff ceiling from a streak that never
+        // gets to run again.
         currentState: "unknown",
         firingInstanceCount: 0,
+        healthStatus: "healthy",
+        consecutiveFailures: 0,
+        degradedSince: null,
         updatedAt: now,
       })
       .where(

--- a/packages/app/src/data/alerting/rules/resource/apply.server.test.ts
+++ b/packages/app/src/data/alerting/rules/resource/apply.server.test.ts
@@ -513,8 +513,14 @@ describe("applyAlertSpecs", () => {
   it("never infers non-string columns, and explicit instanceLabels win", async () => {
     ch.mockResolvedValue({
       rows: [],
-      columns: ["service", "region", "value"],
-      columnTypes: ["LowCardinality(String)", "Nullable(String)", "UInt64"],
+      columns: ["service", "region", "bucket", "value"],
+      columnTypes: [
+        "LowCardinality(String)",
+        "Nullable(String)",
+        // A `toStartOfMinute(...) AS bucket` shape: temporal, not identity.
+        "DateTime",
+        "UInt64",
+      ],
     });
 
     await applyAlertSpecs({
@@ -531,7 +537,7 @@ describe("applyAlertSpecs", () => {
       ],
     });
     // Sorted, not query order: label_columns carries no authored order once
-    // an inference pass produces it either.
+    // an inference pass produces it either. bucket never becomes identity.
     expect(mockedCreateRule.mock.calls[0][1].label_columns).toEqual([
       "region",
       "service",

--- a/packages/app/src/data/alerting/rules/resource/apply.server.test.ts
+++ b/packages/app/src/data/alerting/rules/resource/apply.server.test.ts
@@ -530,9 +530,11 @@ describe("applyAlertSpecs", () => {
         },
       ],
     });
+    // Sorted, not query order: label_columns carries no authored order once
+    // an inference pass produces it either.
     expect(mockedCreateRule.mock.calls[0][1].label_columns).toEqual([
-      "service",
       "region",
+      "service",
     ]);
 
     // Same query result, but the spec names its own identity: the inferred

--- a/packages/app/src/data/alerting/rules/resource/apply.server.ts
+++ b/packages/app/src/data/alerting/rules/resource/apply.server.ts
@@ -63,7 +63,10 @@ function parseAlertRule(path: string, resource: unknown) {
 // Events retain at most 16 non-label evidence columns within 4096 bytes.
 const EVIDENCE_COLUMN_CAP = 16;
 
-// String result columns form the instance identity when instanceLabels is omitted.
+// String result columns form the instance identity when instanceLabels is
+// omitted. Temporal types are deliberately excluded: a `toStartOfMinute(ts)
+// AS bucket` column is a String-adjacent shape but changes every evaluation,
+// so inferring it as identity would open a new episode per bucket forever.
 function isStringTypedColumn(chType: string): boolean {
   let t = chType.trim();
   for (;;) {
@@ -71,9 +74,7 @@ function isStringTypedColumn(chType: string): boolean {
     if (!wrapped) break;
     t = wrapped[1];
   }
-  return /^(?:String|FixedString|Enum8|Enum16|UUID|Date32|Date|DateTime64|DateTime|IPv4|IPv6)(?:\(|$)/.test(
-    t,
-  );
+  return /^(?:String|FixedString|Enum8|Enum16|UUID|IPv4|IPv6)(?:\(|$)/.test(t);
 }
 
 function isNumericTypedColumn(chType: string): boolean {

--- a/packages/app/src/data/alerting/rules/resource/mapping.test.ts
+++ b/packages/app/src/data/alerting/rules/resource/mapping.test.ts
@@ -81,6 +81,26 @@ describe("toRuleInput", () => {
     expect(noDescription.annotations.description).toBeUndefined();
   });
 
+  // instanceFingerprint sorts label keys before hashing, so authored order
+  // carries no identity meaning; storing it as-authored would make a
+  // reorder-only edit look like a membership change to the spec diff.
+  it("sorts label_columns regardless of authored or inferred order", () => {
+    const explicit = toRuleInput(
+      parseRule({ instanceLabels: ["zone", "route"] }),
+      "repo-1",
+    );
+    expect(explicit.label_columns).toEqual(["route", "zone"]);
+
+    const inferred = toRuleInput(
+      parseRule({ instanceLabels: undefined }),
+      "repo-1",
+      {
+        instanceLabels: ["zone", "route"],
+      },
+    );
+    expect(inferred.label_columns).toEqual(["route", "zone"]);
+  });
+
   it("carries a linked runbook via everr.runbook, and link.runbook when appBaseUrl is set", () => {
     const scoped = toRuleInput(
       parseRule({ runbook: "payments/triage-5xx" }),

--- a/packages/app/src/data/alerting/rules/resource/mapping.test.ts
+++ b/packages/app/src/data/alerting/rules/resource/mapping.test.ts
@@ -116,10 +116,12 @@ describe("toRuleInput", () => {
       runbookSlug: "triage-5xx",
     });
 
-    // Bare slug resolves against the alert's own project ("default" here), and
-    // without a base URL (or without a runbook) there is no link annotation.
+    // A bare authored slug resolves against the alert's own project
+    // ("default" here) to interpret user intent, but the stored annotation
+    // is always fully qualified: re-applying the exported document must not
+    // depend on which project the alert happens to live in.
     const bare = toRuleInput(parseRule({ runbook: "triage-5xx" }), "repo-1");
-    expect(bare.annotations["everr.runbook"]).toBe("triage-5xx");
+    expect(bare.annotations["everr.runbook"]).toBe("default/triage-5xx");
     expect(bare.annotations["link.runbook"]).toBeUndefined();
     expect(fromAlertingRule(asRule(bare))).toMatchObject({
       runbookProject: "default",
@@ -266,5 +268,22 @@ describe("toAlertRuleDocument", () => {
     );
     expect(scoped.metadata.project).toBe("payments");
     expect(scoped.metadata.name).toBe("high-5xx");
+  });
+
+  // A runbook in the "default" project, linked from an alert in a
+  // different project, used to lose its project on export (formatRunbookRef
+  // dropped "default"), so the exported document re-resolved the bare slug
+  // against the alert's own project on re-apply.
+  it("keeps a default-project runbook qualified when the alert lives elsewhere", () => {
+    const parsed = parseRule({ runbook: "default/oom" }, { project: "web" });
+    const ruleInput = toRuleInput(parsed, "repo-1");
+    expect(ruleInput.annotations["everr.runbook"]).toBe("default/oom");
+
+    const doc = toAlertRuleDocument(asRule(ruleInput));
+    expect(doc.metadata.project).toBe("web");
+    expect(doc.spec.runbook).toBe("default/oom");
+
+    const reparsed = AlertRuleYamlSchema.parse(JSON.parse(JSON.stringify(doc)));
+    expect(toRuleInput(reparsed, "repo-1")).toEqual(ruleInput);
   });
 });

--- a/packages/app/src/data/alerting/rules/resource/mapping.ts
+++ b/packages/app/src/data/alerting/rules/resource/mapping.ts
@@ -83,7 +83,13 @@ export function toRuleInput(
     sql: rule.spec.query,
     interval_secs: parseEvaluationInterval(rule.spec.evaluationInterval),
     for_secs: parseForDuration(rule.spec.for),
-    label_columns: rule.spec.instanceLabels ?? opts.instanceLabels ?? [],
+    // Sorted, not authored order: identity is fingerprinted over sorted
+    // label keys, so the stored spec must not churn (and reorder-only
+    // updates must not close every open instance) when a user or an
+    // inference pass merely reorders the same columns.
+    label_columns: [
+      ...(rule.spec.instanceLabels ?? opts.instanceLabels ?? []),
+    ].sort(),
     condition: rule.spec.condition,
     severity: rule.spec.severity,
     annotations,

--- a/packages/app/src/data/alerting/rules/resource/mapping.ts
+++ b/packages/app/src/data/alerting/rules/resource/mapping.ts
@@ -142,8 +142,10 @@ export function fromAlertingRule(
 ): SimpleAlertView {
   const { project, slug } = parseResourceName(rule.name);
   const ann = rule.spec.annotations ?? {};
-  // The stored ref is already canonical (project/slug or a bare slug for the
-  // default project), so any alertProject fallback works to split it back out.
+  // formatRunbookRef always qualifies now, so a stored ref is always
+  // "project/slug". A bare ref here can only be a pre-fix legacy row, and
+  // the old bug only ever dropped the "default" project, so that is the
+  // fallback (never the alert's own project, which may differ).
   const runbook = ann[ANN_RUNBOOK]
     ? parseRunbookRef(ann[ANN_RUNBOOK], "default")
     : null;
@@ -205,9 +207,11 @@ export function toAlertRuleDocument(
     },
     spec: {
       ...(display ? { display } : {}),
-      // The stored ref is already canonical (project/slug, or a bare slug for
-      // the default project), which the schema accepts as-is. `undefined`
-      // values drop out when the document is serialized to JSON/YAML.
+      // The stored ref is already qualified ("project/slug"), which the
+      // schema accepts as-is; re-applying this document must resolve the
+      // same runbook regardless of which project the alert itself lives in.
+      // `undefined` values drop out when the document is serialized to
+      // JSON/YAML.
       runbook: ann[ANN_RUNBOOK] ?? undefined,
       evaluationInterval: formatDurationSeconds(rule.spec.interval_secs),
       for: formatDurationSeconds(rule.spec.for_secs),

--- a/packages/app/src/data/alerting/rules/server.test.ts
+++ b/packages/app/src/data/alerting/rules/server.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, expect, it, vi } from "vitest";
+import { listAlertingRules } from "./server";
+
+const mocks = vi.hoisted(() => ({ listAllRules: vi.fn(async () => []) }));
+
+vi.mock("./repository", () => ({ listAllRules: mocks.listAllRules }));
+// server.ts also imports getPreviewScopes for the sibling handlers; stub it
+// so this file doesn't pull in the real db client's env access.
+vi.mock("@/data/previews/repoids", () => ({ getPreviewScopes: vi.fn() }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.listAllRules.mockResolvedValue([]);
+});
+
+// The triage headline count and the routing suggestions both read this as
+// "the organization's rules": a preview rule slipping in here inflates the
+// count and offers a suggestion nobody live can route to.
+it("scopes to live rules, excluding previews", async () => {
+  await listAlertingRules();
+
+  expect(mocks.listAllRules).toHaveBeenCalledWith("test_org", {
+    previewId: null,
+  });
+});

--- a/packages/app/src/data/alerting/rules/server.ts
+++ b/packages/app/src/data/alerting/rules/server.ts
@@ -15,7 +15,9 @@ import { visibleRulesForPreview } from "./resource/preview-overlay";
 export const listAlertingRules = createAuthenticatedServerFn({
   method: "GET",
 }).handler(({ context: { session } }) =>
-  rules.listAllRules(alertingOrganizationId(session)),
+  // Live scope: every caller (triage headline count, routing suggestions)
+  // reads this as "the organization's rules", not "including previews".
+  rules.listAllRules(alertingOrganizationId(session), { previewId: null }),
 );
 
 export const listAlertingRulesPage = createAuthenticatedServerFn({

--- a/packages/app/src/data/alerting/vocabulary.ts
+++ b/packages/app/src/data/alerting/vocabulary.ts
@@ -17,9 +17,6 @@ export const ALERTING_EVENT_TYPES = [
   "instance_fired",
   "instance_resolved",
   "instance_closed",
-  "delivery",
-  "rule_health",
-  "silenced",
   "hold_changed",
   "evaluation_failed",
 ] as const;

--- a/packages/app/src/data/alerting/vocabulary.ts
+++ b/packages/app/src/data/alerting/vocabulary.ts
@@ -34,6 +34,10 @@ const ALERTING_LIFECYCLE_REASONS = [
   "rule_paused",
   "rule_deleted",
   "preview_deleted",
+  // A firing event reached delivery processing after its instance had
+  // already stopped firing (a worker outage and recovery, most often): the
+  // notification is withheld, not dropped silently.
+  "no_longer_firing",
 ] as const;
 
 export type AlertingLifecycleReason =

--- a/packages/app/src/data/alerting/vocabulary.ts
+++ b/packages/app/src/data/alerting/vocabulary.ts
@@ -27,7 +27,7 @@ export const ALERTING_EVENT_TYPES = [
 // The closed vocabulary of reasons a terminal row can carry. History rows are
 // append-only, so a typo here would be an unlabelled reason forever; every
 // writer must pick from this list, not from a bare string.
-const ALERTING_LIFECYCLE_REASONS = [
+export const ALERTING_LIFECYCLE_REASONS = [
   "condition_cleared",
   "pending_cleared",
   "labels_changed",

--- a/packages/app/src/data/alerting/vocabulary.ts
+++ b/packages/app/src/data/alerting/vocabulary.ts
@@ -38,6 +38,10 @@ const ALERTING_LIFECYCLE_REASONS = [
   // already stopped firing (a worker outage and recovery, most often): the
   // notification is withheld, not dropped silently.
   "no_longer_firing",
+  // A group flushed a notification-worthy set to a receiver or rule with no
+  // channels attached: nothing was sent, but the chain still needs an
+  // outcome.
+  "no_channels",
 ] as const;
 
 export type AlertingLifecycleReason =

--- a/packages/app/src/db/schema/alerts.test.ts
+++ b/packages/app/src/db/schema/alerts.test.ts
@@ -1,0 +1,25 @@
+import { getTableConfig, PgDialect } from "drizzle-orm/pg-core";
+import { describe, expect, it } from "vitest";
+import { ALERTING_LIFECYCLE_REASONS } from "@/data/alerting/vocabulary";
+import { alertEvents } from "./alerts";
+
+const dialect = new PgDialect();
+
+function checkSql(name: string): string {
+  const check = getTableConfig(alertEvents).checks.find((c) => c.name === name);
+  if (!check) throw new Error(`check not found: ${name}`);
+  return dialect.sqlToQuery(check.value).sql;
+}
+
+// The CHECK is generated from the vocabulary export, so this guards the
+// generation itself: a reason added to the vocabulary without regenerating
+// the check would otherwise fail silently.
+describe("alert_events_reason_in_vocabulary", () => {
+  it("admits the empty string and every vocabulary reason", () => {
+    const sql = checkSql("alert_events_reason_in_vocabulary");
+    expect(sql).toContain("''");
+    for (const reason of ALERTING_LIFECYCLE_REASONS) {
+      expect(sql).toContain(`'${reason}'`);
+    }
+  });
+});

--- a/packages/app/src/db/schema/alerts.test.ts
+++ b/packages/app/src/db/schema/alerts.test.ts
@@ -1,7 +1,7 @@
 import { getTableConfig, PgDialect } from "drizzle-orm/pg-core";
 import { describe, expect, it } from "vitest";
 import { ALERTING_LIFECYCLE_REASONS } from "@/data/alerting/vocabulary";
-import { alertEvents } from "./alerts";
+import { alertEvents, alertEventTypeEnum } from "./alerts";
 
 const dialect = new PgDialect();
 
@@ -21,5 +21,15 @@ describe("alert_events_reason_in_vocabulary", () => {
     for (const reason of ALERTING_LIFECYCLE_REASONS) {
       expect(sql).toContain(`'${reason}'`);
     }
+  });
+});
+
+// delivery, rule_health and silenced had no writer anywhere and the table
+// migration that introduced the enum leaves no legacy data behind them.
+describe("alert_event_type enum", () => {
+  it("carries no dead event types", () => {
+    expect(alertEventTypeEnum.enumValues).not.toContain("delivery");
+    expect(alertEventTypeEnum.enumValues).not.toContain("rule_health");
+    expect(alertEventTypeEnum.enumValues).not.toContain("silenced");
   });
 });

--- a/packages/app/src/db/schema/alerts.ts
+++ b/packages/app/src/db/schema/alerts.ts
@@ -193,6 +193,11 @@ export const alertInstances = pgTable(
     index("alert_instances_org_firing_idx")
       .on(table.organizationId, sql`updated_at DESC`)
       .where(sql`${table.status} = 'firing'`),
+    // Backs the retention sweep: it selects the oldest inactive rows across
+    // every organization, so the index cannot lead on organization_id.
+    index("alert_instances_inactive_updated_idx")
+      .on(table.updatedAt, table.id)
+      .where(sql`${table.status} = 'inactive'`),
   ],
 );
 

--- a/packages/app/src/db/schema/alerts.ts
+++ b/packages/app/src/db/schema/alerts.ts
@@ -314,6 +314,13 @@ export const alertEvents = pgTable(
       .where(
         sql`${table.processedAt} IS NULL AND ${table.silenceId} IS NOT NULL`,
       ),
+    // Backs cancelableNotifyingEventsFilter: every pause, delete and label
+    // change scans a rule's own unprocessed events inside the mutation's
+    // transaction. Same shape as alert_events_held_silence_idx: the
+    // unprocessed set is tiny next to the full journal.
+    index("alert_events_cancelable_idx")
+      .on(table.organizationId, table.sourceDefinitionId)
+      .where(sql`${table.processedAt} IS NULL`),
     uniqueIndex("alert_events_org_id_uq").on(table.organizationId, table.id),
   ],
 );
@@ -561,6 +568,13 @@ export const alertNotificationGroups = pgTable(
     index("alert_notification_groups_cleanup_idx").on(
       table.updatedAt,
       table.id,
+    ),
+    // Backs orphanedDirectChainsFilter: a rule delete scans its own direct
+    // groups inside the mutation's transaction, with no index on the FK
+    // column otherwise.
+    index("alert_notification_groups_direct_definition_idx").on(
+      table.organizationId,
+      table.directAlertDefinitionId,
     ),
   ],
 );

--- a/packages/app/src/db/schema/alerts.ts
+++ b/packages/app/src/db/schema/alerts.ts
@@ -140,6 +140,13 @@ export const alertDefinitions = pgTable(
       table.id,
     ),
     index("alert_definitions_due_idx").on(table.active, table.nextEvaluationAt),
+    // Backs listRulesPage's ORDER BY updated_at DESC, id DESC per org: every
+    // `everr apply` walks the full listing in 500-row pages.
+    index("alert_definitions_org_updated_idx").on(
+      table.organizationId,
+      sql`updated_at DESC`,
+      sql`id DESC`,
+    ),
   ],
 );
 
@@ -646,6 +653,11 @@ export const alertDeliveries = pgTable(
     }),
     check("alert_deliveries_attempts_nonnegative", sql`${table.attempts} >= 0`),
     index("alert_deliveries_org_idx").on(table.organizationId),
+    // Backs deleteChannel's reference check, filtered on both columns.
+    index("alert_deliveries_org_channel_idx").on(
+      table.organizationId,
+      table.channelId,
+    ),
     index("alert_deliveries_terminal_cleanup_idx")
       .on(table.updatedAt, table.dedupKey)
       .where(

--- a/packages/app/src/db/schema/alerts.ts
+++ b/packages/app/src/db/schema/alerts.ts
@@ -27,8 +27,16 @@ import {
   ALERTING_EVENT_TYPES,
   ALERTING_HEALTH_STATUSES,
   ALERTING_INSTANCE_STATUSES,
+  ALERTING_LIFECYCLE_REASONS,
   ALERTING_SEVERITIES,
 } from "@/data/alerting/vocabulary";
+
+// Derived from the vocabulary export, not hand-listed, so a reason added
+// there without a CHECK update fails loudly instead of journaling silently.
+const ALERT_EVENTS_REASON_VOCABULARY_SQL = ["", ...ALERTING_LIFECYCLE_REASONS]
+  .map((reason) => `'${reason}'`)
+  .join(", ");
+
 import { previews } from "./app";
 
 export const alertStateEnum = pgEnum("alert_state", [
@@ -295,6 +303,14 @@ export const alertEvents = pgTable(
     check(
       "alert_events_kind_matches_type",
       sql`(${table.eventType} NOT IN ('instance_pending', 'instance_closed', 'evaluation_failed', 'hold_changed') OR ${table.kind} = 'state') AND (${table.eventType} NOT IN ('instance_fired', 'instance_resolved') OR ${table.kind} = 'notifying')`,
+    ),
+    // Enforces the closed reason vocabulary the `reason` column comment
+    // promises: derived from ALERTING_LIFECYCLE_REASONS so a reason added
+    // there without a matching migration is caught at write time, not
+    // silently blanked by a reader that doesn't recognize it.
+    check(
+      "alert_events_reason_in_vocabulary",
+      sql`${table.reason} IN (${sql.raw(ALERT_EVENTS_REASON_VOCABULARY_SQL)})`,
     ),
     index("alert_events_org_occurred_idx").on(
       table.organizationId,

--- a/packages/app/src/db/schema/alerts.ts
+++ b/packages/app/src/db/schema/alerts.ts
@@ -30,14 +30,13 @@ import {
   ALERTING_LIFECYCLE_REASONS,
   ALERTING_SEVERITIES,
 } from "@/data/alerting/vocabulary";
+import { previews } from "./app";
 
 // Derived from the vocabulary export, not hand-listed, so a reason added
 // there without a CHECK update fails loudly instead of journaling silently.
 const ALERT_EVENTS_REASON_VOCABULARY_SQL = ["", ...ALERTING_LIFECYCLE_REASONS]
   .map((reason) => `'${reason}'`)
   .join(", ");
-
-import { previews } from "./app";
 
 export const alertStateEnum = pgEnum("alert_state", [
   "unknown",
@@ -297,9 +296,7 @@ export const alertEvents = pgTable(
     // The born-processed boundary rests on kind agreeing with event_type: the
     // delivery reads select kind = 'notifying', and kind defaults to it, so a
     // state-stream row journaled by a writer that forgot the field becomes a
-    // notification candidate. One-directional per type: the legacy types stay
-    // unconstrained, and future streams pick their side when their writers
-    // land.
+    // notification candidate. Every event type falls on exactly one side.
     check(
       "alert_events_kind_matches_type",
       sql`(${table.eventType} NOT IN ('instance_pending', 'instance_closed', 'evaluation_failed', 'hold_changed') OR ${table.kind} = 'state') AND (${table.eventType} NOT IN ('instance_fired', 'instance_resolved') OR ${table.kind} = 'notifying')`,

--- a/packages/app/src/lib/clickhouse.test.ts
+++ b/packages/app/src/lib/clickhouse.test.ts
@@ -82,6 +82,30 @@ describe("query", () => {
       expect.any(Function),
     );
   });
+
+  it("forwards caller-supplied settings alongside the tenant scope", async () => {
+    await query("SELECT 1", ORG, undefined, { max_execution_time: 30 });
+
+    expect(mockQuery).toHaveBeenCalledWith({
+      query: "SELECT 1",
+      query_params: undefined,
+      format: "JSONEachRow",
+      clickhouse_settings: {
+        max_execution_time: 30,
+        SQL_everr_tenant_id: ORG,
+      },
+    });
+  });
+
+  it("never lets a caller-supplied setting override the tenant scope", async () => {
+    await query("SELECT 1", ORG, undefined, {
+      SQL_everr_tenant_id: "someone-elses-org",
+    });
+
+    expect(mockQuery.mock.calls[0][0].clickhouse_settings).toEqual({
+      SQL_everr_tenant_id: ORG,
+    });
+  });
 });
 
 describe("querySqlApi", () => {

--- a/packages/app/src/lib/clickhouse.ts
+++ b/packages/app/src/lib/clickhouse.ts
@@ -22,10 +22,17 @@ export type ClickhouseQuery = <T>(
   params?: Record<string, unknown>,
 ) => Promise<T[]>;
 
+type AppQuerySettings = NonNullable<
+  Parameters<typeof clickhouse.query>[0]["clickhouse_settings"]
+>;
+
 export async function query<T>(
   query: string,
   organizationId: string,
   query_params?: Record<string, unknown>,
+  // Per-query, not a client default: this client is shared with dashboards,
+  // where a global execution-time cap could cut off a legitimate long scan.
+  clickhouse_settings?: AppQuerySettings,
 ): Promise<T[]> {
   if (typeof organizationId !== "string" || !organizationId) {
     throw new Error("Missing ClickHouse tenant context");
@@ -39,6 +46,8 @@ export async function query<T>(
         query_params,
         format: "JSONEachRow",
         clickhouse_settings: {
+          ...clickhouse_settings,
+          // Last, so a caller-supplied setting can never override the tenant scope.
           SQL_everr_tenant_id: organizationId,
         },
       }),

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/-components/rules/history.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/-components/rules/history.tsx
@@ -12,7 +12,7 @@ import {
   TabsTrigger,
 } from "@everr/ui/components/tabs";
 import type { Tone } from "@everr/ui/components/tone";
-import type { AlertEventType } from "@/data/alerting/history/event-types";
+import type { AlertTransitionEventType } from "@/data/alerting/history/event-types";
 import type { AlertEventLogRow } from "@/data/alerting/history/repository.server";
 import type {
   AlertingRuleCondition,
@@ -28,18 +28,26 @@ import { EvidenceChips, LabelSet } from "../shared/signal";
 import { AlertingStatusLabel } from "../shared/status";
 import { AlertRuleEvaluationHistoryTable } from "./evaluation-details";
 
-const EVENT_META: Record<AlertEventType, { label: string; tone: Tone }> = {
+// Keyed over AlertTransitionEventType, the exact set
+// queryClickHouseAlertEventLog's WHERE clause can return: every entry here is
+// reachable, and a new transition type is a compile error until it gets one.
+const EVENT_META: Record<
+  AlertTransitionEventType,
+  { label: string; tone: Tone }
+> = {
   instance_pending: { label: "Pending", tone: "warning" },
   instance_fired: { label: "Fired", tone: "danger" },
   instance_resolved: { label: "Resolved", tone: "healthy" },
   // Closed ends the instance without a recovery, so it stays neutral rather
   // than borrowing the healthy tone of a resolve.
   instance_closed: { label: "Closed", tone: "muted" },
-  hold_changed: { label: "Hold changed", tone: "muted" },
-  evaluation_failed: { label: "Evaluation failed", tone: "warning" },
 };
 
-function EventTypeLabel({ eventType }: { eventType: AlertEventType }) {
+function EventTypeLabel({
+  eventType,
+}: {
+  eventType: AlertTransitionEventType;
+}) {
   const { label, tone } = EVENT_META[eventType];
   return <AlertingStatusLabel tone={tone}>{label}</AlertingStatusLabel>;
 }

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/-components/rules/history.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/-components/rules/history.tsx
@@ -60,6 +60,7 @@ const CLOSE_REASON_LABELS: Record<
   rule_paused: "Rule paused",
   rule_deleted: "Rule deleted",
   preview_deleted: "Preview deleted",
+  no_longer_firing: "No longer firing",
 };
 
 function closeReasonLabel(reason: AlertingLifecycleReason | ""): string | null {

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/-components/rules/history.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/-components/rules/history.tsx
@@ -61,6 +61,7 @@ const CLOSE_REASON_LABELS: Record<
   rule_deleted: "Rule deleted",
   preview_deleted: "Preview deleted",
   no_longer_firing: "No longer firing",
+  no_channels: "No channels configured",
 };
 
 function closeReasonLabel(reason: AlertingLifecycleReason | ""): string | null {

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/-components/rules/history.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/-components/rules/history.tsx
@@ -35,9 +35,6 @@ const EVENT_META: Record<AlertEventType, { label: string; tone: Tone }> = {
   // Closed ends the instance without a recovery, so it stays neutral rather
   // than borrowing the healthy tone of a resolve.
   instance_closed: { label: "Closed", tone: "muted" },
-  delivery: { label: "Delivery", tone: "info" },
-  rule_health: { label: "Rule health", tone: "warning" },
-  silenced: { label: "Silenced", tone: "muted" },
   hold_changed: { label: "Hold changed", tone: "muted" },
   evaluation_failed: { label: "Evaluation failed", tone: "warning" },
 };

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/-components/triage/instance-detail.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/-components/triage/instance-detail.tsx
@@ -29,6 +29,9 @@ export function TriageInstanceDetail({
     alertHistoryQueries.events(TRIAGE_EVENT_RANGE, {
       fingerprint: alert.fingerprint,
       sourceId: alert.rule,
+      // `rule` can be undefined for a raced or deleted rule; the fingerprint
+      // and sourceId filters alone still scope this to one alert.
+      ...(rule ? { repoid: rule.repoid } : {}),
       limit: TRIAGE_INSTANCE_EVENT_LIMIT,
     }),
   );

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/rules_.$project.$slug.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/rules_.$project.$slug.tsx
@@ -240,6 +240,7 @@ export const Route = createFileRoute(
       queryClient.prefetchQuery(
         alertHistoryQueries.events(deps.timeRange, {
           slugs: alertingRuleHandles(rule),
+          repoid: rule.repoid,
           preview: deps.preview,
         }),
       ),
@@ -282,6 +283,7 @@ function AlertingRuleDetailPage() {
   const eventHistory = useQuery({
     ...alertHistoryQueries.events(timeRange, {
       slugs: pendingScope,
+      ...(rule.data ? { repoid: rule.data.repoid } : {}),
       preview,
     }),
     enabled: rule.data !== undefined,

--- a/packages/app/src/server/alerts/delivery/flush-group.test.ts
+++ b/packages/app/src/server/alerts/delivery/flush-group.test.ts
@@ -13,11 +13,23 @@ const mocks = vi.hoisted(() => ({
   ),
   recordHistory: vi.fn(() => Promise.resolve()),
   transactionCalls: 0,
+  // The channels attached to a group's receiver or direct rule.
+  channelRows: [] as unknown[],
 }));
 
 vi.mock("@/db/client", () => {
   return {
     db: {
+      // The receiver/rule -> channels lookup, outside any transaction.
+      select: () => ({
+        from: () => ({
+          innerJoin: () => ({
+            where: () => ({
+              orderBy: () => Promise.resolve(mocks.channelRows),
+            }),
+          }),
+        }),
+      }),
       transaction: (fn: (tx: unknown) => Promise<unknown>) => {
         mocks.transactionCalls += 1;
         if (mocks.transactionCalls === 1) {
@@ -106,6 +118,7 @@ beforeEach(() => {
   mocks.loadSilences.mockClear();
   mocks.loadInhibition.mockClear();
   mocks.recordHistory.mockClear();
+  mocks.channelRows = [];
 });
 
 function event(overrides: Partial<NotificationEvent> = {}): NotificationEvent {
@@ -347,5 +360,85 @@ describe("flushAlertGroup flap handling", () => {
       { notificationEventId: string }[],
     ];
     expect(rows).toHaveLength(1);
+  });
+});
+
+describe("flushAlertGroup zero channels", () => {
+  const GROUP_ID = "5cbb1c68-5cc9-4444-8000-000000000004";
+  const group = {
+    id: GROUP_ID,
+    organizationId: "org-1",
+    nextFlushAt: new Date("2026-08-10T09:00:00Z"),
+    directAlertDefinitionId: null,
+    receiverId: "receiver-1",
+    repeatIntervalSeconds: null,
+    lastNotifiedAt: null,
+  };
+
+  it("records a terminal when a notification-worthy set has no channel to send to", async () => {
+    mocks.groupRow = group;
+    mocks.channelRows = []; // the receiver has no channels attached
+    mocks.memberRows = [
+      {
+        event: {
+          id: "fire-event",
+          organizationId: "org-1",
+          sourceDefinitionId: "def-1",
+          instanceFingerprint: "fp-1",
+          occurredAt: new Date("2026-08-10T08:59:00Z"),
+          eventType: "instance_fired",
+          instanceLabels: {},
+          silenced: false,
+          inhibited: false,
+          silenceId: null,
+        },
+        flushedAt: null,
+        ruleActive: true,
+      },
+    ];
+    mocks.commitSelectQueue = [[group], [{ unflushed: 0 }]];
+
+    await flushAlertGroup({ groupId: GROUP_ID });
+
+    expect(mocks.recordHistory).toHaveBeenCalledWith(
+      null,
+      expect.arrayContaining([
+        expect.objectContaining({
+          notificationEventId: "fire-event",
+          reason: "no_channels",
+        }),
+      ]),
+    );
+  });
+
+  it("writes nothing when there is nothing to notify either", async () => {
+    mocks.groupRow = group;
+    mocks.channelRows = [];
+    // A paused rule drops before notificationEvents is computed from any
+    // live candidate: nothing to notify, so nothing to blame on missing
+    // channels.
+    mocks.memberRows = [
+      {
+        event: {
+          id: "fire-event",
+          organizationId: "org-1",
+          sourceDefinitionId: "def-1",
+          instanceFingerprint: "fp-1",
+          occurredAt: new Date("2026-08-10T08:59:00Z"),
+          eventType: "instance_fired",
+          instanceLabels: {},
+          silenced: false,
+          inhibited: false,
+          silenceId: null,
+        },
+        flushedAt: new Date("2026-08-10T08:00:00Z"),
+        ruleActive: false,
+      },
+    ];
+    mocks.commitSelectQueue = [[group], [{ unflushed: 0 }]];
+
+    await flushAlertGroup({ groupId: GROUP_ID });
+
+    expect(mocks.recordHistory).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/server/alerts/delivery/flush-group.test.ts
+++ b/packages/app/src/server/alerts/delivery/flush-group.test.ts
@@ -4,37 +4,82 @@ const mocks = vi.hoisted(() => ({
   groupRow: null as Record<string, unknown> | null,
   memberRows: [] as unknown[],
   updates: [] as Record<string, unknown>[],
+  // Consumed in order by the commit transaction: the re-read-under-lock
+  // select, then the pending-unflushed-count select.
+  commitSelectQueue: [] as unknown[][],
+  loadSilences: vi.fn(() => Promise.resolve([])),
+  loadInhibition: vi.fn(() =>
+    Promise.resolve({ inhibitions: [], sources: [] }),
+  ),
+  transactionCalls: 0,
 }));
 
-vi.mock("@/db/client", () => ({
-  db: {
-    transaction: (fn: (tx: unknown) => Promise<unknown>) => {
-      const tx = {
-        select: () => ({
-          from: () => ({
-            where: () => ({
-              for: () => ({
-                limit: () =>
-                  Promise.resolve(mocks.groupRow ? [mocks.groupRow] : []),
+vi.mock("@/db/client", () => {
+  return {
+    db: {
+      transaction: (fn: (tx: unknown) => Promise<unknown>) => {
+        mocks.transactionCalls += 1;
+        if (mocks.transactionCalls === 1) {
+          // The claim transaction: lock-read the group, maybe park it idle.
+          const tx = {
+            select: () => ({
+              from: () => ({
+                where: () => ({
+                  for: () => ({
+                    limit: () =>
+                      Promise.resolve(mocks.groupRow ? [mocks.groupRow] : []),
+                  }),
+                }),
               }),
             }),
+            update: () => ({
+              set: (values: Record<string, unknown>) => {
+                mocks.updates.push(values);
+                return { where: () => Promise.resolve(undefined) };
+              },
+            }),
+          };
+          return fn(tx);
+        }
+        // The commit transaction: re-read under lock, insert/delete
+        // memberships, read the pending count, reschedule.
+        const tx = {
+          select: () => ({
+            from: () => ({
+              where: () => {
+                const rows = mocks.commitSelectQueue.shift() ?? [];
+                return Object.assign(Promise.resolve(rows), {
+                  for: () => ({ limit: () => Promise.resolve(rows) }),
+                });
+              },
+            }),
           }),
-        }),
-        update: () => ({
-          set: (values: Record<string, unknown>) => {
-            mocks.updates.push(values);
-            return { where: () => Promise.resolve(undefined) };
-          },
-        }),
-      };
-      return fn(tx);
+          insert: () => ({ values: () => Promise.resolve(undefined) }),
+          delete: () => ({ where: () => Promise.resolve(undefined) }),
+          update: () => ({
+            set: (values: Record<string, unknown>) => {
+              mocks.updates.push(values);
+              return { where: () => Promise.resolve(undefined) };
+            },
+          }),
+        };
+        return fn(tx);
+      },
     },
-  },
-  pool: {},
-}));
+    pool: {},
+  };
+});
 
 vi.mock("./journal-reader", () => ({
   deliverableGroupMemberQuery: () => Promise.resolve(mocks.memberRows),
+}));
+
+vi.mock("./suppression", () => ({
+  loadActiveSilences: mocks.loadSilences,
+  loadInhibitionContext: mocks.loadInhibition,
+  matchSilence: () => null,
+  matchInhibition: () => false,
+  deferSuppressedEvent: vi.fn(),
 }));
 
 import { CHANNEL_TEXT_MAX } from "@/lib/channel-text-limits";
@@ -49,6 +94,10 @@ beforeEach(() => {
   mocks.groupRow = null;
   mocks.memberRows = [];
   mocks.updates = [];
+  mocks.commitSelectQueue = [];
+  mocks.transactionCalls = 0;
+  mocks.loadSilences.mockClear();
+  mocks.loadInhibition.mockClear();
 });
 
 function event(overrides: Partial<NotificationEvent> = {}): NotificationEvent {
@@ -150,5 +199,74 @@ describe("flushAlertGroup empty claim", () => {
     await flushAlertGroup({ groupId: "5cbb1c68-5cc9-4444-8000-000000000001" });
 
     expect(mocks.updates).toEqual([]);
+  });
+});
+
+describe("flushAlertGroup suppression batching", () => {
+  const GROUP_ID = "5cbb1c68-5cc9-4444-8000-000000000002";
+
+  function member(i: number) {
+    return {
+      event: {
+        id: `event-${i}`,
+        organizationId: "org-1",
+        sourceDefinitionId: "def-1",
+        instanceFingerprint: `fp-${i}`,
+        occurredAt: new Date("2026-08-10T08:59:00Z"),
+        eventType: "instance_fired",
+        instanceLabels: {},
+        silenced: false,
+        inhibited: false,
+        silenceId: null,
+      },
+      flushedAt: null,
+      ruleActive: true,
+    };
+  }
+
+  it("loads silences and inhibition sources once, not once per member", async () => {
+    const group = {
+      id: GROUP_ID,
+      organizationId: "org-1",
+      nextFlushAt: new Date("2026-08-10T09:00:00Z"),
+      directAlertDefinitionId: null,
+      receiverId: null,
+      repeatIntervalSeconds: null,
+      lastNotifiedAt: null,
+    };
+    mocks.groupRow = group;
+    // 5 distinct firing members: with the per-member design this would have
+    // been 5 silence scans and 5 inhibition scans.
+    mocks.memberRows = Array.from({ length: 5 }, (_, i) => member(i));
+    mocks.commitSelectQueue = [
+      [group], // re-read under lock
+      [{ unflushed: 0 }], // pending count
+    ];
+
+    await flushAlertGroup({ groupId: GROUP_ID });
+
+    expect(mocks.loadSilences).toHaveBeenCalledTimes(1);
+    expect(mocks.loadInhibition).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not load either when nothing survives to the suppression check", async () => {
+    const group = {
+      id: GROUP_ID,
+      organizationId: "org-1",
+      nextFlushAt: new Date("2026-08-10T09:00:00Z"),
+      directAlertDefinitionId: null,
+      receiverId: null,
+      repeatIntervalSeconds: null,
+      lastNotifiedAt: null,
+    };
+    mocks.groupRow = group;
+    // A paused rule: dropped before the suppression check runs.
+    mocks.memberRows = [{ ...member(0), ruleActive: false }];
+    mocks.commitSelectQueue = [[group], [{ unflushed: 0 }]];
+
+    await flushAlertGroup({ groupId: GROUP_ID });
+
+    expect(mocks.loadSilences).not.toHaveBeenCalled();
+    expect(mocks.loadInhibition).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/server/alerts/delivery/flush-group.test.ts
+++ b/packages/app/src/server/alerts/delivery/flush-group.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   loadInhibition: vi.fn(() =>
     Promise.resolve({ inhibitions: [], sources: [] }),
   ),
+  recordHistory: vi.fn(() => Promise.resolve()),
   transactionCalls: 0,
 }));
 
@@ -82,6 +83,12 @@ vi.mock("./suppression", () => ({
   deferSuppressedEvent: vi.fn(),
 }));
 
+vi.mock("../history/clickhouse", () => ({
+  recordAlertHistory: mocks.recordHistory,
+  historyDefFromJournalRow: (row: unknown) => row,
+  suppressionHistoryRow: (opts: unknown) => opts,
+}));
+
 import { CHANNEL_TEXT_MAX } from "@/lib/channel-text-limits";
 import {
   flushAlertGroup,
@@ -98,6 +105,7 @@ beforeEach(() => {
   mocks.transactionCalls = 0;
   mocks.loadSilences.mockClear();
   mocks.loadInhibition.mockClear();
+  mocks.recordHistory.mockClear();
 });
 
 function event(overrides: Partial<NotificationEvent> = {}): NotificationEvent {
@@ -268,5 +276,76 @@ describe("flushAlertGroup suppression batching", () => {
 
     expect(mocks.loadSilences).not.toHaveBeenCalled();
     expect(mocks.loadInhibition).not.toHaveBeenCalled();
+  });
+});
+
+describe("flushAlertGroup flap handling", () => {
+  const GROUP_ID = "5cbb1c68-5cc9-4444-8000-000000000003";
+
+  it("records a terminal for a flap instead of notifying an unannounced resolve", async () => {
+    const group = {
+      id: GROUP_ID,
+      organizationId: "org-1",
+      nextFlushAt: new Date("2026-08-10T09:00:00Z"),
+      directAlertDefinitionId: null,
+      receiverId: null,
+      repeatIntervalSeconds: null,
+      lastNotifiedAt: null,
+    };
+    mocks.groupRow = group;
+    // Fire at T, resolve at T+15, both still unflushed at the flush: the
+    // fire never went out.
+    mocks.memberRows = [
+      {
+        event: {
+          id: "fire-event",
+          organizationId: "org-1",
+          sourceDefinitionId: "def-1",
+          instanceFingerprint: "fp-1",
+          occurredAt: new Date("2026-08-10T08:59:00Z"),
+          eventType: "instance_fired",
+          instanceLabels: {},
+          silenced: false,
+          inhibited: false,
+          silenceId: null,
+        },
+        flushedAt: null,
+        ruleActive: true,
+      },
+      {
+        event: {
+          id: "resolve-event",
+          organizationId: "org-1",
+          sourceDefinitionId: "def-1",
+          instanceFingerprint: "fp-1",
+          occurredAt: new Date("2026-08-10T08:59:15Z"),
+          eventType: "instance_resolved",
+          instanceLabels: {},
+          silenced: false,
+          inhibited: false,
+          silenceId: null,
+        },
+        flushedAt: null,
+        ruleActive: true,
+      },
+    ];
+    mocks.commitSelectQueue = [
+      [group], // re-read under lock
+      [{ unflushed: 0 }], // pending count
+    ];
+
+    await flushAlertGroup({ groupId: GROUP_ID });
+
+    expect(mocks.recordHistory).toHaveBeenCalledWith(
+      null,
+      expect.arrayContaining([
+        expect.objectContaining({ notificationEventId: "resolve-event" }),
+      ]),
+    );
+    const [, rows] = mocks.recordHistory.mock.calls[0] as unknown as [
+      unknown,
+      { notificationEventId: string }[],
+    ];
+    expect(rows).toHaveLength(1);
   });
 });

--- a/packages/app/src/server/alerts/delivery/flush-group.test.ts
+++ b/packages/app/src/server/alerts/delivery/flush-group.test.ts
@@ -1,11 +1,55 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// formatNotification is pure; the mock only keeps the module import from
-// reaching the real database client.
-vi.mock("@/db/client", () => ({ db: {}, pool: {} }));
+const mocks = vi.hoisted(() => ({
+  groupRow: null as Record<string, unknown> | null,
+  memberRows: [] as unknown[],
+  updates: [] as Record<string, unknown>[],
+}));
+
+vi.mock("@/db/client", () => ({
+  db: {
+    transaction: (fn: (tx: unknown) => Promise<unknown>) => {
+      const tx = {
+        select: () => ({
+          from: () => ({
+            where: () => ({
+              for: () => ({
+                limit: () =>
+                  Promise.resolve(mocks.groupRow ? [mocks.groupRow] : []),
+              }),
+            }),
+          }),
+        }),
+        update: () => ({
+          set: (values: Record<string, unknown>) => {
+            mocks.updates.push(values);
+            return { where: () => Promise.resolve(undefined) };
+          },
+        }),
+      };
+      return fn(tx);
+    },
+  },
+  pool: {},
+}));
+
+vi.mock("./journal-reader", () => ({
+  deliverableGroupMemberQuery: () => Promise.resolve(mocks.memberRows),
+}));
 
 import { CHANNEL_TEXT_MAX } from "@/lib/channel-text-limits";
-import { formatNotification, type NotificationEvent } from "./flush-group";
+import {
+  flushAlertGroup,
+  formatNotification,
+  type NotificationEvent,
+} from "./flush-group";
+import { IDLE_GROUP_FLUSH_AT } from "./tasks";
+
+beforeEach(() => {
+  mocks.groupRow = null;
+  mocks.memberRows = [];
+  mocks.updates = [];
+});
 
 function event(overrides: Partial<NotificationEvent> = {}): NotificationEvent {
   return {
@@ -78,5 +122,33 @@ describe("formatNotification", () => {
     expect(formatNotification(events).title).toBe(
       "Everr alert: 50 firing, 30 resolved",
     );
+  });
+});
+
+describe("flushAlertGroup empty claim", () => {
+  it("parks nextFlushAt on the idle sentinel instead of leaving it in the past", async () => {
+    mocks.groupRow = {
+      id: "5cbb1c68-5cc9-4444-8000-000000000001",
+      nextFlushAt: new Date("2026-08-10T09:00:00Z"),
+    };
+    mocks.memberRows = [];
+
+    await flushAlertGroup({ groupId: "5cbb1c68-5cc9-4444-8000-000000000001" });
+
+    expect(mocks.updates).toEqual([
+      expect.objectContaining({ nextFlushAt: IDLE_GROUP_FLUSH_AT }),
+    ]);
+  });
+
+  it("touches nothing when the group is not due yet", async () => {
+    mocks.groupRow = {
+      id: "5cbb1c68-5cc9-4444-8000-000000000001",
+      nextFlushAt: new Date(Date.now() + 60_000),
+    };
+    mocks.memberRows = [];
+
+    await flushAlertGroup({ groupId: "5cbb1c68-5cc9-4444-8000-000000000001" });
+
+    expect(mocks.updates).toEqual([]);
   });
 });

--- a/packages/app/src/server/alerts/delivery/flush-group.ts
+++ b/packages/app/src/server/alerts/delivery/flush-group.ts
@@ -37,6 +37,7 @@ import {
   ALERT_SEND_DELIVERY_TASK,
   AlertGroupTaskPayloadSchema,
   flushGroupJobKey,
+  IDLE_GROUP_FLUSH_AT,
 } from "./tasks";
 
 // The body budgets against the tightest channel limit, keeping a margin for
@@ -113,7 +114,17 @@ export async function flushAlertGroup(rawPayload: unknown): Promise<void> {
       .limit(1);
     if (!group || group.nextFlushAt > new Date()) return null;
     const rows = await deliverableGroupMemberQuery(tx, group.id);
-    return rows.length === 0 ? null : { group, rows };
+    if (rows.length === 0) {
+      // Nothing claimed: park on the idle sentinel instead of leaving
+      // nextFlushAt in the past, or the next event dispatched to this group
+      // would skip its whole group wait and page alone.
+      await tx
+        .update(alertNotificationGroups)
+        .set({ nextFlushAt: IDLE_GROUP_FLUSH_AT, updatedAt: new Date() })
+        .where(eq(alertNotificationGroups.id, group.id));
+      return null;
+    }
+    return { group, rows };
   });
   if (!claimed) return;
   const { group, rows } = claimed;

--- a/packages/app/src/server/alerts/delivery/flush-group.ts
+++ b/packages/app/src/server/alerts/delivery/flush-group.ts
@@ -128,9 +128,6 @@ export async function flushAlertGroup(rawPayload: unknown): Promise<void> {
   const droppedRows: typeof rows = [];
   for (const row of rows) {
     const { event, flushedAt, ruleActive } = row;
-    // Muted chains sit outside the terminal surface: history consumers filter
-    // `rule_muted = false`, so a muted member is neither notified nor closed.
-    if (event.suppressed) continue;
     const liveness = memberLiveness(ruleActive, flushedAt);
     if (liveness === "dropped_unnotified") {
       droppedRows.push(row);

--- a/packages/app/src/server/alerts/delivery/flush-group.ts
+++ b/packages/app/src/server/alerts/delivery/flush-group.ts
@@ -203,7 +203,11 @@ export async function flushAlertGroup(rawPayload: unknown): Promise<void> {
     }
     members.push({ event, flushedAt });
   }
-  const { active, notify: notificationEvents } = groupNotificationPlan(members);
+  const {
+    active,
+    notify: notificationEvents,
+    droppedUnannounced,
+  } = groupNotificationPlan(members);
   const channels = group.directAlertDefinitionId
     ? await db
         .select({ channel: alertChannels })
@@ -366,11 +370,10 @@ export async function flushAlertGroup(rawPayload: unknown): Promise<void> {
       );
     }
   });
-  if (droppedRows.length > 0) {
+  if (droppedRows.length > 0 || droppedUnannounced.length > 0) {
     const decidedAt = new Date();
-    await recordAlertHistory(
-      null,
-      droppedRows.map(({ event, ruleActive }) =>
+    await recordAlertHistory(null, [
+      ...droppedRows.map(({ event, ruleActive }) =>
         suppressionHistoryRow({
           def: historyDefFromJournalRow(event),
           notificationEventId: event.id,
@@ -383,6 +386,22 @@ export async function flushAlertGroup(rawPayload: unknown): Promise<void> {
           reason: ruleActive === null ? "rule_deleted" : "rule_paused",
         }),
       ),
-    );
+      // A resolve whose fire never went out: nobody was ever told this
+      // instance was firing, so the resolve does not notify either, but its
+      // chain still needs a terminal so it does not read as forever in
+      // flight.
+      ...droppedUnannounced.map((event) =>
+        suppressionHistoryRow({
+          def: historyDefFromJournalRow(event),
+          notificationEventId: event.id,
+          occurredAt: decidedAt,
+          fingerprint: event.instanceFingerprint,
+          labels: event.instanceLabels,
+          silenced: false,
+          inhibited: false,
+          silenceId: null,
+        }),
+      ),
+    ]);
   }
 }

--- a/packages/app/src/server/alerts/delivery/flush-group.ts
+++ b/packages/app/src/server/alerts/delivery/flush-group.ts
@@ -254,6 +254,15 @@ export async function flushAlertGroup(rawPayload: unknown): Promise<void> {
           )
           .orderBy(asc(alertReceiverChannels.position))
       : [];
+  // A notification-worthy set with nowhere to send it: the flush below still
+  // marks these members flushed and advances lastNotifiedAt, so without a
+  // terminal here their chains would read as delivered with no record of why
+  // nothing went out. Guarded on repo-level channel requirements today, but
+  // the invariant ("chains end in an outcome") must hold regardless.
+  const noChannelDrops =
+    channels.length === 0 && notificationEvents.length > 0
+      ? notificationEvents
+      : [];
   const notification = formatNotification(notificationEvents);
   await db.transaction(async (tx) => {
     // Re-read under lock: another writer may have moved nextFlushAt while this
@@ -370,7 +379,11 @@ export async function flushAlertGroup(rawPayload: unknown): Promise<void> {
       );
     }
   });
-  if (droppedRows.length > 0 || droppedUnannounced.length > 0) {
+  if (
+    droppedRows.length > 0 ||
+    droppedUnannounced.length > 0 ||
+    noChannelDrops.length > 0
+  ) {
     const decidedAt = new Date();
     await recordAlertHistory(null, [
       ...droppedRows.map(({ event, ruleActive }) =>
@@ -400,6 +413,21 @@ export async function flushAlertGroup(rawPayload: unknown): Promise<void> {
           silenced: false,
           inhibited: false,
           silenceId: null,
+        }),
+      ),
+      // A receiver or rule with no channels attached: nothing was sent, but
+      // the flush still marked these flushed and advanced lastNotifiedAt.
+      ...noChannelDrops.map((event) =>
+        suppressionHistoryRow({
+          def: historyDefFromJournalRow(event),
+          notificationEventId: event.id,
+          occurredAt: decidedAt,
+          fingerprint: event.instanceFingerprint,
+          labels: event.instanceLabels,
+          silenced: false,
+          inhibited: false,
+          silenceId: null,
+          reason: "no_channels",
         }),
       ),
     ]);

--- a/packages/app/src/server/alerts/delivery/flush-group.ts
+++ b/packages/app/src/server/alerts/delivery/flush-group.ts
@@ -36,6 +36,7 @@ import {
   ALERT_FLUSH_GROUP_TASK,
   ALERT_SEND_DELIVERY_TASK,
   AlertGroupTaskPayloadSchema,
+  flushGroupJobKey,
 } from "./tasks";
 
 // The body budgets against the tightest channel limit, keeping a margin for
@@ -318,7 +319,7 @@ export async function flushAlertGroup(rawPayload: unknown): Promise<void> {
         ALERT_FLUSH_GROUP_TASK,
         { groupId: group.id },
         {
-          jobKey: `${ALERT_FLUSH_GROUP_TASK}:${group.id}:${nextFlushAt.toISOString()}`,
+          jobKey: flushGroupJobKey(group.id, nextFlushAt),
           jobKeyMode: "replace",
           maxAttempts: 5,
           queueName: alertingPartitionQueue("group", group.id),

--- a/packages/app/src/server/alerts/delivery/flush-group.ts
+++ b/packages/app/src/server/alerts/delivery/flush-group.ts
@@ -28,8 +28,10 @@ import {
 import { deliverableGroupMemberQuery } from "./journal-reader";
 import {
   deferSuppressedEvent,
-  isInhibited,
-  matchingSilence,
+  loadActiveSilences,
+  loadInhibitionContext,
+  matchInhibition,
+  matchSilence,
 } from "./suppression";
 import { alertDeliveryHash } from "./targeting";
 import {
@@ -50,6 +52,14 @@ const BODY_MAX_EVENTS = 20;
 const LINE_MAX_CHARS = 200;
 // Room kept back for the "…and N more" line so appending it cannot overflow.
 const OMITTED_LINE_RESERVE = 48;
+
+// Bounds one flush's claimed membership set. Past this, a storm feeding one
+// group (thousands of firing instances into one receiver) would push a
+// single worker through a suppression check per member with no upper bound.
+// Whatever is left past the cap stays linked and unflushed, and the pending
+// count this flush already computes turns that into an immediate follow-up
+// flush rather than a lost member.
+const FLUSH_GROUP_MEMBER_CLAIM_CAP = 500;
 
 export type NotificationEvent = Pick<
   typeof alertEvents.$inferSelect,
@@ -113,7 +123,11 @@ export async function flushAlertGroup(rawPayload: unknown): Promise<void> {
       .for("update")
       .limit(1);
     if (!group || group.nextFlushAt > new Date()) return null;
-    const rows = await deliverableGroupMemberQuery(tx, group.id);
+    const rows = await deliverableGroupMemberQuery(
+      tx,
+      group.id,
+      FLUSH_GROUP_MEMBER_CLAIM_CAP,
+    );
     if (rows.length === 0) {
       // Nothing claimed: park on the idle sentinel instead of leaving
       // nextFlushAt in the past, or the next event dispatched to this group
@@ -137,17 +151,33 @@ export async function flushAlertGroup(rawPayload: unknown): Promise<void> {
   // delete below removes it; a member that never made a notification also
   // gets its terminal suppression row so its chain does not dangle.
   const droppedRows: typeof rows = [];
+  const candidateRows: typeof rows = [];
   for (const row of rows) {
-    const { event, flushedAt, ruleActive } = row;
-    const liveness = memberLiveness(ruleActive, flushedAt);
+    const liveness = memberLiveness(row.ruleActive, row.flushedAt);
     if (liveness === "dropped_unnotified") {
       droppedRows.push(row);
       continue;
     }
     if (liveness !== "deliverable") continue;
-    const now = new Date();
-    const silence = await matchingSilence(event, now);
-    const inhibited = silence ? false : await isInhibited(event);
+    candidateRows.push(row);
+  }
+  // Loaded once for the whole flush, not once per member: matchingSilence
+  // and isInhibited each ran an org-wide scan, so a flush with hundreds of
+  // members used to issue hundreds of identical scans.
+  const now = new Date();
+  const [silences, inhibitionContext] =
+    candidateRows.length > 0
+      ? await Promise.all([
+          loadActiveSilences(group.organizationId, now),
+          loadInhibitionContext(group.organizationId),
+        ])
+      : [[], { inhibitions: [], sources: [] }];
+  for (const row of candidateRows) {
+    const { event, flushedAt } = row;
+    const silence = matchSilence(event, silences, now);
+    const inhibited = silence
+      ? false
+      : matchInhibition(event, inhibitionContext);
     if (silence || inhibited) {
       await deferSuppressedEvent(event, silence, inhibited, now);
       // Drop the membership now and disown the id. Deferral reschedules

--- a/packages/app/src/server/alerts/delivery/grouping.test.ts
+++ b/packages/app/src/server/alerts/delivery/grouping.test.ts
@@ -145,16 +145,56 @@ describe("groupNotificationPlan", () => {
     ).toEqual(["a", "b"]);
   });
 
-  it("keeps only the newest event per instance", () => {
+  // The regression this fix closes: fire at T, resolve at T+15, flush at
+  // T+30. Both memberships are unflushed (never carried into a
+  // notification), so the old code reported only the newest event per
+  // instance: "1 resolved" for an alert nobody was ever told was firing.
+  it("drops a flap instead of announcing a resolve whose fire never went out", () => {
     const plan = groupNotificationPlan([
-      member({ occurredAt: "2026-08-06T09:00:00Z" }),
+      member({ occurredAt: "2026-08-06T09:00:00Z", flushedAt: null }),
       member({
         eventType: "instance_resolved",
         occurredAt: "2026-08-06T09:30:00Z",
+        flushedAt: null,
+      }),
+    ]);
+    expect(plan.notify).toEqual([]);
+    expect(plan.droppedUnannounced).toHaveLength(1);
+    expect(plan.droppedUnannounced[0].eventType).toBe("instance_resolved");
+    expect(plan.active).toEqual([]);
+  });
+
+  it("keeps notifying a resolve once its fire already went out in an earlier flush", () => {
+    const plan = groupNotificationPlan([
+      member({
+        occurredAt: "2026-08-06T09:00:00Z",
+        flushedAt: "2026-08-06T09:10:00Z",
+      }),
+      member({
+        eventType: "instance_resolved",
+        occurredAt: "2026-08-06T09:30:00Z",
+        flushedAt: null,
       }),
     ]);
     expect(plan.notify).toHaveLength(1);
     expect(plan.notify[0].eventType).toBe("instance_resolved");
+    expect(plan.droppedUnannounced).toEqual([]);
+  });
+
+  it("does not treat a lone deferred resolve as a flap", () => {
+    // No fire-type member for this instance is in the batch at all: the
+    // fire went out through an earlier, separate flush whose membership row
+    // is already gone. This is the deferred-silence case the module doc
+    // above describes, not a flap.
+    const plan = groupNotificationPlan([
+      member({
+        eventType: "instance_resolved",
+        occurredAt: "2026-08-06T09:50:00Z",
+        flushedAt: null,
+      }),
+    ]);
+    expect(plan.notify).toHaveLength(1);
+    expect(plan.droppedUnannounced).toEqual([]);
   });
 });
 

--- a/packages/app/src/server/alerts/delivery/grouping.ts
+++ b/packages/app/src/server/alerts/delivery/grouping.ts
@@ -23,6 +23,14 @@ export interface GroupNotificationPlan<E> {
   active: E[];
   /** What this flush reports. `active` is always a subset. */
   notify: E[];
+  /**
+   * A resolve whose fire never reached a notification: this instance's only
+   * fire-type member in this batch was never flushed. Excluded from
+   * `notify` (announcing a recovery nobody was told about is worse than
+   * silence), but the chain still needs a terminal so it does not read as
+   * forever in flight.
+   */
+  droppedUnannounced: E[];
 }
 
 /**
@@ -37,21 +45,42 @@ export interface GroupNotificationPlan<E> {
 export function groupNotificationPlan<E extends GroupedEvent>(
   members: GroupMember<E>[],
 ): GroupNotificationPlan<E> {
-  const latestByInstance = new Map<string, E>();
-  for (const { event } of [...members].sort(
+  const sorted = [...members].sort(
     (a, b) => a.event.occurredAt.getTime() - b.event.occurredAt.getTime(),
-  )) {
-    latestByInstance.set(
-      `${event.sourceDefinitionId}:${event.instanceFingerprint}`,
-      event,
-    );
-  }
-  const latest = [...latestByInstance.values()];
-  const active = latest.filter(
-    (event) => event.eventType !== "instance_resolved",
   );
+  const latestByInstance = new Map<string, E>();
+  // Whether this instance's fire-type member(s) in this batch were ever
+  // carried into a prior notification. Only tracked from fire-type members:
+  // a lone resolve with no fire counterpart in the batch is a reconsidered
+  // deferral (the fire went out through an earlier, separate flush whose
+  // membership row is already gone), not a flap, and this must not touch it.
+  const fireMemberSeen = new Map<string, boolean>();
+  for (const { event, flushedAt } of sorted) {
+    const key = `${event.sourceDefinitionId}:${event.instanceFingerprint}`;
+    latestByInstance.set(key, event);
+    if (event.eventType !== "instance_resolved") {
+      fireMemberSeen.set(
+        key,
+        (fireMemberSeen.get(key) ?? false) || flushedAt !== null,
+      );
+    }
+  }
+  const latest = [...latestByInstance.entries()];
+  const active = latest
+    .filter(([, event]) => event.eventType !== "instance_resolved")
+    .map(([, event]) => event);
   const hasUnflushed = members.some((member) => member.flushedAt === null);
-  return { active, notify: hasUnflushed ? latest : active };
+  const announced = hasUnflushed ? latest.map(([, event]) => event) : active;
+  const notify: E[] = [];
+  const droppedUnannounced: E[] = [];
+  for (const event of announced) {
+    const key = `${event.sourceDefinitionId}:${event.instanceFingerprint}`;
+    const flap =
+      event.eventType === "instance_resolved" &&
+      fireMemberSeen.get(key) === false;
+    (flap ? droppedUnannounced : notify).push(event);
+  }
+  return { active, notify, droppedUnannounced };
 }
 
 type MemberLiveness = "deliverable" | "dropped" | "dropped_unnotified";

--- a/packages/app/src/server/alerts/delivery/journal-reader.test.ts
+++ b/packages/app/src/server/alerts/delivery/journal-reader.test.ts
@@ -29,6 +29,7 @@ describe("the delivery pipeline's journal boundary", () => {
     const { sql, params } = deliverableGroupMemberQuery(
       builder(),
       "1af52a7c-c9d7-4bca-9c67-a21db2096acf",
+      500,
     ).toSQL();
 
     expect(sql).toContain('"kind" = ');
@@ -39,10 +40,23 @@ describe("the delivery pipeline's journal boundary", () => {
     const { sql } = deliverableGroupMemberQuery(
       builder(),
       "1af52a7c-c9d7-4bca-9c67-a21db2096acf",
+      500,
     ).toSQL();
 
     expect(sql).toContain('left join "alert_definitions"');
     expect(sql).toContain('"active"');
+  });
+
+  it("caps and orders the claim so a storm cannot pull an unbounded set", () => {
+    const { sql, params } = deliverableGroupMemberQuery(
+      builder(),
+      "1af52a7c-c9d7-4bca-9c67-a21db2096acf",
+      500,
+    ).toSQL();
+
+    expect(sql).toContain("order by");
+    expect(sql).toContain("limit");
+    expect(params).toContain(500);
   });
 
   it("counts a delivery's rules as live only when notifying and active", () => {

--- a/packages/app/src/server/alerts/delivery/journal-reader.ts
+++ b/packages/app/src/server/alerts/delivery/journal-reader.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { type DbExecutor, db } from "@/db/client";
 import {
   alertDefinitions,
@@ -32,10 +32,19 @@ export async function claimDeliverableEvent(eventId: string) {
  * same statement. `ruleActive` is null when the definition is gone (the rule
  * was deleted; its journal rows outlive it), false when it is paused. The
  * flush drops both instead of notifying.
+ *
+ * `cap` bounds how many rows one flush claims: a storm feeding one group
+ * (thousands of firing instances into one receiver) must not push a single
+ * worker through a suppression check per member unbounded. Ordered by event
+ * id (UUIDv7, creation-ordered) so a capped claim always takes the oldest
+ * members first; whatever is left stays linked and unflushed, which the
+ * flush's own pending-member count already turns into an immediate
+ * follow-up flush.
  */
 export function deliverableGroupMemberQuery(
   executor: DbExecutor,
   groupId: string,
+  cap: number,
 ) {
   return executor
     .select({
@@ -62,7 +71,9 @@ export function deliverableGroupMemberQuery(
         eq(alertEvents.sourceDefinitionId, alertDefinitions.id),
       ),
     )
-    .where(eq(alertNotificationGroupEvents.groupId, groupId));
+    .where(eq(alertNotificationGroupEvents.groupId, groupId))
+    .orderBy(asc(alertEvents.id))
+    .limit(cap);
 }
 
 /**

--- a/packages/app/src/server/alerts/delivery/process-event.test.ts
+++ b/packages/app/src/server/alerts/delivery/process-event.test.ts
@@ -1,10 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  rows: [] as unknown[],
+  // Consumed in call order: claimDeliverableEvent's own select first, then
+  // (only on the branches that reach it) eventStillFiring's.
+  selectQueue: [] as unknown[][],
+  stampReturn: [] as { id: string }[],
   set: vi.fn(),
   update: vi.fn(),
   where: vi.fn(),
+  history: [] as unknown[][],
 }));
 
 vi.mock("@/db/client", () => ({
@@ -12,13 +16,22 @@ vi.mock("@/db/client", () => ({
     select: () => ({
       from: () => ({
         where: () => ({
-          limit: () => Promise.resolve(mocks.rows),
+          limit: () => Promise.resolve(mocks.selectQueue.shift() ?? []),
         }),
       }),
     }),
     update: mocks.update,
   },
   pool: {},
+}));
+
+vi.mock("../history/clickhouse", () => ({
+  recordAlertHistory: (_defId: string | null, rows: unknown[]) => {
+    mocks.history.push(rows);
+    return Promise.resolve();
+  },
+  suppressionHistoryRow: (opts: unknown) => opts,
+  historyDefFromJournalRow: (row: unknown) => row,
 }));
 
 import { QueryBuilder } from "drizzle-orm/pg-core";
@@ -51,44 +64,95 @@ describe("notification destination precedence", () => {
   });
 });
 
+const EVENT_ID = "0ee52a7c-c9d7-4bca-9c67-a21db2096acf";
+
 describe("processAlertEvent retention lifecycle", () => {
   beforeEach(() => {
-    mocks.rows = [];
-    mocks.where.mockReset().mockResolvedValue(undefined);
+    mocks.selectQueue = [];
+    mocks.stampReturn = [{ id: EVENT_ID }];
+    mocks.history = [];
+    mocks.where
+      .mockReset()
+      .mockReturnValue({ returning: () => Promise.resolve(mocks.stampReturn) });
     mocks.set.mockReset().mockReturnValue({ where: mocks.where });
     mocks.update.mockReset().mockReturnValue({ set: mocks.set });
   });
 
   it("marks intentionally suppressed events as processed", async () => {
-    mocks.rows = [
-      {
-        id: "0ee52a7c-c9d7-4bca-9c67-a21db2096acf",
-        processedAt: null,
-        suppressed: true,
-      },
+    mocks.selectQueue = [
+      [{ id: EVENT_ID, processedAt: null, suppressed: true }],
     ];
 
-    await processAlertEvent({
-      eventId: "0ee52a7c-c9d7-4bca-9c67-a21db2096acf",
-    });
+    await processAlertEvent({ eventId: EVENT_ID });
 
     expect(mocks.set).toHaveBeenCalledWith({ processedAt: expect.any(Date) });
+    expect(mocks.history).toEqual([]);
   });
 
   it("does not process an event twice after completion", async () => {
-    mocks.rows = [
-      {
-        id: "0ee52a7c-c9d7-4bca-9c67-a21db2096acf",
-        processedAt: new Date("2026-08-06T12:00:00Z"),
-        suppressed: false,
-      },
+    mocks.selectQueue = [
+      [
+        {
+          id: EVENT_ID,
+          processedAt: new Date("2026-08-06T12:00:00Z"),
+          suppressed: false,
+        },
+      ],
     ];
 
-    await processAlertEvent({
-      eventId: "0ee52a7c-c9d7-4bca-9c67-a21db2096acf",
-    });
+    await processAlertEvent({ eventId: EVENT_ID });
 
     expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it("records a terminal when a fire is no longer firing by the time it is processed", async () => {
+    mocks.selectQueue = [
+      // claimDeliverableEvent's own read.
+      [
+        {
+          id: EVENT_ID,
+          processedAt: null,
+          suppressed: false,
+          eventType: "instance_fired",
+          sourceDefinitionId: "def-1",
+          instanceFingerprint: "fp-1",
+          instanceLabels: {},
+        },
+      ],
+      // eventStillFiring's firing-instance lookup: none found.
+      [],
+    ];
+
+    await processAlertEvent({ eventId: EVENT_ID });
+
+    expect(mocks.set).toHaveBeenCalledWith({ processedAt: expect.any(Date) });
+    expect(mocks.history).toHaveLength(1);
+    expect(mocks.history[0]).toEqual([
+      expect.objectContaining({ reason: "no_longer_firing" }),
+    ]);
+  });
+
+  it("records no terminal when the no-longer-firing claim is lost to a concurrent cancel", async () => {
+    mocks.selectQueue = [
+      [
+        {
+          id: EVENT_ID,
+          processedAt: null,
+          suppressed: false,
+          eventType: "instance_fired",
+          sourceDefinitionId: "def-1",
+          instanceFingerprint: "fp-1",
+          instanceLabels: {},
+        },
+      ],
+      [],
+    ];
+    // The stamp write finds the event already claimed by a lifecycle cancel.
+    mocks.stampReturn = [];
+
+    await processAlertEvent({ eventId: EVENT_ID });
+
+    expect(mocks.history).toEqual([]);
   });
 });
 

--- a/packages/app/src/server/alerts/delivery/process-event.ts
+++ b/packages/app/src/server/alerts/delivery/process-event.ts
@@ -7,6 +7,11 @@ import {
   alertNotificationGroups,
 } from "@/db/schema";
 import { addWorkerJobInTransaction } from "@/server/worker/jobs";
+import {
+  historyDefFromJournalRow,
+  recordAlertHistory,
+  suppressionHistoryRow,
+} from "../history/clickhouse";
 import { nextGroupFlushAt } from "./grouping";
 import { claimDeliverableEvent } from "./journal-reader";
 import {
@@ -28,20 +33,45 @@ export async function processAlertEvent(rawPayload: unknown): Promise<void> {
   if (!event || event.processedAt) return;
   const now = new Date();
   if (event.suppressed) {
+    // Guarded the same as the dispatch stamp below: a concurrent lifecycle
+    // cancel may have already claimed this event and projected its own
+    // terminal. Muted chains carry no terminal of their own either way, so a
+    // lost claim needs nothing further here.
     await db
       .update(alertEvents)
       .set({ processedAt: now })
-      .where(eq(alertEvents.id, event.id));
+      .where(processedStampGuard(event.id));
     return;
   }
   if (
     event.eventType !== "instance_resolved" &&
     !(await eventStillFiring(event))
   ) {
-    await db
+    const stamped = await db
       .update(alertEvents)
       .set({ processedAt: now })
-      .where(eq(alertEvents.id, event.id));
+      .where(processedStampGuard(event.id))
+      .returning({ id: alertEvents.id });
+    // Lost to a concurrent cancel: its projection owns the terminal.
+    if (stamped.length === 0) return;
+    // A fire reached here after its instance had already stopped firing (a
+    // worker outage and recovery, most often). Nobody was ever told it
+    // fired, so notifying a resolve later would announce an alert that was
+    // never announced as firing; the chain still needs a terminal so it does
+    // not read as forever in flight.
+    await recordAlertHistory(event.sourceDefinitionId, [
+      suppressionHistoryRow({
+        def: historyDefFromJournalRow(event),
+        notificationEventId: event.id,
+        occurredAt: now,
+        fingerprint: event.instanceFingerprint,
+        labels: event.instanceLabels,
+        silenced: false,
+        inhibited: false,
+        silenceId: null,
+        reason: "no_longer_firing",
+      }),
+    ]);
     return;
   }
   const silence = await matchingSilence(event, now);

--- a/packages/app/src/server/alerts/delivery/process-event.ts
+++ b/packages/app/src/server/alerts/delivery/process-event.ts
@@ -16,7 +16,11 @@ import {
   matchingSilence,
 } from "./suppression";
 import { dispatchTargetsForEvent } from "./targeting";
-import { ALERT_FLUSH_GROUP_TASK, AlertEventTaskPayloadSchema } from "./tasks";
+import {
+  ALERT_FLUSH_GROUP_TASK,
+  AlertEventTaskPayloadSchema,
+  flushGroupJobKey,
+} from "./tasks";
 
 export async function processAlertEvent(rawPayload: unknown): Promise<void> {
   const { eventId } = AlertEventTaskPayloadSchema.parse(rawPayload);
@@ -82,7 +86,7 @@ export async function processAlertEvent(rawPayload: unknown): Promise<void> {
           ALERT_FLUSH_GROUP_TASK,
           { groupId: group.id },
           {
-            jobKey: `${ALERT_FLUSH_GROUP_TASK}:${group.id}:${group.nextFlushAt.toISOString()}:${event.id}`,
+            jobKey: flushGroupJobKey(group.id, group.nextFlushAt),
             jobKeyMode: "replace",
             maxAttempts: 5,
             queueName: alertingPartitionQueue("group", group.id),

--- a/packages/app/src/server/alerts/delivery/send-delivery.test.ts
+++ b/packages/app/src/server/alerts/delivery/send-delivery.test.ts
@@ -2,15 +2,25 @@ import { is, SQL } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mocks = vi.hoisted(() => ({
-  deliveryRows: [] as unknown[],
-  liveRules: [] as unknown[],
-  set: vi.fn(),
-  update: vi.fn(),
-  where: vi.fn(),
-  send: vi.fn(),
-  outcome: vi.fn(),
-}));
+const mocks = vi.hoisted(() => {
+  class MockChannelSendError extends Error {
+    readonly permanent: boolean;
+    constructor(message: string, opts: { permanent: boolean }) {
+      super(message);
+      this.permanent = opts.permanent;
+    }
+  }
+  return {
+    deliveryRows: [] as unknown[],
+    liveRules: [] as unknown[],
+    set: vi.fn(),
+    update: vi.fn(),
+    where: vi.fn(),
+    send: vi.fn(),
+    outcome: vi.fn(),
+    ChannelSendError: MockChannelSendError,
+  };
+});
 
 vi.mock("@/db/client", () => ({
   db: {
@@ -35,6 +45,7 @@ vi.mock("@/data/alerting/delivery/channel-secrets.server", () => ({
 }));
 vi.mock("@/data/alerting/delivery/channel-sender.server", () => ({
   sendChannelNotification: mocks.send,
+  ChannelSendError: mocks.ChannelSendError,
 }));
 vi.mock("./history", () => ({ recordDeliveryOutcome: mocks.outcome }));
 
@@ -220,5 +231,50 @@ describe("sendAlertDelivery status write after a successful send", () => {
       (call) => call[0]?.status === "sent",
     );
     expect(sentCall).toBeDefined();
+  });
+});
+
+describe("sendAlertDelivery permanent vs transient send errors", () => {
+  beforeEach(() => {
+    mocks.deliveryRows = [deliveryRow];
+    mocks.liveRules = [{ eventId: "e-1" }];
+    mocks.outcome.mockReset().mockResolvedValue(undefined);
+    mocks.where.mockReset().mockResolvedValue(undefined);
+    mocks.set.mockReset().mockReturnValue({ where: mocks.where });
+    mocks.update.mockReset().mockReturnValue({ set: mocks.set });
+  });
+
+  it("records a permanent failure at the max attempts and does not rethrow", async () => {
+    mocks.send.mockReset().mockRejectedValue(
+      new mocks.ChannelSendError("notification webhook failed: 400", {
+        permanent: true,
+      }),
+    );
+
+    await expect(
+      sendAlertDelivery({ dedupKey: "dk-1" }),
+    ).resolves.toBeUndefined();
+
+    expect(mocks.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "failed",
+        attempts: ALERT_DELIVERY_MAX_ATTEMPTS,
+      }),
+    );
+  });
+
+  it("rethrows a transient failure for the job queue to retry", async () => {
+    mocks.send.mockReset().mockRejectedValue(
+      new mocks.ChannelSendError("notification webhook failed: 500", {
+        permanent: false,
+      }),
+    );
+
+    await expect(sendAlertDelivery({ dedupKey: "dk-1" })).rejects.toThrow();
+
+    const [failedCall] = mocks.set.mock.calls.filter(
+      (call) => call[0]?.status === "failed",
+    );
+    expect(is(failedCall?.[0].attempts, SQL)).toBe(true);
   });
 });

--- a/packages/app/src/server/alerts/delivery/send-delivery.test.ts
+++ b/packages/app/src/server/alerts/delivery/send-delivery.test.ts
@@ -158,4 +158,67 @@ describe("sendAlertDelivery send failure", () => {
     // delivery must not both compute the same stale count.
     expect(is(failedCall?.[0].attempts, SQL)).toBe(true);
   });
+
+  it("keeps the original send error when failDelivery's own write also throws", async () => {
+    const sendError = new Error("provider rejected the request");
+    mocks.send.mockReset().mockRejectedValue(sendError);
+    // The failure bookkeeping write itself fails too.
+    mocks.where.mockReset().mockRejectedValue(new Error("db unavailable"));
+
+    let thrown: unknown;
+    try {
+      await sendAlertDelivery({ dedupKey: "dk-1" });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    const cause = (thrown as Error).cause as {
+      sendError: Error;
+      bookkeepingError: Error;
+    };
+    expect(cause.sendError.message).toBe(sendError.message);
+  });
+});
+
+describe("sendAlertDelivery status write after a successful send", () => {
+  beforeEach(() => {
+    mocks.deliveryRows = [deliveryRow];
+    mocks.liveRules = [{ eventId: "e-1" }];
+    mocks.send.mockReset().mockResolvedValue(undefined);
+    mocks.outcome.mockReset().mockResolvedValue(undefined);
+    mocks.where.mockReset().mockResolvedValue(undefined);
+    mocks.set.mockReset().mockReturnValue({ where: mocks.where });
+    mocks.update.mockReset().mockReturnValue({ set: mocks.set });
+  });
+
+  it("does not classify the delivery failed when only the status write fails", async () => {
+    mocks.where.mockReset().mockRejectedValue(new Error("db unavailable"));
+
+    await expect(sendAlertDelivery({ dedupKey: "dk-1" })).rejects.toThrow();
+
+    expect(mocks.send).toHaveBeenCalledOnce();
+    // Never classified failed: the send succeeded, only the bookkeeping
+    // write did not land.
+    const failedCalls = mocks.set.mock.calls.filter(
+      (call) => call[0]?.status === "failed",
+    );
+    expect(failedCalls).toHaveLength(0);
+    expect(mocks.outcome).not.toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: "failed" }),
+    );
+    // Retried once before giving up.
+    expect(mocks.where).toHaveBeenCalledTimes(2);
+  });
+
+  it("records the succeeded outcome once the status write lands", async () => {
+    await sendAlertDelivery({ dedupKey: "dk-1" });
+
+    expect(mocks.outcome).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: "succeeded" }),
+    );
+    const sentCall = mocks.set.mock.calls.find(
+      (call) => call[0]?.status === "sent",
+    );
+    expect(sentCall).toBeDefined();
+  });
 });

--- a/packages/app/src/server/alerts/delivery/send-delivery.test.ts
+++ b/packages/app/src/server/alerts/delivery/send-delivery.test.ts
@@ -1,3 +1,5 @@
+import { is, SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -130,5 +132,30 @@ describe("sendAlertDelivery send failure", () => {
     );
     expect(failedCall?.[0].lastError).not.toContain("SECRET");
     expect(failedCall?.[0].lastError).toContain("[redacted-url]");
+  });
+
+  it("guards the failure write so a racing sent row can never flip back to failed", async () => {
+    mocks.send.mockReset().mockRejectedValue(new Error("boom"));
+
+    await expect(sendAlertDelivery({ dedupKey: "dk-1" })).rejects.toThrow();
+
+    const condition = mocks.where.mock.calls[0]?.[0] as SQL;
+    const rendered = new PgDialect().sqlToQuery(condition);
+    expect(rendered.sql).toContain('"status" <> ');
+    expect(rendered.params).toContain("sent");
+  });
+
+  it("increments attempts in the database, not from the Node-side read", async () => {
+    mocks.send.mockReset().mockRejectedValue(new Error("boom"));
+
+    await expect(sendAlertDelivery({ dedupKey: "dk-1" })).rejects.toThrow();
+
+    const [failedCall] = mocks.set.mock.calls.filter(
+      (call) => call[0]?.status === "failed",
+    );
+    // An SQL fragment (`attempts + 1` computed by Postgres), not the plain
+    // number read at the top of this run: two racing sends of the same
+    // delivery must not both compute the same stale count.
+    expect(is(failedCall?.[0].attempts, SQL)).toBe(true);
   });
 });

--- a/packages/app/src/server/alerts/delivery/send-delivery.test.ts
+++ b/packages/app/src/server/alerts/delivery/send-delivery.test.ts
@@ -103,3 +103,32 @@ describe("sendAlertDelivery rule liveness", () => {
     );
   });
 });
+
+describe("sendAlertDelivery send failure", () => {
+  beforeEach(() => {
+    mocks.deliveryRows = [deliveryRow];
+    mocks.liveRules = [{ eventId: "e-1" }];
+    mocks.outcome.mockReset().mockResolvedValue(undefined);
+    mocks.where.mockReset().mockResolvedValue(undefined);
+    mocks.set.mockReset().mockReturnValue({ where: mocks.where });
+    mocks.update.mockReset().mockReturnValue({ set: mocks.set });
+  });
+
+  it("sanitizes the webhook url out of last_error before it reaches Postgres", async () => {
+    mocks.send
+      .mockReset()
+      .mockRejectedValue(
+        new Error(
+          "notification webhook failed: 500 at https://hooks.slack.com/services/T0/B0/SECRET",
+        ),
+      );
+
+    await expect(sendAlertDelivery({ dedupKey: "dk-1" })).rejects.toThrow();
+
+    const [failedCall] = mocks.set.mock.calls.filter(
+      (call) => call[0]?.status === "failed",
+    );
+    expect(failedCall?.[0].lastError).not.toContain("SECRET");
+    expect(failedCall?.[0].lastError).toContain("[redacted-url]");
+  });
+});

--- a/packages/app/src/server/alerts/delivery/send-delivery.test.ts
+++ b/packages/app/src/server/alerts/delivery/send-delivery.test.ts
@@ -36,6 +36,7 @@ vi.mock("@/data/alerting/delivery/channel-sender.server", () => ({
 }));
 vi.mock("./history", () => ({ recordDeliveryOutcome: mocks.outcome }));
 
+import { ALERT_DELIVERY_MAX_ATTEMPTS } from "./config";
 import { sendAlertDelivery } from "./send-delivery";
 
 const deliveryRow = {
@@ -71,6 +72,13 @@ describe("sendAlertDelivery rule liveness", () => {
     // Failed permanently, not thrown: a retry can never revive the rule.
     expect(mocks.set).toHaveBeenCalledWith(
       expect.objectContaining({ status: "failed" }),
+    );
+    // Attempts pinned at the max, not incremented from the current count: the
+    // retention sweep and the terminal-cleanup index only treat a failed row
+    // as done once attempts >= ALERT_DELIVERY_MAX_ATTEMPTS, or this row (and
+    // the journal events it links) would never become eligible for cleanup.
+    expect(mocks.set).toHaveBeenCalledWith(
+      expect.objectContaining({ attempts: ALERT_DELIVERY_MAX_ATTEMPTS }),
     );
     expect(mocks.outcome).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/app/src/server/alerts/delivery/send-delivery.ts
+++ b/packages/app/src/server/alerts/delivery/send-delivery.ts
@@ -1,6 +1,9 @@
 import { and, eq, ne, type SQL, sql } from "drizzle-orm";
 import { decryptChannelConfig } from "@/data/alerting/delivery/channel-secrets.server";
-import { sendChannelNotification } from "@/data/alerting/delivery/channel-sender.server";
+import {
+  ChannelSendError,
+  sendChannelNotification,
+} from "@/data/alerting/delivery/channel-sender.server";
 import { db } from "@/db/client";
 import { alertChannels, alertDeliveries } from "@/db/schema";
 import { errorMessage } from "@/telemetry/logger";
@@ -105,6 +108,11 @@ export async function sendAlertDelivery(rawPayload: unknown): Promise<void> {
     channelType = config.type;
     await sendChannelNotification(config, row.delivery.notification);
   } catch (cause) {
+    // A permanent failure (a 4xx other than 408/429: a revoked webhook, a
+    // malformed payload) cannot succeed on retry, so it is recorded
+    // terminally at the max attempts and not rethrown. Anything else is
+    // transient and must reach Graphile's retry.
+    const permanent = cause instanceof ChannelSendError && cause.permanent;
     // failDelivery's own write can throw too (a transient DB error, say);
     // let that one through unchanged rather than the real send failure it
     // would otherwise replace. `cause` on the original still carries it.
@@ -114,8 +122,12 @@ export async function sendAlertDelivery(rawPayload: unknown): Promise<void> {
         errorMessage(cause).slice(0, 8_000),
         // Computed in the UPDATE, not from the Node-side `row` read: two
         // racing runs of the same delivery would otherwise both compute the
-        // same stale count and one attempt would go uncounted.
-        sql`${alertDeliveries.attempts} + 1`,
+        // same stale count and one attempt would go uncounted. A permanent
+        // failure instead jumps straight to the max, the same terminal
+        // count retention and the cleanup index already require.
+        permanent
+          ? ALERT_DELIVERY_MAX_ATTEMPTS
+          : sql`${alertDeliveries.attempts} + 1`,
       );
     } catch (bookkeepingError) {
       throw new Error(
@@ -125,6 +137,7 @@ export async function sendAlertDelivery(rawPayload: unknown): Promise<void> {
         },
       );
     }
+    if (permanent) return;
     throw cause;
   }
   // The send succeeded. Nothing from here on may run inside a try whose catch

--- a/packages/app/src/server/alerts/delivery/send-delivery.ts
+++ b/packages/app/src/server/alerts/delivery/send-delivery.ts
@@ -4,6 +4,7 @@ import { sendChannelNotification } from "@/data/alerting/delivery/channel-sender
 import { db } from "@/db/client";
 import { alertChannels, alertDeliveries } from "@/db/schema";
 import { errorMessage } from "@/telemetry/logger";
+import { sanitizeAlertError } from "../history/content";
 import { ALERT_DELIVERY_MAX_ATTEMPTS } from "./config";
 import { recordDeliveryOutcome } from "./history";
 import { liveRuleForDeliveryQuery } from "./journal-reader";
@@ -26,9 +27,14 @@ export async function sendAlertDelivery(rawPayload: unknown): Promise<void> {
   if (!row || row.delivery.status === "sent") return;
   const failDelivery = async (
     channelType: string,
-    error: string,
+    rawError: string,
     attempts: number,
   ) => {
+    // A provider's error text routinely echoes back the webhook URL, which
+    // for Slack, Discord and Telegram IS the secret; sanitize before it
+    // reaches Postgres, same as the identical string already does on the
+    // ClickHouse path (deliveryHistoryRow).
+    const error = sanitizeAlertError(rawError);
     await db
       .update(alertDeliveries)
       .set({

--- a/packages/app/src/server/alerts/delivery/send-delivery.ts
+++ b/packages/app/src/server/alerts/delivery/send-delivery.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, ne, type SQL, sql } from "drizzle-orm";
 import { decryptChannelConfig } from "@/data/alerting/delivery/channel-secrets.server";
 import { sendChannelNotification } from "@/data/alerting/delivery/channel-sender.server";
 import { db } from "@/db/client";
@@ -28,7 +28,7 @@ export async function sendAlertDelivery(rawPayload: unknown): Promise<void> {
   const failDelivery = async (
     channelType: string,
     rawError: string,
-    attempts: number,
+    attempts: number | SQL,
   ) => {
     // A provider's error text routinely echoes back the webhook URL, which
     // for Slack, Discord and Telegram IS the secret; sanitize before it
@@ -43,7 +43,15 @@ export async function sendAlertDelivery(rawPayload: unknown): Promise<void> {
         lastError: error,
         updatedAt: new Date(),
       })
-      .where(eq(alertDeliveries.dedupKey, dedupKey));
+      // Guarded on status <> 'sent': a racing or duplicate run must never be
+      // able to mark an already-delivered row failed, whatever this read of
+      // `row` saw.
+      .where(
+        and(
+          eq(alertDeliveries.dedupKey, dedupKey),
+          ne(alertDeliveries.status, "sent"),
+        ),
+      );
     await recordDeliveryOutcome({
       organizationId: row.delivery.organizationId,
       dedupKey,
@@ -109,7 +117,10 @@ export async function sendAlertDelivery(rawPayload: unknown): Promise<void> {
     await failDelivery(
       channelType,
       errorMessage(cause).slice(0, 8_000),
-      row.delivery.attempts + 1,
+      // Computed in the UPDATE, not from the Node-side `row` read: two racing
+      // runs of the same delivery would otherwise both compute the same
+      // stale count and one attempt would go uncounted.
+      sql`${alertDeliveries.attempts} + 1`,
     );
     throw cause;
   }

--- a/packages/app/src/server/alerts/delivery/send-delivery.ts
+++ b/packages/app/src/server/alerts/delivery/send-delivery.ts
@@ -104,29 +104,66 @@ export async function sendAlertDelivery(rawPayload: unknown): Promise<void> {
     );
     channelType = config.type;
     await sendChannelNotification(config, row.delivery.notification);
-    await db
+  } catch (cause) {
+    // failDelivery's own write can throw too (a transient DB error, say);
+    // let that one through unchanged rather than the real send failure it
+    // would otherwise replace. `cause` on the original still carries it.
+    try {
+      await failDelivery(
+        channelType,
+        errorMessage(cause).slice(0, 8_000),
+        // Computed in the UPDATE, not from the Node-side `row` read: two
+        // racing runs of the same delivery would otherwise both compute the
+        // same stale count and one attempt would go uncounted.
+        sql`${alertDeliveries.attempts} + 1`,
+      );
+    } catch (bookkeepingError) {
+      throw new Error(
+        "alert delivery send failed, and recording it failed too",
+        {
+          cause: { sendError: cause, bookkeepingError },
+        },
+      );
+    }
+    throw cause;
+  }
+  // The send succeeded. Nothing from here on may run inside a try whose catch
+  // reaches failDelivery: that would mark a delivered notification failed and
+  // have Graphile send it a second time.
+  const markSent = () =>
+    db
       .update(alertDeliveries)
       .set({
         status: "sent",
-        attempts: row.delivery.attempts + 1,
+        attempts: sql`${alertDeliveries.attempts} + 1`,
         lastError: null,
         updatedAt: new Date(),
       })
-      .where(eq(alertDeliveries.dedupKey, dedupKey));
-  } catch (cause) {
-    await failDelivery(
-      channelType,
-      errorMessage(cause).slice(0, 8_000),
-      // Computed in the UPDATE, not from the Node-side `row` read: two racing
-      // runs of the same delivery would otherwise both compute the same
-      // stale count and one attempt would go uncounted.
-      sql`${alertDeliveries.attempts} + 1`,
-    );
-    throw cause;
+      .where(
+        and(
+          eq(alertDeliveries.dedupKey, dedupKey),
+          ne(alertDeliveries.status, "sent"),
+        ),
+      );
+  try {
+    await markSent();
+  } catch {
+    try {
+      await markSent();
+    } catch (statusWriteError) {
+      // The send went out but neither attempt to record it landed. Do not
+      // classify this row failed: it was not a failed send. Leave it
+      // pending and throw a distinct error so this run is not confused with
+      // a send failure; the job queue's retry (or the reconciliation sweep,
+      // ticket 23) is what resolves a row stuck here.
+      throw new Error(
+        "alert delivery sent, but its status write failed twice",
+        { cause: statusWriteError },
+      );
+    }
   }
-  // Outside the try on purpose. Recording history must never be able to send
-  // this delivery down the failure path, which would mark a delivered
-  // notification as failed and have Graphile send it a second time.
+  // Outside the write's own try on purpose. Recording history must never be
+  // able to send this delivery down the failure path.
   await recordDeliveryOutcome({
     organizationId: row.delivery.organizationId,
     dedupKey,

--- a/packages/app/src/server/alerts/delivery/send-delivery.ts
+++ b/packages/app/src/server/alerts/delivery/send-delivery.ts
@@ -4,6 +4,7 @@ import { sendChannelNotification } from "@/data/alerting/delivery/channel-sender
 import { db } from "@/db/client";
 import { alertChannels, alertDeliveries } from "@/db/schema";
 import { errorMessage } from "@/telemetry/logger";
+import { ALERT_DELIVERY_MAX_ATTEMPTS } from "./config";
 import { recordDeliveryOutcome } from "./history";
 import { liveRuleForDeliveryQuery } from "./journal-reader";
 import { AlertDeliveryTaskPayloadSchema } from "./tasks";
@@ -23,12 +24,16 @@ export async function sendAlertDelivery(rawPayload: unknown): Promise<void> {
     .where(eq(alertDeliveries.dedupKey, dedupKey))
     .limit(1);
   if (!row || row.delivery.status === "sent") return;
-  const failDelivery = async (channelType: string, error: string) => {
+  const failDelivery = async (
+    channelType: string,
+    error: string,
+    attempts: number,
+  ) => {
     await db
       .update(alertDeliveries)
       .set({
         status: "failed",
-        attempts: row.delivery.attempts + 1,
+        attempts,
         lastError: error,
         updatedAt: new Date(),
       })
@@ -62,9 +67,15 @@ export async function sendAlertDelivery(rawPayload: unknown): Promise<void> {
     } catch {
       // Config unreadable; the placeholder stays.
     }
+    // The max, not row.delivery.attempts + 1: this is a terminal decision
+    // independent of how many sends were already tried, and both the
+    // retention sweep and the terminal-cleanup index key "failed and done"
+    // on attempts >= ALERT_DELIVERY_MAX_ATTEMPTS. A lower count would leave
+    // this row, and the journal events it links, undeletable forever.
     await failDelivery(
       withheldChannelType,
       "Withheld: every rule behind this notification was paused or deleted before the send ran",
+      ALERT_DELIVERY_MAX_ATTEMPTS,
     );
     return;
   }
@@ -89,7 +100,11 @@ export async function sendAlertDelivery(rawPayload: unknown): Promise<void> {
       })
       .where(eq(alertDeliveries.dedupKey, dedupKey));
   } catch (cause) {
-    await failDelivery(channelType, errorMessage(cause).slice(0, 8_000));
+    await failDelivery(
+      channelType,
+      errorMessage(cause).slice(0, 8_000),
+      row.delivery.attempts + 1,
+    );
     throw cause;
   }
   // Outside the try on purpose. Recording history must never be able to send

--- a/packages/app/src/server/alerts/delivery/suppression.test.ts
+++ b/packages/app/src/server/alerts/delivery/suppression.test.ts
@@ -63,7 +63,11 @@ vi.mock("../history/clickhouse", () => ({
 }));
 
 import type { alertEvents } from "@/db/schema";
-import { deferSuppressedEvent, isInhibited } from "./suppression";
+import {
+  deferSuppressedEvent,
+  isInhibited,
+  matchInhibition,
+} from "./suppression";
 
 beforeEach(() => {
   mocks.wheres = [];
@@ -74,7 +78,7 @@ beforeEach(() => {
   mocks.history = [];
 });
 
-it("draws inhibition sources only from the event's own world", async () => {
+it("resolves false with no inhibition rules configured", async () => {
   const event = {
     eventType: "instance_fired",
     organizationId: "org-1",
@@ -83,12 +87,61 @@ it("draws inhibition sources only from the event's own world", async () => {
     severity: "critical",
     instanceLabels: {},
   } as unknown as typeof alertEvents.$inferSelect;
+  // loadInhibitionContext's two queries: inhibitions, then firing sources.
+  mocks.selectRows = [[], []];
 
   await expect(isInhibited(event)).resolves.toBe(false);
+});
 
-  const sources = new PgDialect().sqlToQuery(mocks.wheres[1] as SQL);
-  expect(sources.sql).toContain('"preview_id" IS NOT DISTINCT FROM');
-  expect(sources.params).toContain("prev-1");
+// The context is loaded once per flush and evaluated in memory for every
+// member, so the world scoping that used to sit in the SQL filter
+// (preview_id IS NOT DISTINCT FROM) is now matchInhibition's job.
+describe("matchInhibition", () => {
+  const target = {
+    eventType: "instance_fired",
+    organizationId: "org-1",
+    previewId: "prev-1",
+    sourceDefinitionId: "def-1",
+    severity: "critical",
+    instanceLabels: {},
+  } as unknown as typeof alertEvents.$inferSelect;
+  const config = { target_matchers: [], source_matchers: [], equal: [] };
+  const sourceLabels = {
+    rule: "def-2",
+    status: "firing",
+    severity: "critical",
+    kind: "alert",
+  };
+
+  it("does not let a source from a different preview inhibit a live target", () => {
+    expect(
+      matchInhibition(target, {
+        inhibitions: [{ config }] as never,
+        sources: [{ previewId: null, labels: sourceLabels }],
+      }),
+    ).toBe(false);
+  });
+
+  it("does not let a live source inhibit a preview target", () => {
+    expect(
+      matchInhibition(
+        { ...target, previewId: null },
+        {
+          inhibitions: [{ config }] as never,
+          sources: [{ previewId: "prev-1", labels: sourceLabels }],
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it("inhibits once a source shares the target's own world", () => {
+    expect(
+      matchInhibition(target, {
+        inhibitions: [{ config }] as never,
+        sources: [{ previewId: "prev-1", labels: sourceLabels }],
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("deferSuppressedEvent", () => {

--- a/packages/app/src/server/alerts/delivery/suppression.ts
+++ b/packages/app/src/server/alerts/delivery/suppression.ts
@@ -1,4 +1,4 @@
-import { and, eq, gt, isNull, lte, sql } from "drizzle-orm";
+import { and, eq, gt, isNull, lte } from "drizzle-orm";
 import {
   alertingMatchingSilence,
   alertingRouteMatches,
@@ -20,28 +20,54 @@ import {
 import { alertEventDispatchLabels } from "./targeting";
 import { enqueueProcessAlertEvent } from "./tasks";
 
-export async function matchingSilence(
-  event: typeof alertEvents.$inferSelect,
-  now: Date,
-) {
+export type ActiveSilence = Awaited<
+  ReturnType<typeof loadActiveSilences>
+>[number];
+
+/**
+ * Every silence active for the org right now. Load once per batch of events
+ * being evaluated and pass the result to `matchSilence`, rather than
+ * re-querying per event: a flush evaluating hundreds of members must not
+ * issue hundreds of identical org-wide scans.
+ */
+export async function loadActiveSilences(organizationId: string, now: Date) {
   const silences = await db
     .select()
     .from(alertSilences)
     .where(
       and(
-        eq(alertSilences.organizationId, event.organizationId),
+        eq(alertSilences.organizationId, organizationId),
         lte(alertSilences.startsAt, now),
         gt(alertSilences.endsAt, now),
       ),
     );
+  return silences.map((silence) => ({
+    ...silence,
+    starts_at: silence.startsAt.toISOString(),
+    ends_at: silence.endsAt.toISOString(),
+  }));
+}
+
+export function matchSilence(
+  event: typeof alertEvents.$inferSelect,
+  silences: ActiveSilence[],
+  now: Date,
+) {
   return alertingMatchingSilence(
     alertEventDispatchLabels(event),
-    silences.map((silence) => ({
-      ...silence,
-      starts_at: silence.startsAt.toISOString(),
-      ends_at: silence.endsAt.toISOString(),
-    })),
+    silences,
     now.getTime(),
+  );
+}
+
+export async function matchingSilence(
+  event: typeof alertEvents.$inferSelect,
+  now: Date,
+) {
+  return matchSilence(
+    event,
+    await loadActiveSilences(event.organizationId, now),
+    now,
   );
 }
 
@@ -128,12 +154,24 @@ export async function deferSuppressedEvent(
   ]);
 }
 
-export async function isInhibited(event: typeof alertEvents.$inferSelect) {
-  if (event.eventType === "instance_resolved") return false;
+export type InhibitionContext = Awaited<
+  ReturnType<typeof loadInhibitionContext>
+>;
+
+/**
+ * Every inhibition rule and every firing instance for the org right now, for
+ * `matchInhibition` to evaluate in memory. Load once per batch rather than
+ * per event: `isInhibited` used to run this pair of org-wide scans for every
+ * single member a flush considered.
+ */
+export async function loadInhibitionContext(organizationId: string): Promise<{
+  inhibitions: (typeof alertInhibitions.$inferSelect)[];
+  sources: { previewId: string | null; labels: Record<string, string> }[];
+}> {
   const inhibitions = await db
     .select()
     .from(alertInhibitions)
-    .where(eq(alertInhibitions.organizationId, event.organizationId));
+    .where(eq(alertInhibitions.organizationId, organizationId));
   const ruleSources = await db
     .select({ instance: alertInstances, def: alertDefinitions })
     .from(alertInstances)
@@ -143,31 +181,51 @@ export async function isInhibited(event: typeof alertEvents.$inferSelect) {
     )
     .where(
       and(
-        eq(alertInstances.organizationId, event.organizationId),
+        eq(alertInstances.organizationId, organizationId),
         eq(alertInstances.status, "firing"),
-        // Sources must come from the same world as the target: live rules for
-        // live events, and only the same preview for preview events. A firing
-        // preview instance must not mute a live alert. Muted rules stay valid
-        // sources on purpose: a muted root cause still holds its dependents.
-        sql`${alertDefinitions.previewId} IS NOT DISTINCT FROM ${event.previewId}`,
       ),
     );
-  const sources = ruleSources.map(({ instance, def }) =>
-    alertingSyntheticLabels(instance.labels, {
-      severity: def.spec.severity,
-      status: "firing",
-      rule: def.id,
-    }),
-  );
+  return {
+    inhibitions,
+    sources: ruleSources.map(({ instance, def }) => ({
+      previewId: def.previewId,
+      labels: alertingSyntheticLabels(instance.labels, {
+        severity: def.spec.severity,
+        status: "firing",
+        rule: def.id,
+      }),
+    })),
+  };
+}
+
+export function matchInhibition(
+  event: typeof alertEvents.$inferSelect,
+  context: InhibitionContext,
+): boolean {
+  if (event.eventType === "instance_resolved") return false;
   const target = alertEventDispatchLabels(event);
-  return inhibitions.some(({ config }) => {
+  return context.inhibitions.some(({ config }) => {
     if (!alertingRouteMatches(config.target_matchers, target)) return false;
-    return sources.some(
+    return context.sources.some(
       (source) =>
-        alertingRouteMatches(config.source_matchers, source) &&
+        // Sources must come from the same world as the target: live rules
+        // for live events, and only the same preview for preview events. A
+        // firing preview instance must not mute a live alert. Muted rules
+        // stay valid sources on purpose: a muted root cause still holds its
+        // dependents.
+        source.previewId === event.previewId &&
+        alertingRouteMatches(config.source_matchers, source.labels) &&
         config.equal.every(
-          (key) => (source[key] ?? "") === (target[key] ?? ""),
+          (key) => (source.labels[key] ?? "") === (target[key] ?? ""),
         ),
     );
   });
+}
+
+export async function isInhibited(event: typeof alertEvents.$inferSelect) {
+  if (event.eventType === "instance_resolved") return false;
+  return matchInhibition(
+    event,
+    await loadInhibitionContext(event.organizationId),
+  );
 }

--- a/packages/app/src/server/alerts/delivery/targeting.test.ts
+++ b/packages/app/src/server/alerts/delivery/targeting.test.ts
@@ -25,6 +25,10 @@ vi.mock("@/db/client", () => ({
   pool: {},
 }));
 
+import {
+  ALERTING_DEFAULT_GROUP_INTERVAL_SECS,
+  ALERTING_DEFAULT_GROUP_WAIT_SECS,
+} from "@/data/alerting/routing/defaults";
 import type { alertEvents } from "@/db/schema";
 import { dispatchTargetsForEvent } from "./targeting";
 
@@ -108,5 +112,34 @@ describe("routedDispatchTargets group_by default", () => {
     );
 
     expect(first.groupKey).not.toBe(second.groupKey);
+  });
+});
+
+describe("routedDispatchTargets timing defaults", () => {
+  it("falls back to the shared default wait and interval, not a local literal", async () => {
+    mocks.limitQueue = [[], [{ id: "receiver-1" }]];
+    mocks.joinQueue = [
+      [
+        {
+          route: {
+            id: "route-1",
+            priority: 0,
+            config: {
+              matchers: [],
+              group_wait_secs: null,
+              group_interval_secs: null,
+            },
+          },
+          receiver: "on-call",
+        },
+      ],
+    ];
+
+    const [target] = await dispatchTargetsForEvent(event());
+
+    expect(target.groupWaitSeconds).toBe(ALERTING_DEFAULT_GROUP_WAIT_SECS);
+    expect(target.groupIntervalSeconds).toBe(
+      ALERTING_DEFAULT_GROUP_INTERVAL_SECS,
+    );
   });
 });

--- a/packages/app/src/server/alerts/delivery/targeting.test.ts
+++ b/packages/app/src/server/alerts/delivery/targeting.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// dispatchTargetsForEvent issues three query shapes in order: the direct
+// destination lookup (from/where/limit), the route join (from/innerJoin/
+// where), then one receiver lookup (from/where/limit) per matched route.
+// Each queue entry answers the next query of its matching shape.
+const mocks = vi.hoisted(() => ({
+  limitQueue: [] as unknown[][],
+  joinQueue: [] as unknown[][],
+}));
+
+vi.mock("@/db/client", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => Promise.resolve(mocks.limitQueue.shift() ?? []),
+        }),
+        innerJoin: () => ({
+          where: () => Promise.resolve(mocks.joinQueue.shift() ?? []),
+        }),
+      }),
+    }),
+  },
+  pool: {},
+}));
+
+import type { alertEvents } from "@/db/schema";
+import { dispatchTargetsForEvent } from "./targeting";
+
+function event(
+  overrides: Partial<typeof alertEvents.$inferSelect> = {},
+): typeof alertEvents.$inferSelect {
+  return {
+    id: "019c3aba-29f8-7d6e-9e55-301cf47fa80d",
+    organizationId: "org-1",
+    sourceDefinitionId: "def-1",
+    eventType: "instance_fired",
+    severity: "critical",
+    instanceLabels: {},
+    ...overrides,
+  } as unknown as typeof alertEvents.$inferSelect;
+}
+
+beforeEach(() => {
+  mocks.limitQueue = [];
+  mocks.joinQueue = [];
+});
+
+describe("routedDispatchTargets group_by default", () => {
+  it("groups Automatic routes (group_by: null) by rule and severity", async () => {
+    mocks.limitQueue = [
+      [], // no direct destination: falls through to routing
+      [{ id: "receiver-1" }], // receiver lookup for the matched route
+    ];
+    mocks.joinQueue = [
+      [
+        {
+          route: {
+            id: "route-1",
+            priority: 0,
+            config: { matchers: [], group_by: null },
+          },
+          receiver: "on-call",
+        },
+      ],
+    ];
+
+    const targets = await dispatchTargetsForEvent(event());
+
+    expect(targets).toHaveLength(1);
+    expect(targets[0].groupLabels).toEqual({
+      rule: "def-1",
+      severity: "critical",
+    });
+  });
+
+  it("puts two different rules into two different groups under Automatic routing", async () => {
+    mocks.limitQueue = [[], [{ id: "receiver-1" }], [], [{ id: "receiver-1" }]];
+    mocks.joinQueue = [
+      [
+        {
+          route: {
+            id: "route-1",
+            priority: 0,
+            config: { matchers: [], group_by: null },
+          },
+          receiver: "on-call",
+        },
+      ],
+      [
+        {
+          route: {
+            id: "route-1",
+            priority: 0,
+            config: { matchers: [], group_by: null },
+          },
+          receiver: "on-call",
+        },
+      ],
+    ];
+
+    const [first] = await dispatchTargetsForEvent(
+      event({ sourceDefinitionId: "def-1" }),
+    );
+    const [second] = await dispatchTargetsForEvent(
+      event({ sourceDefinitionId: "def-2" }),
+    );
+
+    expect(first.groupKey).not.toBe(second.groupKey);
+  });
+});

--- a/packages/app/src/server/alerts/delivery/targeting.ts
+++ b/packages/app/src/server/alerts/delivery/targeting.ts
@@ -121,7 +121,10 @@ async function routedDispatchTargets(
     if (!receiver) continue;
     const labels = alertEventDispatchLabels(event);
     const groupLabels = Object.fromEntries(
-      (route.group_by ?? []).map((key) => [key, labels[key] ?? ""]),
+      (route.group_by ?? [...ALERTING_DEFAULT_GROUP_BY]).map((key) => [
+        key,
+        labels[key] ?? "",
+      ]),
     );
     targets.push({
       receiverId: receiver.id,

--- a/packages/app/src/server/alerts/delivery/targeting.ts
+++ b/packages/app/src/server/alerts/delivery/targeting.ts
@@ -131,8 +131,10 @@ async function routedDispatchTargets(
       directAlertDefinitionId: null,
       groupKey: alertDeliveryHash(receiver.id, stableJson(groupLabels)),
       groupLabels,
-      groupWaitSeconds: route.group_wait_secs ?? 30,
-      groupIntervalSeconds: route.group_interval_secs ?? 300,
+      groupWaitSeconds:
+        route.group_wait_secs ?? ALERTING_DEFAULT_GROUP_WAIT_SECS,
+      groupIntervalSeconds:
+        route.group_interval_secs ?? ALERTING_DEFAULT_GROUP_INTERVAL_SECS,
       repeatIntervalSeconds: route.repeat_interval_secs,
     });
   }

--- a/packages/app/src/server/alerts/delivery/tasks.test.ts
+++ b/packages/app/src/server/alerts/delivery/tasks.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+
+// The tasks module reaches the worker enqueue plumbing; the mock only keeps
+// the import from reaching the real database client.
+vi.mock("@/db/client", () => ({ db: {}, pool: {} }));
+
+import { flushGroupJobKey } from "./tasks";
+
+describe("flushGroupJobKey", () => {
+  it("keys on the group and its due time only, not the triggering event", () => {
+    const flushAt = new Date("2026-08-10T10:00:30.000Z");
+
+    // Two different events dispatching to the same group at the same
+    // nextFlushAt must build the identical key, or a storm of events fans
+    // out into one flush job per event instead of collapsing onto one.
+    expect(flushGroupJobKey("group-1", flushAt)).toBe(
+      flushGroupJobKey("group-1", flushAt),
+    );
+    expect(flushGroupJobKey("group-1", flushAt)).toBe(
+      "alerts/flush-group:group-1:2026-08-10T10:00:30.000Z",
+    );
+  });
+
+  it("differs across groups and across due times", () => {
+    const flushAt = new Date("2026-08-10T10:00:30.000Z");
+    const later = new Date("2026-08-10T10:05:00.000Z");
+
+    expect(flushGroupJobKey("group-1", flushAt)).not.toBe(
+      flushGroupJobKey("group-2", flushAt),
+    );
+    expect(flushGroupJobKey("group-1", flushAt)).not.toBe(
+      flushGroupJobKey("group-1", later),
+    );
+  });
+});

--- a/packages/app/src/server/alerts/delivery/tasks.ts
+++ b/packages/app/src/server/alerts/delivery/tasks.ts
@@ -22,6 +22,14 @@ export const IDLE_GROUP_FLUSH_AT = new Date("9999-12-31T23:59:59.999Z");
 
 export const PROCESS_EVENT_MAX_ATTEMPTS = 5;
 
+// A flush job's identity is the group and when it is due, nothing else. A
+// storm of events landing on one group must collapse onto the one job that
+// runs at that time, not enqueue one job per event: `jobKeyMode: "replace"`
+// only dedupes when both dispatch sites build the same key.
+export function flushGroupJobKey(groupId: string, flushAt: Date): string {
+  return `${ALERT_FLUSH_GROUP_TASK}:${groupId}:${flushAt.toISOString()}`;
+}
+
 // Every process-event enqueue shares one retry policy and one job-key scheme,
 // so a policy change is a one-site edit. The optional key suffix keeps
 // re-checks (deferrals, releases) from replacing the original dispatch job.

--- a/packages/app/src/server/alerts/evaluation/instances.test.ts
+++ b/packages/app/src/server/alerts/evaluation/instances.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   extractInstanceLabels,
   instanceFingerprint,
+  NULL_LABEL_VALUE,
   rowsToInstances,
 } from "./instances";
 
@@ -25,6 +26,20 @@ describe("extractInstanceLabels", () => {
     expect(extractInstanceLabels({ route: "/x" }, ["zone"])).toEqual({
       zone: "",
     });
+  });
+
+  // The regression: a SQL NULL and the literal empty string both mapped to
+  // "", so two distinct series shared one instance row.
+  it("maps an explicit SQL NULL to a value distinct from the empty string", () => {
+    expect(extractInstanceLabels({ zone: null }, ["zone"])).toEqual({
+      zone: NULL_LABEL_VALUE,
+    });
+    expect(NULL_LABEL_VALUE).not.toBe("");
+    expect(
+      instanceFingerprint(extractInstanceLabels({ zone: null }, ["zone"])),
+    ).not.toBe(
+      instanceFingerprint(extractInstanceLabels({ zone: "" }, ["zone"])),
+    );
   });
 
   it("returns empty labels for rows with no string columns", () => {

--- a/packages/app/src/server/alerts/evaluation/instances.test.ts
+++ b/packages/app/src/server/alerts/evaluation/instances.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  diffInstances,
   extractInstanceLabels,
   instanceFingerprint,
   rowsToInstances,
@@ -51,7 +50,6 @@ describe("instanceFingerprint", () => {
 
 describe("rowsToInstances", () => {
   it("keeps the first row per fingerprint", () => {
-    const firedAt = new Date("2026-06-12T10:00:00Z");
     const instances = rowsToInstances(
       [
         { route: "/x", error_count: 9 },
@@ -59,38 +57,9 @@ describe("rowsToInstances", () => {
         { route: "/y", error_count: 1 },
       ],
       [],
-      firedAt,
     );
     expect(instances).toHaveLength(2);
     expect(instances[0].labels).toEqual({ route: "/x" });
     expect(instances[0].row).toEqual({ route: "/x", error_count: 9 });
-    expect(instances[0].firedAt).toBe(firedAt);
-  });
-});
-
-describe("diffInstances", () => {
-  const inst = (route: string) => {
-    const labels = { route };
-    return { fingerprint: instanceFingerprint(labels), labels, row: { route } };
-  };
-
-  it("computes newlyFired and nowResolved", () => {
-    const prevX = {
-      fingerprint: instanceFingerprint({ route: "/x" }),
-      labels: { route: "/x" },
-    };
-    const prevZ = {
-      fingerprint: instanceFingerprint({ route: "/z" }),
-      labels: { route: "/z" },
-    };
-    const diff = diffInstances([prevX, prevZ], [inst("/x"), inst("/y")]);
-    expect(diff.newlyFired.map((i) => i.labels.route)).toEqual(["/y"]);
-    expect(diff.nowResolved.map((i) => i.labels.route)).toEqual(["/z"]);
-  });
-
-  it("handles empty to empty", () => {
-    const diff = diffInstances([], []);
-    expect(diff.newlyFired).toEqual([]);
-    expect(diff.nowResolved).toEqual([]);
   });
 });

--- a/packages/app/src/server/alerts/evaluation/instances.ts
+++ b/packages/app/src/server/alerts/evaluation/instances.ts
@@ -1,20 +1,9 @@
 import { createHash } from "node:crypto";
 
-export interface FiringInstance {
+export interface AlertInstance {
   fingerprint: string;
   labels: Record<string, string>;
-  // Start of the current firing streak. Absent when the backing event predates
-  // this field or its timestamp failed to parse.
-  firedAt?: Date;
-}
-
-export interface AlertInstance extends FiringInstance {
   row: Record<string, unknown>;
-}
-
-export interface InstanceDiff {
-  newlyFired: AlertInstance[];
-  nowResolved: FiringInstance[];
 }
 
 export function extractInstanceLabels(
@@ -44,13 +33,9 @@ export function instanceFingerprint(labels: Record<string, string>): string {
   return createHash("sha256").update(canonical).digest("hex").slice(0, 16);
 }
 
-// firedAt is the evaluation time: it is only meaningful for instances that
-// turn out to be newly fired (diffInstances keeps the previous set's own
-// timestamps for everything else that consumers look at).
 export function rowsToInstances(
   rows: readonly Record<string, unknown>[],
   instanceLabelColumns: readonly string[],
-  firedAt: Date,
 ): AlertInstance[] {
   const instances: AlertInstance[] = [];
   const seen = new Set<string>();
@@ -59,21 +44,7 @@ export function rowsToInstances(
     const fingerprint = instanceFingerprint(labels);
     if (seen.has(fingerprint)) continue;
     seen.add(fingerprint);
-    instances.push({ fingerprint, labels, firedAt, row });
+    instances.push({ fingerprint, labels, row });
   }
   return instances;
-}
-
-export function diffInstances(
-  previous: readonly FiringInstance[],
-  current: readonly AlertInstance[],
-): InstanceDiff {
-  const previousFingerprints = new Set(previous.map((i) => i.fingerprint));
-  const currentFingerprints = new Set(current.map((i) => i.fingerprint));
-  return {
-    newlyFired: current.filter((i) => !previousFingerprints.has(i.fingerprint)),
-    nowResolved: previous.filter(
-      (i) => !currentFingerprints.has(i.fingerprint),
-    ),
-  };
 }

--- a/packages/app/src/server/alerts/evaluation/instances.ts
+++ b/packages/app/src/server/alerts/evaluation/instances.ts
@@ -6,6 +6,12 @@ export interface AlertInstance {
   row: Record<string, unknown>;
 }
 
+// A SQL NULL and the literal empty string are different values; collapsing
+// both to "" would fingerprint two distinct series as the same instance.
+// Missing columns (the key absent from the row entirely) still map to "",
+// since there is no SQL value there to distinguish.
+export const NULL_LABEL_VALUE = "<null>";
+
 export function extractInstanceLabels(
   row: Record<string, unknown>,
   instanceLabelColumns: readonly string[],
@@ -15,7 +21,11 @@ export function extractInstanceLabels(
     for (const column of instanceLabelColumns) {
       const value = row[column];
       labels[column] =
-        value === undefined || value === null ? "" : String(value);
+        value === undefined
+          ? ""
+          : value === null
+            ? NULL_LABEL_VALUE
+            : String(value);
     }
     return labels;
   }

--- a/packages/app/src/server/alerts/evaluation/rule.test.ts
+++ b/packages/app/src/server/alerts/evaluation/rule.test.ts
@@ -52,6 +52,7 @@ vi.mock("../history/clickhouse", async (importOriginal) => ({
 import { ALERT_EVALUATE_TASK } from "@/data/alerting/scheduling/evaluation-jobs.server";
 import {
   evaluateAlert,
+  isNoopInactiveTransition,
   shouldEnqueueProcessEvent,
   transitionEventRows,
 } from "./rule";
@@ -438,5 +439,44 @@ describe("shouldEnqueueProcessEvent", () => {
     const [fired] = transitionEventRows(args("firing"));
     expect(fired?.outbox.kind).not.toBe("state");
     expect(shouldEnqueueProcessEvent(fired?.outbox ?? {})).toBe(true);
+  });
+});
+
+describe("isNoopInactiveTransition", () => {
+  const evaluatedAt = new Date("2026-08-06T10:00:00Z");
+  const inactiveInstance = {
+    fingerprint: "api",
+    status: "inactive" as const,
+    labels: { service: "api" },
+    evidence: {},
+    value: null,
+    pendingSince: null,
+    activeSince: null,
+    lastSeenAt: evaluatedAt,
+    absentCount: 0,
+  };
+
+  it("is true for a row that stayed inactive with no event", () => {
+    expect(
+      isNoopInactiveTransition({ next: inactiveInstance, event: null }),
+    ).toBe(true);
+  });
+
+  it("is false once an event fires, even if the row lands inactive", () => {
+    expect(
+      isNoopInactiveTransition({
+        next: inactiveInstance,
+        event: "pending_cleared",
+      }),
+    ).toBe(false);
+  });
+
+  it("is false for a live status with no event, such as a held pending", () => {
+    expect(
+      isNoopInactiveTransition({
+        next: { ...inactiveInstance, status: "pending" },
+        event: null,
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/app/src/server/alerts/evaluation/rule.test.ts
+++ b/packages/app/src/server/alerts/evaluation/rule.test.ts
@@ -2,6 +2,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   definition: null as unknown,
+  // The row a failure transaction's FOR UPDATE re-read sees. Defaults to
+  // mirror `definition`; tests that need to simulate a concurrent pause or
+  // delete between the outer read and the failure transaction override it.
+  freshDefinition: undefined as Record<string, unknown> | null | undefined,
   query: vi.fn(),
   transaction: vi.fn(),
   definitionUpdates: [] as Record<string, unknown>[],
@@ -63,7 +67,17 @@ function recordingTx() {
   return {
     select: () => ({
       from: () => ({
-        where: () => ({ for: () => ({ limit: () => Promise.resolve([]) }) }),
+        where: () => ({
+          for: () => ({
+            limit: () => {
+              const fresh =
+                mocks.freshDefinition === undefined
+                  ? { active: true, version: 3, consecutiveFailures: 0 }
+                  : mocks.freshDefinition;
+              return Promise.resolve(fresh === null ? [] : [fresh]);
+            },
+          }),
+        }),
       }),
     }),
     insert: () => ({
@@ -118,6 +132,7 @@ const payload = {
 describe("evaluateAlert scheduling state", () => {
   beforeEach(() => {
     mocks.definition = definition;
+    mocks.freshDefinition = undefined;
     mocks.definitionUpdates = [];
     mocks.scheduledJobs = [];
     mocks.query.mockReset();
@@ -186,6 +201,64 @@ describe("evaluateAlert scheduling state", () => {
     );
     expect(reschedule).toBeDefined();
     expect(reschedule?.lastEnqueuedAt).toEqual(reschedule?.nextEvaluationAt);
+  });
+
+  // A pause or delete racing the failed evaluation must win: writing the
+  // rule back degraded with a queued retry would resurrect a rule the user
+  // just turned off, and a deleted rule's id would violate the
+  // alert_evaluations foreign key.
+  it("drops the failure silently when the rule went inactive mid-flight", async () => {
+    mocks.query.mockResolvedValue({ rows: [] });
+    mocks.freshDefinition = {
+      active: false,
+      version: 3,
+      consecutiveFailures: 0,
+    };
+    mocks.transaction
+      .mockRejectedValueOnce(new Error("instance write blew up"))
+      .mockImplementationOnce((cb: (tx: unknown) => Promise<unknown>) =>
+        cb(recordingTx()),
+      );
+
+    await expect(evaluateAlert(payload)).resolves.toBeUndefined();
+
+    expect(mocks.definitionUpdates).toEqual([]);
+    expect(mocks.scheduledJobs).toEqual([]);
+    expect(mocks.history).not.toHaveBeenCalled();
+  });
+
+  it("drops the failure silently when the rule was deleted mid-flight", async () => {
+    mocks.query.mockResolvedValue({ rows: [] });
+    mocks.freshDefinition = null;
+    mocks.transaction
+      .mockRejectedValueOnce(new Error("instance write blew up"))
+      .mockImplementationOnce((cb: (tx: unknown) => Promise<unknown>) =>
+        cb(recordingTx()),
+      );
+
+    await expect(evaluateAlert(payload)).resolves.toBeUndefined();
+
+    expect(mocks.definitionUpdates).toEqual([]);
+    expect(mocks.scheduledJobs).toEqual([]);
+  });
+
+  it("drops the failure silently when the rule's spec version moved on", async () => {
+    mocks.query.mockResolvedValue({ rows: [] });
+    mocks.freshDefinition = {
+      active: true,
+      version: 4,
+      consecutiveFailures: 0,
+    };
+    mocks.transaction
+      .mockRejectedValueOnce(new Error("instance write blew up"))
+      .mockImplementationOnce((cb: (tx: unknown) => Promise<unknown>) =>
+        cb(recordingTx()),
+      );
+
+    await expect(evaluateAlert(payload)).resolves.toBeUndefined();
+
+    expect(mocks.definitionUpdates).toEqual([]);
+    expect(mocks.scheduledJobs).toEqual([]);
   });
 
   it("records the failure reason for a non-query error", async () => {

--- a/packages/app/src/server/alerts/evaluation/rule.test.ts
+++ b/packages/app/src/server/alerts/evaluation/rule.test.ts
@@ -166,6 +166,27 @@ describe("evaluateAlert scheduling state", () => {
     );
   });
 
+  // The regression: only nextEvaluationAt advanced, so the scanner's
+  // lastEnqueuedAt < nextEvaluationAt clause stayed permanently true and it
+  // re-enqueued every rule on every tick, on top of whatever chain the rule
+  // itself was already running.
+  it("advances lastEnqueuedAt together with nextEvaluationAt on reschedule", async () => {
+    mocks.query.mockResolvedValue({ rows: [] });
+    mocks.transaction
+      .mockRejectedValueOnce(new Error("instance write blew up"))
+      .mockImplementationOnce((cb: (tx: unknown) => Promise<unknown>) =>
+        cb(recordingTx()),
+      );
+
+    await evaluateAlert(payload);
+
+    const reschedule = mocks.definitionUpdates.find(
+      (update) => "nextEvaluationAt" in update,
+    );
+    expect(reschedule).toBeDefined();
+    expect(reschedule?.lastEnqueuedAt).toEqual(reschedule?.nextEvaluationAt);
+  });
+
   it("records the failure reason for a non-query error", async () => {
     mocks.query.mockResolvedValue({ rows: [] });
     mocks.transaction

--- a/packages/app/src/server/alerts/evaluation/rule.test.ts
+++ b/packages/app/src/server/alerts/evaluation/rule.test.ts
@@ -466,6 +466,24 @@ describe("transitionEventRows episode stamping", () => {
     expect(resolved?.outbox.kind).toBe("notifying");
     expect(resolved?.history.reason).toBe("condition_cleared");
   });
+
+  // The caller (evaluateAlertRule) computes bounded evidence once per
+  // transition and passes it in so it is not recomputed here from the same
+  // inputs.
+  it("uses the caller's precomputed bounded evidence instead of recomputing it", () => {
+    const [fired] = transitionEventRows({
+      def: episodeDef,
+      historyDef,
+      transition: transition("firing"),
+      evaluatedAt,
+      storedEpisodeId: null,
+      bounded: { evidence: { injected: "marker" }, truncated: true },
+    });
+    expect(fired?.history.evidence_json).toBe(
+      JSON.stringify({ injected: "marker" }),
+    );
+    expect(fired?.history.evidence_truncated).toBe(true);
+  });
 });
 
 describe("shouldEnqueueProcessEvent", () => {

--- a/packages/app/src/server/alerts/evaluation/rule.test.ts
+++ b/packages/app/src/server/alerts/evaluation/rule.test.ts
@@ -6,6 +6,11 @@ const mocks = vi.hoisted(() => ({
   // mirror `definition`; tests that need to simulate a concurrent pause or
   // delete between the outer read and the failure transaction override it.
   freshDefinition: undefined as Record<string, unknown> | null | undefined,
+  // The alert_instances rows a fresh evaluateAlertRule call reads back, as
+  // if they were the previous call's persisted state.
+  instanceRows: [] as Record<string, unknown>[],
+  instanceUpserts: [] as Record<string, unknown>[],
+  eventRows: [] as Record<string, unknown>[],
   query: vi.fn(),
   transaction: vi.fn(),
   definitionUpdates: [] as Record<string, unknown>[],
@@ -29,7 +34,7 @@ vi.mock("@/db/client", () => ({
         // The two reads differ in shape: the definition lookup ends in
         // .limit(1), the instance lookup awaits .where() directly.
         where: () =>
-          Object.assign(Promise.resolve([] as unknown[]), {
+          Object.assign(Promise.resolve(mocks.instanceRows), {
             limit: () => Promise.resolve([mocks.definition]),
           }),
       }),
@@ -54,6 +59,8 @@ vi.mock("../history/clickhouse", async (importOriginal) => ({
 }));
 
 import { ALERT_EVALUATE_TASK } from "@/data/alerting/scheduling/evaluation-jobs.server";
+import { alertEvaluations, alertEvents, alertInstances } from "@/db/schema";
+import { ALERT_PROCESS_EVENT_TASK } from "../delivery/tasks";
 import {
   evaluateAlert,
   isNoopInactiveTransition,
@@ -96,6 +103,94 @@ function recordingTx() {
   };
 }
 
+/**
+ * Drives the real success-path transaction: the FOR UPDATE guard, the
+ * alert_evaluations dedup insert, and a table-aware insert() that applies
+ * INSERT ... ON CONFLICT DO UPDATE semantics against `mocks.instanceRows`
+ * (unset fields on a conflict keep the existing row's value, the same way
+ * Postgres does), so a later evaluateAlert call reading previousRows sees
+ * exactly what this one persisted.
+ */
+function fullTx(opts?: {
+  active?: boolean;
+  version?: number;
+  applies?: boolean;
+}) {
+  return {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          for: () => ({
+            limit: () =>
+              Promise.resolve(
+                (opts?.active ?? true)
+                  ? [
+                      {
+                        active: true,
+                        version: opts?.version ?? definition.version,
+                      },
+                    ]
+                  : [],
+              ),
+          }),
+        }),
+      }),
+    }),
+    insert: (table: unknown) => {
+      if (table === alertEvaluations) {
+        return {
+          values: () => ({
+            onConflictDoNothing: () => ({
+              returning: () =>
+                Promise.resolve(
+                  (opts?.applies ?? true)
+                    ? [{ alertDefinitionId: RULE_ID }]
+                    : [],
+                ),
+            }),
+          }),
+        };
+      }
+      if (table === alertInstances) {
+        return {
+          values: (row: Record<string, unknown>) => ({
+            onConflictDoUpdate: (upsert: { set: Record<string, unknown> }) => {
+              const existing = mocks.instanceRows.find(
+                (candidate) => candidate.fingerprint === row.fingerprint,
+              );
+              mocks.instanceUpserts.push(
+                existing ? { ...existing, ...upsert.set } : row,
+              );
+              return Promise.resolve();
+            },
+          }),
+        };
+      }
+      if (table === alertEvents) {
+        return {
+          values: (rows: Record<string, unknown>[]) => {
+            mocks.eventRows.push(...rows);
+            return Promise.resolve();
+          },
+        };
+      }
+      throw new Error("fullTx: unexpected insert table");
+    },
+    update: () => ({
+      set: (values: Record<string, unknown>) => {
+        mocks.definitionUpdates.push(values);
+        return { where: () => Promise.resolve() };
+      },
+    }),
+  };
+}
+
+/** Feeds the previous call's persisted instance rows into the next call. */
+function persistInstances() {
+  mocks.instanceRows = mocks.instanceUpserts;
+  mocks.instanceUpserts = [];
+}
+
 const RULE_ID = "6f1c9d20-3b7a-4c11-9f2e-8a5d4c3b2a10";
 
 const definition = {
@@ -116,9 +211,9 @@ const definition = {
     suppressed: false,
     interval_secs: 60,
     for_secs: 0,
-    resolve_after: 0,
-    label_columns: [],
-    condition: { column: "value", op: "gt", value: 0 },
+    resolve_after: 1,
+    label_columns: ["service"],
+    condition: { operator: "gt", threshold: 0 },
     annotations: {},
   },
 };
@@ -133,6 +228,9 @@ describe("evaluateAlert scheduling state", () => {
   beforeEach(() => {
     mocks.definition = definition;
     mocks.freshDefinition = undefined;
+    mocks.instanceRows = [];
+    mocks.instanceUpserts = [];
+    mocks.eventRows = [];
     mocks.definitionUpdates = [];
     mocks.scheduledJobs = [];
     mocks.query.mockReset();
@@ -569,5 +667,159 @@ describe("isNoopInactiveTransition", () => {
         event: null,
       }),
     ).toBe(false);
+  });
+});
+
+describe("evaluateAlert full evaluation lifecycle", () => {
+  const scheduledAt = (minute: number) => ({
+    ...payload,
+    scheduledFor: `2026-08-06T10:0${minute}:00.000Z`,
+  });
+
+  beforeEach(() => {
+    mocks.definition = definition;
+    mocks.instanceRows = [];
+    mocks.instanceUpserts = [];
+    mocks.eventRows = [];
+    mocks.definitionUpdates = [];
+    mocks.scheduledJobs = [];
+    mocks.query.mockReset();
+    mocks.transaction.mockReset();
+    mocks.history.mockReset().mockResolvedValue(undefined);
+    mocks.previewAlerts = "on";
+  });
+
+  it("drives an instance through fire, hold, and resolve across three evaluations", async () => {
+    // Fire: the first breaching evaluation, from no prior instance.
+    mocks.query.mockResolvedValueOnce({
+      rows: [{ service: "api", value: 5 }],
+    });
+    mocks.transaction.mockImplementationOnce(
+      (cb: (tx: unknown) => Promise<unknown>) => cb(fullTx()),
+    );
+    await evaluateAlert(scheduledAt(0));
+
+    expect(mocks.eventRows).toHaveLength(1);
+    expect(mocks.eventRows[0]).toMatchObject({
+      eventType: "instance_fired",
+      kind: "notifying",
+    });
+    const firedEventId = mocks.eventRows[0].id as string;
+    expect(mocks.scheduledJobs).toContainEqual(
+      expect.objectContaining({
+        task: ALERT_PROCESS_EVENT_TASK,
+        payload: { eventId: firedEventId },
+      }),
+    );
+    expect(mocks.instanceUpserts).toHaveLength(1);
+    expect(mocks.instanceUpserts[0]).toMatchObject({
+      status: "firing",
+      value: 5,
+      episodeId: firedEventId,
+    });
+    expect(mocks.definitionUpdates).toContainEqual(
+      expect.objectContaining({
+        currentState: "firing",
+        firingInstanceCount: 1,
+      }),
+    );
+
+    persistInstances();
+    mocks.eventRows = [];
+    mocks.scheduledJobs = [];
+    mocks.definitionUpdates = [];
+
+    // Hold: still breaching, so no new event, but the instance row keeps
+    // tracking the latest value on the episode fire already opened.
+    mocks.query.mockResolvedValueOnce({
+      rows: [{ service: "api", value: 7 }],
+    });
+    mocks.transaction.mockImplementationOnce(
+      (cb: (tx: unknown) => Promise<unknown>) => cb(fullTx()),
+    );
+    await evaluateAlert(scheduledAt(1));
+
+    expect(mocks.eventRows).toHaveLength(0);
+    expect(mocks.instanceUpserts).toHaveLength(1);
+    expect(mocks.instanceUpserts[0]).toMatchObject({
+      status: "firing",
+      value: 7,
+      episodeId: firedEventId,
+    });
+    expect(
+      mocks.scheduledJobs.some((job) => job.task === ALERT_PROCESS_EVENT_TASK),
+    ).toBe(false);
+
+    persistInstances();
+    mocks.eventRows = [];
+    mocks.scheduledJobs = [];
+    mocks.definitionUpdates = [];
+
+    // Resolve: the row drops out of the query result entirely.
+    mocks.query.mockResolvedValueOnce({ rows: [] });
+    mocks.transaction.mockImplementationOnce(
+      (cb: (tx: unknown) => Promise<unknown>) => cb(fullTx()),
+    );
+    await evaluateAlert(scheduledAt(2));
+
+    expect(mocks.eventRows).toHaveLength(1);
+    expect(mocks.eventRows[0]).toMatchObject({
+      eventType: "instance_resolved",
+      kind: "notifying",
+    });
+    expect(mocks.instanceUpserts[0]).toMatchObject({
+      status: "inactive",
+      episodeId: null,
+    });
+    expect(mocks.definitionUpdates).toContainEqual(
+      expect.objectContaining({
+        currentState: "resolved",
+        firingInstanceCount: 0,
+      }),
+    );
+  });
+
+  // The applied === false guard: a duplicate scheduledFor (already recorded)
+  // must not write a second copy of anything.
+  it("suppresses a stale evaluation instead of writing anything", async () => {
+    mocks.query.mockResolvedValueOnce({
+      rows: [{ service: "api", value: 5 }],
+    });
+    mocks.transaction.mockImplementationOnce(
+      (cb: (tx: unknown) => Promise<unknown>) => cb(fullTx({ applies: false })),
+    );
+
+    await evaluateAlert(payload);
+
+    expect(mocks.instanceUpserts).toEqual([]);
+    expect(mocks.eventRows).toEqual([]);
+    expect(mocks.history).not.toHaveBeenCalled();
+  });
+
+  it("does not enqueue a process job for a state-kind pending transition", async () => {
+    mocks.definition = {
+      ...definition,
+      spec: { ...definition.spec, for_secs: 300 },
+    };
+    mocks.query.mockResolvedValueOnce({
+      rows: [{ service: "api", value: 5 }],
+    });
+    mocks.transaction.mockImplementationOnce(
+      (cb: (tx: unknown) => Promise<unknown>) => cb(fullTx()),
+    );
+
+    await evaluateAlert(payload);
+
+    expect(mocks.eventRows).toHaveLength(1);
+    expect(mocks.eventRows[0]).toMatchObject({
+      eventType: "instance_pending",
+      kind: "state",
+    });
+    expect(
+      mocks.scheduledJobs.some((job) => job.task === ALERT_PROCESS_EVENT_TASK),
+    ).toBe(false);
+    expect(
+      mocks.scheduledJobs.some((job) => job.task === ALERT_EVALUATE_TASK),
+    ).toBe(true);
   });
 });

--- a/packages/app/src/server/alerts/evaluation/rule.ts
+++ b/packages/app/src/server/alerts/evaluation/rule.ts
@@ -146,6 +146,17 @@ export function shouldEnqueueProcessEvent(
   return outbox.kind !== "state";
 }
 
+/**
+ * A row that was already inactive and is still absent carries nothing new:
+ * rewriting it every tick would defeat the retention cutoff on
+ * `alert_instances`, since `updated_at` would never age.
+ */
+export function isNoopInactiveTransition(
+  transition: Pick<AlertInstanceTransition, "event" | "next">,
+): boolean {
+  return transition.event === null && transition.next.status === "inactive";
+}
+
 export function transitionEventRows(opts: {
   def: typeof alertDefinitions.$inferSelect;
   historyDef: AlertHistoryDefinition;
@@ -465,6 +476,7 @@ async function evaluateAlertRule(
     if (inserted.length === 0) return false;
 
     for (const transition of transitions) {
+      if (isNoopInactiveTransition(transition)) continue;
       const next = transition.next;
       const boundedInstanceEvidence = boundEventEvidence(
         next.evidence,

--- a/packages/app/src/server/alerts/evaluation/rule.ts
+++ b/packages/app/src/server/alerts/evaluation/rule.ts
@@ -246,7 +246,7 @@ async function scheduleAlertAtInTransaction(
   };
   await tx
     .update(alertDefinitions)
-    .set({ nextEvaluationAt: runAt })
+    .set({ nextEvaluationAt: runAt, lastEnqueuedAt: runAt })
     .where(eq(alertDefinitions.id, def.id));
   await addWorkerJobInTransaction(tx, ALERT_EVALUATE_TASK, payload, {
     jobKey: alertEvaluationJobKey(def.id, payload.scheduledFor),

--- a/packages/app/src/server/alerts/evaluation/rule.ts
+++ b/packages/app/src/server/alerts/evaluation/rule.ts
@@ -164,11 +164,18 @@ export function transitionEventRows(opts: {
   evaluatedAt: Date;
   /** The instance's open episode before this evaluation, if any. */
   storedEpisodeId: string | null;
+  /**
+   * Precomputed `boundEventEvidence(transition.next.evidence,
+   * transition.next.labels)`, when the caller already needs it elsewhere for
+   * the same transition. Computed on demand otherwise.
+   */
+  bounded?: { evidence: Record<string, unknown>; truncated: boolean };
 }): TransitionEvent[] {
   const { def, historyDef, transition, evaluatedAt } = opts;
   if (!transition.event) return [];
   const next = transition.next;
-  const bounded = boundEventEvidence(next.evidence, next.labels);
+  const bounded =
+    opts.bounded ?? boundEventEvidence(next.evidence, next.labels);
   const firstRow: Record<string, unknown> = {
     ...bounded.evidence,
     ...next.labels,
@@ -459,6 +466,17 @@ async function evaluateAlertRule(
     previousRows.map((row) => [row.fingerprint, row.episodeId]),
   );
   const historyDef = historyDefinition(def);
+  // Computed once per transition and reused for both the journal row below
+  // and the instance upsert further down, instead of recomputing the same
+  // bound evidence twice from the same inputs.
+  const boundedEvidenceByFingerprint = new Map(
+    transitions
+      .filter((transition) => !isNoopInactiveTransition(transition))
+      .map((transition) => [
+        transition.next.fingerprint,
+        boundEventEvidence(transition.next.evidence, transition.next.labels),
+      ]),
+  );
   const transitionEvents = transitions.flatMap((transition) =>
     transitionEventRows({
       def,
@@ -467,6 +485,7 @@ async function evaluateAlertRule(
       evaluatedAt,
       storedEpisodeId:
         storedEpisodeByFingerprint.get(transition.next.fingerprint) ?? null,
+      bounded: boundedEvidenceByFingerprint.get(transition.next.fingerprint),
     }),
   );
   const episodeUpdateByFingerprint = new Map(
@@ -502,10 +521,16 @@ async function evaluateAlertRule(
     for (const transition of transitions) {
       if (isNoopInactiveTransition(transition)) continue;
       const next = transition.next;
-      const boundedInstanceEvidence = boundEventEvidence(
-        next.evidence,
-        next.labels,
+      const boundedInstanceEvidence = boundedEvidenceByFingerprint.get(
+        next.fingerprint,
       );
+      // Every non-skipped transition got an entry above, keyed by the same
+      // fingerprint.
+      if (!boundedInstanceEvidence) {
+        throw new Error(
+          `missing bounded evidence for fingerprint ${next.fingerprint}`,
+        );
+      }
       // Only a transition moves the episode; a quiet evaluation must not
       // clear an open one.
       const episodeUpdate = episodeUpdateByFingerprint.get(next.fingerprint);

--- a/packages/app/src/server/alerts/evaluation/rule.ts
+++ b/packages/app/src/server/alerts/evaluation/rule.ts
@@ -399,10 +399,6 @@ async function evaluateAlertRule(
 
   const evaluatedAt = new Date();
   const evidence = boundEvidence(rows);
-  const capturedSamples = captureAlertEvaluationSamples(
-    rows,
-    def.spec.label_columns,
-  );
   const present = rowsToInstances(
     rows.filter((row) => alertingConditionMatches(row, def.spec.condition)),
     def.spec.label_columns,
@@ -417,6 +413,14 @@ async function evaluateAlertRule(
   );
   const presentByFingerprint = new Map(
     present.map((instance) => [instance.fingerprint, instance]),
+  );
+  // Matching rows first, so a rule with more than the sample cap's worth of
+  // label sets never buries the breaching ones under healthy filler and the
+  // series doesn't miss a breach that paged someone.
+  const capturedSamples = captureAlertEvaluationSamples(
+    rows,
+    def.spec.label_columns,
+    new Set(presentByFingerprint.keys()),
   );
   const previousRows = await db
     .select()

--- a/packages/app/src/server/alerts/evaluation/rule.ts
+++ b/packages/app/src/server/alerts/evaluation/rule.ts
@@ -270,12 +270,33 @@ async function scheduleAlertAtInTransaction(
 
 async function recordEvaluationFailure(
   def: typeof alertDefinitions.$inferSelect,
+  payload: z.infer<typeof EvaluatePayloadSchema>,
   scheduledFor: Date,
   cause: unknown,
 ) {
   const message = errorMessage(cause).slice(0, 8_000);
   const occurredAt = new Date();
   const applied = await db.transaction(async (tx) => {
+    // Mirrors the success path's guard: a rule paused or deleted between the
+    // outer read and this transaction must not be written back degraded
+    // with a queued retry, and a deleted rule's id would violate the
+    // alert_evaluations FK below.
+    const [fresh] = await tx
+      .select({
+        active: alertDefinitions.active,
+        version: alertDefinitions.version,
+        consecutiveFailures: alertDefinitions.consecutiveFailures,
+      })
+      .from(alertDefinitions)
+      .where(eq(alertDefinitions.id, def.id))
+      .for("update")
+      .limit(1);
+    if (
+      !fresh?.active ||
+      (payload.ruleVersion !== undefined &&
+        fresh.version !== payload.ruleVersion)
+    )
+      return false;
     const inserted = await tx
       .insert(alertEvaluations)
       .values({ alertDefinitionId: def.id, scheduledFor })
@@ -293,7 +314,7 @@ async function recordEvaluationFailure(
         degradedSince: sql`coalesce(${alertDefinitions.degradedSince}, now())`,
       })
       .where(eq(alertDefinitions.id, def.id));
-    const failureCount = def.consecutiveFailures + 1;
+    const failureCount = fresh.consecutiveFailures + 1;
     const maximum = def.spec.max_interval_secs ?? def.spec.interval_secs * 16;
     const backoff = alertingRetryDelaySeconds(
       def.spec.interval_secs,
@@ -360,7 +381,7 @@ export async function evaluateAlert(rawPayload: unknown): Promise<void> {
   try {
     await evaluateAlertRule(def, payload, scheduledFor);
   } catch (cause) {
-    await recordEvaluationFailure(def, scheduledFor, cause);
+    await recordEvaluationFailure(def, payload, scheduledFor, cause);
   }
 }
 

--- a/packages/app/src/server/alerts/evaluation/rule.ts
+++ b/packages/app/src/server/alerts/evaluation/rule.ts
@@ -402,7 +402,6 @@ async function evaluateAlertRule(
   const present = rowsToInstances(
     rows.filter((row) => alertingConditionMatches(row, def.spec.condition)),
     def.spec.label_columns,
-    evaluatedAt,
   ).map(
     (instance): PresentAlertInstance => ({
       fingerprint: instance.fingerprint,

--- a/packages/app/src/server/alerts/evaluation/samples.test.ts
+++ b/packages/app/src/server/alerts/evaluation/samples.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { instanceFingerprint } from "./instances";
 import {
   ALERT_EVALUATION_SAMPLE_LIMIT,
   captureAlertEvaluationSamples,
@@ -12,6 +13,7 @@ describe("captureAlertEvaluationSamples", () => {
         { service: "worker", value: 2 },
       ],
       ["service"],
+      new Set(),
     );
 
     expect(result).toEqual({
@@ -38,12 +40,38 @@ describe("captureAlertEvaluationSamples", () => {
     );
     rows.push({ service: "service-0", value: 999 });
 
-    const result = captureAlertEvaluationSamples(rows, ["service"]);
+    const result = captureAlertEvaluationSamples(rows, ["service"], new Set());
 
     expect(result.samples).toHaveLength(ALERT_EVALUATION_SAMPLE_LIMIT);
     expect(result.samples[0]).toMatchObject({
       labels: { service: "service-0" },
       value: 0,
+    });
+    expect(result.truncated).toBe(true);
+  });
+
+  // The regression: samples sliced raw query order, so a breach sitting past
+  // the cap in an otherwise-healthy result set never made it into the stored
+  // samples at all, and the series that reads them (evaluation-series.ts)
+  // had nothing to find.
+  it("puts matching label sets first so a late breach survives the sample cap", () => {
+    const rows = Array.from(
+      { length: ALERT_EVALUATION_SAMPLE_LIMIT },
+      (_, i) => ({ service: `healthy-${i}`, value: 1 }),
+    );
+    rows.push({ service: "breaching", value: 999 });
+    const matchingFingerprint = instanceFingerprint({ service: "breaching" });
+
+    const result = captureAlertEvaluationSamples(
+      rows,
+      ["service"],
+      new Set([matchingFingerprint]),
+    );
+
+    expect(result.samples).toHaveLength(ALERT_EVALUATION_SAMPLE_LIMIT);
+    expect(result.samples[0]).toMatchObject({
+      labels: { service: "breaching" },
+      value: 999,
     });
     expect(result.truncated).toBe(true);
   });

--- a/packages/app/src/server/alerts/evaluation/samples.ts
+++ b/packages/app/src/server/alerts/evaluation/samples.ts
@@ -13,7 +13,7 @@ export function captureAlertEvaluationSamples(
   instanceLabelColumns: readonly string[],
   matchingFingerprints: ReadonlySet<string>,
 ): { samples: AlertingEvaluationSample[]; truncated: boolean } {
-  const instances = rowsToInstances(rows, instanceLabelColumns, new Date(0));
+  const instances = rowsToInstances(rows, instanceLabelColumns);
   // Matching instances first: a rule with more label sets than the sample
   // budget must not let healthy filler crowd out the breaching ones, or a
   // breach the chart is supposed to guarantee survives downsampling

--- a/packages/app/src/server/alerts/evaluation/samples.ts
+++ b/packages/app/src/server/alerts/evaluation/samples.ts
@@ -11,16 +11,29 @@ export const ALERT_EVALUATION_SAMPLE_LIMIT = 64;
 export function captureAlertEvaluationSamples(
   rows: readonly Record<string, unknown>[],
   instanceLabelColumns: readonly string[],
+  matchingFingerprints: ReadonlySet<string>,
 ): { samples: AlertingEvaluationSample[]; truncated: boolean } {
   const instances = rowsToInstances(rows, instanceLabelColumns, new Date(0));
+  // Matching instances first: a rule with more label sets than the sample
+  // budget must not let healthy filler crowd out the breaching ones, or a
+  // breach the chart is supposed to guarantee survives downsampling
+  // (evaluation-series.ts) never makes it into the samples that feed it.
+  const ordered = [
+    ...instances.filter((instance) =>
+      matchingFingerprints.has(instance.fingerprint),
+    ),
+    ...instances.filter(
+      (instance) => !matchingFingerprints.has(instance.fingerprint),
+    ),
+  ];
   return {
-    samples: instances
+    samples: ordered
       .slice(0, ALERT_EVALUATION_SAMPLE_LIMIT)
       .map((instance) => ({
         fingerprint: instance.fingerprint,
         labels: instance.labels,
         value: alertingConditionValue(instance.row),
       })),
-    truncated: instances.length > ALERT_EVALUATION_SAMPLE_LIMIT,
+    truncated: ordered.length > ALERT_EVALUATION_SAMPLE_LIMIT,
   };
 }

--- a/packages/app/src/server/alerts/history/clickhouse.test.ts
+++ b/packages/app/src/server/alerts/history/clickhouse.test.ts
@@ -97,6 +97,8 @@ describe("ClickHouse alert history", () => {
     expect(transition).toMatchObject({
       event_id: "019c3aba-29f8-7d6e-9e55-301cf47fa80d",
       event_type: "instance_fired",
+      // A transition runs no query; row_count must not claim otherwise.
+      row_count: 0,
       evidence_json: '{"value":42}',
       context_json: '{"summary":"42 errors"}',
       instance_labels: { service: "api" },

--- a/packages/app/src/server/alerts/history/clickhouse.test.ts
+++ b/packages/app/src/server/alerts/history/clickhouse.test.ts
@@ -19,6 +19,7 @@ import {
   evaluationHistoryRow,
   instanceHistoryRow,
   recordAlertHistory,
+  recordAlertHistoryStrict,
   suppressionHistoryRow,
   ZERO_UUID,
 } from "./clickhouse";
@@ -361,5 +362,81 @@ describe("ClickHouse alert history", () => {
         "error.handled": true,
       }),
     );
+  });
+
+  describe("recordAlertHistoryStrict", () => {
+    // A Graphile retry resends the exact same rows (built from the same
+    // journal rows read by id), so a stable token is what makes the retry
+    // converge instead of duplicating terminal rows.
+    it("inserts synchronously with a token derived from the sorted row ids", async () => {
+      const first = suppressionHistoryRow({
+        def,
+        notificationEventId: "019c3aba-29f8-7d6e-9e55-301cf47fa80d",
+        occurredAt,
+        fingerprint: "api",
+        labels: { service: "api" },
+        silenced: false,
+        inhibited: false,
+        silenceId: null,
+        reason: "rule_paused",
+      });
+      const second = instanceHistoryRow({
+        def,
+        eventId: "019c3aba-1111-7d6e-9e55-301cf47fa80d",
+        eventType: "instance_closed",
+        occurredAt,
+        episodeId: ZERO_UUID,
+        fingerprint: "api",
+        labels: { service: "api" },
+        evidence: {},
+        evidenceTruncated: false,
+        contextJson: "{}",
+        reason: "rule_paused",
+      });
+
+      // Passed in reverse-sorted order: the token must not depend on it.
+      await recordAlertHistoryStrict([first, second]);
+
+      expect(mocks.insertAdminRows).toHaveBeenCalledWith(
+        "app.alert_events",
+        [first, second],
+        {
+          async_insert: 0,
+          date_time_input_format: "best_effort",
+          insert_deduplication_token: `app.alert_events:${[
+            first.event_id,
+            second.event_id,
+          ]
+            .sort()
+            .join(",")}`,
+        },
+      );
+    });
+
+    it("does not insert for an empty batch", async () => {
+      await recordAlertHistoryStrict([]);
+      expect(mocks.insertAdminRows).not.toHaveBeenCalled();
+    });
+
+    it("throws rather than swallowing a failed insert", async () => {
+      mocks.insertAdminRows.mockRejectedValue(new Error("unavailable"));
+      const row = instanceHistoryRow({
+        def,
+        eventId: "019c3aba-29f8-7d6e-9e55-301cf47fa80d",
+        eventType: "instance_closed",
+        occurredAt,
+        episodeId: ZERO_UUID,
+        fingerprint: "api",
+        labels: { service: "api" },
+        evidence: {},
+        evidenceTruncated: false,
+        contextJson: "{}",
+        reason: "rule_paused",
+      });
+
+      await expect(recordAlertHistoryStrict([row])).rejects.toThrow(
+        "unavailable",
+      );
+    });
   });
 });

--- a/packages/app/src/server/alerts/history/clickhouse.ts
+++ b/packages/app/src/server/alerts/history/clickhouse.ts
@@ -19,7 +19,11 @@ export const ZERO_UUID = "00000000-0000-0000-0000-000000000000";
 // evaluation rows it is the epoch sentinel, never a smuggled second timestamp.
 const EPOCH_ISO = "1970-01-01T00:00:00.000Z";
 
-type AlertHistoryEventType =
+// The single source of truth for what `event_type` can hold in ClickHouse.
+// Readers (data/alerting/history/event-types.ts) type-only import this so a
+// renamed or removed event type is a compile error everywhere it is
+// consumed, not a silently empty query result.
+export type AlertHistoryEventType =
   | "evaluation_succeeded"
   | "evaluation_failed"
   | "instance_pending"

--- a/packages/app/src/server/alerts/history/clickhouse.ts
+++ b/packages/app/src/server/alerts/history/clickhouse.ts
@@ -343,7 +343,7 @@ export function deliveryHistoryRow(opts: {
   };
 }
 
-function insertAlertHistoryRows(rows: AlertHistoryRow[]): Promise<void> {
+function insertAlertHistoryRowsAsync(rows: AlertHistoryRow[]): Promise<void> {
   return insertAdminRows("app.alert_events", rows, {
     async_insert: 1,
     wait_for_async_insert: 1,
@@ -351,17 +351,42 @@ function insertAlertHistoryRows(rows: AlertHistoryRow[]): Promise<void> {
   });
 }
 
+// Anchors dedup to the batch's logical identity (which journal or hold-decision
+// rows it projects), not to matching insert bytes: the same rows in a
+// different order, or from a racing second writer, still converge.
+function alertHistoryDedupToken(rows: readonly AlertHistoryRow[]): string {
+  const ids = rows.map((row) => row.event_id).sort();
+  return `app.alert_events:${ids.join(",")}`;
+}
+
+// Retry convergence needs insert_deduplication_token to actually dedup, and
+// that requires a synchronous insert: non_replicated_deduplication_window
+// (set on the table) documents token dedup for regular inserts on a
+// non-replicated MergeTree, but token handling under async_insert has been
+// inconsistent across ClickHouse versions. This path is a rare lifecycle
+// projection, not the hot path, so paying for a synchronous insert here is
+// cheap.
+function insertAlertHistoryRowsSync(rows: AlertHistoryRow[]): Promise<void> {
+  return insertAdminRows("app.alert_events", rows, {
+    async_insert: 0,
+    date_time_input_format: "best_effort",
+    insert_deduplication_token: alertHistoryDedupToken(rows),
+  });
+}
+
 /**
  * The throwing form, for callers whose only job is the insert: the lifecycle
  * projection runs as a Graphile task with retries, and a swallowed failure
- * there would report success while the chain's terminals are lost. Deterministic
- * row ids make the retry convergent.
+ * there would report success while the chain's terminals are lost. This path
+ * inserts synchronously with insert_deduplication_token set from the sorted
+ * row ids, so a retry that resends the same logical batch converges on one
+ * write instead of duplicating terminal rows.
  */
 export async function recordAlertHistoryStrict(
   rows: AlertHistoryRow[],
 ): Promise<void> {
   if (rows.length === 0) return;
-  await insertAlertHistoryRows(rows);
+  await insertAlertHistoryRowsSync(rows);
 }
 
 export async function recordAlertHistory(
@@ -372,7 +397,7 @@ export async function recordAlertHistory(
 ): Promise<void> {
   if (rows.length === 0) return;
   try {
-    await insertAlertHistoryRows(rows);
+    await insertAlertHistoryRowsAsync(rows);
   } catch (error) {
     serverLogger.error("alerts.history.insert_failed", {
       ...exceptionAttributes(error),

--- a/packages/app/src/server/alerts/history/clickhouse.ts
+++ b/packages/app/src/server/alerts/history/clickhouse.ts
@@ -255,7 +255,10 @@ export function instanceHistoryRow(opts: {
     }),
     ...instanceRowFields(opts.fingerprint, opts.labels),
     episode_id: opts.episodeId,
-    row_count: 1,
+    // row_count means one thing: rows the rule's query returned. A
+    // transition or a lifecycle terminal runs no query, so it stays 0, the
+    // DDL default, rather than a hardcoded 1 that claims a query result.
+    row_count: 0,
     evidence_json: JSON.stringify(opts.evidence),
     evidence_truncated: opts.evidenceTruncated,
     context_json: opts.contextJson,

--- a/packages/app/src/server/alerts/history/project-lifecycle.test.ts
+++ b/packages/app/src/server/alerts/history/project-lifecycle.test.ts
@@ -105,6 +105,30 @@ describe("projectAlertLifecycle", () => {
     ).rejects.toThrow("clickhouse unavailable");
   });
 
+  // processedAt is always stamped by the claiming update before this task
+  // runs (closeRuleLifecycle's own transaction, or an earlier group claim).
+  // A null here means that invariant broke; minting `new Date()` would give
+  // a retry a different event_time on the same deterministic event_id.
+  it("throws rather than minting an event_time for an unprocessed suppression row", async () => {
+    mocks.rows = [
+      journalRow({
+        id: CANCELED_ID,
+        eventType: "instance_fired",
+        kind: "notifying",
+        processedAt: null,
+      }),
+    ];
+
+    await expect(
+      projectAlertLifecycle({
+        closedEventIds: [],
+        suppressedEventIds: [CANCELED_ID],
+        reason: "rule_paused",
+      }),
+    ).rejects.toThrow(/processedAt/);
+    expect(mocks.history).not.toHaveBeenCalled();
+  });
+
   it("writes nothing for ids the journal no longer has", async () => {
     mocks.rows = [];
 

--- a/packages/app/src/server/alerts/history/project-lifecycle.ts
+++ b/packages/app/src/server/alerts/history/project-lifecycle.ts
@@ -10,6 +10,26 @@ import {
 } from "./clickhouse";
 import { AlertLifecycleProjectionPayloadSchema } from "./tasks";
 
+// suppressedEventIds only ever names rows a claiming update already stamped:
+// closeRuleLifecycle sets processedAt on the events it cancels in the same
+// transaction that enqueues this task, and an orphaned membership belongs to
+// an event a group dispatch already claimed earlier. A null here means that
+// invariant broke, and a minted `new Date()` would silently give a Graphile
+// retry a different event_time than the first attempt on the same
+// deterministic event_id, which the design doc requires to stay stable.
+function requireProcessedAt(row: {
+  id: string;
+  processedAt: Date | null;
+}): Date {
+  if (row.processedAt === null) {
+    throw new Error(
+      `alert_events row ${row.id} has no processedAt; the lifecycle projection` +
+        " only reads rows a claiming update already stamped",
+    );
+  }
+  return row.processedAt;
+}
+
 /**
  * Project the lifecycle terminals a pause or delete journaled. Runs after the
  * mutation's commit; the journal rows are self-sufficient, so a definition
@@ -57,7 +77,7 @@ export async function projectAlertLifecycle(
         suppressionHistoryRow({
           def: historyDefFromJournalRow(row),
           notificationEventId: row.id,
-          occurredAt: row.processedAt ?? new Date(),
+          occurredAt: requireProcessedAt(row),
           fingerprint: row.instanceFingerprint,
           labels: row.instanceLabels,
           silenced: false,

--- a/packages/app/src/server/alerts/maintenance/cleanup.test.ts
+++ b/packages/app/src/server/alerts/maintenance/cleanup.test.ts
@@ -31,6 +31,15 @@ describe("cleanupAlertingHistory", () => {
     );
   });
 
+  /** A clock that advances by one tick on every call, starting at 0. */
+  function tickingClock() {
+    let ticks = -1;
+    return () => {
+      ticks += 1;
+      return ticks;
+    };
+  }
+
   it("deletes bounded history and reports each table", async () => {
     for (const rowCount of [11, 12, 13, 14, 15, 16]) {
       mocks.execute.mockResolvedValueOnce({ rowCount });
@@ -40,7 +49,6 @@ describe("cleanupAlertingHistory", () => {
       cleanupAlertingHistory({
         now: new Date("2026-08-06T12:00:00Z"),
         batchSize: 100,
-        maxBatches: 3,
       }),
     ).resolves.toEqual({
       alertEvaluations: 11,
@@ -54,14 +62,18 @@ describe("cleanupAlertingHistory", () => {
     expect(mocks.execute).toHaveBeenCalledTimes(6);
   });
 
-  it("keeps running full batches but respects the per-run cap", async () => {
+  it("keeps running full batches until the time budget runs out", async () => {
     mocks.execute.mockResolvedValue({ rowCount: 2 });
 
+    // deadline = clock() [0] + budgetMs; each loop iteration spends one
+    // tick checking it, so a budget of 3 admits 3 batches: the check reads
+    // 1, 2, then 3 (>= 3) on the batch that stops the loop.
     await expect(
       cleanupAlertingHistory({
         now: new Date("2026-08-06T12:00:00Z"),
         batchSize: 2,
-        maxBatches: 3,
+        budgetMs: 3,
+        clock: tickingClock(),
       }),
     ).resolves.toEqual({
       alertEvaluations: 6,
@@ -75,13 +87,30 @@ describe("cleanupAlertingHistory", () => {
     expect(mocks.execute).toHaveBeenCalledTimes(18);
   });
 
+  it("stops on a short batch even with budget left over", async () => {
+    // Six deletes per batch (one per table); the first batch comes back
+    // full on every table, the second short on every table.
+    for (let i = 0; i < 6; i += 1) {
+      mocks.execute.mockResolvedValueOnce({ rowCount: 2 });
+    }
+    mocks.execute.mockResolvedValue({ rowCount: 0 });
+
+    await cleanupAlertingHistory({
+      now: new Date("2026-08-06T12:00:00Z"),
+      batchSize: 2,
+      budgetMs: 1_000_000,
+      clock: tickingClock(),
+    });
+
+    expect(mocks.transaction).toHaveBeenCalledTimes(2);
+  });
+
   it("protects unfinished events, active groups, and delivery history", async () => {
     mocks.execute.mockResolvedValue({ rowCount: 0 });
 
     await cleanupAlertingHistory({
       now: new Date("2026-08-06T12:00:00Z"),
       batchSize: 100,
-      maxBatches: 1,
     });
 
     const eventDelete = sqlText(mocks.execute.mock.calls[1][0]);
@@ -106,7 +135,6 @@ describe("cleanupAlertingHistory", () => {
     await cleanupAlertingHistory({
       now: new Date("2026-08-06T12:00:00Z"),
       batchSize: 100,
-      maxBatches: 1,
     });
 
     const instanceDelete = sqlText(mocks.execute.mock.calls[5][0]);

--- a/packages/app/src/server/alerts/maintenance/cleanup.test.ts
+++ b/packages/app/src/server/alerts/maintenance/cleanup.test.ts
@@ -32,7 +32,7 @@ describe("cleanupAlertingHistory", () => {
   });
 
   it("deletes bounded history and reports each table", async () => {
-    for (const rowCount of [11, 12, 13, 14, 15]) {
+    for (const rowCount of [11, 12, 13, 14, 15, 16]) {
       mocks.execute.mockResolvedValueOnce({ rowCount });
     }
 
@@ -48,9 +48,10 @@ describe("cleanupAlertingHistory", () => {
       deliveries: 13,
       notificationGroups: 14,
       silences: 15,
+      instances: 16,
     });
     expect(mocks.transaction).toHaveBeenCalledOnce();
-    expect(mocks.execute).toHaveBeenCalledTimes(5);
+    expect(mocks.execute).toHaveBeenCalledTimes(6);
   });
 
   it("keeps running full batches but respects the per-run cap", async () => {
@@ -68,9 +69,10 @@ describe("cleanupAlertingHistory", () => {
       deliveries: 6,
       notificationGroups: 6,
       silences: 6,
+      instances: 6,
     });
     expect(mocks.transaction).toHaveBeenCalledTimes(3);
-    expect(mocks.execute).toHaveBeenCalledTimes(15);
+    expect(mocks.execute).toHaveBeenCalledTimes(18);
   });
 
   it("protects unfinished events, active groups, and delivery history", async () => {
@@ -96,5 +98,20 @@ describe("cleanupAlertingHistory", () => {
 
     const groupDelete = sqlText(mocks.execute.mock.calls[3][0]);
     expect(groupDelete).toContain("alert_notification_group_events");
+  });
+
+  it("only sweeps inactive instances past the cutoff", async () => {
+    mocks.execute.mockResolvedValue({ rowCount: 0 });
+
+    await cleanupAlertingHistory({
+      now: new Date("2026-08-06T12:00:00Z"),
+      batchSize: 100,
+      maxBatches: 1,
+    });
+
+    const instanceDelete = sqlText(mocks.execute.mock.calls[5][0]);
+    expect(instanceDelete).toContain("status = 'inactive'");
+    expect(instanceDelete).toContain("updated_at <");
+    expect(instanceDelete).toContain("alert_instances");
   });
 });

--- a/packages/app/src/server/alerts/maintenance/cleanup.ts
+++ b/packages/app/src/server/alerts/maintenance/cleanup.ts
@@ -6,6 +6,9 @@ const DAY_MS = 24 * 60 * 60 * 1_000;
 const EVALUATION_RETENTION_DAYS = 7;
 const HISTORY_RETENTION_DAYS = 90;
 const IDLE_GROUP_RETENTION_DAYS = 7;
+// Inactive instance rows carry no history a reader still needs: the journal
+// (alert_events) is the durable record of what happened to an instance.
+const INSTANCE_RETENTION_DAYS = 7;
 const CLEANUP_BATCH_SIZE = 1_000;
 const MAX_BATCHES_PER_RUN = 10;
 
@@ -15,6 +18,7 @@ type AlertingCleanupCounts = {
   deliveries: number;
   notificationGroups: number;
   silences: number;
+  instances: number;
 };
 
 const EMPTY_COUNTS: AlertingCleanupCounts = {
@@ -23,6 +27,7 @@ const EMPTY_COUNTS: AlertingCleanupCounts = {
   deliveries: 0,
   notificationGroups: 0,
   silences: 0,
+  instances: 0,
 };
 
 function addCounts(
@@ -35,6 +40,7 @@ function addCounts(
     deliveries: total.deliveries + batch.deliveries,
     notificationGroups: total.notificationGroups + batch.notificationGroups,
     silences: total.silences + batch.silences,
+    instances: total.instances + batch.instances,
   };
 }
 
@@ -58,6 +64,9 @@ export async function cleanupAlertingHistory(options?: {
   );
   const idleGroupCutoff = new Date(
     now.getTime() - IDLE_GROUP_RETENTION_DAYS * DAY_MS,
+  );
+  const instanceCutoff = new Date(
+    now.getTime() - INSTANCE_RETENTION_DAYS * DAY_MS,
   );
   let totals = { ...EMPTY_COUNTS };
 
@@ -169,6 +178,20 @@ export async function cleanupAlertingHistory(options?: {
         USING doomed
         WHERE target.ctid = doomed.ctid
       `);
+      const instances = await tx.execute(sql`
+        WITH doomed AS (
+          SELECT id
+          FROM alert_instances
+          WHERE status = 'inactive'
+            AND updated_at < ${instanceCutoff}
+          ORDER BY updated_at, id
+          LIMIT ${batchSize}
+          FOR UPDATE SKIP LOCKED
+        )
+        DELETE FROM alert_instances AS target
+        USING doomed
+        WHERE target.id = doomed.id
+      `);
 
       return {
         alertEvaluations: deletedRows(alertEvaluations),
@@ -176,6 +199,7 @@ export async function cleanupAlertingHistory(options?: {
         deliveries: deletedRows(deliveries),
         notificationGroups: deletedRows(notificationGroups),
         silences: deletedRows(silences),
+        instances: deletedRows(instances),
       };
     });
     totals = addCounts(totals, counts);

--- a/packages/app/src/server/alerts/maintenance/cleanup.ts
+++ b/packages/app/src/server/alerts/maintenance/cleanup.ts
@@ -10,7 +10,12 @@ const IDLE_GROUP_RETENTION_DAYS = 7;
 // (alert_events) is the durable record of what happened to an instance.
 const INSTANCE_RETENTION_DAYS = 7;
 const CLEANUP_BATCH_SIZE = 1_000;
-const MAX_BATCHES_PER_RUN = 10;
+// A backlog outgrows a fixed batch count long before it outgrows a time
+// budget: at 100 rules on a 1-minute interval, alert_evaluations alone
+// accumulates ~144k rows/day, far past what MAX_BATCHES_PER_RUN=10 could
+// ever drain in one run. Loop on wall clock instead, bounded well inside the
+// hourly cron cadence so a run never overlaps the next one.
+const CLEANUP_BUDGET_MS = 5 * 60 * 1_000;
 
 type AlertingCleanupCounts = {
   alertEvaluations: number;
@@ -51,11 +56,15 @@ function deletedRows(result: { rowCount?: number | null }): number {
 export async function cleanupAlertingHistory(options?: {
   now?: Date;
   batchSize?: number;
-  maxBatches?: number;
+  budgetMs?: number;
+  /** Wall clock for the budget loop, separate from `now`'s cutoff math. */
+  clock?: () => number;
 }): Promise<AlertingCleanupCounts> {
   const now = options?.now ?? new Date();
   const batchSize = options?.batchSize ?? CLEANUP_BATCH_SIZE;
-  const maxBatches = options?.maxBatches ?? MAX_BATCHES_PER_RUN;
+  const budgetMs = options?.budgetMs ?? CLEANUP_BUDGET_MS;
+  const clock = options?.clock ?? Date.now;
+  const deadline = clock() + budgetMs;
   const evaluationCutoff = new Date(
     now.getTime() - EVALUATION_RETENTION_DAYS * DAY_MS,
   );
@@ -70,7 +79,7 @@ export async function cleanupAlertingHistory(options?: {
   );
   let totals = { ...EMPTY_COUNTS };
 
-  for (let batch = 0; batch < maxBatches; batch += 1) {
+  for (;;) {
     const counts = await db.transaction(async (tx) => {
       const alertEvaluations = await tx.execute(sql`
         WITH doomed AS (
@@ -204,6 +213,7 @@ export async function cleanupAlertingHistory(options?: {
     });
     totals = addCounts(totals, counts);
     if (Object.values(counts).every((count) => count < batchSize)) break;
+    if (clock() >= deadline) break;
   }
 
   return totals;

--- a/packages/app/src/server/alerts/runtime.ts
+++ b/packages/app/src/server/alerts/runtime.ts
@@ -61,6 +61,7 @@ export const alertTaskList: TaskList = {
         "alerts.retention.events": counts.events,
         "alerts.retention.notification_groups": counts.notificationGroups,
         "alerts.retention.silences": counts.silences,
+        "alerts.retention.instances": counts.instances,
       });
     }
   }),

--- a/packages/app/src/server/alerts/runtime.ts
+++ b/packages/app/src/server/alerts/runtime.ts
@@ -76,7 +76,9 @@ export const alertCronItems: ParsedCronItem[] = parseCronItems([
   },
   {
     task: ALERT_RETENTION_TASK,
-    match: "43 3 * * *",
+    // Hourly, not daily: a day between runs let the backlog outrun what one
+    // run's time budget can drain.
+    match: "43 * * * *",
     identifier: "alerts-retention",
     options: { backfillPeriod: 0 },
   },

--- a/packages/app/src/server/alerts/scheduling/scanner.ts
+++ b/packages/app/src/server/alerts/scheduling/scanner.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, inArray, isNull, lt, lte, or } from "drizzle-orm";
+import { and, asc, eq, inArray, isNull, lt, lte, or, sql } from "drizzle-orm";
 import { enqueueAlertEvaluation } from "@/data/alerting/scheduling/evaluation-jobs.server";
 import { db } from "@/db/client";
 import { alertDefinitions } from "@/db/schema";
@@ -60,7 +60,11 @@ export async function scanDueAlerts(
   const rows = await db
     .select({
       id: alertDefinitions.id,
-      scheduledFor: alertDefinitions.nextEvaluationAt,
+      // The lte(nextEvaluationAt, now) predicate below excludes NULL, so
+      // every row this query returns has one; the cast reflects that instead
+      // of carrying the column's nullable type into a fallback that can
+      // never run.
+      scheduledFor: sql<Date>`${alertDefinitions.nextEvaluationAt}`,
       version: alertDefinitions.version,
     })
     .from(alertDefinitions)
@@ -87,7 +91,7 @@ export async function scanDueAlerts(
   await boundedEnqueue(rows, (row) =>
     enqueueAlertEvaluation({
       alertDefinitionId: row.id,
-      scheduledFor: row.scheduledFor?.toISOString() ?? now.toISOString(),
+      scheduledFor: row.scheduledFor.toISOString(),
       ruleVersion: row.version,
     }),
   );

--- a/packages/docs/content/docs/guides/set-up-notifications.mdx
+++ b/packages/docs/content/docs/guides/set-up-notifications.mdx
@@ -9,8 +9,8 @@ Alert rules are defined as code, but delivery is configured in the app and appli
 
 When an alert fires or resolves, it walks a fixed path:
 
-1. **Routes** are checked top to bottom by priority; the first route whose matchers fit the alert's labels decides the receiver.
-2. The matched **receiver** fans the notification out to every **channel** it references (Slack, Discord, email, webhook, or Telegram).
+1. **Routes** are checked top to bottom by priority; the first route whose matchers fit the alert's labels picks a receiver (a route with continue enabled lets later routes also pick a receiver for the same alert).
+2. Each matched **receiver** fans the notification out to every **channel** it references (Slack, Discord, email, webhook, or Telegram).
 3. An alert that matches no route is **not delivered**, so end the route list with a catch-all (a route with no matchers) if you want a default receiver.
 
 Silences and inhibitions suppress delivery without stopping evaluation.
@@ -23,7 +23,7 @@ Channel types: **email** (recipient addresses), **Slack** (an [Incoming Webhook]
 
 Webhook URLs (generic, Slack, and Discord) and Telegram bot tokens are write-only: after saving, Everr shows them redacted (`***`). Email recipients are not secrets and stay visible as entered. To rotate a redacted secret, edit the channel and enter the new value; the secret fields start blank on edit precisely because the stored values are never shown again. Names are editable labels: renaming a channel or receiver never breaks the receivers and routes that reference it.
 
-A channel that is still referenced cannot be deleted: Everr surfaces the engine's refusal, naming the receivers that still use it. Delete or repoint those receivers first.
+A channel that is still referenced cannot be deleted. Everr refuses and names what still uses it: receivers that include the channel, or alert rules that name it directly in `spec.notification.channels`. A channel with delivery history also cannot be deleted. Delete or repoint the receivers and rules first.
 
 ## Receivers
 
@@ -31,7 +31,9 @@ A receiver is a named set of channels; routes reference receivers by name, and a
 
 ## Routes
 
-A route is a set of **matchers** (label comparisons such as `severity = critical`, with equals, not-equals, and regex operators), a target receiver, and a priority. Routes are checked in priority order and the first match wins.
+A route is a set of **matchers** (label comparisons such as `severity = critical`, using equals or not-equals operators), a target receiver, and a priority. `severity` is set on every alert rule (see [the AlertRule spec](/docs/reference/alert-spec#spec)) and is one of the labels a matcher can compare against.
+
+Routes are checked in priority order. The first route whose matchers fit the alert's labels receives it. Enable **Continue matching later routes** on a route to pass the alert on to later routes too, so more than one receiver can act on the same alert.
 
 ### Group notifications
 

--- a/packages/docs/content/docs/reference/alert-spec.mdx
+++ b/packages/docs/content/docs/reference/alert-spec.mdx
@@ -3,7 +3,7 @@ title: AlertRule Spec
 description: The full AlertRule file format, the apply manifest, and the alert evaluation states.
 ---
 
-An `AlertRule` is a resource with three top-level keys. Everr validates it on `everr apply` and again on read. The `spec` holds a ClickHouse query, a threshold condition, and the notification text to send when instances start and stop firing. The query always returns its useful data; the condition decides which rows fire.
+An `AlertRule` is a resource with three top-level keys. Everr validates it on `everr apply`; reads return the spec exactly as it was stored at apply time, with no re-validation. The `spec` holds a ClickHouse query, a threshold condition, and the notification text to send when instances start and stop firing. The query always returns its useful data; the condition decides which rows fire.
 
 ```yaml
 kind: AlertRule
@@ -16,7 +16,9 @@ spec:
 | Key | Type | Notes |
 | --- | --- | --- |
 | `kind` | `"AlertRule"` | Selects the reconciler. Required. |
-| `metadata.name` | string | The rule's **slug** and identity. Required, non-empty. |
+| `metadata.name` | string | The rule's **slug**. Required. 1 to 128 characters from `[A-Za-z0-9_.-]`; cannot be exactly `.` or `..`. |
+| `metadata.project` | string | Groups the rule with other resources. Optional, defaults to `default`. Lowercase letters, digits, and hyphens only; cannot start or end with a hyphen. Together with `metadata.name` it forms the rule's canonical identity, `<project>/<slug>`. |
+| `metadata.labels` | map (string to string) | Optional, descriptive metadata. Stored as `everr.label.<key>` annotations on the rule; routes cannot match on them. Use `spec.annotations` or the synthetic labels described in [set up notifications](/docs/guides/set-up-notifications) for values that need to drive routing. |
 | `spec` | object | The rule contents, below. |
 
 ## `spec`
@@ -26,6 +28,7 @@ spec:
 | `evaluationInterval` | string | yes | How often the query runs. `<int><s\|m\|h\|d>`, **minimum `1m`**. |
 | `for` | string | no | How long the condition must hold continuously before firing. `<int><s\|m\|h\|d>`; default `0s` (fire on the first matching evaluation). While waiting, the instance is pending and sends nothing. |
 | `resolveAfter` | int | no | Consecutive evaluations where a firing instance is absent or no longer matches before it resolves. Default `1`; raise it (for example `3`) to tolerate gaps in the data. Must be ≥ 1. |
+| `severity` | string | no | One of `info`, `warning`, `critical`. Default `info`. Stamped as the `severity` label on every dispatched event, so notification routes can match on it. See [set up notifications](/docs/guides/set-up-notifications). |
 | `query` | string | yes | ClickHouse SQL. Must return a numeric column named `value`. **No `${...}` templating.** |
 | `condition` | object | yes | A numeric threshold applied to each row's `value`: `{ operator, threshold }`. Supported operators: `gt`, `gte`, `lt`, `lte`, `eq`, `neq`. A matching row is a firing instance. |
 | `notification` | object | no | An explicit notification destination. When present, its channels receive this alert and advanced route matching is skipped. Silences and inhibitions still apply. |
@@ -88,6 +91,7 @@ Declarations sit flat in `everr/`, named by kind: `*.alert.yaml`, `*.dashboard.y
 - `evaluationInterval` must be ≥ `1m`.
 - `for` must be a valid duration (`0s` is allowed).
 - `resolveAfter` must be an integer ≥ 1.
+- `severity`, when set, must be `info`, `warning`, or `critical`.
 - `notificationMessage.title` is required and non-empty.
 - `notification.channels` must contain unique, non-empty names, and every named channel must exist at apply time.
 - `${...}` in messages must reference a column the `query` returns or be `${value}`.

--- a/todo/issues/alerting-surface/02-alerting-clickhouse-surface.md
+++ b/todo/issues/alerting-surface/02-alerting-clickhouse-surface.md
@@ -775,7 +775,7 @@ queries must not add a `tenant_id` predicate.
 | `service_name` | `LowCardinality(String)` | The service the alert concerns, resolved at write time; `'alert'` when none |
 | `severity` | `LowCardinality(String)` | `info`, `warning` or `critical`, validated at the spec boundary, not by the insert path (a non-throwing writer must not drop rows when a value is added). The rule's severity when the row was written; editing a rule changes later rows, not past ones |
 | `rule_muted` | `Bool` | The rule never notifies (`spec.suppressed` or a preview). Set on every row; unrelated to `silenced` |
-| `reason` | `LowCardinality(String)` | `condition_cleared` on `instance_resolved`; `pending_cleared`, `rule_paused`, `rule_deleted` or `preview_deleted` on `instance_closed`; the matching value on a terminal `notification_suppressed` |
+| `reason` | `LowCardinality(String)` | `condition_cleared` on `instance_resolved`; `pending_cleared`, `labels_changed`, `rule_paused`, `rule_deleted` or `preview_deleted` on `instance_closed`; `rule_paused`, `rule_deleted`, `no_longer_firing` or `no_channels` on a terminal `notification_suppressed`. The closed vocabulary is `ALERTING_LIFECYCLE_REASONS` in `data/alerting/vocabulary.ts` |
 | `silenced`, `inhibited` | `Bool` | Frozen at write time. Meaningful only on `notification_deferred` and `notification_suppressed` rows; always false on a transition |
 | `silence_id` | `UUID` | The matched silence, zero if none |
 | `silence_comment`, `silence_matchers_json` | `String` | Frozen from the silence, so the row reads without PostgreSQL |

--- a/todo/issues/alerting-surface/tickets/04-cloud-query-access.md
+++ b/todo/issues/alerting-surface/tickets/04-cloud-query-access.md
@@ -12,8 +12,12 @@ design doc's findings.
 
 **Status:** ready-for-agent
 
-- [ ] SELECT grant for the SQL API role on the table
-- [ ] Default-deny policy plus per-organization row policy
-- [ ] Provisioning code creates the policy for new organizations
+- [x] SELECT grant for the SQL API role on the table
+- [x] Default-deny policy plus per-organization row policy
+- [x] Provisioning code creates the policy for new organizations
 - [ ] Verified with `everr-dev cloud query`: own rows visible, other tenants' rows absent
-- [ ] Documented as the copyable tenancy template
+- [x] Documented as the copyable tenancy template
+
+Record check 2026-08-10: the code side is complete (`15-create-sql-api-role.sql`,
+`provisionSqlApiOrgUser`, `sql-api-tables.ts`). Open: the live query check, and
+the backfill migration's manual second step for pre-existing organizations.

--- a/todo/issues/alerting-surface/tickets/05-skill-file-and-reference-hygiene.md
+++ b/todo/issues/alerting-surface/tickets/05-skill-file-and-reference-hygiene.md
@@ -12,10 +12,15 @@ under the SQL API profile.
 
 **Status:** ready-for-agent
 
-- [ ] The skill file exists with the column reference and worked queries
-- [ ] The lockstep rule with the design doc's Reference is stated
-- [ ] Entry queries return `notification_event_id` so the chain query is reachable
+- [x] The skill file exists with the column reference and worked queries
+- [x] The lockstep rule with the design doc's Reference is stated
+- [x] Entry queries return `notification_event_id` so the chain query is reachable
 - [ ] Every documented query carries a `LIMIT` and runs under the SQL API profile, verified with `everr-dev`
-- [ ] The skill file copies the corrected query forms; no documented query depends on a session setting
-- [ ] The no-personal-data claim in Constraints is conditioned on the open labels-redaction question
-- [ ] If the reference does not fit the page budget, that is reported as a design signal, not papered over
+- [x] The skill file copies the corrected query forms; no documented query depends on a session setting
+- [x] The no-personal-data claim in Constraints is conditioned on the open labels-redaction question
+- [x] If the reference does not fit the page budget, that is reported as a design signal, not papered over
+
+Record check 2026-08-10: every worked query carries `LIMIT 100`; only the live
+run under the SQL API profile is open. Page budget report: the skill file is
+223 lines, roughly four times the stated one-page budget. Decide whether to
+split it or to accept the size.

--- a/todo/issues/alerting-surface/tickets/07-delivery-reconciliation-and-sweep.md
+++ b/todo/issues/alerting-surface/tickets/07-delivery-reconciliation-and-sweep.md
@@ -14,7 +14,7 @@ the design doc's findings; finding 21 in
 
 **Status:** ready-for-agent
 
-- [ ] Delivery rows get deterministic ids derived from the journal
+- [x] Delivery rows get deterministic ids derived from the journal
 - [ ] The diff compares outcomes: a succeeded journal status with no succeeded row is repaired
 - [ ] A sweep moves abandoned deliveries past the retry horizon to terminal failed, with a stuck-delivery counter
 - [ ] The "Excluded from ClickHouse" row on dedup keys is narrowed in the design doc

--- a/todo/issues/alerting-surface/tickets/08-insert-and-repair-counters.md
+++ b/todo/issues/alerting-surface/tickets/08-insert-and-repair-counters.md
@@ -10,6 +10,6 @@ visible before an incident finds it.
 
 **Status:** ready-for-agent
 
-- [ ] A counter or span event on both history insert failure sites
+- [x] A counter or span event on both history insert failure sites (implemented as named error log records: `alerts.history.insert_failed`, `alerts.history.delivery_outcome_failed`)
 - [ ] A repair counter per stream in the reconciler
 - [ ] Verified visible through Everr telemetry with `everr-dev`

--- a/todo/issues/alerting-surface/tickets/10-notification-deferred-with-freezes.md
+++ b/todo/issues/alerting-surface/tickets/10-notification-deferred-with-freezes.md
@@ -16,3 +16,8 @@ join to read it.
 - [ ] The silence comment and matchers freeze onto deferred and suppressed rows
 - [ ] The inhibiting source freezes into the columns ticket 02 reserved
 - [ ] A deferred chain that ends without delivery gets its own terminal suppressed row with a matching reason
+
+Record check 2026-08-10: the terminal row on the deferred path exists
+(`deferSuppressedEvent`), but it omits `reason`, so the column defaults to the
+empty string. The parallel direct drop in `process-event.ts` writes
+`no_longer_firing`. The freeze columns from ticket 02 are still written empty.

--- a/todo/issues/alerting-surface/tickets/20-transactional-alert-applies.md
+++ b/todo/issues/alerting-surface/tickets/20-transactional-alert-applies.md
@@ -10,5 +10,9 @@ executor the resource registry supplies.
 
 **Status:** ready-for-agent
 
-- [ ] The supplied executor passes through every alert repository mutation, or the transaction contract is explicitly replaced with a durable convergence protocol
+- [x] The supplied executor passes through every alert repository mutation, or the transaction contract is explicitly replaced with a durable convergence protocol
 - [ ] An integration test where a later resource kind fails after alerting mutations begin
+
+Record check 2026-08-10: the executor is threaded through every mutation and
+the reconcile loop runs in one transaction. The existing tests assert the
+plumbing against mocks; no test exercises a real rollback across kinds.

--- a/todo/issues/alerting-surface/tickets/21-org-deletion-with-direct-channels.md
+++ b/todo/issues/alerting-surface/tickets/21-org-deletion-with-direct-channels.md
@@ -10,5 +10,10 @@ reject the cleanup and roll it back.
 
 **Status:** ready-for-agent
 
-- [ ] Cleanup ordering handles direct rule-to-channel mappings
+- [x] Cleanup ordering handles direct rule-to-channel mappings
 - [ ] An organization cleanup integration test with direct rule channels
+
+Record check 2026-08-10: the ordering fix is in
+`organization-data-cleanup.server.ts` with the constraint stated in a comment.
+The existing test asserts delete ordering against mocks; no test exercises the
+real foreign keys.

--- a/todo/issues/alerting-surface/tickets/22-safe-matcher-regexes.md
+++ b/todo/issues/alerting-surface/tickets/22-safe-matcher-regexes.md
@@ -17,7 +17,7 @@ of this branch.
 
 **Status:** ready-for-agent
 
-- [ ] `regex` and `notregex` are removed from the matcher op enum and every consumer (routing resolution, silences, inhibitions)
-- [ ] Apply rejects specs that still use the removed ops, with a clear error
-- [ ] The regex evaluation path and its process-wide cache are deleted
-- [ ] Matcher counts and value lengths keep sane bounds at the schema boundary
+- [x] `regex` and `notregex` are removed from the matcher op enum and every consumer (routing resolution, silences, inhibitions)
+- [x] Apply rejects specs that still use the removed ops, with a clear error
+- [x] The regex evaluation path and its process-wide cache are deleted
+- [x] Matcher counts and value lengths keep sane bounds at the schema boundary

--- a/todo/issues/alerting-surface/tickets/23-delivery-idempotency.md
+++ b/todo/issues/alerting-surface/tickets/23-delivery-idempotency.md
@@ -16,4 +16,4 @@ exists.
 
 - [ ] Provider idempotency where available
 - [ ] Recipient-level fan-out state when one delivery targets several recipients
-- [ ] The remaining at-least-once behavior is documented
+- [x] The remaining at-least-once behavior is documented (design doc Durability section; not yet in the user docs)

--- a/todo/issues/alerting-surface/tickets/24-downsampling-keeps-exceptional-points.md
+++ b/todo/issues/alerting-surface/tickets/24-downsampling-keeps-exceptional-points.md
@@ -10,5 +10,5 @@ downsampling.
 
 **Status:** ready-for-agent
 
-- [ ] Exceptional points and state transitions are preserved before the display budget fills with representative samples
-- [ ] A test with one exceptional point between sampled indexes
+- [x] Exceptional points and state transitions are preserved before the display budget fills with representative samples
+- [x] A test with one exceptional point between sampled indexes

--- a/todo/issues/alerting-surface/tickets/25-rule-polling-with-pagination.md
+++ b/todo/issues/alerting-surface/tickets/25-rule-polling-with-pagination.md
@@ -9,5 +9,5 @@ receiving live list updates instead of polling silently stopping.
 
 **Status:** ready-for-agent
 
-- [ ] Paginated rule data refreshes without silently disabling updates
-- [ ] Coverage for an organization with at least two pages
+- [x] Paginated rule data refreshes without silently disabling updates
+- [x] Coverage for an organization with at least two pages

--- a/todo/issues/alerting-surface/tickets/26-preview-history-identity.md
+++ b/todo/issues/alerting-surface/tickets/26-preview-history-identity.md
@@ -11,3 +11,7 @@ the preview's own evidence and transitions, not empty or live-scope data.
 
 - [ ] Preview identity carries through the history query
 - [ ] A test covers the same rule identity in live and preview scopes
+
+Record check 2026-08-10: the rule detail page carries preview scope correctly.
+The triage-board expander, the surface this ticket names, still queries with a
+null preview scope, and preview rows are not `is_live`, so it returns empty.

--- a/todo/issues/alerting-surface/tickets/27-preview-kill-switch.md
+++ b/todo/issues/alerting-surface/tickets/27-preview-kill-switch.md
@@ -10,5 +10,9 @@ never used.
 
 **Status:** ready-for-agent
 
-- [ ] The switch is enforced before preview work is enqueued
+- [x] The switch is enforced before preview work is enqueued
 - [ ] Both values are tested
+
+Record check 2026-08-10: enforcement exists at the scanner and at the per-rule
+reschedule. The off value is tested; the on branch of the gate condition is not
+reached by any current test.


### PR DESCRIPTION
Fixes for the findings of the alerting review pass (engine, contract, Postgres store, ClickHouse store). One commit per fix, 50 commits total. Each finding was re-verified against the code before it was fixed; verdicts are below. UI findings were out of scope, except where a type fix required touching a UI file.

## Engine (11 commits)

- The reschedule now advances `last_enqueued_at`, so the scanner is a backstop again instead of a co-scheduler that re-enqueues every rule each tick and zeroes the retry budget of in-flight jobs.
- Settled inactive instance rows are no longer rewritten every evaluation, and retention now sweeps inactive `alert_instances` rows (new partial index in `schema/alerts.ts`).
- Retention drains on a wall-clock budget until batches come back short, and the cron runs hourly. The old fixed cap deleted at most 10k rows per day against a much larger write rate.
- `recordEvaluationFailure` re-checks rule liveness and version, the same guard the success path has. A paused rule is no longer marked degraded by an in-flight failure; a deleted rule no longer burns retries on an FK violation.
- The evaluation series derives breach state from stored samples plus the rule condition instead of the unfiltered `row_count`, so downsampling keeps breaching points for `GROUP BY` rules.
- Stored samples put matching rows first, so the rule detail page cannot show a healthy tick for an evaluation that paged someone.
- A full behavioral test now drives `evaluateAlert` through fire, hold, and resolve; the fixture uses real schema shapes.
- Smaller: dead `diffInstances` API removed, bounded evidence computed once, scanner type cleanup, SQL NULL labels get a distinct fingerprint sentinel.

## Delivery (14 commits)

- "Automatic" route grouping now actually groups by rule and severity. Before, `group_by: null` collapsed all routed alerts into one group per receiver.
- Dispatcher timing defaults come from `defaults.ts` (wait 10s, interval 300s), matching what the UI shows.
- A flap inside the group window no longer notifies "1 resolved" for an alert that was never announced. The unannounced resolve is dropped with a `notification_suppressed` terminal instead.
- A successful send can no longer be recorded as failed and re-sent when the status write fails. The failure UPDATE is also guarded with `status <> 'sent'` and increments attempts in SQL.
- Withheld deliveries are terminal for retention now (`attempts` set to max), so they and their journal events stop being immortal.
- Fires dropped as "no longer firing" write a terminal with the new `no_longer_firing` reason, and both early exits in `process-event` go through `processedStampGuard`.
- Suppression sources (silences, inhibition set) load once per flush instead of once per member, and the member claim is capped at 500 with a follow-up flush. This removes the quadratic storm behavior.
- Smaller: empty claims park `next_flush_at` on the idle sentinel, the flush job key drops the event-id suffix so dedup works, zero-channel groups write terminals (`no_channels` reason), `last_error` is sanitized, HTTP 4xx (except 408/429) fails terminally instead of retrying five times, dead `event.suppressed` branch removed.
- `flushAlertGroup` and the send path now have behavioral tests (claims, suppression batching, flap handling, crash paths).

## Contract and Postgres (10 commits)

- New indexes: cancelable-events partial index and direct-definition group index (the lifecycle cancel scan no longer walks the whole org journal under locks), rule listing sort index, delivery channel-reference index, inactive-instances sweep index.
- `alert_events.reason` gets a CHECK derived from the exported vocabulary, so the comment's "closed vocabulary" promise is real.
- The three dead event types (`delivery`, `rule_health`, `silenced`) are removed from the vocabulary and the enum.
- `pauseRule` resets health state, so a paused rule no longer reads degraded forever and no longer resumes at the backoff ceiling.
- Reordering `label_columns` is a no-op: comparison is order-insensitive and `toRuleInput` stores the columns sorted. Before, a reorder closed and re-fired every open instance mid-incident.
- Runbook refs always export as `project/slug`, so a default-project runbook referenced from another project round-trips.
- Temporal columns (Date, DateTime) are no longer inferred as instance identity, matching the documented string-columns rule and preventing per-bucket episode churn.
- Smaller: slugs `.` and `..` rejected, `listAlertingRules` scoped to live rules (preview rules no longer leak into the triage count and suggestions).

## ClickHouse and history (13 commits)

- The live history filter no longer hides muted live rules (`rule_muted = false` clause dropped; the UI already renders the muted flag).
- One event-type vocabulary: the writer module exports the ClickHouse union, both SQL literal arrays are checked with `satisfies`, and `EVENT_META` keys over the derived type. A rename is now a compile error.
- `recordAlertHistoryStrict` earns its docstring: strict writes are synchronous with an `insert_deduplication_token` derived from the sorted row ids. The async hot path is unchanged.
- The `reason` DDL comment and design-doc reference now list the full vocabulary, including `labels_changed`, `no_longer_firing`, `no_channels`.
- Per-rule history reads filter `repoid` again, so they use the full sort-key prefix. Org-wide reads stay unfiltered.
- Label suggestions aggregate in ClickHouse (`arrayJoin(mapKeys(...))`, `GROUP BY`, `LIMIT`) instead of shipping 10k JSON blobs to Node and ranking over a truncated sample.
- Smaller: `is_live` replaces hand-typed zero-UUID comparisons, `instance_labels` is read natively instead of via `toJSONString`, lifecycle rows write `row_count: 0`, the unreachable projection-timestamp fallback now throws, the row-policy backfill migration states its mandatory second step and gains a verification query, per-call `max_execution_time: 30` on the new queries, `evaluation_scheduled_at` gets its sentinel DEFAULT.
- Init and final-shape migration were re-verified in lockstep after all DDL edits (normalized diff is empty).

## Docs (2 commits)

- `alert-spec.mdx` documents `spec.severity`, `metadata.project`, `metadata.labels` (descriptive only, not routable), and the slug charset. The "validated again on read" claim is corrected.
- `set-up-notifications.mdx` drops the removed regex operators, describes `continue` semantics, and covers both channel-deletion guards.

## False positives

Two half-findings did not survive verification: `flush-group`'s `decidedAt` does not feed a deterministic id (only `event_time` on a non-strict path), and the docs' identity-inference wording needed no edit once the code matched it. Everything else was confirmed real.

## Deferred: needs a decision

These need a call from you and were left out on purpose:

1. **Silences terminally drop resolves of already-paged alerts** (`suppression.ts:71`). The design doc frames silences as deferral, not drop. Option A: defer the resolve to `ends_at` when the fire was delivered. Option B: keep the drop and record it as a decision. I lean A, but it changes notification semantics.
2. **`for`/`resolveAfter` gap semantics** (`state-machine.ts`). `for` is wall clock, so an outage satisfies it with no evidence; `resolveAfter` counts ticks; the reappear path resets `pendingSince`, so `for` plus `resolveAfter` on a flaky series can never fire. Needs a semantic redesign, not a patch.
3. **Engine spans** (ticket 15). Correction to an earlier version of this text: `classifyCloudQueryError` is not dead code, it is wired into the cloud query endpoint at `routes/api/cli/sql.ts:54`. What remains is ticket 15 itself: spans on the six engine operations and the same error classification on the evaluation path.
4. **`alert_evaluations` lacks the tenant-composite FK pattern** and the PG-side JSON payloads (`labels`, `evidence`) are uncapped (capped only at the ClickHouse boundary, ticket 02).
5. **CLI `resource_path` segments are not URL-encoded** (`crates/everr-core/src/api.rs`). The TS slug fix removes the practical hazard; the Rust side is still literal string concat.
6. **Parse-on-read for rule specs**: the docs were corrected instead; adding a read-side parse is a perf and behavior decision.

## Ticket records

A follow-up commit checks the ticket records in `todo/issues/alerting-surface/tickets/` against the code, checkbox by checkbox. Tickets 22, 24 and 25 turned out fully complete and are now checked off. Tickets 04, 05, 07, 08, 20, 21, 23 and 27 get their proven boxes checked, each with a dated note stating what remains. Tickets 10 and 26 stay open with notes pinning their still-live gaps: the deferred-path terminal row omits its `reason`, and the triage-board expander still queries preview alerts with a null preview scope and gets an empty history.

## Note

`src/db/schema/alerts.ts` changed (five new indexes, one CHECK, three enum values removed) and, per the repo rule, no migration was generated. Migration 0011 needs regeneration before this ships.
