### PR TITLE
feat(app): add variant, showAxis, showThresholdLabels to GaugeChart

### DIFF
--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/gaugechart.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/gaugechart.md
@@ -1,6 +1,6 @@
 # GaugeChart
 
-One or more gauges, each showing a single value filled between `min` and `max`, with optional threshold coloring and tick marks. Renders as a semicircular arc by default; `variant` switches to a flat horizontal or vertical bar.
+One or more gauges, each showing a single value filled between `min` and `max`, with optional threshold coloring and tick marks. Renders as a semicircular arc by default; `variant` switches to a flat horizontal bar.
 
 ## Options (`plugin.spec`)
 
@@ -13,8 +13,8 @@ One or more gauges, each showing a single value filled between `min` and `max`, 
 | `max` | number | `100` | any number | Gauge axis upper bound. **Set it to the metric's real ceiling** — the default 100 only suits percentages. Inverting the bounds (`min > max`) inverts the arc, so a lower value reads as fuller — useful for "lower is better" metrics. |
 | `showLabel` | boolean | `false` | `true` | Show the column-name label even on a single-gauge panel (multi-gauge always shows it). |
 | `noValue` | string | `–` | any string | Text rendered for a query that produced no value (empty result / no numeric column). |
-| `variant` | string | none (= `arc`) | `arc`, `horizontal`, `vertical` | Rendering shape. Omitted or `arc`: semicircular arc. `horizontal`: flat bar filling left→right with the value text above it. `vertical`: flat bar filling bottom→top with the value text beside it. Bar variants show a triangle marker at the value position and, with thresholds, multi-colored fill segments per band. |
-| `showAxis` | boolean | `true` | `false` | Show the `min`/`max` axis labels: at the arc ends, below the horizontal bar, or beside the vertical bar. |
+| `variant` | string | none (= `arc`) | `arc`, `horizontal` | Rendering shape. Omitted or `arc`: semicircular arc. `horizontal`: flat bar filling left→right with the value text above it, a triangle marker at the value position and, with thresholds, multi-colored fill segments per band. |
+| `showAxis` | boolean | `true` | `false` | Show the `min`/`max` axis labels: at the arc ends, or below the horizontal bar. |
 | `showThresholdLabels` | boolean | `false` | `true` | Show a numeric label at each threshold tick mark (any variant). |
 | `thresholds` | object | none | see below | Color the arc and mark step positions on the gauge. Omit for the default series color. |
 

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/gaugechart.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/gaugechart.md
@@ -15,7 +15,7 @@ One or more gauges, each showing a single value filled between `min` and `max`, 
 | `noValue` | string | `–` | any string | Text rendered for a query that produced no value (empty result / no numeric column). |
 | `variant` | string | none (= `arc`) | `arc`, `horizontal` | Rendering shape. Omitted or `arc`: semicircular arc. `horizontal`: flat bar filling left→right with the value text above it, a triangle marker at the value position and, with thresholds, multi-colored fill segments per band. |
 | `showAxis` | boolean | `true` | `false` | Show the `min`/`max` axis labels: at the arc ends, or below the horizontal bar. |
-| `showThresholdLabels` | boolean | `false` | `true` | Show a numeric label at each threshold tick mark (any variant). |
+| `showThresholdLabels` | boolean | `false` | `true` | Show a numeric label at each threshold tick mark (any variant). The label is the step position in axis units with the `unit` suffix, so a `percent` step reads as the value it lands on, not as the percentage you wrote. |
 | `thresholds` | object | none | see below | Color the arc and mark step positions on the gauge. Omit for the default series color. |
 
 ### `thresholds`

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/gaugechart.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/gaugechart.md
@@ -1,6 +1,6 @@
 # GaugeChart
 
-One or more semicircular gauges, each showing a single value as an arc filled between `min` and `max`, with optional threshold coloring and tick marks.
+One or more gauges, each showing a single value filled between `min` and `max`, with optional threshold coloring and tick marks. Renders as a semicircular arc by default; `variant` switches to a flat horizontal or vertical bar.
 
 ## Options (`plugin.spec`)
 
@@ -13,6 +13,9 @@ One or more semicircular gauges, each showing a single value as an arc filled be
 | `max` | number | `100` | any number | Gauge axis upper bound. **Set it to the metric's real ceiling** — the default 100 only suits percentages. Inverting the bounds (`min > max`) inverts the arc, so a lower value reads as fuller — useful for "lower is better" metrics. |
 | `showLabel` | boolean | `false` | `true` | Show the column-name label even on a single-gauge panel (multi-gauge always shows it). |
 | `noValue` | string | `–` | any string | Text rendered for a query that produced no value (empty result / no numeric column). |
+| `variant` | string | none (= `arc`) | `arc`, `horizontal`, `vertical` | Rendering shape. Omitted or `arc`: semicircular arc. `horizontal`: flat bar filling left→right with the value text above it. `vertical`: flat bar filling bottom→top with the value text beside it. Bar variants show a triangle marker at the value position and, with thresholds, multi-colored fill segments per band. |
+| `showAxis` | boolean | `true` | `false` | Show the `min`/`max` axis labels: at the arc ends, below the horizontal bar, or beside the vertical bar. |
+| `showThresholdLabels` | boolean | `false` | `true` | Show a numeric label at each threshold tick mark (any variant). |
 | `thresholds` | object | none | see below | Color the arc and mark step positions on the gauge. Omit for the default series color. |
 
 ### `thresholds`

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/gaugechart.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/gaugechart.md
@@ -58,5 +58,4 @@ There is **no** `title`, `orientation`, `sparkline`, or `colorMode`. `calculatio
 - A query that returns no value still renders its gauge (empty arc, `noValue` text) — it does not silently vanish from a multi-query panel.
 - **`percent` thresholds** compare against `thresholds.max`, falling back to the gauge `max` — unlike StatChart there is no series-max fallback, so single-value queries behave predictably.
 - Threshold ticks only render for steps that have a `color` and fall strictly inside `(min, max)`.
-- The `min`/`max` end labels carry the `unit` unless the end is `0`, which reads bare.
 - Values ≥ 1 million **abbreviate** (`1234567` → `1.23M`, then `B`, `T`); the `min`/`max` end labels use the same formatting.

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/gaugechart.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/gaugechart.md
@@ -13,9 +13,9 @@ One or more gauges, each showing a single value filled between `min` and `max`, 
 | `max` | number | `100` | any number | Gauge axis upper bound. **Set it to the metric's real ceiling** — the default 100 only suits percentages. Inverting the bounds (`min > max`) inverts the arc, so a lower value reads as fuller — useful for "lower is better" metrics. |
 | `showLabel` | boolean | `false` | `true` | Show the column-name label even on a single-gauge panel (multi-gauge always shows it). |
 | `noValue` | string | `–` | any string | Text rendered for a query that produced no value (empty result / no numeric column). |
-| `variant` | string | none (= `arc`) | `arc`, `horizontal` | Rendering shape. Omitted or `arc`: semicircular arc. `horizontal`: flat bar filling left→right with the value text above it, a triangle marker at the value position and, with thresholds, multi-colored fill segments per band. |
+| `variant` | string | `arc` | `arc`, `horizontal` | Rendering shape. `arc`: semicircular arc. `horizontal`: flat bar filling left→right with the value text above it, a triangle marker at the value position and, with thresholds, multi-colored fill segments per band. |
 | `showAxis` | boolean | `true` | `false` | Show the `min`/`max` axis labels: at the arc ends, or below the horizontal bar. |
-| `showThresholdLabels` | boolean | `false` | `true` | Show a numeric label at each threshold tick mark (any variant). The label is the step position in axis units with the `unit` suffix, so a `percent` step reads as the value it lands on, not as the percentage you wrote. |
+| `showThresholdLabels` | boolean | `false` | `true` | Show a numeric label at each threshold tick mark (any variant). |
 | `thresholds` | object | none | see below | Color the arc and mark step positions on the gauge. Omit for the default series color. |
 
 ### `thresholds`

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/gaugechart.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/gaugechart.md
@@ -58,4 +58,5 @@ There is **no** `title`, `orientation`, `sparkline`, or `colorMode`. `calculatio
 - A query that returns no value still renders its gauge (empty arc, `noValue` text) — it does not silently vanish from a multi-query panel.
 - **`percent` thresholds** compare against `thresholds.max`, falling back to the gauge `max` — unlike StatChart there is no series-max fallback, so single-value queries behave predictably.
 - Threshold ticks only render for steps that have a `color` and fall strictly inside `(min, max)`.
+- The `min`/`max` end labels carry the `unit` unless the end is `0`, which reads bare.
 - Values ≥ 1 million **abbreviate** (`1234567` → `1.23M`, then `B`, `T`); the `min`/`max` end labels use the same formatting.

--- a/everr/demo/gauge.dashboard.yaml
+++ b/everr/demo/gauge.dashboard.yaml
@@ -406,7 +406,7 @@ spec:
       spec:
         display:
           name: "Gauge: arc, threshold labels"
-          description: "variant: arc (explicit) · showThresholdLabels: true — numeric labels at each threshold tick on the semicircle"
+          description: "variant: arc (explicit) · showThresholdLabels: true. Numeric labels at each threshold tick on the semicircle"
         plugin:
           kind: GaugeChart
           spec:
@@ -434,7 +434,7 @@ spec:
       spec:
         display:
           name: "Gauge: arc, no axis"
-          description: "showAxis: false on the default arc — min/max end labels hidden"
+          description: "showAxis: false on the default arc. The min/max end labels are hidden"
         plugin:
           kind: GaugeChart
           spec:
@@ -483,7 +483,7 @@ spec:
       spec:
         display:
           name: "Gauge: horizontal, only threshold labels"
-          description: "variant: horizontal · showAxis: false + showThresholdLabels: true — numeric labels below each tick, no min/max row"
+          description: "variant: horizontal · showAxis: false + showThresholdLabels: true. Numeric labels below each tick, no min/max row"
         plugin:
           kind: GaugeChart
           spec:

--- a/everr/demo/gauge.dashboard.yaml
+++ b/everr/demo/gauge.dashboard.yaml
@@ -8,7 +8,7 @@ spec:
     description: >-
       GaugeChart regression sheet — every option (all 9 calculations, unit,
       decimals, min/max bounds, thresholds absolute/percent with and without
-      thresholds.max, showLabel, noValue, variant arc/horizontal/vertical,
+      thresholds.max, showLabel, noValue, variant arc/horizontal,
       showAxis, showThresholdLabels) and behavior (spec defaults, clamping
       past the bounds, multi-query placeholder, multi-gauge, empty, inverted
       bounds) exercised with deterministic TestData.
@@ -536,71 +536,6 @@ spec:
                   columns: [cache_hit, uptime, success]
                   rows:
                     - [20, 85, 99]
