### PR TITLE
fix(docs): complete the docs image and telemetry wiring

### DIFF
--- a/.github/workflows/build-and-push-images.yml
+++ b/.github/workflows/build-and-push-images.yml
@@ -187,6 +187,8 @@ jobs:
           build-args: |
             VITE_POSTHOG_PROJECT_TOKEN=${{ vars.DOCS_POSTHOG_PROJECT_TOKEN }}
             VITE_POSTHOG_HOST=${{ vars.DOCS_POSTHOG_HOST }}
+            VITE_EVERR_PUBLIC_INGEST_KEY=${{ vars.DOCS_EVERR_PUBLIC_INGEST_KEY }}
+            VITE_COMMIT_SHA=${{ github.sha }}
           tags: |
             ${{ env.SCW_REGISTRY_HOST }}/${{ env.SCW_REGISTRY_NAMESPACE }}/docs:${{ github.sha }}
             ${{ env.SCW_REGISTRY_HOST }}/${{ env.SCW_REGISTRY_NAMESPACE }}/docs:latest

--- a/packages/docs/Dockerfile
+++ b/packages/docs/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 FROM base AS deps
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY packages/docs/package.json ./packages/docs/
+COPY packages/otel-errors/package.json ./packages/otel-errors/
 COPY packages/otel-web/package.json ./packages/otel-web/
 COPY packages/ui/package.json ./packages/ui/
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
@@ -14,7 +15,12 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 # Stage 2: build
 FROM deps AS build
 ARG VITE_POSTHOG_PROJECT_TOKEN
-ARG VITE_PUBLIC_POSTHOG_HOST
+ARG VITE_POSTHOG_HOST
+# Public (origin-bound, ingest-only) browser key baked into the client bundle
+# by Vite at build time. Optional: when unset, browser telemetry stays off.
+ARG VITE_EVERR_PUBLIC_INGEST_KEY
+ARG VITE_COMMIT_SHA
+COPY packages/otel-errors ./packages/otel-errors
 COPY packages/otel-web ./packages/otel-web
 COPY packages/ui ./packages/ui
 COPY packages/docs ./packages/docs

--- a/packages/docs/src/env.ts
+++ b/packages/docs/src/env.ts
@@ -13,6 +13,7 @@ export const env = createEnv({
     VITE_POSTHOG_HOST: z.string().default("https://eu.i.posthog.com"),
     VITE_EVERR_PUBLIC_INGEST_KEY: z.string().optional(),
     VITE_EVERR_INGEST_ENDPOINT: z.string().optional(),
+    VITE_COMMIT_SHA: z.string().optional(),
   },
 
   runtimeEnv: {
@@ -21,6 +22,7 @@ export const env = createEnv({
     VITE_POSTHOG_HOST: import.meta.env.VITE_POSTHOG_HOST,
     VITE_EVERR_PUBLIC_INGEST_KEY: import.meta.env.VITE_EVERR_PUBLIC_INGEST_KEY,
     VITE_EVERR_INGEST_ENDPOINT: import.meta.env.VITE_EVERR_INGEST_ENDPOINT,
+    VITE_COMMIT_SHA: import.meta.env.VITE_COMMIT_SHA,
   },
 
   emptyStringAsUndefined: true,

--- a/packages/docs/src/lib/route-pattern.ts
+++ b/packages/docs/src/lib/route-pattern.ts
@@ -4,7 +4,8 @@ import { setRouteResolver } from "@everr/otel-web";
 // the SDK. This site owns this module. The telemetry construction operates
 // before the router exists. Thus `getRouter()` registers the router here. Then
 // the SDK uses the matcher of the router to change the page URL of each record
-// into the deepest route id that agrees, for example `/blog/$slug`.
+// into the template of the deepest route that agrees, for example
+// `/blog/$slug`.
 //
 // The code matches the URL, and it does not read the current state of the
 // router. Thus a record for a previous page, for example page_leave, keeps the
@@ -12,17 +13,22 @@ import { setRouteResolver } from "@everr/otel-web";
 // imports nothing from the router.
 
 type RouterLike = {
-  matchRoutes(pathname: string): ReadonlyArray<{ routeId: string }>;
+  matchRoutes(
+    pathname: string,
+  ): ReadonlyArray<{ routeId: string; fullPath: string }>;
 };
 
 /** Call this from `getRouter()` immediately after you make the router. */
 export function registerRouter(router: RouterLike): void {
   setRouteResolver({
     page: (url) => {
-      const id = router.matchRoutes(new URL(url).pathname).at(-1)?.routeId;
+      const match = router.matchRoutes(new URL(url).pathname).at(-1);
       // matchRoutes falls through to the root match on unknown paths; an
-      // unmatched page has no pattern rather than a fake one.
-      return id === "__root__" ? undefined : id;
+      // unmatched page has no pattern rather than a fake one. The fullPath
+      // keeps pathless layout segments out of the pattern.
+      return match === undefined || match.routeId === "__root__"
+        ? undefined
+        : match.fullPath;
     },
   });
 }

--- a/packages/docs/src/lib/telemetry.ts
+++ b/packages/docs/src/lib/telemetry.ts
@@ -23,6 +23,8 @@ import { env } from "@/env";
 new WebSDK({
   persistence: "memory",
   serviceName: "everr-docs",
+  // Without the commit, the SDK falls back to its own package version.
+  serviceVersion: env.VITE_COMMIT_SHA,
   deploymentEnvironment: import.meta.env.MODE,
   ingestKey: env.VITE_EVERR_PUBLIC_INGEST_KEY,
   endpoint: env.VITE_EVERR_INGEST_ENDPOINT,


### PR DESCRIPTION
Fixes the second Build Docs Image failure on main (trace 645c15d688962670cd6bcedccb0dd472) and closes the telemetry wiring gaps found while reviewing the docs setup:

- **Image fix**: the SSR build resolves `@everr/otel-web`'s `node` export (`src/server.ts`), which imports `@everr/otel-errors/core`; the Dockerfile now copies `otel-errors` too. Verified with an uncached `docker build --target build -f packages/docs/Dockerfile .`.
- **Ingest key**: the workflow never passed `VITE_EVERR_PUBLIC_INGEST_KEY` to the docs build, so deployed docs telemetry was inert; it now passes `vars.DOCS_EVERR_PUBLIC_INGEST_KEY` (the repo variable still needs to be created with an origin-bound key for the docs domain, until then telemetry stays off as before).
- **PostHog host arg**: the Dockerfile declared `VITE_PUBLIC_POSTHOG_HOST` while the workflow passes `VITE_POSTHOG_HOST`, silently dropping the value; names now agree.
- **service.version**: stamped from `github.sha` via `VITE_COMMIT_SHA` instead of defaulting to the SDK's package version.
- **Route pattern**: the page resolver returns the match's `fullPath` (same pattern as the app), so pathless layouts can never leak into `everr.route.pattern`.