### PR TITLE
feat(app): linear bar gauge visualization

### DIFF
--- a/everr/docs-homepage.dashboard.yaml
+++ b/everr/docs-homepage.dashboard.yaml
@@ -1,0 +1,230 @@
+kind: Dashboard
+metadata:
+  name: docs-homepage
+spec:
+  display:
+    description: 'Everr-native browser telemetry from the docs homepage (cookieless @everr/web-sdk): traffic and sessions at a glance, top pages, scroll depth, and frustration signals (rage and dead clicks). Populates once the homepage ships with an ingest key.'
+    name: Docs Homepage
+  duration: 24h
+  layouts:
+  - kind: Grid
+    spec:
+      items:
+      - content:
+          $ref: '#/spec/panels/pageviews'
+        height: 5
+        width: 6
+        x: 0
+        y: 0
+      - content:
+          $ref: '#/spec/panels/sessions'
+        height: 5
+        width: 6
+        x: 6
+        y: 0
+      - content:
+          $ref: '#/spec/panels/scroll-depth'
+        height: 5
+        width: 6
+        x: 12
+        y: 0
+      - content:
+          $ref: '#/spec/panels/frustration'
+        height: 5
+        width: 6
+        x: 18
+        y: 0
+      - content:
+          $ref: '#/spec/panels/traffic'
+        height: 9
+        width: 16
+        x: 0
+        y: 5
+      - content:
+          $ref: '#/spec/panels/top-pages'
+        height: 9
+        width: 8
+        x: 16
+        y: 5
+      - content:
+          $ref: '#/spec/panels/frustration-over-time'
+        height: 9
+        width: 24
+        x: 0
+        y: 14
+  panels:
+    frustration:
+      kind: Panel
+      spec:
+        display:
+          name: Frustration clicks
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            thresholds:
+              defaultColor: '#22c55e'
+              mode: absolute
+              steps:
+              - color: '#f59e0b'
+                value: 1
+              - color: '#ef4444'
+                value: 20
+        queries:
+        - kind: ClickHouseSQL
+          spec:
+            plugin:
+              kind: ClickHouseSQL
+              spec:
+                query: |
+                  SELECT countIf(EventName = 'browser.interaction.rage_click') AS rage,
+                         countIf(EventName = 'browser.interaction.dead_click') AS dead
+                  FROM logs
+                  WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                    AND ServiceName = 'everr-docs'
+    frustration-over-time:
+      kind: Panel
+      spec:
+        display:
+          name: Rage and dead clicks
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            showLegend: true
+        queries:
+        - kind: ClickHouseSQL
+          spec:
+            plugin:
+              kind: ClickHouseSQL
+              spec:
+                query: |
+                  SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} SECOND) AS ts,
+                         countIf(EventName = 'browser.interaction.rage_click') AS rage_clicks,
+                         countIf(EventName = 'browser.interaction.dead_click') AS dead_clicks
+                  FROM logs
+                  WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                    AND ServiceName = 'everr-docs'
+                    AND EventName IN ('browser.interaction.rage_click', 'browser.interaction.dead_click')
+                  GROUP BY ts
+                  ORDER BY ts
+    pageviews:
+      kind: Panel
+      spec:
+        display:
+          name: Pageviews
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: sum
+            sparkline: true
+        queries:
+        - kind: ClickHouseSQL
+          spec:
+            plugin:
+              kind: ClickHouseSQL
+              spec:
+                query: |
+                  SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} SECOND) AS ts,
+                         count() AS pageviews
+                  FROM logs
+                  WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                    AND ServiceName = 'everr-docs'
+                    AND EventName = 'browser.page_view'
+                  GROUP BY ts
+                  ORDER BY ts
+    scroll-depth:
+      kind: Panel
+      spec:
+        display:
+          name: Avg scroll depth
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            decimals: 0
+            unit: '%'
+        queries:
+        - kind: ClickHouseSQL
+          spec:
+            plugin:
+              kind: ClickHouseSQL
+              spec:
+                query: |
+                  SELECT round(avg(toFloat64OrZero(LogAttributes['everr.scroll.depth'])) * 100) AS scroll_depth
+                  FROM logs
+                  WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                    AND ServiceName = 'everr-docs'
+                    AND EventName = 'browser.page_leave'
+    sessions:
+      kind: Panel
+      spec:
+        display:
+          name: Sessions
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+        queries:
+        - kind: ClickHouseSQL
+          spec:
+            plugin:
+              kind: ClickHouseSQL
+              spec:
+                query: |
+                  SELECT uniqExact(LogAttributes['session.id']) AS sessions
+                  FROM logs
+                  WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                    AND ServiceName = 'everr-docs'
+                    AND EventName = 'browser.page_view'
+    top-pages:
+      kind: Panel
+      spec:
+        display:
+          name: Top pages
+        plugin:
+          kind: Table
+          spec:
+            stickyHeader: true
+        queries:
+        - kind: ClickHouseSQL
+          spec:
+            plugin:
+              kind: ClickHouseSQL
+              spec:
+                query: |
+                  SELECT LogAttributes['url.path'] AS path,
+                         count() AS views,
+                         uniqExact(LogAttributes['session.id']) AS sessions
+                  FROM logs
+                  WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                    AND ServiceName = 'everr-docs'
+                    AND EventName = 'browser.page_view'
+                  GROUP BY path
+                  ORDER BY views DESC
+                  LIMIT 10
+    traffic:
+      kind: Panel
+      spec:
+        display:
+          name: Traffic
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            showLegend: true
+        queries:
+        - kind: ClickHouseSQL
+          spec:
+            plugin:
+              kind: ClickHouseSQL
+              spec:
+                query: |
+                  SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} SECOND) AS ts,
+                         count() AS pageviews,
+                         uniqExact(LogAttributes['session.id']) AS sessions
+                  FROM logs
+                  WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                    AND ServiceName = 'everr-docs'
+                    AND EventName = 'browser.page_view'
+                  GROUP BY ts
+                  ORDER BY ts
+  refreshInterval: 1m

