### PR TITLE
refactor(traces): key the service color on the service name alone

### DIFF
--- a/packages/telemetry-explorer/src/traces/index.ts
+++ b/packages/telemetry-explorer/src/traces/index.ts
@@ -9,6 +9,7 @@ export * from "./data/schemas";
 export * from "./data/types";
 export * from "./data/window";
 export { TimeRangeSearchSchema } from "./time-range";
+export { serviceColor } from "./ui/shared/service-color";
 export type {
   TraceDetailProps,
   TraceDetailSearch,

--- a/packages/telemetry-explorer/src/traces/ui/shared/service-color.test.ts
+++ b/packages/telemetry-explorer/src/traces/ui/shared/service-color.test.ts
@@ -2,34 +2,28 @@ import { describe, expect, it } from "vitest";
 import { serviceColor } from "./service-color";
 
 describe("serviceColor", () => {
-  it("returns a stable color for the same (namespace, name)", () => {
-    const first = serviceColor("github", "actions-runner");
+  it("returns a stable color for the same name", () => {
+    const first = serviceColor("actions-runner");
     for (let i = 0; i < 100; i++) {
-      expect(serviceColor("github", "actions-runner")).toBe(first);
+      expect(serviceColor("actions-runner")).toBe(first);
     }
   });
 
-  it("differentiates namespace from name", () => {
-    const a = serviceColor("github", "actions");
-    const b = serviceColor("", "github/actions");
-    expect(a).not.toBe(b);
-  });
-
   it("spreads across multiple palette slots on a small set", () => {
-    const services: Array<[string, string]> = [
-      ["github", "actions-runner"],
-      ["github", "scheduler"],
-      ["app", "api"],
-      ["app", "worker"],
-      ["everr", "ingest"],
-      ["everr", "query"],
-      ["", "lonely"],
+    const services = [
+      "actions-runner",
+      "scheduler",
+      "api",
+      "worker",
+      "ingest",
+      "query",
+      "lonely",
     ];
-    const colors = new Set(services.map(([ns, n]) => serviceColor(ns, n)));
+    const colors = new Set(services.map((n) => serviceColor(n)));
     expect(colors.size).toBeGreaterThanOrEqual(2);
   });
 
   it("returns a CSS variable reference", () => {
-    expect(serviceColor("ns", "svc")).toMatch(/^var\(--trace-service-\d\)$/);
+    expect(serviceColor("svc")).toMatch(/^var\(--trace-service-\d\)$/);
   });
 });

--- a/packages/telemetry-explorer/src/traces/ui/shared/service-color.ts
+++ b/packages/telemetry-explorer/src/traces/ui/shared/service-color.ts
@@ -18,8 +18,7 @@ function fnv1a(str: string): number {
   return h;
 }
 
-export function serviceColor(namespace: string, name: string): string {
-  const key = `${namespace}/${name}`;
-  const idx = fnv1a(key) % PALETTE.length;
+export function serviceColor(name: string): string {
+  const idx = fnv1a(name) % PALETTE.length;
   return `var(${PALETTE[idx]})`;
 }

--- a/packages/telemetry-explorer/src/traces/ui/timeline/span-bar.tsx
+++ b/packages/telemetry-explorer/src/traces/ui/timeline/span-bar.tsx
@@ -32,7 +32,7 @@ export function SpanBar({ span, traceStartNs, traceEndNs }: Props) {
         left: `${leftPct}%`,
         width: isZero ? undefined : `${Math.max(widthPct, 0.1)}%`,
         minWidth: isZero ? "1px" : undefined,
-        backgroundColor: serviceColor(span.serviceNamespace, span.serviceName),
+        backgroundColor: serviceColor(span.serviceName),
       }}
     >
       {isError && (

--- a/packages/telemetry-explorer/src/traces/ui/timeline/span-row.tsx
+++ b/packages/telemetry-explorer/src/traces/ui/timeline/span-row.tsx
@@ -66,10 +66,7 @@ export function SpanRow({
         <span
           className="size-2 shrink-0 rounded-full"
           style={{
-            backgroundColor: serviceColor(
-              span.serviceNamespace,
-              span.serviceName,
-            ),
+            backgroundColor: serviceColor(span.serviceName),
           }}
         />
         <span className="truncate font-medium">{span.spanName}</span>

--- a/packages/telemetry-explorer/src/traces/ui/trace-detail-page.tsx
+++ b/packages/telemetry-explorer/src/traces/ui/trace-detail-page.tsx
@@ -156,10 +156,7 @@ function TraceHeader({
       <span
         className="size-2.5 rounded-full"
         style={{
-          backgroundColor: serviceColor(
-            root.serviceNamespace,
-            root.serviceName,
-          ),
+          backgroundColor: serviceColor(root.serviceName),
         }}
       />
       <div className="min-w-0 max-w-2xl flex-1">

--- a/packages/telemetry-explorer/src/traces/ui/trace-results-list.tsx
+++ b/packages/telemetry-explorer/src/traces/ui/trace-results-list.tsx
@@ -194,7 +194,7 @@ function TraceRow({
         <span
           className="size-2 shrink-0 rounded-full"
           style={{
-            backgroundColor: serviceColor(row.rootNamespace, row.rootService),
+            backgroundColor: serviceColor(row.rootService),
           }}
         />
         <span className="min-w-0 truncate" title={row.rootService}>


### PR DESCRIPTION
Split out of the homepage overview work so the color change can be reviewed on its own.

## Why

`serviceColor` hashed `` `${namespace}/${name}` `` to pick a palette slot. The same service therefore drew a different color depending on whether its namespace was present or spelled differently, and any surface outside the traces views could not agree with them at all.

## What changed

- `serviceColor(name)` takes the service name alone and hashes that.
- Exported from `@everr/telemetry-explorer/traces` so other surfaces can key on the same palette.
- The four call sites (span bar, span row, trace header, trace results list) pass the name only.

`serviceNamespace` is untouched everywhere else: it still shows on the span detail panel and still drives the service filter. Only the color key changes.

## Testing

`pnpm --filter @everr/telemetry-explorer test` (45 files, 244 tests) and `pnpm --filter @everr/app typecheck` both pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Service colors in trace views are now determined consistently from the service name alone.
  - Updated trace timelines, span rows, trace details, and results to reflect the simplified color assignment.
  - The service color utility is now publicly available for broader use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->