-    gauge-vertical:
-      kind: Panel
-      spec:
-        display:
-          name: "Gauge: vertical"
-          description: "variant: vertical · bar fills bottom-to-top, marker beside the bar, colored ticks, value beside the bar, min/max beside (showAxis default true)"
-        plugin:
-          kind: GaugeChart
-          spec:
-            variant: vertical
-            unit: "%"
-            thresholds:
-              mode: absolute
-              defaultColor: "#22c55e"
-              steps:
-                - { value: 50, color: "#f59e0b" }
-                - { value: 80, color: "#ef4444" }
-        queries:
-          - kind: TestData
-            spec:
-              plugin:
-                kind: TestData
-                spec:
-                  scenario: csv
-                  columns: [pct]
-                  rows:
-                    - [65]
-    gauge-vertical-threshold-labels:
-      kind: Panel
-      spec:
-        display:
-          name: "Gauge: vertical, threshold labels, no axis"
-          description: "variant: vertical · showAxis: false + showThresholdLabels: true · noValue second column shows the placeholder regardless of variant"
-        plugin:
-          kind: GaugeChart
-          spec:
-            variant: vertical
-            unit: "%"
-            showAxis: false
-            showThresholdLabels: true
-            noValue: "n/a"
-            thresholds:
-              mode: percent
-              defaultColor: "#22c55e"
-              steps:
-                - { value: 70, color: "#f59e0b" }
-                - { value: 90, color: "#ef4444" }
-        queries:
-          - kind: TestData
-            spec:
-              plugin:
-                kind: TestData
-                spec:
-                  scenario: csv
-                  columns: [pct]
-                  rows:
-                    - [82]
-          - kind: TestData
-            spec:
-              plugin:
-                kind: TestData
-                spec:
-                  scenario: csv
-                  columns: [svc, never]
-                  rows: []
   layouts:
     - kind: Grid
       spec:
@@ -626,5 +561,3 @@ spec:
           - { x: 8,  y: 31, width: 8,  height: 5, content: { $ref: "#/spec/panels/gauge-horizontal" } }
           - { x: 16, y: 31, width: 8,  height: 5, content: { $ref: "#/spec/panels/gauge-horizontal-threshold-labels" } }
           - { x: 0,  y: 36, width: 12, height: 7, content: { $ref: "#/spec/panels/gauge-horizontal-inverted-multi" } }
-          - { x: 12, y: 36, width: 6,  height: 7, content: { $ref: "#/spec/panels/gauge-vertical" } }
-          - { x: 18, y: 36, width: 6,  height: 7, content: { $ref: "#/spec/panels/gauge-vertical-threshold-labels" } }

--- a/everr/demo/gauge.dashboard.yaml
+++ b/everr/demo/gauge.dashboard.yaml
@@ -8,9 +8,10 @@ spec:
     description: >-
       GaugeChart regression sheet — every option (all 9 calculations, unit,
       decimals, min/max bounds, thresholds absolute/percent with and without
-      thresholds.max, showLabel, noValue) and behavior (spec defaults, clamping
-      past the bounds, multi-query placeholder, multi-gauge, empty) exercised
-      with deterministic TestData.
+      thresholds.max, showLabel, noValue, variant arc/horizontal/vertical,
+      showAxis, showThresholdLabels) and behavior (spec defaults, clamping
+      past the bounds, multi-query placeholder, multi-gauge, empty, inverted
+      bounds) exercised with deterministic TestData.
   duration: 7d
   refreshInterval: 1m
   panels:
@@ -399,6 +400,207 @@ spec:
                   scenario: csv
                   columns: [ts, value]
                   rows: []
+    # ── Variants + axis/threshold label toggles ──────────────────────
+    gauge-arc-threshold-labels:
+      kind: Panel
+      spec:
+        display:
+          name: "Gauge: arc, threshold labels"
+          description: "variant: arc (explicit) · showThresholdLabels: true — numeric labels at each threshold tick on the semicircle"
+        plugin:
+          kind: GaugeChart
+          spec:
+            variant: arc
+            unit: "%"
+            showThresholdLabels: true
+            thresholds:
+              mode: absolute
+              defaultColor: "#22c55e"
+              steps:
+                - { value: 70, color: "#f59e0b" }
+                - { value: 90, color: "#ef4444" }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: csv
+                  columns: [pct]
+                  rows:
+                    - [55]
+    gauge-arc-no-axis:
+      kind: Panel
+      spec:
+        display:
+          name: "Gauge: arc, no axis"
+          description: "showAxis: false on the default arc — min/max end labels hidden"
+        plugin:
+          kind: GaugeChart
+          spec:
+            unit: "%"
+            showAxis: false
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: csv
+                  columns: [pct]
+                  rows:
+                    - [42]
+    gauge-horizontal:
+      kind: Panel
+      spec:
+        display:
+          name: "Gauge: horizontal"
+          description: "variant: horizontal · thresholds → multi-colored fill segments, colored ticks below the bar, triangle marker at the value, min/max axis below (showAxis default true)"
+        plugin:
+          kind: GaugeChart
+          spec:
+            variant: horizontal
+            unit: "%"
+            decimals: 1
+            thresholds:
+              mode: absolute
+              defaultColor: "#22c55e"
+              steps:
+                - { value: 50, color: "#f59e0b" }
+                - { value: 80, color: "#ef4444" }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: csv
+                  columns: [pct]
+                  rows:
+                    - [65]
+    gauge-horizontal-threshold-labels:
+      kind: Panel
+      spec:
+        display:
+          name: "Gauge: horizontal, only threshold labels"
+          description: "variant: horizontal · showAxis: false + showThresholdLabels: true — numeric labels below each tick, no min/max row"
+        plugin:
+          kind: GaugeChart
+          spec:
+            variant: horizontal
+            unit: ms
+            max: 500
+            showAxis: false
+            showThresholdLabels: true
+            thresholds:
+              mode: absolute
+              defaultColor: "#22c55e"
+              steps:
+                - { value: 200, color: "#f59e0b" }
+                - { value: 400, color: "#ef4444" }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: csv
+                  columns: [p95_ms]
+                  rows:
+                    - [310]
+    gauge-horizontal-inverted-multi:
+      kind: Panel
+      spec:
+        display:
+          name: "Gauge: horizontal, inverted bounds, multi"
+          description: "variant: horizontal · min: 100 / max: 0 (inverted) · three numeric columns → three bars with labels"
+        plugin:
+          kind: GaugeChart
+          spec:
+            variant: horizontal
+            unit: "%"
+            min: 100
+            max: 0
+            thresholds:
+              mode: absolute
+              defaultColor: "#22c55e"
+              steps:
+                - { value: 40, color: "#ef4444" }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: csv
+                  columns: [cache_hit, uptime, success]
+                  rows:
+                    - [20, 85, 99]
+    gauge-vertical:
+      kind: Panel
+      spec:
+        display:
+          name: "Gauge: vertical"
+          description: "variant: vertical · bar fills bottom-to-top, marker beside the bar, colored ticks, value beside the bar, min/max beside (showAxis default true)"
+        plugin:
+          kind: GaugeChart
+          spec:
+            variant: vertical
+            unit: "%"
+            thresholds:
+              mode: absolute
+              defaultColor: "#22c55e"
+              steps:
+                - { value: 50, color: "#f59e0b" }
+                - { value: 80, color: "#ef4444" }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: csv
+                  columns: [pct]
+                  rows:
+                    - [65]
+    gauge-vertical-threshold-labels:
+      kind: Panel
+      spec:
+        display:
+          name: "Gauge: vertical, threshold labels, no axis"
+          description: "variant: vertical · showAxis: false + showThresholdLabels: true · noValue second column shows the placeholder regardless of variant"
+        plugin:
+          kind: GaugeChart
+          spec:
+            variant: vertical
+            unit: "%"
+            showAxis: false
+            showThresholdLabels: true
+            noValue: "n/a"
+            thresholds:
+              mode: percent
+              defaultColor: "#22c55e"
+              steps:
+                - { value: 70, color: "#f59e0b" }
+                - { value: 90, color: "#ef4444" }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: csv
+                  columns: [pct]
+                  rows:
+                    - [82]
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: csv
+                  columns: [svc, never]
+                  rows: []
   layouts:
     - kind: Grid
       spec:
@@ -419,3 +621,10 @@ spec:
           - { x: 16, y: 20, width: 8,  height: 6, content: { $ref: "#/spec/panels/gauge-empty" } }
           - { x: 0,  y: 26, width: 8,  height: 5, content: { $ref: "#/spec/panels/gauge-inverted" } }
           - { x: 8,  y: 26, width: 8,  height: 5, content: { $ref: "#/spec/panels/gauge-mid-band" } }
+          - { x: 16, y: 26, width: 8,  height: 5, content: { $ref: "#/spec/panels/gauge-arc-threshold-labels" } }
+          - { x: 0,  y: 31, width: 8,  height: 5, content: { $ref: "#/spec/panels/gauge-arc-no-axis" } }
+          - { x: 8,  y: 31, width: 8,  height: 5, content: { $ref: "#/spec/panels/gauge-horizontal" } }
+          - { x: 16, y: 31, width: 8,  height: 5, content: { $ref: "#/spec/panels/gauge-horizontal-threshold-labels" } }
+          - { x: 0,  y: 36, width: 12, height: 7, content: { $ref: "#/spec/panels/gauge-horizontal-inverted-multi" } }
+          - { x: 12, y: 36, width: 6,  height: 7, content: { $ref: "#/spec/panels/gauge-vertical" } }
+          - { x: 18, y: 36, width: 6,  height: 7, content: { $ref: "#/spec/panels/gauge-vertical-threshold-labels" } }

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-axis.test.ts
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-axis.test.ts
@@ -4,6 +4,7 @@ import {
   axisFraction,
   bandColors,
   fillSegments,
+  formatAxisEnd,
   thresholdMarks,
 } from "./gauge-axis";
 