--- a/everr/web-vitals.dashboard.yaml
+++ b/everr/web-vitals.dashboard.yaml
@@ -1,0 +1,337 @@
+kind: Dashboard
+metadata:
+  name: web-vitals
+spec:
+  display:
+    description: 'Core Web Vitals from the @everr/web-sdk browser clients (web app and docs): p75 per vital against the standard good/poor thresholds, trends over time, rating distribution, and the worst routes.'
+    name: Web Vitals
+  duration: 24h
+  layouts:
+  - kind: Grid
+    spec:
+      items:
+      - content:
+          $ref: '#/spec/panels/p75-lcp'
+        height: 5
+        width: 6
+        x: 0
+        y: 0
+      - content:
+          $ref: '#/spec/panels/p75-inp'
+        height: 5
+        width: 6
+        x: 6
+        y: 0
+      - content:
+          $ref: '#/spec/panels/p75-cls'
+        height: 5
+        width: 6
+        x: 12
+        y: 0
+      - content:
+          $ref: '#/spec/panels/p75-ttfb'
+        height: 5
+        width: 6
+        x: 18
+        y: 0
+      - content:
+          $ref: '#/spec/panels/ms-vitals-over-time'
+        height: 9
+        width: 16
+        x: 0
+        y: 5
+      - content:
+          $ref: '#/spec/panels/cls-over-time'
+        height: 9
+        width: 8
+        x: 16
+        y: 5
+      - content:
+          $ref: '#/spec/panels/rating-by-vital'
+        height: 9
+        width: 10
+        x: 0
+        y: 14
+      - content:
+          $ref: '#/spec/panels/worst-routes'
+        height: 9
+        width: 14
+        x: 10
+        y: 14
+  panels:
+    cls-over-time:
+      kind: Panel
+      spec:
+        display:
+          name: CLS p75 over time
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            connectNulls: true
+            showLegend: true
+        queries:
+        - kind: ClickHouseSQL
+          spec:
+            plugin:
+              kind: ClickHouseSQL
+              spec:
+                query: |
+                  SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} SECOND) AS ts,
+                         ServiceName,
+                         round(quantile(0.75)(toFloat64OrNull(LogAttributes['browser.web_vital.value'])), 3) AS cls
+                  FROM logs
+                  WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                    AND EventName = 'browser.web_vital'
+                    AND LogAttributes['browser.web_vital.name'] = 'cls'
+                    AND ServiceName IN $service
+                  GROUP BY ts, ServiceName
+                  ORDER BY ts
+    ms-vitals-over-time:
+      kind: Panel
+      spec:
+        display:
+          description: LCP, INP, TTFB, and FCP p75 per bucket.
+          name: p75 over time (ms vitals)
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            connectNulls: true
+            showLegend: true
+            unit: ms
+        queries:
+        - kind: ClickHouseSQL
+          spec:
+            plugin:
+              kind: ClickHouseSQL
+              spec:
+                query: |
+                  SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} SECOND) AS ts,
+                         round(quantileIf(0.75)(toFloat64OrNull(LogAttributes['browser.web_vital.value']), LogAttributes['browser.web_vital.name'] = 'lcp')) AS lcp,
+                         round(quantileIf(0.75)(toFloat64OrNull(LogAttributes['browser.web_vital.value']), LogAttributes['browser.web_vital.name'] = 'inp')) AS inp,
+                         round(quantileIf(0.75)(toFloat64OrNull(LogAttributes['browser.web_vital.value']), LogAttributes['browser.web_vital.name'] = 'ttfb')) AS ttfb,
+                         round(quantileIf(0.75)(toFloat64OrNull(LogAttributes['browser.web_vital.value']), LogAttributes['browser.web_vital.name'] = 'fcp')) AS fcp
+                  FROM logs
+                  WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                    AND EventName = 'browser.web_vital'
+                    AND ServiceName IN $service
+                  GROUP BY ts
+                  ORDER BY ts
+    p75-cls:
+      kind: Panel
+      spec:
+        display:
+          name: CLS p75
+        plugin:
+          kind: GaugeChart
+          spec:
+            calculation: last
+            decimals: 3
+            min: 0
+            max: 0.35
+            thresholds:
+              defaultColor: '#22c55e'
+              defaultName: Good
+              mode: absolute
+              steps:
+              - color: '#f59e0b'
+                name: Needs improvement
+                value: 0.1
+              - color: '#ef4444'
+                name: Poor
+                value: 0.25
+        queries:
+        - kind: ClickHouseSQL
+          spec:
+            plugin:
+              kind: ClickHouseSQL
+              spec:
+                query: |
+                  SELECT round(quantile(0.75)(toFloat64OrNull(LogAttributes['browser.web_vital.value'])), 3) AS cls
+                  FROM logs
+                  WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                    AND EventName = 'browser.web_vital'
+                    AND LogAttributes['browser.web_vital.name'] = 'cls'
+                    AND ServiceName IN $service
+    p75-inp:
+      kind: Panel
+      spec:
+        display:
+          name: INP p75
+        plugin:
+          kind: GaugeChart
+          spec:
+            calculation: last
+            decimals: 0
+            min: 0
+            max: 700
+            thresholds:
+              defaultColor: '#22c55e'
+              defaultName: Good
+              mode: absolute
+              steps:
+              - color: '#f59e0b'
+                name: Needs improvement
+                value: 200
+              - color: '#ef4444'
+                name: Poor
+                value: 500
+            unit: ms
+        queries:
+        - kind: ClickHouseSQL
+          spec:
+            plugin:
+              kind: ClickHouseSQL
+              spec:
+                query: |
+                  SELECT round(quantile(0.75)(toFloat64OrNull(LogAttributes['browser.web_vital.value']))) AS inp
+                  FROM logs
+                  WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                    AND EventName = 'browser.web_vital'
+                    AND LogAttributes['browser.web_vital.name'] = 'inp'
+                    AND ServiceName IN $service
+    p75-lcp:
+      kind: Panel
+      spec:
+        display:
+          name: LCP p75
+        plugin:
+          kind: GaugeChart
+          spec:
+            calculation: last
+            decimals: 0
+            min: 0
+            max: 5300
+            thresholds:
+              defaultColor: '#22c55e'
+              defaultName: Good
+              mode: absolute
+              steps:
+              - color: '#f59e0b'
+                name: Needs improvement
+                value: 2500
+              - color: '#ef4444'
+                name: Poor
+                value: 4000
+            unit: ms
+        queries:
+        - kind: ClickHouseSQL
+          spec:
+            plugin:
+              kind: ClickHouseSQL
+              spec:
+                query: |
+                  SELECT round(quantile(0.75)(toFloat64OrNull(LogAttributes['browser.web_vital.value']))) AS lcp
+                  FROM logs
+                  WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                    AND EventName = 'browser.web_vital'
+                    AND LogAttributes['browser.web_vital.name'] = 'lcp'
+                    AND ServiceName IN $service
+    p75-ttfb:
+      kind: Panel
+      spec:
+        display:
+          name: TTFB p75
+        plugin:
+          kind: GaugeChart
+          spec:
+            calculation: last
+            decimals: 0
+            min: 0
+            max: 2400
+            thresholds:
+              defaultColor: '#22c55e'
+              defaultName: Good
+              mode: absolute
+              steps:
+              - color: '#f59e0b'
+                name: Needs improvement
+                value: 800
+              - color: '#ef4444'
+                name: Poor
+                value: 1800
+            unit: ms
+        queries:
+        - kind: ClickHouseSQL
+          spec:
+            plugin:
+              kind: ClickHouseSQL
+              spec:
+                query: |
+                  SELECT round(quantile(0.75)(toFloat64OrNull(LogAttributes['browser.web_vital.value']))) AS ttfb
+                  FROM logs
+                  WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                    AND EventName = 'browser.web_vital'
+                    AND LogAttributes['browser.web_vital.name'] = 'ttfb'
+                    AND ServiceName IN $service
+    rating-by-vital:
+      kind: Panel
+      spec:
+        display:
+          description: Share of good / needs-improvement / poor samples per vital.
+          name: Rating distribution by vital
+        plugin:
+          kind: BarChart
+          spec:
+            showLegend: true
+            stacking: percent
+        queries:
+        - kind: ClickHouseSQL
+          spec:
+            plugin:
+              kind: ClickHouseSQL
+              spec:
+                query: |
+                  SELECT LogAttributes['browser.web_vital.name'] AS vital,
+                         LogAttributes['browser.web_vital.rating'] AS rating,
+                         count() AS samples
+                  FROM logs
+                  WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                    AND EventName = 'browser.web_vital'
+                    AND ServiceName IN $service
+                  GROUP BY vital, rating
+                  ORDER BY vital, rating
+    worst-routes:
+      kind: Panel
+      spec:
+        display:
+          description: Route pattern when the router reported one, else the raw path.
+          name: Worst routes by LCP p75
+        plugin:
+          kind: Table
+          spec:
+            stickyHeader: true
+        queries:
+        - kind: ClickHouseSQL
+          spec:
+            plugin:
+              kind: ClickHouseSQL
+              spec:
+                query: |
+                  SELECT ServiceName AS service,
+                         if(LogAttributes['everr.route.pattern'] != '', LogAttributes['everr.route.pattern'], LogAttributes['url.path']) AS route,
+                         count() AS samples,
+                         round(quantileIf(0.75)(toFloat64OrNull(LogAttributes['browser.web_vital.value']), LogAttributes['browser.web_vital.name'] = 'lcp')) AS lcp_p75_ms,
+                         round(quantileIf(0.75)(toFloat64OrNull(LogAttributes['browser.web_vital.value']), LogAttributes['browser.web_vital.name'] = 'inp')) AS inp_p75_ms,
+                         round(quantileIf(0.75)(toFloat64OrNull(LogAttributes['browser.web_vital.value']), LogAttributes['browser.web_vital.name'] = 'cls'), 3) AS cls_p75
+                  FROM logs
+                  WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
+                    AND EventName = 'browser.web_vital'
+                    AND ServiceName IN $service
+                  GROUP BY service, route
+                  ORDER BY lcp_p75_ms DESC NULLS LAST
+                  LIMIT 15
+  refreshInterval: 1m
+  variables:
+  - kind: ListVariable
+    spec:
+      allowAllValue: true
+      allowMultiple: true
+      defaultValue: __all
+      display:
+        name: Service
+      name: service
+      plugin:
+        kind: ClickHouseSQLVariable
+        spec:
+          query: SELECT DISTINCT ServiceName FROM logs WHERE EventName = 'browser.web_vital' ORDER BY ServiceName
+      sort: alphabetical-asc

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.tsx
@@ -5,36 +5,16 @@ import { queryLabel, SERIES_COLORS } from "../data-utils";
 import type { VisualizationProps } from "../index";
 import {
   formatStatValue,
-  resolveThresholdColor,
+  resolveThresholdBand,
   type ThresholdsSpec,
 } from "../stat-chart/stat-calculations";
 import { computeStatTiles } from "../stat-chart/stat-series";
 import type { GaugeChartSpec } from "./spec";
 
