### PR TITLE
fix(docs): copy otel-web into the docs image

### DIFF
--- a/packages/docs/Dockerfile
+++ b/packages/docs/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 FROM base AS deps
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY packages/docs/package.json ./packages/docs/
+COPY packages/otel-web/package.json ./packages/otel-web/
 COPY packages/ui/package.json ./packages/ui/
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
     pnpm install --frozen-lockfile --ignore-scripts
@@ -14,6 +15,7 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 FROM deps AS build
 ARG VITE_POSTHOG_PROJECT_TOKEN
 ARG VITE_PUBLIC_POSTHOG_HOST
+COPY packages/otel-web ./packages/otel-web
 COPY packages/ui ./packages/ui
 COPY packages/docs ./packages/docs
 RUN pnpm --filter docs build


### PR DESCRIPTION
The docs app depends on `@everr/otel-web` since the browser SDK adoption (#352), but `packages/docs/Dockerfile` never copies the package, so `pnpm --filter docs build` fails to resolve the import and the Build Docs Image job on main is red. The PR pipeline stayed green because the image workflow only runs on main.

Verified locally with `docker build --target build -f packages/docs/Dockerfile .`, which now completes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation build reliability by including the web package’s required files during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->