### PR TITLE
fix(ui): do not animate the sidebar when restoring its stored state

### DIFF
--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -115,14 +115,26 @@ function SidebarProvider({
 
   // Restore the last collapsed/expanded choice. This runs once, before paint,
   // so there is no flash and the server markup still hydrates against
-  // `defaultOpen`.
+  // `defaultOpen`. Width transitions stay disabled until the restored state has
+  // been painted, otherwise restoring a collapsed sidebar animates it shut.
+  const [restoring, setRestoring] = useState(true);
   const isControlled = openProp !== undefined;
   useIsomorphicLayoutEffect(() => {
-    if (isControlled) return;
-    const stored = readStoredOpen();
-    if (stored !== null) {
-      _setOpen(stored);
+    if (!isControlled) {
+      const stored = readStoredOpen();
+      if (stored !== null) {
+        _setOpen(stored);
+      }
     }
+    // Two frames: the first still precedes the paint of the restored state.
+    let inner = 0;
+    const outer = requestAnimationFrame(() => {
+      inner = requestAnimationFrame(() => setRestoring(false));
+    });
+    return () => {
+      cancelAnimationFrame(outer);
+      cancelAnimationFrame(inner);
+    };
   }, [isControlled]);
 
   // Helper to toggle the sidebar.
@@ -167,6 +179,7 @@ function SidebarProvider({
     <SidebarContext.Provider value={contextValue}>
       <div
         data-slot="sidebar-wrapper"
+        data-restoring={restoring ? "true" : undefined}
         style={
           {
             "--sidebar-width": SIDEBAR_WIDTH,
@@ -176,6 +189,10 @@ function SidebarProvider({
         }
         className={cn(
           "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full",
+          // Restoring the stored state must not animate: kill every transition
+          // under the provider (sidebar rail plus any chrome that tracks it)
+          // until that state has been painted.
+          "data-[restoring=true]:[&_*]:transition-none",
           className,
         )}
         {...props}


### PR DESCRIPTION
## Problem

The persisted sidebar open/collapsed state is applied in a layout effect, so it lands after the first render. That runs before paint, but CSS transitions fire on the style recalc, so a stored collapsed sidebar animated shut on every reload. The viewport-fixed topnav, whose `left` tracks the sidebar width, animated with it.

## Fix

`SidebarProvider` now tracks a `restoring` flag: `true` on the server and on the first client render, cleared two frames later, once the restored state has actually been painted. While it is set, `data-restoring="true"` on the provider wrapper disables every transition beneath it, which covers the rail, the gap, the menu items, and the fixed chrome that tracks the sidebar width. Normal toggling is unaffected.

## Verification

Manual, against the dev app with a `transitionrun` listener installed before page load:

- stored `sidebar:state=false`, reload: no sidebar or header transitions run, `header.left` and the gap are `48px` on first paint
- ⌘B afterwards: `HEADER:left` and `sidebar-gap:width` still animate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar state restoration to prevent visual flickering during startup.
  * Sidebar transitions are temporarily paused while the saved state is being restored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->