-// Semicircle geometry in viewBox units. The round caps and the threshold
-// ticks extend past the arc radius, hence the margins in the viewBox.
-const VIEWBOX = "0 0 100 64";
-const CX = 50;
-const CY = 50;
-const R = 38;
-const STROKE = 9;
-
-function polar(r: number, angleDeg: number): { x: number; y: number } {
-  const rad = (angleDeg * Math.PI) / 180;
-  return { x: CX + r * Math.cos(rad), y: CY - r * Math.sin(rad) };
-}
-
-/** Arc along the semicircle: 180° is the left end, 0° the right end. */
-function arcPath(startAngle: number, endAngle: number): string {
-  const s = polar(R, startAngle);
-  const e = polar(R, endAngle);
-  return `M ${s.x} ${s.y} A ${R} ${R} 0 0 1 ${e.x} ${e.y}`;
-}
-
 /**
  * 0..1 position of `value` along the gauge axis, measured from the `min` end.
  * Inverted bounds (`min > max`) are supported: the signed span flips the
- * direction so the arc fills toward the `max` end as the value approaches it.
+ * direction so the bar fills toward the `max` end as the value approaches it.
  * Returns 0 only for a truly degenerate axis (`min === max`).
  */
 function axisFraction(value: number, min: number, max: number): number {
@@ -42,42 +22,68 @@ function axisFraction(value: number, min: number, max: number): number {
   return Math.min(1, Math.max(0, (value - min) / (max - min)));
 }
 
-interface ThresholdTick {
+interface ThresholdMark {
   fraction: number;
+  /** Step value in axis units, for the tick label. */
+  value: number;
+}
+
+interface FillSegment {
+  from: number;
+  to: number;
   color: string;
 }
 
 /**
- * Step positions projected onto the gauge axis. Percent steps resolve against
- * the same reference `resolveThresholdColor` uses (thresholds.max, falling
- * back to the gauge max), so a tick always sits where the color changes.
+ * Step positions projected onto the gauge axis, in axis units. Percent steps
+ * resolve against the same reference `resolveThresholdBand` uses
+ * (thresholds.max, falling back to the gauge max), so a mark always sits where
+ * the band changes. Only steps strictly inside the axis span are kept — works
+ * for inverted bounds too.
  */
-function thresholdTicks(
+function thresholdMarks(
   thresholds: ThresholdsSpec | undefined,
   min: number,
   max: number,
-): ThresholdTick[] {
+): ThresholdMark[] {
   if (!thresholds?.steps) return [];
   const ref = thresholds.max ?? max;
-  return (
-    thresholds.steps
-      .map((step) => ({
-        value:
-          thresholds.mode === "percent" ? (step.value / 100) * ref : step.value,
-        color: step.color,
-      }))
-      .filter(
-        (t): t is { value: number; color: string } => t.color !== undefined,
-      )
-      // Keep ticks strictly inside the axis span — works for inverted bounds too.
-      .filter(
-        (t) => t.value > Math.min(min, max) && t.value < Math.max(min, max),
-      )
-      .map((t) => ({
-        fraction: axisFraction(t.value, min, max),
-        color: t.color,
-      }))
-  );
+  return thresholds.steps
+    .map((step) => ({
+      value:
+        thresholds.mode === "percent" ? (step.value / 100) * ref : step.value,
+    }))
+    .filter((t) => t.value > Math.min(min, max) && t.value < Math.max(min, max))
+    .map((t) => ({ fraction: axisFraction(t.value, min, max), value: t.value }))
+    .sort((a, b) => a.fraction - b.fraction);
+}
+
+/**
+ * The filled part of the track, split at each threshold the value has crossed,
+ * each piece painted with its band's color. Each segment resolves its color
+ * from the axis value at its midpoint, so inverted bounds (`min > max`) paint
+ * the bands on the correct side without any ascending-axis assumption.
+ */
+function fillSegments(
+  fraction: number,
+  marks: ThresholdMark[],
+  thresholds: ThresholdsSpec | undefined,
+  min: number,
+  max: number,
+  fallback: string,
+): FillSegment[] {
+  const bounds = [0, ...marks.map((m) => m.fraction), 1];
+  const segments: FillSegment[] = [];
+  for (let i = 0; i < bounds.length - 1; i++) {
+    const from = bounds[i] ?? 0;
+    const to = Math.min(fraction, bounds[i + 1] ?? 1);
+    if (to <= from) continue;
+    const midValue = min + ((from + to) / 2) * (max - min);
+    const color =
+      resolveThresholdBand(midValue, thresholds, max).color ?? fallback;
+    segments.push({ from, to, color });
+  }
+  return segments;
 }
 
 export function GaugeChartVisualization({
@@ -100,8 +106,8 @@ export function GaugeChartVisualization({
     [data, calculation],
   );
   const hasAnyValue = tiles.some((t) => t.value !== undefined);
-  const ticks = useMemo(
-    () => thresholdTicks(thresholds, min, max),
+  const marks = useMemo(
+    () => thresholdMarks(thresholds, min, max),
     [thresholds, min, max],
   );
 
@@ -117,115 +123,99 @@ export function GaugeChartVisualization({
   }
 
   const multi = tiles.length > 1;
+  const fallbackColor = SERIES_COLORS[0] ?? "currentColor";
 
   return (
-    <div className="flex h-full flex-wrap items-stretch justify-center gap-4">
+    <div className="flex h-full flex-wrap content-center justify-center gap-x-6 gap-y-4 px-1">
       {tiles.map((tile) => {
         const value = tile.value;
         const label = tile.label || queryLabel(tile.frame);
-        const color =
-          (value !== undefined
-            ? resolveThresholdColor(value, thresholds, max)
-            : undefined) ??
-          SERIES_COLORS[0] ??
-          "currentColor";
+        const band =
+          value !== undefined
+            ? resolveThresholdBand(value, thresholds, max)
+            : { color: undefined, name: undefined };
+        const color = band.color ?? fallbackColor;
         const fraction =
           value !== undefined ? axisFraction(value, min, max) : 0;
+        const segments =
+          value !== undefined
+            ? fillSegments(fraction, marks, thresholds, min, max, fallbackColor)
+            : [];
         const valueText =
           value === undefined ? noValue : formatStatValue(value, decimals);
         return (
           <div
             key={`${tile.frame}-${tile.label}`}
-            className="flex min-w-28 flex-1 flex-col items-center"
+            className="min-w-40 flex-1"
+            role="img"
+            aria-label={`${label}: ${valueText}${unit ? ` ${unit}` : ""}${
+              band.name ? ` (${band.name})` : ""
+            }`}
           >
             {(multi || showLabel) && (
-              <p className="text-xs text-muted-foreground">{label}</p>
+              <p className="mb-1 truncate text-xs text-muted-foreground">
+                {label}
+              </p>
             )}
-            {/* The SVG is absolutely positioned: inside a wrapped flex line a
-                percentage height can't resolve and the SVG would fall back to
-                width-driven sizing and overflow the panel. */}
-            <div className="relative min-h-0 w-full flex-1">
-              <svg
-                viewBox={VIEWBOX}
-                preserveAspectRatio="xMidYMid meet"
-                className="absolute inset-0 h-full w-full"
-                role="img"
-                aria-label={`${label}: ${valueText}${unit ? ` ${unit}` : ""}`}
-              >
-                <path
-                  d={arcPath(180, 0)}
-                  className="stroke-muted"
-                  strokeWidth={STROKE}
-                  strokeLinecap="round"
-                  fill="none"
-                />
-                {fraction > 0 && (
-                  <path
-                    d={arcPath(180, 180 - fraction * 180)}
-                    stroke={color}
-                    strokeWidth={STROKE}
-                    strokeLinecap="round"
-                    fill="none"
-                  />
+            <p className="mb-2 leading-none">
+              <span
+                className={cn(
+                  "text-2xl font-semibold tabular-nums",
+                  value === undefined && "text-muted-foreground",
                 )}
-                {ticks.map((tick) => {
-                  const angle = 180 - tick.fraction * 180;
-                  const inner = polar(R - STROKE / 2 - 2, angle);
-                  const outer = polar(R + STROKE / 2 + 2, angle);
-                  return (
-                    <line
-                      key={`${tick.fraction}-${tick.color}`}
-                      x1={inner.x}
-                      y1={inner.y}
-                      x2={outer.x}
-                      y2={outer.y}
-                      stroke={tick.color}
-                      strokeWidth={1.25}
-                    />
-                  );
-                })}
-                <text
-                  x={CX}
-                  y={46}
-                  textAnchor="middle"
-                  fontSize={13}
-                  className={cn(
-                    "font-semibold tabular-nums",
-                    value === undefined
-                      ? "fill-muted-foreground"
-                      : "fill-foreground",
-                  )}
-                >
-                  {valueText}
-                  {value !== undefined && unit && (
-                    <tspan
-                      dx={1.5}
-                      fontSize={7}
-                      className="fill-muted-foreground font-normal"
+                style={value !== undefined ? { color } : undefined}
+              >
+                {valueText}
+              </span>
+              {value !== undefined && unit && (
+                <span className="ml-1 text-xs text-muted-foreground">
+                  {unit}
+                </span>
+              )}
+              {value !== undefined && band.name && (
+                <span className="ml-1.5 text-xs text-muted-foreground">
+                  ({band.name})
+                </span>
+              )}
+            </p>
+            <div className="relative pt-2">
+              {/* Triangle marker pointing down at the value position. */}
+              {value !== undefined && (
+                <div
+                  className="absolute top-0 -translate-x-1/2 border-x-[5px] border-t-[6px] border-x-transparent border-t-foreground"
+                  style={{ left: `${fraction * 100}%` }}
+                />
+              )}
+              <div className="relative h-2.5 overflow-hidden rounded-sm bg-muted">
+                {segments.map((s) => (
+                  <div
+                    key={s.from}
+                    className="absolute inset-y-0"
+                    style={{
+                      left: `${s.from * 100}%`,
+                      width: `${(s.to - s.from) * 100}%`,
+                      backgroundColor: s.color,
+                    }}
+                  />
+                ))}
+              </div>
+              {marks.length > 0 && (
+                <div className="relative h-6">
+                  {marks.map((mark) => (
+                    <div
+                      key={mark.fraction}
+                      className="absolute top-0 -translate-x-1/2"
+                      style={{ left: `${mark.fraction * 100}%` }}
                     >
-                      {unit}
-                    </tspan>
-                  )}
-                </text>
-                <text
-                  x={CX - R}
-                  y={62}
-                  textAnchor="middle"
-                  fontSize={5.5}
-                  className="fill-muted-foreground tabular-nums"
-                >
-                  {formatStatValue(min, undefined)}
-                </text>
-                <text
-                  x={CX + R}
-                  y={62}
-                  textAnchor="middle"
-                  fontSize={5.5}
-                  className="fill-muted-foreground tabular-nums"
-                >
-                  {formatStatValue(max, undefined)}
-                </text>
-              </svg>
+                      <div className="mx-auto h-1.5 w-px bg-muted-foreground" />
+                      <p className="whitespace-nowrap text-[10px] tabular-nums text-muted-foreground">
+                        {formatStatValue(mark.value, undefined)}
+                        {unit}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
           </div>
         );

--- a/packages/app/src/components/dashboards/visualizations/stat-chart/spec.ts
+++ b/packages/app/src/components/dashboards/visualizations/stat-chart/spec.ts
@@ -3,11 +3,15 @@ import * as z from "zod";
 const thresholdStep = z.looseObject({
   value: z.number(),
   color: z.string().optional(),
+  /** Qualitative label for the band this step starts (e.g. "Poor"). */
+  name: z.string().optional(),
 });
 
 export const thresholdsSpec = z.looseObject({
   mode: z.enum(["absolute", "percent"]).default("absolute"),
   defaultColor: z.string().optional(),
+  /** Qualitative label for the band below the first step (e.g. "Good"). */
+  defaultName: z.string().optional(),
   steps: z.array(thresholdStep).optional(),
   /**
    * Reference value for `percent` mode: steps compare against value/max*100.

--- a/packages/app/src/components/dashboards/visualizations/stat-chart/stat-calculations.ts
+++ b/packages/app/src/components/dashboards/visualizations/stat-chart/stat-calculations.ts
@@ -34,12 +34,17 @@ export function calculate(
   }
 }
 
-export function resolveThresholdColor(
+export interface ThresholdBand {
+  color: string | undefined;
+  name: string | undefined;
+}
+
+export function resolveThresholdBand(
   value: number,
   thresholds: ThresholdsSpec | undefined,
   seriesMax: number,
-): string | undefined {
-  if (!thresholds) return undefined;
+): ThresholdBand {
+  if (!thresholds) return { color: undefined, name: undefined };
   const steps = [...(thresholds.steps ?? [])].sort((a, b) => a.value - b.value);
   // Percent mode divides by the configured max, else the series' own max. A
   // non-positive divisor would invert the comparison (e.g. an all-negative
@@ -48,10 +53,24 @@ export function resolveThresholdColor(
   const compare =
     thresholds.mode === "percent" ? (max > 0 ? (value / max) * 100 : 0) : value;
   let color = thresholds.defaultColor;
+  // Unlike colors, names don't carry across an unnamed step: the crossed band
+  // simply has no qualitative label.
+  let name = thresholds.defaultName;
   for (const step of steps) {
-    if (compare >= step.value) color = step.color ?? color;
+    if (compare >= step.value) {
+      color = step.color ?? color;
+      name = step.name;
+    }
   }
-  return color;
+  return { color, name };
+}
+
+export function resolveThresholdColor(
+  value: number,
+  thresholds: ThresholdsSpec | undefined,
+  seriesMax: number,
+): string | undefined {
+  return resolveThresholdBand(value, thresholds, seriesMax).color;
 }
 
 const ABBREVIATIONS: ReadonlyArray<[number, string]> = [


### PR DESCRIPTION
## What

- Rebuilds the `GaugeChart` visualization from a semicircular arc to a horizontal bar gauge:
  - large value tinted with the active threshold color, with the unit and the band's qualitative name (e.g. `72 ms (Good)`) beside it
  - triangle marker at the value position on the track
  - segmented fill that changes color at each crossed threshold; the unfilled track stays muted
  - labeled tick marks below the bar at each threshold (e.g. `800ms`, `1800ms`); the min/max end labels are gone
  - multi-series panels keep the side-by-side wrapping layout
- Threshold steps gain an optional `name`, and `thresholds` gains `defaultName` for the band below the first step (both optional and Perses-aligned; `resolveThresholdColor` behavior for StatChart is unchanged)
- Switches the Web Vitals dashboard's first row to gauges with the standard good / needs-improvement / poor bands, and removes the FCP panel
- Restores `everr/web-vitals.dashboard.yaml` and `everr/docs-homepage.dashboard.yaml`, which were deleted in fc9cfd1c5 while both dashboards were still live under this repo's apply id (a future `everr apply` would have deleted them)

## Before / After

`demo-gauge` regression dashboard in the dev app:

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/everr-labs/everr/assets/linear-gauge-2026-08/gauge-before.png) | ![after](https://raw.githubusercontent.com/everr-labs/everr/assets/linear-gauge-2026-08/gauge-after.png) |

## Testing

- Verified every panel of the `demo-gauge` regression dashboard in the dev app, including clamping, inverted bounds, percent thresholds, multi-gauge, and empty states
- Verified the Web Vitals dashboard renders the four gauges with named bands after `everr apply`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation telemetry dashboards for page views, traffic, engagement, and frustration trends.
  * Added Web Vitals dashboards with performance gauges, trends, rating distributions, and worst-performing routes.
  * Enhanced gauge visualizations with clearer threshold labels, units, responsive styling, and accessibility information.
  * Added qualitative threshold band names and improved threshold status display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
