### PR TITLE
fix(app): borderless search trigger, persist sidebar state

### DIFF
--- a/packages/app/src/components/command-bar.tsx
+++ b/packages/app/src/components/command-bar.tsx
@@ -77,7 +77,7 @@ export function CommandBar() {
     <>
       <Button
         type="button"
-        variant="outline"
+        variant="ghost"
         onClick={() => toggleCommandBar(true)}
         className={cn(
           // Pointless without a keyboard and eats the narrow header on phones.

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -25,6 +25,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useState,
 } from "react";
@@ -33,6 +34,29 @@ const SIDEBAR_WIDTH = "16rem";
 const SIDEBAR_WIDTH_MOBILE = "18rem";
 const SIDEBAR_WIDTH_ICON = "3rem";
 const SIDEBAR_KEYBOARD_SHORTCUT = "b";
+const SIDEBAR_STORAGE_KEY = "sidebar:state";
+
+const useIsomorphicLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
+
+function readStoredOpen(): boolean | null {
+  try {
+    const stored = window.localStorage.getItem(SIDEBAR_STORAGE_KEY);
+    if (stored === "true") return true;
+    if (stored === "false") return false;
+  } catch {
+    // Private mode or a blocked storage partition: fall back to the default.
+  }
+  return null;
+}
+
+function writeStoredOpen(open: boolean) {
+  try {
+    window.localStorage.setItem(SIDEBAR_STORAGE_KEY, String(open));
+  } catch {
+    // Persistence is best effort.
+  }
+}
 
 type SidebarContextProps = {
   state: "expanded" | "collapsed";
@@ -81,11 +105,25 @@ function SidebarProvider({
       if (setOpenProp) {
         setOpenProp(openState);
       } else {
+        // Only uncontrolled providers read the stored value back.
+        writeStoredOpen(openState);
         _setOpen(openState);
       }
     },
     [setOpenProp, open],
   );
+
+  // Restore the last collapsed/expanded choice. This runs once, before paint,
+  // so there is no flash and the server markup still hydrates against
+  // `defaultOpen`.
+  const isControlled = openProp !== undefined;
+  useIsomorphicLayoutEffect(() => {
+    if (isControlled) return;
+    const stored = readStoredOpen();
+    if (stored !== null) {
+      _setOpen(stored);
+    }
+  }, [isControlled]);
 
   // Helper to toggle the sidebar.
   const toggleSidebar = useCallback(() => {


### PR DESCRIPTION
Closes EVE-7.

Two small navbar cleanups.

**Search trigger border.** The command bar ⌘K trigger used the `outline` button variant, so it drew a border right next to the borderless `SidebarTrigger` in the same header. It now uses `ghost`, matching. The base button class already sets `border-transparent`, so no extra class is needed.

**Sidebar state.** `SidebarProvider` kept open/collapsed in plain state, so every reload reset the sidebar to expanded. It now persists to `localStorage` under `sidebar:state` and restores in a layout effect.

The restore runs in an effect rather than as a lazy `useState` initializer on purpose: the app is SSR'd, so seeding from `localStorage` during render would produce a hydration mismatch on the sidebar markup. A layout effect runs before paint, so there is no flash either. Reads and writes are try/caught (blocked storage falls back to `defaultOpen`), and both are skipped when the provider is used in controlled mode.

## Testing

Manually against a dev server, logged in:

- Search trigger renders with no border.
- Collapsed the sidebar, then did a full page load of `/runs`: came back collapsed. Expanded, reloaded: came back at 256px.
- TimeRangePicker and RefreshPicker still render and keep their search params across those reloads. No hydration warnings in the console.