@@ -127,5 +128,40 @@ describe("fillSegments", () => {
 
   it("returns nothing for an empty gauge", () => {
     expect(fillSegments(0, marks, colors)).toEqual([]);
+  });
+});
+
+describe("duplicate steps", () => {
+  const dupes: ThresholdsSpec = {
+    mode: "absolute",
+    defaultColor: GREEN,
+    steps: [
+      { value: 50, color: AMBER },
+      { value: 50, color: RED },
+    ],
+  };
+
+  it("does not emit an empty segment for the collapsed band", () => {
+    const marks = thresholdMarks(dupes, 0, 100);
+    const colors = bandColors(marks, dupes, 0, 100, "fallback");
+    expect(fillSegments(0.9, marks, colors)).toEqual([
+      { from: 0, to: 0.5, color: GREEN },
+      { from: 0.5, to: 0.9, color: RED },
+    ]);
+  });
+});
+
+describe("formatAxisEnd", () => {
+  it("suffixes the unit on a non-zero end", () => {
+    expect(formatAxisEnd(100, "%")).toBe("100%");
+    expect(formatAxisEnd(-500, "ms")).toBe("-500ms");
+  });
+
+  it("leaves a zero end bare", () => {
+    expect(formatAxisEnd(0, "%")).toBe("0");
+  });
+
+  it("works without a unit", () => {
+    expect(formatAxisEnd(50)).toBe("50");
   });
 });

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-axis.test.ts
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-axis.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import type { ThresholdsSpec } from "../stat-chart/stat-calculations";
+import {
+  axisFraction,
+  bandColors,
+  fillSegments,
+  thresholdMarks,
+} from "./gauge-axis";
+
+const GREEN = "#22c55e";
+const AMBER = "#f59e0b";
+const RED = "#ef4444";
+
+const absolute: ThresholdsSpec = {
+  mode: "absolute",
+  defaultColor: GREEN,
+  steps: [
+    { value: 50, color: AMBER },
+    { value: 80, color: RED },
+  ],
+};
+
+describe("axisFraction", () => {
+  it("measures from the min end", () => {
+    expect(axisFraction(25, 0, 100)).toBe(0.25);
+  });
+
+  it("flips for inverted bounds", () => {
+    expect(axisFraction(20, 100, 0)).toBe(0.8);
+  });
+
+  it("clamps outside the bounds", () => {
+    expect(axisFraction(-10, 0, 100)).toBe(0);
+    expect(axisFraction(150, 0, 100)).toBe(1);
+  });
+
+  it("returns 0 for a degenerate axis", () => {
+    expect(axisFraction(5, 5, 5)).toBe(0);
+  });
+});
+
+describe("thresholdMarks", () => {
+  it("projects absolute steps and sorts along the axis", () => {
+    expect(thresholdMarks(absolute, 0, 100)).toEqual([
+      { fraction: 0.5, text: "50", color: AMBER },
+      { fraction: 0.8, text: "80", color: RED },
+    ]);
+  });
+
+  it("projects percent steps against thresholds.max", () => {
+    const percent: ThresholdsSpec = {
+      mode: "percent",
+      max: 200,
+      steps: [{ value: 50, color: RED }],
+    };
+    expect(thresholdMarks(percent, 0, 400)).toEqual([
+      { fraction: 0.25, text: "100", color: RED },
+    ]);
+  });
+
+  it("suffixes the unit on the label", () => {
+    expect(thresholdMarks(absolute, 0, 100, "ms")[0]?.text).toBe("50ms");
+  });
+
+  it("drops steps outside the axis span, inverted bounds included", () => {
+    expect(thresholdMarks(absolute, 0, 40)).toEqual([]);
+    expect(thresholdMarks(absolute, 100, 0).map((m) => m.fraction)).toEqual([
+      0.2, 0.5,
+    ]);
+  });
+
+  it("keeps colorless steps as band edges", () => {
+    const marks = thresholdMarks(
+      { mode: "absolute", steps: [{ value: 50 }] },
+      0,
+      100,
+    );
+    expect(marks).toEqual([{ fraction: 0.5, text: "50", color: undefined }]);
+  });
+
+  it("returns nothing without steps", () => {
+    expect(thresholdMarks(undefined, 0, 100)).toEqual([]);
+  });
+});
+
+describe("bandColors", () => {
+  it("resolves one color per band", () => {
+    const marks = thresholdMarks(absolute, 0, 100);
+    expect(bandColors(marks, absolute, 0, 100, "fallback")).toEqual([
+      GREEN,
+      AMBER,
+      RED,
+    ]);
+  });
+
+  it("mirrors the bands for inverted bounds", () => {
+    const marks = thresholdMarks(absolute, 100, 0);
+    expect(bandColors(marks, absolute, 100, 0, "fallback")).toEqual([
+      RED,
+      AMBER,
+      GREEN,
+    ]);
+  });
+
+  it("falls back when no threshold resolves", () => {
+    expect(bandColors([], undefined, 0, 100, "fallback")).toEqual(["fallback"]);
+  });
+});
+
+describe("fillSegments", () => {
+  const marks = thresholdMarks(absolute, 0, 100);
+  const colors = bandColors(marks, absolute, 0, 100, "fallback");
+
+  it("splits the fill at every crossed threshold", () => {
+    expect(fillSegments(0.9, marks, colors)).toEqual([
+      { from: 0, to: 0.5, color: GREEN },
+      { from: 0.5, to: 0.8, color: AMBER },
+      { from: 0.8, to: 0.9, color: RED },
+    ]);
+  });
+
+  it("stops at the value, leaving later bands unfilled", () => {
+    expect(fillSegments(0.3, marks, colors)).toEqual([
+      { from: 0, to: 0.3, color: GREEN },
+    ]);
+  });
+
+  it("returns nothing for an empty gauge", () => {
+    expect(fillSegments(0, marks, colors)).toEqual([]);
+  });
+});

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-axis.ts
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-axis.ts
@@ -1,0 +1,113 @@
+import {
+  formatStatValue,
+  resolveThresholdColor,
+  type ThresholdsSpec,
+} from "../stat-chart/stat-calculations";
+
+/**
+ * 0..1 position of `value` along the gauge axis, measured from the `min` end.
+ * Inverted bounds (`min > max`) are supported: the signed span flips the
+ * direction so the gauge fills toward the `max` end as the value approaches
+ * it. Returns 0 only for a truly degenerate axis (`min === max`).
+ */
+export function axisFraction(value: number, min: number, max: number): number {
+  if (max === min) return 0;
+  return Math.min(1, Math.max(0, (value - min) / (max - min)));
+}
+
+/**
+ * Axis furniture (min/max ends, threshold ticks) always formats at the default
+ * precision: `decimals` is the value's precision, not the axis'.
+ */
+export function formatAxisValue(value: number, unit?: string): string {
+  return `${formatStatValue(value, undefined)}${unit ?? ""}`;
+}
+
+export interface ThresholdMark {
+  fraction: number;
+  /** Pre-formatted step position, for the tick label. */
+  text: string;
+  /** Ticks only render for steps that declare a color. */
+  color?: string;
+}
+
+export interface FillSegment {
+  from: number;
+  to: number;
+  color: string;
+}
+
+/**
+ * Step positions projected onto the gauge axis, sorted along it. Percent steps
+ * resolve against the same reference `resolveThresholdColor` uses
+ * (thresholds.max, falling back to the gauge max), so a mark always sits where
+ * the color changes. Only steps strictly inside the axis span are kept, which
+ * works for inverted bounds too.
+ */
+export function thresholdMarks(
+  thresholds: ThresholdsSpec | undefined,
+  min: number,
+  max: number,
+  unit?: string,
+): ThresholdMark[] {
+  if (!thresholds?.steps) return [];
+  const ref = thresholds.max ?? max;
+  return thresholds.steps
+    .map((step) => ({
+      value:
+        thresholds.mode === "percent" ? (step.value / 100) * ref : step.value,
+      color: step.color,
+    }))
+    .filter((t) => t.value > Math.min(min, max) && t.value < Math.max(min, max))
+    .map((t) => ({
+      fraction: axisFraction(t.value, min, max),
+      text: formatAxisValue(t.value, unit),
+      color: t.color,
+    }))
+    .sort((a, b) => a.fraction - b.fraction);
+}
+
+/**
+ * The color of each band the marks cut the track into, one entry per band
+ * (`marks.length + 1`). Each band resolves from the axis value at its
+ * midpoint, so inverted bounds (`min > max`) paint the bands on the correct
+ * side without any ascending-axis assumption. The bands do not depend on the
+ * value, so this is computed once per axis rather than per gauge.
+ */
+export function bandColors(
+  marks: ThresholdMark[],
+  thresholds: ThresholdsSpec | undefined,
+  min: number,
+  max: number,
+  fallback: string,
+): string[] {
+  const bounds = axisBounds(marks);
+  return bounds.slice(0, -1).map((from, i) => {
+    const to = bounds[i + 1] ?? 1;
+    const midValue = min + ((from + to) / 2) * (max - min);
+    return resolveThresholdColor(midValue, thresholds, max) ?? fallback;
+  });
+}
+
+/**
+ * The filled part of the track, split at each threshold the value has crossed
+ * and each piece painted with its band's color.
+ */
+export function fillSegments(
+  fraction: number,
+  marks: ThresholdMark[],
+  colors: string[],
+): FillSegment[] {
+  const bounds = axisBounds(marks);
+  const segments: FillSegment[] = [];
+  bounds.slice(0, -1).forEach((from, i) => {
+    const to = Math.min(fraction, bounds[i + 1] ?? 1);
+    if (to > from) segments.push({ from, to, color: colors[i] ?? "" });
+  });
+  return segments;
+}
+
+/** Band edges along the track: the two axis ends plus every mark. */
+function axisBounds(marks: ThresholdMark[]): number[] {
+  return [0, ...marks.map((m) => m.fraction), 1];
+}

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-axis.ts
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-axis.ts
@@ -5,10 +5,10 @@ import {
 } from "../stat-chart/stat-calculations";
 
 /**
- * 0..1 position of `value` along the gauge axis, measured from the `min` end.
- * Inverted bounds (`min > max`) are supported: the signed span flips the
- * direction so the gauge fills toward the `max` end as the value approaches
- * it. Returns 0 only for a truly degenerate axis (`min === max`).
+ * Calculates the position of `value` on the gauge axis, from 0 to 1. The
+ * position 0 is the `min` end. If the bounds are inverted (`min > max`), the
+ * direction of the axis changes. The gauge then fills to the `max` end when
+ * the value moves to `max`. If `min` is equal to `max`, the result is 0.
  */
 export function axisFraction(value: number, min: number, max: number): number {
   if (max === min) return 0;
@@ -16,16 +16,18 @@ export function axisFraction(value: number, min: number, max: number): number {
 }
 
 /**
- * Axis furniture (min/max ends, threshold ticks) always formats at the default
- * precision: `decimals` is the value's precision, not the axis'.
+ * Formats a value on the axis: the min and max ends, and the threshold ticks.
+ * The axis always uses the default precision. The `decimals` option applies
+ * to the gauge value only.
  */
 function formatAxisValue(value: number, unit?: string): string {
   return `${formatStatValue(value, undefined)}${unit ?? ""}`;
 }
 
 /**
- * The min/max end labels: a zero end carries no unit, since "0%" and "0ms" say
- * nothing "0" does not, and the ends are the smallest type on the gauge.
+ * Formats one end of the axis. If the end value is 0, the label does not show
+ * the unit, because "0" is clear without it. The end labels are also the
+ * smallest text on the gauge.
  */
 export function formatAxisEnd(value: number, unit?: string): string {
   return formatAxisValue(value, value === 0 ? undefined : unit);
@@ -33,9 +35,9 @@ export function formatAxisEnd(value: number, unit?: string): string {
 
 export interface ThresholdMark {
   fraction: number;
-  /** Pre-formatted step position, for the tick label. */
+  /** The position of the step as text, for the tick label. */
   text: string;
-  /** Ticks only render for steps that declare a color. */
+  /** A tick shows only if its step has a color. */
   color?: string;
 }
 
@@ -46,11 +48,12 @@ export interface FillSegment {
 }
 
 /**
- * Step positions projected onto the gauge axis, sorted along it. Percent steps
- * resolve against the same reference `resolveThresholdColor` uses
- * (thresholds.max, falling back to the gauge max), so a mark always sits where
- * the color changes. Only steps strictly inside the axis span are kept, which
- * works for inverted bounds too.
+ * Calculates the position of each threshold step on the gauge axis, in the
+ * sequence of the axis. For `percent` steps, this function uses the same
+ * reference as `resolveThresholdColor`: `thresholds.max`, or the gauge `max`
+ * if `thresholds.max` is not set. Each mark is thus at the position where the
+ * color changes. The function keeps only the steps that are inside the span
+ * of the axis. This is also correct if the bounds are inverted.
  */
 export function thresholdMarks(
   thresholds: ThresholdsSpec | undefined,
@@ -77,11 +80,12 @@ export function thresholdMarks(
 }
 
 /**
- * The color of each band the marks cut the track into, one entry per band
- * (`marks.length + 1`). Each band resolves from the axis value at its
- * midpoint, so inverted bounds (`min > max`) paint the bands on the correct
- * side without any ascending-axis assumption. The bands do not depend on the
- * value, so this is computed once per axis rather than per gauge.
+ * Gives the color of each band between the marks. There is one color for each
+ * band (`marks.length + 1`). Each band gets its color from the axis value at
+ * the center of the band. The colors stay on the correct side if the bounds
+ * are inverted (`min > max`), because this function does not assume that the
+ * axis increases. The bands do not change with the gauge value. This function
+ * thus runs one time for each axis, and not one time for each gauge.
  */
 export function bandColors(
   marks: ThresholdMark[],
@@ -101,8 +105,8 @@ export function bandColors(
 }
 
 /**
- * The filled part of the track, split at each threshold the value has crossed
- * and each piece painted with its band's color.
+ * Gives the filled part of the track. The function divides the filled part at
+ * each threshold that the value passes. Each part has the color of its band.
  */
 export function fillSegments(
   fraction: number,
@@ -114,14 +118,14 @@ export function fillSegments(
     const from = bandStart(marks, i);
     if (from >= fraction) break;
     const to = Math.min(fraction, bandEnd(marks, i));
-    // Two steps on the same value make an empty band: skip it, so the
-    // segments stay unique by `from`.
+    // Two steps with the same value make an empty band. The loop does not
+    // add it, because each segment must have a different `from` value.
     if (to > from) segments.push({ from, to, color: colors[i] ?? "" });
   }
   return segments;
 }
 
-/** Band `i` runs from the previous mark (or the min end) to the next one. */
+/** Band `i` starts at the mark before it, or at the `min` end. */
 function bandStart(marks: ThresholdMark[], i: number): number {
   return i === 0 ? 0 : (marks[i - 1]?.fraction ?? 0);
 }

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-axis.ts
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-axis.ts
@@ -19,8 +19,16 @@ export function axisFraction(value: number, min: number, max: number): number {
  * Axis furniture (min/max ends, threshold ticks) always formats at the default
  * precision: `decimals` is the value's precision, not the axis'.
  */
-export function formatAxisValue(value: number, unit?: string): string {
+function formatAxisValue(value: number, unit?: string): string {
   return `${formatStatValue(value, undefined)}${unit ?? ""}`;
+}
+
+/**
+ * The min/max end labels: a zero end carries no unit, since "0%" and "0ms" say
+ * nothing "0" does not, and the ends are the smallest type on the gauge.
+ */
+export function formatAxisEnd(value: number, unit?: string): string {
+  return formatAxisValue(value, value === 0 ? undefined : unit);
 }
 
 export interface ThresholdMark {
@@ -52,19 +60,20 @@ export function thresholdMarks(
 ): ThresholdMark[] {
   if (!thresholds?.steps) return [];
   const ref = thresholds.max ?? max;
-  return thresholds.steps
-    .map((step) => ({
-      value:
-        thresholds.mode === "percent" ? (step.value / 100) * ref : step.value,
+  const lower = Math.min(min, max);
+  const upper = Math.max(min, max);
+  const marks: ThresholdMark[] = [];
+  for (const step of thresholds.steps) {
+    const value =
+      thresholds.mode === "percent" ? (step.value / 100) * ref : step.value;
+    if (value <= lower || value >= upper) continue;
+    marks.push({
+      fraction: axisFraction(value, min, max),
+      text: formatAxisValue(value, unit),
       color: step.color,
-    }))
-    .filter((t) => t.value > Math.min(min, max) && t.value < Math.max(min, max))
-    .map((t) => ({
-      fraction: axisFraction(t.value, min, max),
-      text: formatAxisValue(t.value, unit),
-      color: t.color,
-    }))
-    .sort((a, b) => a.fraction - b.fraction);
+    });
+  }
+  return marks.sort((a, b) => a.fraction - b.fraction);
 }
 
 /**
@@ -81,12 +90,14 @@ export function bandColors(
   max: number,
   fallback: string,
 ): string[] {
-  const bounds = axisBounds(marks);
-  return bounds.slice(0, -1).map((from, i) => {
-    const to = bounds[i + 1] ?? 1;
+  const colors: string[] = [];
+  for (let i = 0; i <= marks.length; i++) {
+    const from = bandStart(marks, i);
+    const to = bandEnd(marks, i);
     const midValue = min + ((from + to) / 2) * (max - min);
-    return resolveThresholdColor(midValue, thresholds, max) ?? fallback;
-  });
+    colors.push(resolveThresholdColor(midValue, thresholds, max) ?? fallback);
+  }
+  return colors;
 }
 
 /**
@@ -98,16 +109,23 @@ export function fillSegments(
   marks: ThresholdMark[],
   colors: string[],
 ): FillSegment[] {
-  const bounds = axisBounds(marks);
   const segments: FillSegment[] = [];
-  bounds.slice(0, -1).forEach((from, i) => {
-    const to = Math.min(fraction, bounds[i + 1] ?? 1);
+  for (let i = 0; i <= marks.length; i++) {
+    const from = bandStart(marks, i);
+    if (from >= fraction) break;
+    const to = Math.min(fraction, bandEnd(marks, i));
+    // Two steps on the same value make an empty band: skip it, so the
+    // segments stay unique by `from`.
     if (to > from) segments.push({ from, to, color: colors[i] ?? "" });
-  });
+  }
   return segments;
 }
 
-/** Band edges along the track: the two axis ends plus every mark. */
-function axisBounds(marks: ThresholdMark[]): number[] {
-  return [0, ...marks.map((m) => m.fraction), 1];
+/** Band `i` runs from the previous mark (or the min end) to the next one. */
+function bandStart(marks: ThresholdMark[], i: number): number {
+  return i === 0 ? 0 : (marks[i - 1]?.fraction ?? 0);
+}
+
+function bandEnd(marks: ThresholdMark[], i: number): number {
+  return marks[i]?.fraction ?? 1;
 }

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.tsx
@@ -13,7 +13,7 @@ import {
   bandColors,
   type FillSegment,
   fillSegments,
-  formatAxisValue,
+  formatAxisEnd,
   type ThresholdMark,
   thresholdMarks,
 } from "./gauge-axis";
@@ -108,8 +108,8 @@ export function GaugeChartVisualization({
 
   const horizontal = variant === "horizontal";
   const multi = tiles.length > 1;
-  const minText = formatAxisValue(min);
-  const maxText = formatAxisValue(max);
+  const minText = formatAxisEnd(min, unit);
+  const maxText = formatAxisEnd(max, unit);
 
   return (
     <div

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.tsx
@@ -203,12 +203,15 @@ export function GaugeChartVisualization({
             >
               {labelEl && <div className="mb-1">{labelEl}</div>}
               <p className="mb-2 leading-none">
+                {/* Like the arc, the number stays neutral: the band color is
+                    carried by the fill segments, not the text. */}
                 <span
                   className={cn(
                     "text-2xl font-semibold tabular-nums",
-                    value === undefined && "text-muted-foreground",
+                    value === undefined
+                      ? "text-muted-foreground"
+                      : "text-foreground",
                   )}
-                  style={value !== undefined ? { color } : undefined}
                 >
                   {valueText}
                 </span>
@@ -250,7 +253,7 @@ export function GaugeChartVisualization({
                       .filter((m) => m.color !== undefined)
                       .map((mark) => (
                         <div
-                          key={mark.fraction}
+                          key={`${mark.fraction}-${mark.color}`}
                           className="absolute top-0 -translate-x-1/2"
                           style={{ left: `${mark.fraction * 100}%` }}
                         >
@@ -335,6 +338,7 @@ export function GaugeChartVisualization({
                             className="fill-muted-foreground tabular-nums"
                           >
                             {formatStatValue(mark.value, undefined)}
+                            {unit}
                           </text>
                         )}
                       </g>

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.tsx
@@ -6,9 +6,17 @@ import type { VisualizationProps } from "../index";
 import {
   formatStatValue,
   resolveThresholdColor,
-  type ThresholdsSpec,
 } from "../stat-chart/stat-calculations";
 import { computeStatTiles } from "../stat-chart/stat-series";
+import {
+  axisFraction,
+  bandColors,
+  type FillSegment,
+  fillSegments,
+  formatAxisValue,
+  type ThresholdMark,
+  thresholdMarks,
+} from "./gauge-axis";
 import type { GaugeChartSpec } from "./spec";
 
 // Semicircle geometry in viewBox units. The round caps and the threshold
@@ -31,85 +39,21 @@ function arcPath(startAngle: number, endAngle: number): string {
   return `M ${s.x} ${s.y} A ${R} ${R} 0 0 1 ${e.x} ${e.y}`;
 }
 
-/**
- * 0..1 position of `value` along the gauge axis, measured from the `min` end.
- * Inverted bounds (`min > max`) are supported: the signed span flips the
- * direction so the gauge fills toward the `max` end as the value approaches
- * it. Returns 0 only for a truly degenerate axis (`min === max`).
- */
-function axisFraction(value: number, min: number, max: number): number {
-  if (max === min) return 0;
-  return Math.min(1, Math.max(0, (value - min) / (max - min)));
-}
+/** A mark that renders: the colorless steps are filtered out up front. */
+type Tick = ThresholdMark & { color: string };
 
-interface ThresholdMark {
+/** Everything both variants draw, prepared once per gauge. */
+interface TileProps {
+  label: React.ReactNode;
+  value: number | undefined;
+  valueText: string;
+  unit: string;
   fraction: number;
-  /** Step value in axis units, for the tick label. */
-  value: number;
-  /** Ticks only render for steps that declare a color. */
-  color?: string;
-}
-
-interface FillSegment {
-  from: number;
-  to: number;
-  color: string;
-}
-
-/**
- * Step positions projected onto the gauge axis. Percent steps resolve against
- * the same reference `resolveThresholdColor` uses (thresholds.max, falling
- * back to the gauge max), so a mark always sits where the color changes.
- * Only steps strictly inside the axis span are kept — works for inverted
- * bounds too.
- */
-function thresholdMarks(
-  thresholds: ThresholdsSpec | undefined,
-  min: number,
-  max: number,
-): ThresholdMark[] {
-  if (!thresholds?.steps) return [];
-  const ref = thresholds.max ?? max;
-  return thresholds.steps
-    .map((step) => ({
-      value:
-        thresholds.mode === "percent" ? (step.value / 100) * ref : step.value,
-      color: step.color,
-    }))
-    .filter((t) => t.value > Math.min(min, max) && t.value < Math.max(min, max))
-    .map((t) => ({
-      fraction: axisFraction(t.value, min, max),
-      value: t.value,
-      color: t.color,
-    }))
-    .sort((a, b) => a.fraction - b.fraction);
-}
-
-/**
- * The filled part of the track, split at each threshold the value has crossed,
- * each piece painted with its band's color. Each segment resolves its color
- * from the axis value at its midpoint, so inverted bounds (`min > max`) paint
- * the bands on the correct side without any ascending-axis assumption.
- */
-function fillSegments(
-  fraction: number,
-  marks: ThresholdMark[],
-  thresholds: ThresholdsSpec | undefined,
-  min: number,
-  max: number,
-  fallback: string,
-): FillSegment[] {
-  const bounds = [0, ...marks.map((m) => m.fraction), 1];
-  const segments: FillSegment[] = [];
-  for (let i = 0; i < bounds.length - 1; i++) {
-    const from = bounds[i] ?? 0;
-    const to = Math.min(fraction, bounds[i + 1] ?? 1);
-    if (to <= from) continue;
-    const midValue = min + ((from + to) / 2) * (max - min);
-    const color = resolveThresholdColor(midValue, thresholds, max) ?? fallback;
-    segments.push({ from, to, color });
-  }
-  return segments;
+  ticks: Tick[];
+  showAxis: boolean;
+  showThresholdLabels: boolean;
+  minText: string;
+  maxText: string;
 }
 
 export function GaugeChartVisualization({
@@ -135,9 +79,20 @@ export function GaugeChartVisualization({
     [data, calculation],
   );
   const hasAnyValue = tiles.some((t) => t.value !== undefined);
+  const fallbackColor = SERIES_COLORS[0] ?? "currentColor";
   const marks = useMemo(
-    () => thresholdMarks(thresholds, min, max),
-    [thresholds, min, max],
+    () => thresholdMarks(thresholds, min, max, unit),
+    [thresholds, min, max, unit],
+  );
+  const ticks = useMemo(
+    () => marks.filter((m): m is Tick => m.color !== undefined),
+    [marks],
+  );
+  // The bands the marks cut the track into are the same for every gauge in the
+  // panel, so they are resolved here rather than per tile.
+  const colors = useMemo(
+    () => bandColors(marks, thresholds, min, max, fallbackColor),
+    [marks, thresholds, min, max, fallbackColor],
   );
 
   if (!data || !hasAnyValue) {
@@ -151,249 +106,281 @@ export function GaugeChartVisualization({
     );
   }
 
+  const horizontal = variant === "horizontal";
   const multi = tiles.length > 1;
-  const fallbackColor = SERIES_COLORS[0] ?? "currentColor";
-  const minText = formatStatValue(min, undefined);
-  const maxText = formatStatValue(max, undefined);
+  const minText = formatAxisValue(min);
+  const maxText = formatAxisValue(max);
 
   return (
     <div
       className={cn(
-        variant === "horizontal" &&
-          "flex h-full flex-wrap content-center-safe justify-center gap-x-6 gap-y-4 overflow-y-auto px-1",
-        (variant === "arc" || variant === undefined) &&
-          "flex h-full flex-wrap items-stretch justify-center gap-4",
+        "flex h-full flex-wrap justify-center",
+        horizontal
+          ? "content-center-safe gap-x-6 gap-y-4 overflow-y-auto px-1"
+          : "items-stretch gap-4",
       )}
     >
       {tiles.map((tile) => {
         const value = tile.value;
-        const label = tile.label || queryLabel(tile.frame);
-        const color =
-          (value !== undefined
-            ? resolveThresholdColor(value, thresholds, max)
-            : undefined) ?? fallbackColor;
+        const name = tile.label || queryLabel(tile.frame);
         const fraction =
           value !== undefined ? axisFraction(value, min, max) : 0;
         const valueText =
           value === undefined ? noValue : formatStatValue(value, decimals);
-        const ariaLabel = `${label}: ${valueText}${unit ? ` ${unit}` : ""}`;
-        const key = `${tile.frame}-${tile.label}`;
-        const labelEl = (multi || showLabel) && (
-          <p className="truncate text-xs text-muted-foreground">{label}</p>
+        const label = (multi || showLabel) && (
+          <p
+            className={cn(
+              "truncate text-xs text-muted-foreground",
+              horizontal && "mb-1",
+            )}
+          >
+            {name}
+          </p>
         );
+        const props: TileProps = {
+          label,
+          value,
+          valueText,
+          unit,
+          fraction,
+          ticks,
+          showAxis,
+          showThresholdLabels,
+          minText,
+          maxText,
+        };
+        const key = `${tile.frame}-${tile.label}`;
+        const ariaLabel = `${name}: ${valueText}${unit ? ` ${unit}` : ""}`;
 
-        if (variant === "horizontal") {
-          const segments =
-            value !== undefined
-              ? fillSegments(
-                  fraction,
-                  marks,
-                  thresholds,
-                  min,
-                  max,
-                  fallbackColor,
-                )
-              : [];
-          return (
-            <div
-              key={key}
-              className="min-w-40 flex-1"
-              role="img"
-              aria-label={ariaLabel}
-            >
-              {labelEl && <div className="mb-1">{labelEl}</div>}
-              <p className="mb-2 leading-none">
-                {/* Like the arc, the number stays neutral: the band color is
-                    carried by the fill segments, not the text. */}
-                <span
-                  className={cn(
-                    "text-2xl font-semibold tabular-nums",
-                    value === undefined
-                      ? "text-muted-foreground"
-                      : "text-foreground",
-                  )}
-                >
-                  {valueText}
-                </span>
-                {value !== undefined && unit && (
-                  <span className="ml-1 text-xs text-muted-foreground">
-                    {unit}
-                  </span>
-                )}
-              </p>
-              <div className="relative pt-2">
-                {/* Triangle marker pointing down at the value position. */}
-                {value !== undefined && (
-                  <div
-                    className="absolute top-0 -translate-x-1/2 border-x-[5px] border-t-[6px] border-x-transparent border-t-foreground"
-                    style={{ left: `${fraction * 100}%` }}
-                  />
-                )}
-                <div className="relative h-2.5 overflow-hidden rounded-sm bg-muted">
-                  {segments.map((s) => (
-                    <div
-                      key={s.from}
-                      className="absolute inset-y-0"
-                      style={{
-                        left: `${s.from * 100}%`,
-                        width: `${(s.to - s.from) * 100}%`,
-                        backgroundColor: s.color,
-                      }}
-                    />
-                  ))}
-                </div>
-                {marks.some((m) => m.color) && (
-                  <div
-                    className={cn(
-                      "relative",
-                      showThresholdLabels ? "h-6" : "h-2",
-                    )}
-                  >
-                    {marks
-                      .filter((m) => m.color !== undefined)
-                      .map((mark) => (
-                        <div
-                          key={`${mark.fraction}-${mark.color}`}
-                          className="absolute top-0 -translate-x-1/2"
-                          style={{ left: `${mark.fraction * 100}%` }}
-                        >
-                          <div
-                            className="mx-auto h-1.5 w-px"
-                            style={{ backgroundColor: mark.color }}
-                          />
-                          {showThresholdLabels && (
-                            <p className="whitespace-nowrap text-[10px] tabular-nums text-muted-foreground">
-                              {formatStatValue(mark.value, undefined)}
-                              {unit}
-                            </p>
-                          )}
-                        </div>
-                      ))}
-                  </div>
-                )}
-                {showAxis && (
-                  <div className="flex justify-between text-[10px] tabular-nums text-muted-foreground">
-                    <span>{minText}</span>
-                    <span>{maxText}</span>
-                  </div>
-                )}
-              </div>
-            </div>
-          );
-        }
-
-        return (
-          <div key={key} className="flex min-w-28 flex-1 flex-col items-center">
-            {labelEl}
-            {/* The SVG is absolutely positioned: inside a wrapped flex line a
-                percentage height can't resolve and the SVG would fall back to
-                width-driven sizing and overflow the panel. */}
-            <div className="relative min-h-0 w-full flex-1">
-              <svg
-                viewBox={VIEWBOX}
-                preserveAspectRatio="xMidYMid meet"
-                className="absolute inset-0 h-full w-full"
-                role="img"
-                aria-label={ariaLabel}
-              >
-                <path
-                  d={arcPath(180, 0)}
-                  className="stroke-muted"
-                  strokeWidth={STROKE}
-                  strokeLinecap="round"
-                  fill="none"
-                />
-                {fraction > 0 && (
-                  <path
-                    d={arcPath(180, 180 - fraction * 180)}
-                    stroke={color}
-                    strokeWidth={STROKE}
-                    strokeLinecap="round"
-                    fill="none"
-                  />
-                )}
-                {marks
-                  .filter((m) => m.color !== undefined)
-                  .map((mark) => {
-                    const angle = 180 - mark.fraction * 180;
-                    const inner = polar(R - STROKE / 2 - 2, angle);
-                    const outer = polar(R + STROKE / 2 + 2, angle);
-                    const labelPos = polar(R + STROKE / 2 + 6, angle);
-                    return (
-                      <g key={`${mark.fraction}-${mark.color}`}>
-                        <line
-                          x1={inner.x}
-                          y1={inner.y}
-                          x2={outer.x}
-                          y2={outer.y}
-                          stroke={mark.color}
-                          strokeWidth={1.25}
-                        />
-                        {showThresholdLabels && (
-                          <text
-                            x={labelPos.x}
-                            y={labelPos.y}
-                            textAnchor="middle"
-                            fontSize={5}
-                            className="fill-muted-foreground tabular-nums"
-                          >
-                            {formatStatValue(mark.value, undefined)}
-                            {unit}
-                          </text>
-                        )}
-                      </g>
-                    );
-                  })}
-                <text
-                  x={CX}
-                  y={46}
-                  textAnchor="middle"
-                  fontSize={13}
-                  className={cn(
-                    "font-semibold tabular-nums",
-                    value === undefined
-                      ? "fill-muted-foreground"
-                      : "fill-foreground",
-                  )}
-                >
-                  {valueText}
-                  {value !== undefined && unit && (
-                    <tspan
-                      dx={1.5}
-                      fontSize={7}
-                      className="fill-muted-foreground font-normal"
-                    >
-                      {unit}
-                    </tspan>
-                  )}
-                </text>
-                {showAxis && (
-                  <>
-                    <text
-                      x={CX - R}
-                      y={62}
-                      textAnchor="middle"
-                      fontSize={5.5}
-                      className="fill-muted-foreground tabular-nums"
-                    >
-                      {minText}
-                    </text>
-                    <text
-                      x={CX + R}
-                      y={62}
-                      textAnchor="middle"
-                      fontSize={5.5}
-                      className="fill-muted-foreground tabular-nums"
-                    >
-                      {maxText}
-                    </text>
-                  </>
-                )}
-              </svg>
-            </div>
-          </div>
+        return horizontal ? (
+          <GaugeBar
+            key={key}
+            {...props}
+            ariaLabel={ariaLabel}
+            segments={fillSegments(fraction, marks, colors)}
+          />
+        ) : (
+          <GaugeArc
+            key={key}
+            {...props}
+            ariaLabel={ariaLabel}
+            color={
+              (value !== undefined
+                ? resolveThresholdColor(value, thresholds, max)
+                : undefined) ?? fallbackColor
+            }
+          />
         );
       })}
+    </div>
+  );
+}
+
+/** Flat bar filling left to right, with a marker at the current value. */
+function GaugeBar({
+  label,
+  value,
+  valueText,
+  unit,
+  fraction,
+  ticks,
+  showAxis,
+  showThresholdLabels,
+  minText,
+  maxText,
+  ariaLabel,
+  segments,
+}: TileProps & { ariaLabel: string; segments: FillSegment[] }) {
+  return (
+    <div className="min-w-40 flex-1" role="img" aria-label={ariaLabel}>
+      {label}
+      <p className="mb-2 leading-none">
+        {/* Like the arc, the number stays neutral: the band color is carried
+            by the fill segments, not the text. */}
+        <span
+          className={cn(
+            "text-2xl font-semibold tabular-nums",
+            value === undefined ? "text-muted-foreground" : "text-foreground",
+          )}
+        >
+          {valueText}
+        </span>
+        {value !== undefined && unit && (
+          <span className="ml-1 text-xs text-muted-foreground">{unit}</span>
+        )}
+      </p>
+      <div className="relative pt-2">
+        {/* Triangle marker pointing down at the value position. */}
+        {value !== undefined && (
+          <div
+            className="absolute top-0 -translate-x-1/2 border-x-[5px] border-t-[6px] border-x-transparent border-t-foreground"
+            style={{ left: `${fraction * 100}%` }}
+          />
+        )}
+        <div className="relative h-2.5 overflow-hidden rounded-sm bg-muted">
+          {segments.map((s) => (
+            <div
+              key={s.from}
+              className="absolute inset-y-0"
+              style={{
+                left: `${s.from * 100}%`,
+                width: `${(s.to - s.from) * 100}%`,
+                backgroundColor: s.color,
+              }}
+            />
+          ))}
+        </div>
+        {ticks.length > 0 && (
+          <div className={cn("relative", showThresholdLabels ? "h-6" : "h-2")}>
+            {ticks.map((tick) => (
+              <div
+                key={`${tick.fraction}-${tick.color}`}
+                className="absolute top-0 -translate-x-1/2"
+                style={{ left: `${tick.fraction * 100}%` }}
+              >
+                <div
+                  className="mx-auto h-1.5 w-px"
+                  style={{ backgroundColor: tick.color }}
+                />
+                {showThresholdLabels && (
+                  <p className="whitespace-nowrap text-[10px] tabular-nums text-muted-foreground">
+                    {tick.text}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+        {showAxis && (
+          <div className="flex justify-between text-[10px] tabular-nums text-muted-foreground">
+            <span>{minText}</span>
+            <span>{maxText}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Semicircular arc filling from the min end, with the value at its center. */
+function GaugeArc({
+  label,
+  value,
+  valueText,
+  unit,
+  fraction,
+  ticks,
+  showAxis,
+  showThresholdLabels,
+  minText,
+  maxText,
+  ariaLabel,
+  color,
+}: TileProps & { ariaLabel: string; color: string }) {
+  return (
+    <div className="flex min-w-28 flex-1 flex-col items-center">
+      {label}
+      {/* The SVG is absolutely positioned: inside a wrapped flex line a
+          percentage height can't resolve and the SVG would fall back to
+          width-driven sizing and overflow the panel. */}
+      <div className="relative min-h-0 w-full flex-1">
+        <svg
+          viewBox={VIEWBOX}
+          preserveAspectRatio="xMidYMid meet"
+          className="absolute inset-0 h-full w-full"
+          role="img"
+          aria-label={ariaLabel}
+        >
+          <path
+            d={arcPath(180, 0)}
+            className="stroke-muted"
+            strokeWidth={STROKE}
+            strokeLinecap="round"
+            fill="none"
+          />
+          {fraction > 0 && (
+            <path
+              d={arcPath(180, 180 - fraction * 180)}
+              stroke={color}
+              strokeWidth={STROKE}
+              strokeLinecap="round"
+              fill="none"
+            />
+          )}
+          {ticks.map((tick) => {
+            const angle = 180 - tick.fraction * 180;
+            const inner = polar(R - STROKE / 2 - 2, angle);
+            const outer = polar(R + STROKE / 2 + 2, angle);
+            const labelPos = polar(R + STROKE / 2 + 6, angle);
+            return (
+              <g key={`${tick.fraction}-${tick.color}`}>
+                <line
+                  x1={inner.x}
+                  y1={inner.y}
+                  x2={outer.x}
+                  y2={outer.y}
+                  stroke={tick.color}
+                  strokeWidth={1.25}
+                />
+                {showThresholdLabels && (
+                  <text
+                    x={labelPos.x}
+                    y={labelPos.y}
+                    textAnchor="middle"
+                    fontSize={5}
+                    className="fill-muted-foreground tabular-nums"
+                  >
+                    {tick.text}
+                  </text>
+                )}
+              </g>
+            );
+          })}
+          <text
+            x={CX}
+            y={46}
+            textAnchor="middle"
+            fontSize={13}
+            className={cn(
+              "font-semibold tabular-nums",
+              value === undefined ? "fill-muted-foreground" : "fill-foreground",
+            )}
+          >
+            {valueText}
+            {value !== undefined && unit && (
+              <tspan
+                dx={1.5}
+                fontSize={7}
+                className="fill-muted-foreground font-normal"
+              >
+                {unit}
+              </tspan>
+            )}
+          </text>
+          {showAxis && (
+            <>
+              <text
+                x={CX - R}
+                y={62}
+                textAnchor="middle"
+                fontSize={5.5}
+                className="fill-muted-foreground tabular-nums"
+              >
+                {minText}
+              </text>
+              <text
+                x={CX + R}
+                y={62}
+                textAnchor="middle"
+                fontSize={5.5}
+                className="fill-muted-foreground tabular-nums"
+              >
+                {maxText}
+              </text>
+            </>
+          )}
+        </svg>
+      </div>
     </div>
   );
 }

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.tsx
@@ -34,50 +34,82 @@ function arcPath(startAngle: number, endAngle: number): string {
 /**
  * 0..1 position of `value` along the gauge axis, measured from the `min` end.
  * Inverted bounds (`min > max`) are supported: the signed span flips the
- * direction so the arc fills toward the `max` end as the value approaches it.
- * Returns 0 only for a truly degenerate axis (`min === max`).
+ * direction so the gauge fills toward the `max` end as the value approaches
+ * it. Returns 0 only for a truly degenerate axis (`min === max`).
  */
 function axisFraction(value: number, min: number, max: number): number {
   if (max === min) return 0;
   return Math.min(1, Math.max(0, (value - min) / (max - min)));
 }
 
-interface ThresholdTick {
+interface ThresholdMark {
   fraction: number;
+  /** Step value in axis units, for the tick label. */
+  value: number;
+  /** Ticks only render for steps that declare a color. */
+  color?: string;
+}
+
+interface FillSegment {
+  from: number;
+  to: number;
   color: string;
 }
 
 /**
  * Step positions projected onto the gauge axis. Percent steps resolve against
  * the same reference `resolveThresholdColor` uses (thresholds.max, falling
- * back to the gauge max), so a tick always sits where the color changes.
+ * back to the gauge max), so a mark always sits where the color changes.
+ * Only steps strictly inside the axis span are kept — works for inverted
+ * bounds too.
  */
-function thresholdTicks(
+function thresholdMarks(
   thresholds: ThresholdsSpec | undefined,
   min: number,
   max: number,
-): ThresholdTick[] {
+): ThresholdMark[] {
   if (!thresholds?.steps) return [];
   const ref = thresholds.max ?? max;
-  return (
-    thresholds.steps
-      .map((step) => ({
-        value:
-          thresholds.mode === "percent" ? (step.value / 100) * ref : step.value,
-        color: step.color,
-      }))
-      .filter(
-        (t): t is { value: number; color: string } => t.color !== undefined,
-      )
-      // Keep ticks strictly inside the axis span — works for inverted bounds too.
-      .filter(
-        (t) => t.value > Math.min(min, max) && t.value < Math.max(min, max),
-      )
-      .map((t) => ({
-        fraction: axisFraction(t.value, min, max),
-        color: t.color,
-      }))
-  );
+  return thresholds.steps
+    .map((step) => ({
+      value:
+        thresholds.mode === "percent" ? (step.value / 100) * ref : step.value,
+      color: step.color,
+    }))
+    .filter((t) => t.value > Math.min(min, max) && t.value < Math.max(min, max))
+    .map((t) => ({
+      fraction: axisFraction(t.value, min, max),
+      value: t.value,
+      color: t.color,
+    }))
+    .sort((a, b) => a.fraction - b.fraction);
+}
+
+/**
+ * The filled part of the track, split at each threshold the value has crossed,
+ * each piece painted with its band's color. Each segment resolves its color
+ * from the axis value at its midpoint, so inverted bounds (`min > max`) paint
+ * the bands on the correct side without any ascending-axis assumption.
+ */
+function fillSegments(
+  fraction: number,
+  marks: ThresholdMark[],
+  thresholds: ThresholdsSpec | undefined,
+  min: number,
+  max: number,
+  fallback: string,
+): FillSegment[] {
+  const bounds = [0, ...marks.map((m) => m.fraction), 1];
+  const segments: FillSegment[] = [];
+  for (let i = 0; i < bounds.length - 1; i++) {
+    const from = bounds[i] ?? 0;
+    const to = Math.min(fraction, bounds[i + 1] ?? 1);
+    if (to <= from) continue;
+    const midValue = min + ((from + to) / 2) * (max - min);
+    const color = resolveThresholdColor(midValue, thresholds, max) ?? fallback;
+    segments.push({ from, to, color });
+  }
+  return segments;
 }
 
 export function GaugeChartVisualization({
@@ -93,6 +125,9 @@ export function GaugeChartVisualization({
     thresholds,
     showLabel,
     noValue,
+    variant,
+    showAxis,
+    showThresholdLabels,
   } = spec;
 
   const tiles = useMemo(
@@ -100,8 +135,8 @@ export function GaugeChartVisualization({
     [data, calculation],
   );
   const hasAnyValue = tiles.some((t) => t.value !== undefined);
-  const ticks = useMemo(
-    () => thresholdTicks(thresholds, min, max),
+  const marks = useMemo(
+    () => thresholdMarks(thresholds, min, max),
     [thresholds, min, max],
   );
 
@@ -117,30 +152,249 @@ export function GaugeChartVisualization({
   }
 
   const multi = tiles.length > 1;
+  const fallbackColor = SERIES_COLORS[0] ?? "currentColor";
+  const minText = formatStatValue(min, undefined);
+  const maxText = formatStatValue(max, undefined);
 
   return (
-    <div className="flex h-full flex-wrap items-stretch justify-center gap-4">
+    <div
+      className={cn(
+        variant === "horizontal" &&
+          "flex h-full flex-wrap content-center-safe justify-center gap-x-6 gap-y-4 overflow-y-auto px-1",
+        variant === "vertical" &&
+          "flex h-full items-stretch justify-center gap-6",
+        (variant === "arc" || variant === undefined) &&
+          "flex h-full flex-wrap items-stretch justify-center gap-4",
+      )}
+    >
       {tiles.map((tile) => {
         const value = tile.value;
         const label = tile.label || queryLabel(tile.frame);
         const color =
           (value !== undefined
             ? resolveThresholdColor(value, thresholds, max)
-            : undefined) ??
-          SERIES_COLORS[0] ??
-          "currentColor";
+            : undefined) ?? fallbackColor;
         const fraction =
           value !== undefined ? axisFraction(value, min, max) : 0;
         const valueText =
           value === undefined ? noValue : formatStatValue(value, decimals);
+        const ariaLabel = `${label}: ${valueText}${unit ? ` ${unit}` : ""}`;
+        const key = `${tile.frame}-${tile.label}`;
+        const labelEl = (multi || showLabel) && (
+          <p className="truncate text-xs text-muted-foreground">{label}</p>
+        );
+
+        if (variant === "horizontal") {
+          const segments =
+            value !== undefined
+              ? fillSegments(
+                  fraction,
+                  marks,
+                  thresholds,
+                  min,
+                  max,
+                  fallbackColor,
+                )
+              : [];
+          return (
+            <div
+              key={key}
+              className="min-w-40 flex-1"
+              role="img"
+              aria-label={ariaLabel}
+            >
+              {labelEl && <div className="mb-1">{labelEl}</div>}
+              <p className="mb-2 leading-none">
+                <span
+                  className={cn(
+                    "text-2xl font-semibold tabular-nums",
+                    value === undefined && "text-muted-foreground",
+                  )}
+                  style={value !== undefined ? { color } : undefined}
+                >
+                  {valueText}
+                </span>
+                {value !== undefined && unit && (
+                  <span className="ml-1 text-xs text-muted-foreground">
+                    {unit}
+                  </span>
+                )}
+              </p>
+              <div className="relative pt-2">
+                {/* Triangle marker pointing down at the value position. */}
+                {value !== undefined && (
+                  <div
+                    className="absolute top-0 -translate-x-1/2 border-x-[5px] border-t-[6px] border-x-transparent border-t-foreground"
+                    style={{ left: `${fraction * 100}%` }}
+                  />
+                )}
+                <div className="relative h-2.5 overflow-hidden rounded-sm bg-muted">
+                  {segments.map((s) => (
+                    <div
+                      key={s.from}
+                      className="absolute inset-y-0"
+                      style={{
+                        left: `${s.from * 100}%`,
+                        width: `${(s.to - s.from) * 100}%`,
+                        backgroundColor: s.color,
+                      }}
+                    />
+                  ))}
+                </div>
+                {marks.some((m) => m.color) && (
+                  <div
+                    className={cn(
+                      "relative",
+                      showThresholdLabels ? "h-6" : "h-2",
+                    )}
+                  >
+                    {marks
+                      .filter((m) => m.color !== undefined)
+                      .map((mark) => (
+                        <div
+                          key={mark.fraction}
+                          className="absolute top-0 -translate-x-1/2"
+                          style={{ left: `${mark.fraction * 100}%` }}
+                        >
+                          <div
+                            className="mx-auto h-1.5 w-px"
+                            style={{ backgroundColor: mark.color }}
+                          />
+                          {showThresholdLabels && (
+                            <p className="whitespace-nowrap text-[10px] tabular-nums text-muted-foreground">
+                              {formatStatValue(mark.value, undefined)}
+                              {unit}
+                            </p>
+                          )}
+                        </div>
+                      ))}
+                  </div>
+                )}
+                {showAxis && (
+                  <div className="flex justify-between text-[10px] tabular-nums text-muted-foreground">
+                    <span>{minText}</span>
+                    <span>{maxText}</span>
+                  </div>
+                )}
+              </div>
+            </div>
+          );
+        }
+
+        if (variant === "vertical") {
+          const segments =
+            value !== undefined
+              ? fillSegments(
+                  fraction,
+                  marks,
+                  thresholds,
+                  min,
+                  max,
+                  fallbackColor,
+                )
+              : [];
+          const coloredMarks = marks.filter((m) => m.color !== undefined);
+          return (
+            <div
+              key={key}
+              className="flex min-w-20 flex-col items-center"
+              role="img"
+              aria-label={ariaLabel}
+            >
+              {labelEl}
+              <div className="flex min-h-0 flex-1 items-stretch gap-2 pt-1">
+                {/* Bar column; pl-3 leaves room for the value marker. */}
+                <div className="relative pl-3">
+                  {value !== undefined && (
+                    <div
+                      className="absolute left-0.5 translate-y-1/2 border-y-[5px] border-l-[6px] border-y-transparent border-l-foreground"
+                      style={{ bottom: `${fraction * 100}%` }}
+                    />
+                  )}
+                  <div className="relative h-full w-2.5 overflow-hidden rounded-sm bg-muted">
+                    {segments.map((s) => (
+                      <div
+                        key={s.from}
+                        className="absolute inset-x-0"
+                        style={{
+                          bottom: `${s.from * 100}%`,
+                          height: `${(s.to - s.from) * 100}%`,
+                          backgroundColor: s.color,
+                        }}
+                      />
+                    ))}
+                  </div>
+                </div>
+                {coloredMarks.length > 0 && (
+                  // Reserve room for the numeric labels so they never overlap
+                  // the value column.
+                  <div
+                    className={cn(
+                      "relative",
+                      showThresholdLabels ? "w-9" : "w-1.5",
+                    )}
+                  >
+                    {coloredMarks.map((mark) => (
+                      <div
+                        key={mark.fraction}
+                        className="absolute left-0 flex translate-y-1/2 items-center gap-1"
+                        style={{ bottom: `${mark.fraction * 100}%` }}
+                      >
+                        <div
+                          className="h-px w-1.5"
+                          style={{ backgroundColor: mark.color }}
+                        />
+                        {showThresholdLabels && (
+                          <p className="whitespace-nowrap text-[10px] leading-none tabular-nums text-muted-foreground">
+                            {formatStatValue(mark.value, undefined)}
+                            {unit}
+                          </p>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+                <div
+                  className={cn(
+                    "flex flex-col",
+                    showAxis ? "justify-between" : "justify-center",
+                  )}
+                >
+                  {showAxis && (
+                    <span className="text-[10px] tabular-nums text-muted-foreground">
+                      {maxText}
+                    </span>
+                  )}
+                  <p className="leading-none">
+                    <span
+                      className={cn(
+                        "text-2xl font-semibold tabular-nums",
+                        value === undefined && "text-muted-foreground",
+                      )}
+                      style={value !== undefined ? { color } : undefined}
+                    >
+                      {valueText}
+                    </span>
+                    {value !== undefined && unit && (
+                      <span className="ml-1 text-xs text-muted-foreground">
+                        {unit}
+                      </span>
+                    )}
+                  </p>
+                  {showAxis && (
+                    <span className="text-[10px] tabular-nums text-muted-foreground">
+                      {minText}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+          );
+        }
+
         return (
-          <div
-            key={`${tile.frame}-${tile.label}`}
-            className="flex min-w-28 flex-1 flex-col items-center"
-          >
-            {(multi || showLabel) && (
-              <p className="text-xs text-muted-foreground">{label}</p>
-            )}
+          <div key={key} className="flex min-w-28 flex-1 flex-col items-center">
+            {labelEl}
             {/* The SVG is absolutely positioned: inside a wrapped flex line a
                 percentage height can't resolve and the SVG would fall back to
                 width-driven sizing and overflow the panel. */}
@@ -150,7 +404,7 @@ export function GaugeChartVisualization({
                 preserveAspectRatio="xMidYMid meet"
                 className="absolute inset-0 h-full w-full"
                 role="img"
-                aria-label={`${label}: ${valueText}${unit ? ` ${unit}` : ""}`}
+                aria-label={ariaLabel}
               >
                 <path
                   d={arcPath(180, 0)}
@@ -168,22 +422,37 @@ export function GaugeChartVisualization({
                     fill="none"
                   />
                 )}
-                {ticks.map((tick) => {
-                  const angle = 180 - tick.fraction * 180;
-                  const inner = polar(R - STROKE / 2 - 2, angle);
-                  const outer = polar(R + STROKE / 2 + 2, angle);
-                  return (
-                    <line
-                      key={`${tick.fraction}-${tick.color}`}
-                      x1={inner.x}
-                      y1={inner.y}
-                      x2={outer.x}
-                      y2={outer.y}
-                      stroke={tick.color}
-                      strokeWidth={1.25}
-                    />
-                  );
-                })}
+                {marks
+                  .filter((m) => m.color !== undefined)
+                  .map((mark) => {
+                    const angle = 180 - mark.fraction * 180;
+                    const inner = polar(R - STROKE / 2 - 2, angle);
+                    const outer = polar(R + STROKE / 2 + 2, angle);
+                    const labelPos = polar(R + STROKE / 2 + 6, angle);
+                    return (
+                      <g key={`${mark.fraction}-${mark.color}`}>
+                        <line
+                          x1={inner.x}
+                          y1={inner.y}
+                          x2={outer.x}
+                          y2={outer.y}
+                          stroke={mark.color}
+                          strokeWidth={1.25}
+                        />
+                        {showThresholdLabels && (
+                          <text
+                            x={labelPos.x}
+                            y={labelPos.y}
+                            textAnchor="middle"
+                            fontSize={5}
+                            className="fill-muted-foreground tabular-nums"
+                          >
+                            {formatStatValue(mark.value, undefined)}
+                          </text>
+                        )}
+                      </g>
+                    );
+                  })}
                 <text
                   x={CX}
                   y={46}
@@ -207,24 +476,28 @@ export function GaugeChartVisualization({
                     </tspan>
                   )}
                 </text>
-                <text
-                  x={CX - R}
-                  y={62}
-                  textAnchor="middle"
-                  fontSize={5.5}
-                  className="fill-muted-foreground tabular-nums"
-                >
-                  {formatStatValue(min, undefined)}
-                </text>
-                <text
-                  x={CX + R}
-                  y={62}
-                  textAnchor="middle"
-                  fontSize={5.5}
-                  className="fill-muted-foreground tabular-nums"
-                >
-                  {formatStatValue(max, undefined)}
-                </text>
+                {showAxis && (
+                  <>
+                    <text
+                      x={CX - R}
+                      y={62}
+                      textAnchor="middle"
+                      fontSize={5.5}
+                      className="fill-muted-foreground tabular-nums"
+                    >
+                      {minText}
+                    </text>
+                    <text
+                      x={CX + R}
+                      y={62}
+                      textAnchor="middle"
+                      fontSize={5.5}
+                      className="fill-muted-foreground tabular-nums"
+                    >
+                      {maxText}
+                    </text>
+                  </>
+                )}
               </svg>
             </div>
           </div>

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.tsx
@@ -161,8 +161,6 @@ export function GaugeChartVisualization({
       className={cn(
         variant === "horizontal" &&
           "flex h-full flex-wrap content-center-safe justify-center gap-x-6 gap-y-4 overflow-y-auto px-1",
-        variant === "vertical" &&
-          "flex h-full items-stretch justify-center gap-6",
         (variant === "arc" || variant === undefined) &&
           "flex h-full flex-wrap items-stretch justify-center gap-4",
       )}
@@ -276,117 +274,6 @@ export function GaugeChartVisualization({
                     <span>{maxText}</span>
                   </div>
                 )}
-              </div>
-            </div>
-          );
-        }
-
-        if (variant === "vertical") {
-          const segments =
-            value !== undefined
-              ? fillSegments(
-                  fraction,
-                  marks,
-                  thresholds,
-                  min,
-                  max,
-                  fallbackColor,
-                )
-              : [];
-          const coloredMarks = marks.filter((m) => m.color !== undefined);
-          return (
-            <div
-              key={key}
-              className="flex min-w-20 flex-col items-center"
-              role="img"
-              aria-label={ariaLabel}
-            >
-              {labelEl}
-              <div className="flex min-h-0 flex-1 items-stretch gap-2 pt-1">
-                {/* Bar column; pl-3 leaves room for the value marker. */}
-                <div className="relative pl-3">
-                  {value !== undefined && (
-                    <div
-                      className="absolute left-0.5 translate-y-1/2 border-y-[5px] border-l-[6px] border-y-transparent border-l-foreground"
-                      style={{ bottom: `${fraction * 100}%` }}
-                    />
-                  )}
-                  <div className="relative h-full w-2.5 overflow-hidden rounded-sm bg-muted">
-                    {segments.map((s) => (
-                      <div
-                        key={s.from}
-                        className="absolute inset-x-0"
-                        style={{
-                          bottom: `${s.from * 100}%`,
-                          height: `${(s.to - s.from) * 100}%`,
-                          backgroundColor: s.color,
-                        }}
-                      />
-                    ))}
-                  </div>
-                </div>
-                {coloredMarks.length > 0 && (
-                  // Reserve room for the numeric labels so they never overlap
-                  // the value column.
-                  <div
-                    className={cn(
-                      "relative",
-                      showThresholdLabels ? "w-9" : "w-1.5",
-                    )}
-                  >
-                    {coloredMarks.map((mark) => (
-                      <div
-                        key={mark.fraction}
-                        className="absolute left-0 flex translate-y-1/2 items-center gap-1"
-                        style={{ bottom: `${mark.fraction * 100}%` }}
-                      >
-                        <div
-                          className="h-px w-1.5"
-                          style={{ backgroundColor: mark.color }}
-                        />
-                        {showThresholdLabels && (
-                          <p className="whitespace-nowrap text-[10px] leading-none tabular-nums text-muted-foreground">
-                            {formatStatValue(mark.value, undefined)}
-                            {unit}
-                          </p>
-                        )}
-                      </div>
-                    ))}
-                  </div>
-                )}
-                <div
-                  className={cn(
-                    "flex flex-col",
-                    showAxis ? "justify-between" : "justify-center",
-                  )}
-                >
-                  {showAxis && (
-                    <span className="text-[10px] tabular-nums text-muted-foreground">
-                      {maxText}
-                    </span>
-                  )}
-                  <p className="leading-none">
-                    <span
-                      className={cn(
-                        "text-2xl font-semibold tabular-nums",
-                        value === undefined && "text-muted-foreground",
-                      )}
-                      style={value !== undefined ? { color } : undefined}
-                    >
-                      {valueText}
-                    </span>
-                    {value !== undefined && unit && (
-                      <span className="ml-1 text-xs text-muted-foreground">
-                        {unit}
-                      </span>
-                    )}
-                  </p>
-                  {showAxis && (
-                    <span className="text-[10px] tabular-nums text-muted-foreground">
-                      {minText}
-                    </span>
-                  )}
-                </div>
               </div>
             </div>
           );

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.tsx
@@ -19,8 +19,9 @@ import {
 } from "./gauge-axis";
 import type { GaugeChartSpec } from "./spec";
 
-// Semicircle geometry in viewBox units. The round caps and the threshold
-// ticks extend past the arc radius, hence the margins in the viewBox.
+// The dimensions of the semicircle, in viewBox units. The round caps and the
+// threshold ticks go outside the radius of the arc. The viewBox thus includes
+// a margin for them.
 const VIEWBOX = "0 0 100 64";
 const CX = 50;
 const CY = 50;
@@ -32,17 +33,20 @@ function polar(r: number, angleDeg: number): { x: number; y: number } {
   return { x: CX + r * Math.cos(rad), y: CY - r * Math.sin(rad) };
 }
 
-/** Arc along the semicircle: 180° is the left end, 0° the right end. */
+/**
+ * Makes the path of an arc on the semicircle. The angle 180° is the left end.
+ * The angle 0° is the right end.
+ */
 function arcPath(startAngle: number, endAngle: number): string {
   const s = polar(R, startAngle);
   const e = polar(R, endAngle);
   return `M ${s.x} ${s.y} A ${R} ${R} 0 0 1 ${e.x} ${e.y}`;
 }
 
-/** A mark that renders: the colorless steps are filtered out up front. */
+/** A mark that the component shows. The steps without a color are removed. */
 type Tick = ThresholdMark & { color: string };
 
-/** Everything both variants draw, prepared once per gauge. */
+/** The data that both variants show. The component prepares it per gauge. */
 interface TileProps {
   label: React.ReactNode;
   value: number | undefined;
@@ -88,8 +92,8 @@ export function GaugeChartVisualization({
     () => marks.filter((m): m is Tick => m.color !== undefined),
     [marks],
   );
-  // The bands the marks cut the track into are the same for every gauge in the
-  // panel, so they are resolved here rather than per tile.
+  // The bands between the marks are the same for all the gauges in the panel.
+  // The component thus calculates the colors here, and not in each tile.
   const colors = useMemo(
     () => bandColors(marks, thresholds, min, max, fallbackColor),
     [marks, thresholds, min, max, fallbackColor],
@@ -176,7 +180,9 @@ export function GaugeChartVisualization({
   );
 }
 
-/** Flat bar filling left to right, with a marker at the current value. */
+/**
+ * A flat bar that fills from left to right. A marker shows the current value.
+ */
 function GaugeBar({
   label,
   value,
@@ -195,8 +201,8 @@ function GaugeBar({
     <div className="min-w-40 flex-1" role="img" aria-label={ariaLabel}>
       {label}
       <p className="mb-2 leading-none">
-        {/* Like the arc, the number stays neutral: the band color is carried
-            by the fill segments, not the text. */}
+        {/* The number keeps a neutral color, as on the arc. The segments of
+            the fill show the color of the band, and not the text. */}
         <span
           className={cn(
             "text-2xl font-semibold tabular-nums",
@@ -210,7 +216,7 @@ function GaugeBar({
         )}
       </p>
       <div className="relative pt-2">
-        {/* Triangle marker pointing down at the value position. */}
+        {/* A triangle marker that points down at the position of the value. */}
         {value !== undefined && (
           <div
             className="absolute top-0 -translate-x-1/2 border-x-[5px] border-t-[6px] border-x-transparent border-t-foreground"
@@ -262,7 +268,9 @@ function GaugeBar({
   );
 }
 
-/** Semicircular arc filling from the min end, with the value at its center. */
+/**
+ * A semicircular arc that fills from the `min` end. The value is at the center.
+ */
 function GaugeArc({
   label,
   value,
@@ -280,9 +288,9 @@ function GaugeArc({
   return (
     <div className="flex min-w-28 flex-1 flex-col items-center">
       {label}
-      {/* The SVG is absolutely positioned: inside a wrapped flex line a
-          percentage height can't resolve and the SVG would fall back to
-          width-driven sizing and overflow the panel. */}
+      {/* The SVG has an absolute position. In a flex line that wraps, a
+          height in percent does not resolve. The SVG then takes its size from
+          its width, and goes outside the panel. */}
       <div className="relative min-h-0 w-full flex-1">
         <svg
           viewBox={VIEWBOX}

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/spec.ts
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/spec.ts
@@ -2,34 +2,41 @@ import * as z from "zod";
 import { calculationSpec, thresholdsSpec } from "../stat-chart/spec";
 
 /**
- * GaugeChart plugin options. Loose so unknown keys flow through verbatim
- * (validation must never be stricter than Perses on shape); every known field
- * is defaulted so `{}` always parses — the lenient render path relies on it.
+ * The options of the GaugeChart plugin. The object is loose, because unknown
+ * keys must stay in the output. The validation must not be more strict than
+ * Perses. All known fields have a default value, because `{}` must always
+ * parse. The lenient render path needs this.
  */
 export const gaugeChartSpec = z.looseObject({
   calculation: calculationSpec.default("last"),
   unit: z.string().default(""),
-  /** Fixed fraction digits; omitted = up to 2, trailing zeros dropped. */
+  /**
+   * The number of fraction digits. If you do not set it, the value shows a
+   * maximum of 2 digits, and the zeros at the end are removed.
+   */
   decimals: z.number().int().min(0).max(10).optional(),
-  /** Gauge axis lower bound. */
+  /** The lower bound of the gauge axis. */
   min: z.number().default(0),
   /**
-   * Gauge axis upper bound. The arc fills (value - min) / (max - min); values
-   * outside the bounds clamp to an empty/full arc while the text shows the
-   * real value. Also the `percent` thresholds reference when `thresholds.max`
-   * is omitted.
+   * The upper bound of the gauge axis. The arc fills to
+   * (value - min) / (max - min). If a value is outside the bounds, the arc
+   * becomes empty or full, but the text shows the true value. The `percent`
+   * thresholds also use this bound if you do not set `thresholds.max`.
    */
   max: z.number().default(100),
   thresholds: thresholdsSpec.optional(),
-  /** Rendering shape: the default semicircle, or a flat horizontal bar. */
+  /** The shape: the default semicircle, or a flat horizontal bar. */
   variant: z.enum(["arc", "horizontal"]).default("arc"),
-  /** Show the min/max axis labels at the ends of the gauge. */
+  /** Shows the min and max labels at the ends of the gauge. */
   showAxis: z.boolean().default(true),
-  /** Show a numeric label at each threshold step tick mark. */
+  /** Shows a number at the tick mark of each threshold step. */
   showThresholdLabels: z.boolean().default(false),
-  /** Show the series label even on a single-gauge panel (multi-gauge always shows it). */
+  /**
+   * Shows the series label on a panel that has one gauge. A panel that has
+   * more than one gauge always shows the labels.
+   */
   showLabel: z.boolean().default(false),
-  /** Text shown for a query that produced no value. */
+  /** The text to show if a query gives no value. */
   noValue: z.string().default("–"),
 });
 

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/spec.ts
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/spec.ts
@@ -21,8 +21,8 @@ export const gaugeChartSpec = z.looseObject({
    */
   max: z.number().default(100),
   thresholds: thresholdsSpec.optional(),
-  /** Rendering variant; omitted means `arc` (the default semicircle). */
-  variant: z.enum(["arc", "horizontal"]).optional(),
+  /** Rendering shape: the default semicircle, or a flat horizontal bar. */
+  variant: z.enum(["arc", "horizontal"]).default("arc"),
   /** Show the min/max axis labels at the ends of the gauge. */
   showAxis: z.boolean().default(true),
   /** Show a numeric label at each threshold step tick mark. */

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/spec.ts
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/spec.ts
@@ -22,7 +22,7 @@ export const gaugeChartSpec = z.looseObject({
   max: z.number().default(100),
   thresholds: thresholdsSpec.optional(),
   /** Rendering variant; omitted means `arc` (the default semicircle). */
-  variant: z.enum(["arc", "horizontal", "vertical"]).optional(),
+  variant: z.enum(["arc", "horizontal"]).optional(),
   /** Show the min/max axis labels at the ends of the gauge. */
   showAxis: z.boolean().default(true),
   /** Show a numeric label at each threshold step tick mark. */

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/spec.ts
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/spec.ts
@@ -21,6 +21,12 @@ export const gaugeChartSpec = z.looseObject({
    */
   max: z.number().default(100),
   thresholds: thresholdsSpec.optional(),
+  /** Rendering variant; omitted means `arc` (the default semicircle). */
+  variant: z.enum(["arc", "horizontal", "vertical"]).optional(),
+  /** Show the min/max axis labels at the ends of the gauge. */
+  showAxis: z.boolean().default(true),
+  /** Show a numeric label at each threshold step tick mark. */
+  showThresholdLabels: z.boolean().default(false),
   /** Show the series label even on a single-gauge panel (multi-gauge always shows it). */
   showLabel: z.boolean().default(false),
   /** Text shown for a query that produced no value. */

--- a/packages/app/src/components/panel-shell.tsx
+++ b/packages/app/src/components/panel-shell.tsx
@@ -149,7 +149,11 @@ export function PanelShell({
       {hasHeader && (
         <CardHeader className={headerClassName}>
           {title && <CardTitle>{title}</CardTitle>}
-          {description && <CardDescription>{description}</CardDescription>}
+          {description && (
+            <CardDescription className="line-clamp-2" title={description}>
+              {description}
+            </CardDescription>
+          )}
           {action && <CardAction>{action}</CardAction>}
         </CardHeader>
       )}

--- a/packages/app/src/components/panel-shell.tsx
+++ b/packages/app/src/components/panel-shell.tsx
@@ -149,11 +149,7 @@ export function PanelShell({
       {hasHeader && (
         <CardHeader className={headerClassName}>
           {title && <CardTitle>{title}</CardTitle>}
-          {description && (
-            <CardDescription className="line-clamp-2" title={description}>
-              {description}
-            </CardDescription>
-          )}
+          {description && <CardDescription>{description}</CardDescription>}
           {action && <CardAction>{action}</CardAction>}
         </CardHeader>
       )}


### PR DESCRIPTION
Closes #371

## What

Adds three optional fields to the GaugeChart spec:

- `variant`: `arc` | `horizontal` — omitted means `arc`, so existing panels render unchanged
- `showAxis` (default `true`): toggles the min/max axis labels (arc ends, or below the horizontal bar)
- `showThresholdLabels` (default `false`): shows a numeric label at each threshold tick, on any variant. The label carries the `unit` suffix on both variants

The horizontal variant fills left to right from the min end, shows a triangle marker at the current value, draws colored threshold ticks below the bar, and splits the fill into per-band colored segments when thresholds are configured. The value text stays neutral on both variants: the band color is carried by the arc/fill, not by the number. Inverted bounds (`min > max`) work on both variants. The no-value placeholder and series-label behavior are shared across variants.

The vertical variant from the original issue scope was dropped: it reads poorly at typical panel heights.

Per the issue's implementation decisions: single component with conditional rendering, `resolveThresholdColor` used as-is, no threshold band names.

## Screenshots

Demo gallery (`everr/demo/gauge.dashboard.yaml`), arc variants and horizontal bars side by side:

![Arc and horizontal gauge variants](https://github.com/everr-labs/everr/blob/a177c5fb567c796d729d52d74e37e8ef344c7d4e/gauge-variants.png?raw=true)

Horizontal with inverted bounds and three columns:

![Horizontal gauges with inverted bounds](https://github.com/everr-labs/everr/blob/a177c5fb567c796d729d52d74e37e8ef344c7d4e/gauge-horizontal-multi.png?raw=true)

## Testing

- `pnpm typecheck` and biome clean; spec parse tests pass (`{}` still parses)
- Extended the demo gauge gallery with panels covering the variants and toggle combinations, applied with everr and verified visually in the app: arcs unchanged, bars fill/mark/tick correctly, inverted multi-column horizontal renders, noValue placeholder shows regardless of variant
- Updated the GaugeChart options table in the everr-setup-resources skill catalog
