### PR TITLE
feat(app): homepage overview with live stats and a services list

### DIFF
--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/gaugechart.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/gaugechart.md
@@ -1,6 +1,6 @@
 # GaugeChart
 
-One or more semicircular gauges, each showing a single value as an arc filled between `min` and `max`, with optional threshold coloring and tick marks.
+One or more gauges, each showing a single value filled between `min` and `max`, with optional threshold coloring and tick marks. Renders as a semicircular arc by default; `variant` switches to a flat horizontal bar.
 
 ## Options (`plugin.spec`)
 
@@ -13,6 +13,9 @@ One or more semicircular gauges, each showing a single value as an arc filled be
 | `max` | number | `100` | any number | Gauge axis upper bound. **Set it to the metric's real ceiling** — the default 100 only suits percentages. Inverting the bounds (`min > max`) inverts the arc, so a lower value reads as fuller — useful for "lower is better" metrics. |
 | `showLabel` | boolean | `false` | `true` | Show the column-name label even on a single-gauge panel (multi-gauge always shows it). |
 | `noValue` | string | `–` | any string | Text rendered for a query that produced no value (empty result / no numeric column). |
+| `variant` | string | `arc` | `arc`, `horizontal` | Rendering shape. `arc`: semicircular arc. `horizontal`: flat bar filling left→right with the value text above it, a triangle marker at the value position and, with thresholds, multi-colored fill segments per band. |
+| `showAxis` | boolean | `true` | `false` | Show the `min`/`max` axis labels: at the arc ends, or below the horizontal bar. |
+| `showThresholdLabels` | boolean | `false` | `true` | Show a numeric label at each threshold tick mark (any variant). |
 | `thresholds` | object | none | see below | Color the arc and mark step positions on the gauge. Omit for the default series color. |
 
 ### `thresholds`

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/metrics.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/metrics.md
@@ -33,7 +33,7 @@ When these instrumentations are present, expect metrics in these domains before 
 | HTTP client | `http.client.request.duration` |
 | Database client | `db.client.operation.duration` |
 | Messaging | `messaging.process.duration`, `messaging.publish.duration` |
-| RPC | `rpc.server.duration`, `rpc.client.duration` |
+| RPC | `rpc.server.call.duration`, `rpc.client.call.duration` (both seconds; the retired names were `rpc.server.duration` and `rpc.client.duration`, in milliseconds) |
 | Runtime/process | `process.runtime.*`, `process.cpu.*`, `process.memory.*` |
 
 Exact names can vary by SDK version and semantic convention stability setting. If a service depends on a metric for alerts or dashboards, test the emitted shape instead of assuming the library uses the current stable name.

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/spans.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/spans.md
@@ -18,7 +18,7 @@ Common formats:
 - HTTP server: `{method} {http.route}`
 - HTTP client: `{method} {url.template}` or `{method}` when no safe template exists
 - Database: `{db.operation.name} {db.collection.name}`
-- RPC: `{rpc.service}/{rpc.method}`
+- RPC: `{rpc.method}`, which is already the fully-qualified `{service}/{method}`
 - Messaging: `{operation} {destination}`
 - Domain work: `{verb} {object}`, such as `process order`
 
@@ -62,6 +62,21 @@ Avoid attributes containing request bodies, raw URLs with query params, serializ
 
 Add business attributes to auto-instrumented spans by retrieving the active span; do not create a redundant child span solely to add attributes.
 
+## RPC Attributes
+
+The RPC conventions moved. Emit the current spelling, not the retired one.
+
+| Retired | Current | Note |
+| --- | --- | --- |
+| `rpc.system` | `rpc.system.name` | Well-known values: `grpc`, `dubbo`, `connectrpc`, `jsonrpc`. Other systems may use their own value. |
+| `rpc.service` | (none) | Absorbed into `rpc.method`. |
+| `rpc.method` | `rpc.method` | Now the fully-qualified `{service}/{method}`, such as `com.example.ExampleService/exampleMethod`. |
+| `rpc.grpc.status_code` | `rpc.response.status_code` | Also changed type: the integer `0` is now the string `OK`. |
+| `rpc.grpc.request.metadata.<key>` | `rpc.request.metadata.<key>` | Same for the response side. |
+| `rpc.message.*` | (none) | Deprecated with no replacement. |
+
+Set `error.type` on a failed call. Auto-instrumentation still emits the retired spelling by default; `OTEL_SEMCONV_STABILITY_OPT_IN=rpc` switches it to the current one, and `rpc/dup` emits both during a migration. Do not read both spellings in a query: the two are not interchangeable, because the old method key needs `rpc.service` concatenated onto it and the two status codes do not even share a type.
+
 ## Headless Work
 
 Cron jobs, background workers, CLI commands, startup tasks, and batch jobs often have no inbound request span. Wrap the unit of work in a manual root span so outbound database or HTTP spans do not become root `CLIENT` spans.
@@ -82,6 +97,7 @@ await tracer.startActiveSpan('process daily orders', async (span) => {
 - `CLIENT` and `PRODUCER` spans should have a parent that explains why the outbound work happened.
 - Every child span should have a parent span in the same trace.
 - Keep `INTERNAL` spans sparse; avoid tracing tight loops.
+- A span that carries RPC attributes but nests inside a `SERVER` span that already covers the same request stays `INTERNAL`. The conventions ask an RPC server span to be `SERVER`, but promoting a nested one makes a single inbound request count twice on every panel that splits traffic by span kind.
 - Replace per-item spans with one batch span plus `batch.size`.
 - Use logs for lightweight annotations.
 - Keep application SDK sampling at the default unless the project has an explicit collector-side sampling plan. Application-side head sampling drops evidence before outcome is known.

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/tanstack-start.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/tanstack-start.md
@@ -106,6 +106,8 @@ export const startInstance = createStart(() => ({
 
 The middleware (`createMiddleware({ type: "function" })`) starts an INTERNAL span per invocation with the function id, name, and filename from `serverFnMeta` as attributes (prefix non-semconv attributes with `everr.`). It nests under the request's SERVER span automatically because the fetch wrapper's context is active.
 
+A server function call is an RPC, so describe it with the RPC conventions in `spans.md`: `rpc.system.name` for the framework and a fully-qualified `rpc.method`. Keep the span INTERNAL even though the conventions ask an RPC server span to be SERVER, because the request already has one and a second would double every inbound count.
+
 TanStack Start signals control flow with throwables: `redirect()` and `notFound()` surface as thrown values inside server functions. Filter those out before calling `captureError`, or every redirect becomes a phantom error.
 
 ## Validation

--- a/everr/demo/gauge.dashboard.yaml
+++ b/everr/demo/gauge.dashboard.yaml
@@ -8,9 +8,10 @@ spec:
     description: >-
       GaugeChart regression sheet — every option (all 9 calculations, unit,
       decimals, min/max bounds, thresholds absolute/percent with and without
-      thresholds.max, showLabel, noValue) and behavior (spec defaults, clamping
-      past the bounds, multi-query placeholder, multi-gauge, empty) exercised
-      with deterministic TestData.
+      thresholds.max, showLabel, noValue, variant arc/horizontal,
+      showAxis, showThresholdLabels) and behavior (spec defaults, clamping
+      past the bounds, multi-query placeholder, multi-gauge, empty, inverted
+      bounds) exercised with deterministic TestData.
   duration: 7d
   refreshInterval: 1m
   panels:
@@ -399,6 +400,142 @@ spec:
                   scenario: csv
                   columns: [ts, value]
                   rows: []
+    # ── Variants + axis/threshold label toggles ──────────────────────
+    gauge-arc-threshold-labels:
+      kind: Panel
+      spec:
+        display:
+          name: "Gauge: arc, threshold labels"
+          description: "variant: arc (explicit) · showThresholdLabels: true. Numeric labels at each threshold tick on the semicircle"
+        plugin:
+          kind: GaugeChart
+          spec:
+            variant: arc
+            unit: "%"
+            showThresholdLabels: true
+            thresholds:
+              mode: absolute
+              defaultColor: "#22c55e"
+              steps:
+                - { value: 70, color: "#f59e0b" }
+                - { value: 90, color: "#ef4444" }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: csv
+                  columns: [pct]
+                  rows:
+                    - [55]
+    gauge-arc-no-axis:
+      kind: Panel
+      spec:
+        display:
+          name: "Gauge: arc, no axis"
+          description: "showAxis: false on the default arc. The min/max end labels are hidden"
+        plugin:
+          kind: GaugeChart
+          spec:
+            unit: "%"
+            showAxis: false
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: csv
+                  columns: [pct]
+                  rows:
+                    - [42]
+    gauge-horizontal:
+      kind: Panel
+      spec:
+        display:
+          name: "Gauge: horizontal"
+          description: "variant: horizontal · thresholds → multi-colored fill segments, colored ticks below the bar, triangle marker at the value, min/max axis below (showAxis default true)"
+        plugin:
+          kind: GaugeChart
+          spec:
+            variant: horizontal
+            unit: "%"
+            decimals: 1
+            thresholds:
+              mode: absolute
+              defaultColor: "#22c55e"
+              steps:
+                - { value: 50, color: "#f59e0b" }
+                - { value: 80, color: "#ef4444" }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: csv
+                  columns: [pct]
+                  rows:
+                    - [65]
+    gauge-horizontal-threshold-labels:
+      kind: Panel
+      spec:
+        display:
+          name: "Gauge: horizontal, only threshold labels"
+          description: "variant: horizontal · showAxis: false + showThresholdLabels: true. Numeric labels below each tick, no min/max row"
+        plugin:
+          kind: GaugeChart
+          spec:
+            variant: horizontal
+            unit: ms
+            max: 500
+            showAxis: false
+            showThresholdLabels: true
+            thresholds:
+              mode: absolute
+              defaultColor: "#22c55e"
+              steps:
+                - { value: 200, color: "#f59e0b" }
+                - { value: 400, color: "#ef4444" }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: csv
+                  columns: [p95_ms]
+                  rows:
+                    - [310]
+    gauge-horizontal-inverted-multi:
+      kind: Panel
+      spec:
+        display:
+          name: "Gauge: horizontal, inverted bounds, multi"
+          description: "variant: horizontal · min: 100 / max: 0 (inverted) · three numeric columns → three bars with labels"
+        plugin:
+          kind: GaugeChart
+          spec:
+            variant: horizontal
+            unit: "%"
+            min: 100
+            max: 0
+            thresholds:
+              mode: absolute
+              defaultColor: "#22c55e"
+              steps:
+                - { value: 40, color: "#ef4444" }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: csv
+                  columns: [cache_hit, uptime, success]
+                  rows:
+                    - [20, 85, 99]
   layouts:
     - kind: Grid
       spec:
@@ -419,3 +556,8 @@ spec:
           - { x: 16, y: 20, width: 8,  height: 6, content: { $ref: "#/spec/panels/gauge-empty" } }
           - { x: 0,  y: 26, width: 8,  height: 5, content: { $ref: "#/spec/panels/gauge-inverted" } }
           - { x: 8,  y: 26, width: 8,  height: 5, content: { $ref: "#/spec/panels/gauge-mid-band" } }
+          - { x: 16, y: 26, width: 8,  height: 5, content: { $ref: "#/spec/panels/gauge-arc-threshold-labels" } }
+          - { x: 0,  y: 31, width: 8,  height: 5, content: { $ref: "#/spec/panels/gauge-arc-no-axis" } }
+          - { x: 8,  y: 31, width: 8,  height: 5, content: { $ref: "#/spec/panels/gauge-horizontal" } }
+          - { x: 16, y: 31, width: 8,  height: 5, content: { $ref: "#/spec/panels/gauge-horizontal-threshold-labels" } }
+          - { x: 0,  y: 36, width: 12, height: 7, content: { $ref: "#/spec/panels/gauge-horizontal-inverted-multi" } }

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-axis.test.ts
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-axis.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import type { ThresholdsSpec } from "../stat-chart/stat-calculations";
+import {
+  axisFraction,
+  bandColors,
+  fillSegments,
+  formatAxisEnd,
+  thresholdMarks,
+} from "./gauge-axis";
+
+const GREEN = "#22c55e";
+const AMBER = "#f59e0b";
+const RED = "#ef4444";
+
+const absolute: ThresholdsSpec = {
+  mode: "absolute",
+  defaultColor: GREEN,
+  steps: [
+    { value: 50, color: AMBER },
+    { value: 80, color: RED },
+  ],
+};
+
+describe("axisFraction", () => {
+  it("measures from the min end", () => {
+    expect(axisFraction(25, 0, 100)).toBe(0.25);
+  });
+
+  it("flips for inverted bounds", () => {
+    expect(axisFraction(20, 100, 0)).toBe(0.8);
+  });
+
+  it("clamps outside the bounds", () => {
+    expect(axisFraction(-10, 0, 100)).toBe(0);
+    expect(axisFraction(150, 0, 100)).toBe(1);
+  });
+
+  it("returns 0 for a degenerate axis", () => {
+    expect(axisFraction(5, 5, 5)).toBe(0);
+  });
+});
+
+describe("thresholdMarks", () => {
+  it("projects absolute steps and sorts along the axis", () => {
+    expect(thresholdMarks(absolute, 0, 100)).toEqual([
+      { fraction: 0.5, text: "50", color: AMBER },
+      { fraction: 0.8, text: "80", color: RED },
+    ]);
+  });
+
+  it("projects percent steps against thresholds.max", () => {
+    const percent: ThresholdsSpec = {
+      mode: "percent",
+      max: 200,
+      steps: [{ value: 50, color: RED }],
+    };
+    expect(thresholdMarks(percent, 0, 400)).toEqual([
+      { fraction: 0.25, text: "100", color: RED },
+    ]);
+  });
+
+  it("suffixes the unit on the label", () => {
+    expect(thresholdMarks(absolute, 0, 100, "ms")[0]?.text).toBe("50ms");
+  });
+
+  it("drops steps outside the axis span, inverted bounds included", () => {
+    expect(thresholdMarks(absolute, 0, 40)).toEqual([]);
+    expect(thresholdMarks(absolute, 100, 0).map((m) => m.fraction)).toEqual([
+      0.2, 0.5,
+    ]);
+  });
+
+  it("keeps colorless steps as band edges", () => {
+    const marks = thresholdMarks(
+      { mode: "absolute", steps: [{ value: 50 }] },
+      0,
+      100,
+    );
+    expect(marks).toEqual([{ fraction: 0.5, text: "50", color: undefined }]);
+  });
+
+  it("returns nothing without steps", () => {
+    expect(thresholdMarks(undefined, 0, 100)).toEqual([]);
+  });
+});
+
+describe("bandColors", () => {
+  it("resolves one color per band", () => {
+    const marks = thresholdMarks(absolute, 0, 100);
+    expect(bandColors(marks, absolute, 0, 100, "fallback")).toEqual([
+      GREEN,
+      AMBER,
+      RED,
+    ]);
+  });
+
+  it("mirrors the bands for inverted bounds", () => {
+    const marks = thresholdMarks(absolute, 100, 0);
+    expect(bandColors(marks, absolute, 100, 0, "fallback")).toEqual([
+      RED,
+      AMBER,
+      GREEN,
+    ]);
+  });
+
+  it("falls back when no threshold resolves", () => {
+    expect(bandColors([], undefined, 0, 100, "fallback")).toEqual(["fallback"]);
+  });
+});
+
+describe("fillSegments", () => {
+  const marks = thresholdMarks(absolute, 0, 100);
+  const colors = bandColors(marks, absolute, 0, 100, "fallback");
+
+  it("splits the fill at every crossed threshold", () => {
+    expect(fillSegments(0.9, marks, colors)).toEqual([
+      { from: 0, to: 0.5, color: GREEN },
+      { from: 0.5, to: 0.8, color: AMBER },
+      { from: 0.8, to: 0.9, color: RED },
+    ]);
+  });
+
+  it("stops at the value, leaving later bands unfilled", () => {
+    expect(fillSegments(0.3, marks, colors)).toEqual([
+      { from: 0, to: 0.3, color: GREEN },
+    ]);
+  });
+
+  it("returns nothing for an empty gauge", () => {
+    expect(fillSegments(0, marks, colors)).toEqual([]);
+  });
+});
+
+describe("duplicate steps", () => {
+  const dupes: ThresholdsSpec = {
+    mode: "absolute",
+    defaultColor: GREEN,
+    steps: [
+      { value: 50, color: AMBER },
+      { value: 50, color: RED },
+    ],
+  };
+
+  it("does not emit an empty segment for the collapsed band", () => {
+    const marks = thresholdMarks(dupes, 0, 100);
+    const colors = bandColors(marks, dupes, 0, 100, "fallback");
+    expect(fillSegments(0.9, marks, colors)).toEqual([
+      { from: 0, to: 0.5, color: GREEN },
+      { from: 0.5, to: 0.9, color: RED },
+    ]);
+  });
+});
+
+describe("formatAxisEnd", () => {
+  it("suffixes the unit on a non-zero end", () => {
+    expect(formatAxisEnd(100, "%")).toBe("100%");
+    expect(formatAxisEnd(-500, "ms")).toBe("-500ms");
+  });
+
+  it("leaves a zero end bare", () => {
+    expect(formatAxisEnd(0, "%")).toBe("0");
+  });
+
+  it("works without a unit", () => {
+    expect(formatAxisEnd(50)).toBe("50");
+  });
+});

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-axis.ts
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-axis.ts
@@ -1,0 +1,135 @@
+import {
+  formatStatValue,
+  resolveThresholdColor,
+  type ThresholdsSpec,
+} from "../stat-chart/stat-calculations";
+
+/**
+ * Calculates the position of `value` on the gauge axis, from 0 to 1. The
+ * position 0 is the `min` end. If the bounds are inverted (`min > max`), the
+ * direction of the axis changes. The gauge then fills to the `max` end when
+ * the value moves to `max`. If `min` is equal to `max`, the result is 0.
+ */
+export function axisFraction(value: number, min: number, max: number): number {
+  if (max === min) return 0;
+  return Math.min(1, Math.max(0, (value - min) / (max - min)));
+}
+
+/**
+ * Formats a value on the axis: the min and max ends, and the threshold ticks.
+ * The axis always uses the default precision. The `decimals` option applies
+ * to the gauge value only.
+ */
+function formatAxisValue(value: number, unit?: string): string {
+  return `${formatStatValue(value, undefined)}${unit ?? ""}`;
+}
+
+/**
+ * Formats one end of the axis. If the end value is 0, the label does not show
+ * the unit, because "0" is clear without it. The end labels are also the
+ * smallest text on the gauge.
+ */
+export function formatAxisEnd(value: number, unit?: string): string {
+  return formatAxisValue(value, value === 0 ? undefined : unit);
+}
+
+export interface ThresholdMark {
+  fraction: number;
+  /** The position of the step as text, for the tick label. */
+  text: string;
+  /** A tick shows only if its step has a color. */
+  color?: string;
+}
+
+export interface FillSegment {
+  from: number;
+  to: number;
+  color: string;
+}
+
+/**
+ * Calculates the position of each threshold step on the gauge axis, in the
+ * sequence of the axis. For `percent` steps, this function uses the same
+ * reference as `resolveThresholdColor`: `thresholds.max`, or the gauge `max`
+ * if `thresholds.max` is not set. Each mark is thus at the position where the
+ * color changes. The function keeps only the steps that are inside the span
+ * of the axis. This is also correct if the bounds are inverted.
+ */
+export function thresholdMarks(
+  thresholds: ThresholdsSpec | undefined,
+  min: number,
+  max: number,
+  unit?: string,
+): ThresholdMark[] {
+  if (!thresholds?.steps) return [];
+  const ref = thresholds.max ?? max;
+  const lower = Math.min(min, max);
+  const upper = Math.max(min, max);
+  const marks: ThresholdMark[] = [];
+  for (const step of thresholds.steps) {
+    const value =
+      thresholds.mode === "percent" ? (step.value / 100) * ref : step.value;
+    if (value <= lower || value >= upper) continue;
+    marks.push({
+      fraction: axisFraction(value, min, max),
+      text: formatAxisValue(value, unit),
+      color: step.color,
+    });
+  }
+  return marks.sort((a, b) => a.fraction - b.fraction);
+}
+
+/**
+ * Gives the color of each band between the marks. There is one color for each
+ * band (`marks.length + 1`). Each band gets its color from the axis value at
+ * the center of the band. The colors stay on the correct side if the bounds
+ * are inverted (`min > max`), because this function does not assume that the
+ * axis increases. The bands do not change with the gauge value. This function
+ * thus runs one time for each axis, and not one time for each gauge.
+ */
+export function bandColors(
+  marks: ThresholdMark[],
+  thresholds: ThresholdsSpec | undefined,
+  min: number,
+  max: number,
+  fallback: string,
+): string[] {
+  const colors: string[] = [];
+  for (let i = 0; i <= marks.length; i++) {
+    const from = bandStart(marks, i);
+    const to = bandEnd(marks, i);
+    const midValue = min + ((from + to) / 2) * (max - min);
+    colors.push(resolveThresholdColor(midValue, thresholds, max) ?? fallback);
+  }
+  return colors;
+}
+
+/**
+ * Gives the filled part of the track. The function divides the filled part at
+ * each threshold that the value passes. Each part has the color of its band.
+ */
+export function fillSegments(
+  fraction: number,
+  marks: ThresholdMark[],
+  colors: string[],
+): FillSegment[] {
+  const segments: FillSegment[] = [];
+  for (let i = 0; i <= marks.length; i++) {
+    const from = bandStart(marks, i);
+    if (from >= fraction) break;
+    const to = Math.min(fraction, bandEnd(marks, i));
+    // Two steps with the same value make an empty band. The loop does not
+    // add it, because each segment must have a different `from` value.
+    if (to > from) segments.push({ from, to, color: colors[i] ?? "" });
+  }
+  return segments;
+}
+
+/** Band `i` starts at the mark before it, or at the `min` end. */
+function bandStart(marks: ThresholdMark[], i: number): number {
+  return i === 0 ? 0 : (marks[i - 1]?.fraction ?? 0);
+}
+
+function bandEnd(marks: ThresholdMark[], i: number): number {
+  return marks[i]?.fraction ?? 1;
+}

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.tsx
@@ -6,13 +6,22 @@ import type { VisualizationProps } from "../index";
 import {
   formatStatValue,
   resolveThresholdColor,
-  type ThresholdsSpec,
 } from "../stat-chart/stat-calculations";
 import { computeStatTiles } from "../stat-chart/stat-series";
+import {
+  axisFraction,
+  bandColors,
+  type FillSegment,
+  fillSegments,
+  formatAxisEnd,
+  type ThresholdMark,
+  thresholdMarks,
+} from "./gauge-axis";
 import type { GaugeChartSpec } from "./spec";
 
-// Semicircle geometry in viewBox units. The round caps and the threshold
-// ticks extend past the arc radius, hence the margins in the viewBox.
+// The dimensions of the semicircle, in viewBox units. The round caps and the
+// threshold ticks go outside the radius of the arc. The viewBox thus includes
+// a margin for them.
 const VIEWBOX = "0 0 100 64";
 const CX = 50;
 const CY = 50;
@@ -24,60 +33,31 @@ function polar(r: number, angleDeg: number): { x: number; y: number } {
   return { x: CX + r * Math.cos(rad), y: CY - r * Math.sin(rad) };
 }
 
-/** Arc along the semicircle: 180° is the left end, 0° the right end. */
+/**
+ * Makes the path of an arc on the semicircle. The angle 180° is the left end.
+ * The angle 0° is the right end.
+ */
 function arcPath(startAngle: number, endAngle: number): string {
   const s = polar(R, startAngle);
   const e = polar(R, endAngle);
   return `M ${s.x} ${s.y} A ${R} ${R} 0 0 1 ${e.x} ${e.y}`;
 }
 
-/**
- * 0..1 position of `value` along the gauge axis, measured from the `min` end.
- * Inverted bounds (`min > max`) are supported: the signed span flips the
- * direction so the arc fills toward the `max` end as the value approaches it.
- * Returns 0 only for a truly degenerate axis (`min === max`).
- */
-function axisFraction(value: number, min: number, max: number): number {
-  if (max === min) return 0;
-  return Math.min(1, Math.max(0, (value - min) / (max - min)));
-}
+/** A mark that the component shows. The steps without a color are removed. */
+type Tick = ThresholdMark & { color: string };
 
-interface ThresholdTick {
+/** The data that both variants show. The component prepares it per gauge. */
+interface TileProps {
+  label: React.ReactNode;
+  value: number | undefined;
+  valueText: string;
+  unit: string;
   fraction: number;
-  color: string;
-}
-
-/**
- * Step positions projected onto the gauge axis. Percent steps resolve against
- * the same reference `resolveThresholdColor` uses (thresholds.max, falling
- * back to the gauge max), so a tick always sits where the color changes.
- */
-function thresholdTicks(
-  thresholds: ThresholdsSpec | undefined,
-  min: number,
-  max: number,
-): ThresholdTick[] {
-  if (!thresholds?.steps) return [];
-  const ref = thresholds.max ?? max;
-  return (
-    thresholds.steps
-      .map((step) => ({
-        value:
-          thresholds.mode === "percent" ? (step.value / 100) * ref : step.value,
-        color: step.color,
-      }))
-      .filter(
-        (t): t is { value: number; color: string } => t.color !== undefined,
-      )
-      // Keep ticks strictly inside the axis span — works for inverted bounds too.
-      .filter(
-        (t) => t.value > Math.min(min, max) && t.value < Math.max(min, max),
-      )
-      .map((t) => ({
-        fraction: axisFraction(t.value, min, max),
-        color: t.color,
-      }))
-  );
+  ticks: Tick[];
+  showAxis: boolean;
+  showThresholdLabels: boolean;
+  minText: string;
+  maxText: string;
 }
 
 export function GaugeChartVisualization({
@@ -93,6 +73,9 @@ export function GaugeChartVisualization({
     thresholds,
     showLabel,
     noValue,
+    variant,
+    showAxis,
+    showThresholdLabels,
   } = spec;
 
   const tiles = useMemo(
@@ -100,9 +83,20 @@ export function GaugeChartVisualization({
     [data, calculation],
   );
   const hasAnyValue = tiles.some((t) => t.value !== undefined);
+  const fallbackColor = SERIES_COLORS[0] ?? "currentColor";
+  const marks = useMemo(
+    () => thresholdMarks(thresholds, min, max, unit),
+    [thresholds, min, max, unit],
+  );
   const ticks = useMemo(
-    () => thresholdTicks(thresholds, min, max),
-    [thresholds, min, max],
+    () => marks.filter((m): m is Tick => m.color !== undefined),
+    [marks],
+  );
+  // The bands between the marks are the same for all the gauges in the panel.
+  // The component thus calculates the colors here, and not in each tile.
+  const colors = useMemo(
+    () => bandColors(marks, thresholds, min, max, fallbackColor),
+    [marks, thresholds, min, max, fallbackColor],
   );
 
   if (!data || !hasAnyValue) {
@@ -116,120 +110,285 @@ export function GaugeChartVisualization({
     );
   }
 
+  const horizontal = variant === "horizontal";
   const multi = tiles.length > 1;
+  const minText = formatAxisEnd(min, unit);
+  const maxText = formatAxisEnd(max, unit);
 
   return (
-    <div className="flex h-full flex-wrap items-stretch justify-center gap-4">
+    <div
+      className={cn(
+        "flex h-full flex-wrap justify-center",
+        horizontal
+          ? "content-center-safe gap-x-6 gap-y-4 overflow-y-auto px-1"
+          : "items-stretch gap-4",
+      )}
+    >
       {tiles.map((tile) => {
         const value = tile.value;
-        const label = tile.label || queryLabel(tile.frame);
-        const color =
-          (value !== undefined
-            ? resolveThresholdColor(value, thresholds, max)
-            : undefined) ??
-          SERIES_COLORS[0] ??
-          "currentColor";
+        const name = tile.label || queryLabel(tile.frame);
         const fraction =
           value !== undefined ? axisFraction(value, min, max) : 0;
         const valueText =
           value === undefined ? noValue : formatStatValue(value, decimals);
-        return (
-          <div
-            key={`${tile.frame}-${tile.label}`}
-            className="flex min-w-28 flex-1 flex-col items-center"
-          >
-            {(multi || showLabel) && (
-              <p className="text-xs text-muted-foreground">{label}</p>
+        const label = (multi || showLabel) && (
+          <p
+            className={cn(
+              "truncate text-xs text-muted-foreground",
+              horizontal && "mb-1",
             )}
-            {/* The SVG is absolutely positioned: inside a wrapped flex line a
-                percentage height can't resolve and the SVG would fall back to
-                width-driven sizing and overflow the panel. */}
-            <div className="relative min-h-0 w-full flex-1">
-              <svg
-                viewBox={VIEWBOX}
-                preserveAspectRatio="xMidYMid meet"
-                className="absolute inset-0 h-full w-full"
-                role="img"
-                aria-label={`${label}: ${valueText}${unit ? ` ${unit}` : ""}`}
-              >
-                <path
-                  d={arcPath(180, 0)}
-                  className="stroke-muted"
-                  strokeWidth={STROKE}
-                  strokeLinecap="round"
-                  fill="none"
-                />
-                {fraction > 0 && (
-                  <path
-                    d={arcPath(180, 180 - fraction * 180)}
-                    stroke={color}
-                    strokeWidth={STROKE}
-                    strokeLinecap="round"
-                    fill="none"
-                  />
-                )}
-                {ticks.map((tick) => {
-                  const angle = 180 - tick.fraction * 180;
-                  const inner = polar(R - STROKE / 2 - 2, angle);
-                  const outer = polar(R + STROKE / 2 + 2, angle);
-                  return (
-                    <line
-                      key={`${tick.fraction}-${tick.color}`}
-                      x1={inner.x}
-                      y1={inner.y}
-                      x2={outer.x}
-                      y2={outer.y}
-                      stroke={tick.color}
-                      strokeWidth={1.25}
-                    />
-                  );
-                })}
-                <text
-                  x={CX}
-                  y={46}
-                  textAnchor="middle"
-                  fontSize={13}
-                  className={cn(
-                    "font-semibold tabular-nums",
-                    value === undefined
-                      ? "fill-muted-foreground"
-                      : "fill-foreground",
-                  )}
-                >
-                  {valueText}
-                  {value !== undefined && unit && (
-                    <tspan
-                      dx={1.5}
-                      fontSize={7}
-                      className="fill-muted-foreground font-normal"
-                    >
-                      {unit}
-                    </tspan>
-                  )}
-                </text>
-                <text
-                  x={CX - R}
-                  y={62}
-                  textAnchor="middle"
-                  fontSize={5.5}
-                  className="fill-muted-foreground tabular-nums"
-                >
-                  {formatStatValue(min, undefined)}
-                </text>
-                <text
-                  x={CX + R}
-                  y={62}
-                  textAnchor="middle"
-                  fontSize={5.5}
-                  className="fill-muted-foreground tabular-nums"
-                >
-                  {formatStatValue(max, undefined)}
-                </text>
-              </svg>
-            </div>
-          </div>
+          >
+            {name}
+          </p>
+        );
+        const props: TileProps = {
+          label,
+          value,
+          valueText,
+          unit,
+          fraction,
+          ticks,
+          showAxis,
+          showThresholdLabels,
+          minText,
+          maxText,
+        };
+        const key = `${tile.frame}-${tile.label}`;
+        const ariaLabel = `${name}: ${valueText}${unit ? ` ${unit}` : ""}`;
+
+        return horizontal ? (
+          <GaugeBar
+            key={key}
+            {...props}
+            ariaLabel={ariaLabel}
+            segments={fillSegments(fraction, marks, colors)}
+          />
+        ) : (
+          <GaugeArc
+            key={key}
+            {...props}
+            ariaLabel={ariaLabel}
+            color={
+              (value !== undefined
+                ? resolveThresholdColor(value, thresholds, max)
+                : undefined) ?? fallbackColor
+            }
+          />
         );
       })}
+    </div>
+  );
+}
+
+/**
+ * A flat bar that fills from left to right. A marker shows the current value.
+ */
+function GaugeBar({
+  label,
+  value,
+  valueText,
+  unit,
+  fraction,
+  ticks,
+  showAxis,
+  showThresholdLabels,
+  minText,
+  maxText,
+  ariaLabel,
+  segments,
+}: TileProps & { ariaLabel: string; segments: FillSegment[] }) {
+  return (
+    <div className="min-w-40 flex-1" role="img" aria-label={ariaLabel}>
+      {label}
+      <p className="mb-2 leading-none">
+        {/* The number keeps a neutral color, as on the arc. The segments of
+            the fill show the color of the band, and not the text. */}
+        <span
+          className={cn(
+            "text-2xl font-semibold tabular-nums",
+            value === undefined ? "text-muted-foreground" : "text-foreground",
+          )}
+        >
+          {valueText}
+        </span>
+        {value !== undefined && unit && (
+          <span className="ml-1 text-xs text-muted-foreground">{unit}</span>
+        )}
+      </p>
+      <div className="relative pt-2">
+        {/* A triangle marker that points down at the position of the value. */}
+        {value !== undefined && (
+          <div
+            className="absolute top-0 -translate-x-1/2 border-x-[5px] border-t-[6px] border-x-transparent border-t-foreground"
+            style={{ left: `${fraction * 100}%` }}
+          />
+        )}
+        <div className="relative h-2.5 overflow-hidden rounded-sm bg-muted">
+          {segments.map((s) => (
+            <div
+              key={s.from}
+              className="absolute inset-y-0"
+              style={{
+                left: `${s.from * 100}%`,
+                width: `${(s.to - s.from) * 100}%`,
+                backgroundColor: s.color,
+              }}
+            />
+          ))}
+        </div>
+        {ticks.length > 0 && (
+          <div className={cn("relative", showThresholdLabels ? "h-6" : "h-2")}>
+            {ticks.map((tick) => (
+              <div
+                key={`${tick.fraction}-${tick.color}`}
+                className="absolute top-0 -translate-x-1/2"
+                style={{ left: `${tick.fraction * 100}%` }}
+              >
+                <div
+                  className="mx-auto h-1.5 w-px"
+                  style={{ backgroundColor: tick.color }}
+                />
+                {showThresholdLabels && (
+                  <p className="whitespace-nowrap text-[10px] tabular-nums text-muted-foreground">
+                    {tick.text}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+        {showAxis && (
+          <div className="flex justify-between text-[10px] tabular-nums text-muted-foreground">
+            <span>{minText}</span>
+            <span>{maxText}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * A semicircular arc that fills from the `min` end. The value is at the center.
+ */
+function GaugeArc({
+  label,
+  value,
+  valueText,
+  unit,
+  fraction,
+  ticks,
+  showAxis,
+  showThresholdLabels,
+  minText,
+  maxText,
+  ariaLabel,
+  color,
+}: TileProps & { ariaLabel: string; color: string }) {
+  return (
+    <div className="flex min-w-28 flex-1 flex-col items-center">
+      {label}
+      {/* The SVG has an absolute position. In a flex line that wraps, a
+          height in percent does not resolve. The SVG then takes its size from
+          its width, and goes outside the panel. */}
+      <div className="relative min-h-0 w-full flex-1">
+        <svg
+          viewBox={VIEWBOX}
+          preserveAspectRatio="xMidYMid meet"
+          className="absolute inset-0 h-full w-full"
+          role="img"
+          aria-label={ariaLabel}
+        >
+          <path
+            d={arcPath(180, 0)}
+            className="stroke-muted"
+            strokeWidth={STROKE}
+            strokeLinecap="round"
+            fill="none"
+          />
+          {fraction > 0 && (
+            <path
+              d={arcPath(180, 180 - fraction * 180)}
+              stroke={color}
+              strokeWidth={STROKE}
+              strokeLinecap="round"
+              fill="none"
+            />
+          )}
+          {ticks.map((tick) => {
+            const angle = 180 - tick.fraction * 180;
+            const inner = polar(R - STROKE / 2 - 2, angle);
+            const outer = polar(R + STROKE / 2 + 2, angle);
+            const labelPos = polar(R + STROKE / 2 + 6, angle);
+            return (
+              <g key={`${tick.fraction}-${tick.color}`}>
+                <line
+                  x1={inner.x}
+                  y1={inner.y}
+                  x2={outer.x}
+                  y2={outer.y}
+                  stroke={tick.color}
+                  strokeWidth={1.25}
+                />
+                {showThresholdLabels && (
+                  <text
+                    x={labelPos.x}
+                    y={labelPos.y}
+                    textAnchor="middle"
+                    fontSize={5}
+                    className="fill-muted-foreground tabular-nums"
+                  >
+                    {tick.text}
+                  </text>
+                )}
+              </g>
+            );
+          })}
+          <text
+            x={CX}
+            y={46}
+            textAnchor="middle"
+            fontSize={13}
+            className={cn(
+              "font-semibold tabular-nums",
+              value === undefined ? "fill-muted-foreground" : "fill-foreground",
+            )}
+          >
+            {valueText}
+            {value !== undefined && unit && (
+              <tspan
+                dx={1.5}
+                fontSize={7}
+                className="fill-muted-foreground font-normal"
+              >
+                {unit}
+              </tspan>
+            )}
+          </text>
+          {showAxis && (
+            <>
+              <text
+                x={CX - R}
+                y={62}
+                textAnchor="middle"
+                fontSize={5.5}
+                className="fill-muted-foreground tabular-nums"
+              >
+                {minText}
+              </text>
+              <text
+                x={CX + R}
+                y={62}
+                textAnchor="middle"
+                fontSize={5.5}
+                className="fill-muted-foreground tabular-nums"
+              >
+                {maxText}
+              </text>
+            </>
+          )}
+        </svg>
+      </div>
     </div>
   );
 }

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/spec.ts
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/spec.ts
@@ -2,28 +2,41 @@ import * as z from "zod";
 import { calculationSpec, thresholdsSpec } from "../stat-chart/spec";
 
 /**
- * GaugeChart plugin options. Loose so unknown keys flow through verbatim
- * (validation must never be stricter than Perses on shape); every known field
- * is defaulted so `{}` always parses — the lenient render path relies on it.
+ * The options of the GaugeChart plugin. The object is loose, because unknown
+ * keys must stay in the output. The validation must not be more strict than
+ * Perses. All known fields have a default value, because `{}` must always
+ * parse. The lenient render path needs this.
  */
 export const gaugeChartSpec = z.looseObject({
   calculation: calculationSpec.default("last"),
   unit: z.string().default(""),
-  /** Fixed fraction digits; omitted = up to 2, trailing zeros dropped. */
+  /**
+   * The number of fraction digits. If you do not set it, the value shows a
+   * maximum of 2 digits, and the zeros at the end are removed.
+   */
   decimals: z.number().int().min(0).max(10).optional(),
-  /** Gauge axis lower bound. */
+  /** The lower bound of the gauge axis. */
   min: z.number().default(0),
   /**
-   * Gauge axis upper bound. The arc fills (value - min) / (max - min); values
-   * outside the bounds clamp to an empty/full arc while the text shows the
-   * real value. Also the `percent` thresholds reference when `thresholds.max`
-   * is omitted.
+   * The upper bound of the gauge axis. The arc fills to
+   * (value - min) / (max - min). If a value is outside the bounds, the arc
+   * becomes empty or full, but the text shows the true value. The `percent`
+   * thresholds also use this bound if you do not set `thresholds.max`.
    */
   max: z.number().default(100),
   thresholds: thresholdsSpec.optional(),
-  /** Show the series label even on a single-gauge panel (multi-gauge always shows it). */
+  /** The shape: the default semicircle, or a flat horizontal bar. */
+  variant: z.enum(["arc", "horizontal"]).default("arc"),
+  /** Shows the min and max labels at the ends of the gauge. */
+  showAxis: z.boolean().default(true),
+  /** Shows a number at the tick mark of each threshold step. */
+  showThresholdLabels: z.boolean().default(false),
+  /**
+   * Shows the series label on a panel that has one gauge. A panel that has
+   * more than one gauge always shows the labels.
+   */
   showLabel: z.boolean().default(false),
-  /** Text shown for a query that produced no value. */
+  /** The text to show if a query gives no value. */
   noValue: z.string().default("–"),
 });
 

--- a/packages/app/src/components/home/services-section.tsx
+++ b/packages/app/src/components/home/services-section.tsx
@@ -1,0 +1,69 @@
+import { serviceColor } from "@everr/telemetry-explorer/traces";
+import { Card } from "@everr/ui/components/card";
+import { Skeleton } from "@everr/ui/components/skeleton";
+import { Link } from "@tanstack/react-router";
+import type { HomeService } from "@/data/home/server";
+
+const compactNumber = new Intl.NumberFormat("en-US", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+
+/** Undefined services render the loading skeleton; an empty list renders nothing. */
+export function ServicesSection({
+  services,
+}: {
+  services: HomeService[] | undefined;
+}) {
+  if (services && services.length === 0) return null;
+  return (
+    <section className="space-y-2">
+      <h2 className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
+        Services
+      </h2>
+      <Card className="divide-border gap-0 divide-y py-0">
+        {services === undefined
+          ? Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-3 px-4 py-3">
+                <Skeleton className="size-2 rounded-full" />
+                <Skeleton className="h-4 w-40" />
+              </div>
+            ))
+          : services.map((service) => (
+              <Link
+                key={service.name}
+                to="/traces"
+                search={{ service: [service.name] }}
+                className="hover:bg-muted/30 flex items-center gap-3 px-4 py-3 transition-colors"
+              >
+                <span
+                  aria-hidden
+                  className="size-2 shrink-0 rounded-full"
+                  style={{ backgroundColor: serviceColor(service.name) }}
+                />
+                <span className="truncate text-sm font-medium">
+                  {service.name}
+                </span>
+                <span className="flex-1" />
+                <ServiceStat value={service.logCount} label="logs" />
+                <ServiceStat value={service.traceCount} label="traces" />
+                <ServiceStat value={service.errorCount} label="errors" />
+              </Link>
+            ))}
+      </Card>
+    </section>
+  );
+}
+
+function ServiceStat({ value, label }: { value: number; label: string }) {
+  return (
+    <span className="w-20 text-right">
+      <span className="block text-sm tabular-nums">
+        {compactNumber.format(value)}
+      </span>
+      <span className="text-muted-foreground block text-[10px] uppercase tracking-wider">
+        {label}
+      </span>
+    </span>
+  );
+}

--- a/packages/app/src/components/home/setup-cards.tsx
+++ b/packages/app/src/components/home/setup-cards.tsx
@@ -1,0 +1,59 @@
+import { Button } from "@everr/ui/components/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@everr/ui/components/card";
+import { ArrowUpRight, Download, GitBranch } from "lucide-react";
+import { INSTALL_COMMAND } from "@/common/install-command";
+import { InstallCommandBlock } from "@/components/install-command-block";
+
+export function InstallEverrCard() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Download className="size-4 text-primary" />
+          Install Everr
+        </CardTitle>
+        <CardDescription>
+          Get notified when CI fails, run queries from your terminal, and
+          integrate with your coding assistant.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <InstallCommandBlock command={INSTALL_COMMAND} />
+      </CardContent>
+    </Card>
+  );
+}
+
+/** Stands in for the CI tiles until a GitHub app installation is active. */
+export function ConnectGithubCard() {
+  return (
+    <Card className="sm:col-span-2 lg:col-span-3">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <GitBranch className="size-4 text-primary" />
+          Connect GitHub
+        </CardTitle>
+        <CardDescription>
+          Install the Everr GitHub app to track workflow runs, test results, and
+          CI cost for your repositories.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Button
+          render={
+            <a href="/api/github/install/start" target="_blank" rel="noopener">
+              Install GitHub app
+              <ArrowUpRight className="size-4" />
+            </a>
+          }
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/app/src/components/home/stat-tile.tsx
+++ b/packages/app/src/components/home/stat-tile.tsx
@@ -1,0 +1,67 @@
+import { Card, CardContent } from "@everr/ui/components/card";
+import { Skeleton } from "@everr/ui/components/skeleton";
+import { Sparkline } from "@everr/ui/components/sparkline";
+import { Link, type LinkProps } from "@tanstack/react-router";
+import { ArrowUpRight } from "lucide-react";
+import type { ReactNode } from "react";
+
+export function StatSection({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="space-y-2">
+      <h2 className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
+        {label}
+      </h2>
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">{children}</div>
+    </section>
+  );
+}
+
+/** An undefined `value` renders the loading skeleton. */
+export function StatTile({
+  label,
+  to,
+  value,
+  series,
+  color,
+}: {
+  label: string;
+  to: LinkProps["to"];
+  value: string | undefined;
+  series?: number[];
+  color?: string;
+}) {
+  return (
+    <Link to={to} className="block h-full">
+      <Card className="group relative h-full gap-2 overflow-hidden py-4 transition-colors hover:bg-muted/30">
+        {series?.some((v) => v > 0) && (
+          <Sparkline
+            data={series}
+            color={color}
+            className="pointer-events-none absolute inset-x-0 bottom-0 h-10 opacity-20 transition-opacity group-hover:opacity-35"
+          />
+        )}
+        <CardContent className="relative space-y-1 px-4">
+          <div className="flex items-center justify-between">
+            <p className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
+              {label}
+            </p>
+            <ArrowUpRight className="size-3.5 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
+          </div>
+          {value === undefined ? (
+            <Skeleton className="h-8 w-16" />
+          ) : (
+            <p className="text-2xl font-semibold tabular-nums leading-8">
+              {value}
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/packages/app/src/data/home/buckets.ts
+++ b/packages/app/src/data/home/buckets.ts
@@ -1,0 +1,43 @@
+import type { BucketGranularity } from "@/lib/time-range";
+
+/**
+ * The bucket key a row falls into, as ClickHouse SQL.
+ *
+ * Both the rounding and the formatting are pinned to UTC. `Timestamp` and
+ * `TimestampTime` carry no timezone, so on a server whose timezone is not UTC
+ * these functions would round and format in local time while still writing a
+ * literal `Z`. The keys would then miss every entry in `bucketGrid`, and each
+ * series would come back fully zero-filled.
+ */
+export function bucketExpr(
+  column: string,
+  granularity: BucketGranularity,
+): string {
+  return granularity === "hour"
+    ? `formatDateTime(toStartOfHour(${column}, 'UTC'), '%Y-%m-%dT%H:00:00Z', 'UTC')`
+    : `formatDateTime(toStartOfDay(${column}, 'UTC'), '%Y-%m-%dT00:00:00Z', 'UTC')`;
+}
+
+/**
+ * Every bucket key in the range, in order, so a series can be zero-filled
+ * where the query returned no row at all. Keys match `bucketExpr` exactly.
+ */
+export function bucketGrid(
+  fromDate: Date,
+  toDate: Date,
+  granularity: BucketGranularity,
+): string[] {
+  const cursor = new Date(fromDate);
+  cursor.setUTCMinutes(0, 0, 0);
+  if (granularity === "day") cursor.setUTCHours(0);
+  const buckets: string[] = [];
+  while (cursor.getTime() <= toDate.getTime()) {
+    buckets.push(`${cursor.toISOString().slice(0, 13)}:00:00Z`);
+    if (granularity === "hour") {
+      cursor.setUTCHours(cursor.getUTCHours() + 1);
+    } else {
+      cursor.setUTCDate(cursor.getUTCDate() + 1);
+    }
+  }
+  return buckets;
+}

--- a/packages/app/src/data/home/buckets.ts
+++ b/packages/app/src/data/home/buckets.ts
@@ -1,6 +1,15 @@
 import type { BucketGranularity } from "@/lib/time-range";
 
 /**
+ * Bucketing splits across two layers on purpose: `@/lib/time-range` decides
+ * which granularity a range deserves, and each data module renders that
+ * granularity into its own SQL and its own key grid. `cost-analysis/server.ts`
+ * has the same shape. Choosing the granularity is a product rule shared by
+ * every chart; emitting the keys is coupled to one module's column names and
+ * row shapes, so it stays next to the queries that depend on it.
+ */
+
+/**
  * The bucket key a row falls into, as ClickHouse SQL.
  *
  * Both the rounding and the formatting are pinned to UTC. `Timestamp` and

--- a/packages/app/src/data/home/buckets.ts
+++ b/packages/app/src/data/home/buckets.ts
@@ -12,24 +12,26 @@ import type { BucketGranularity } from "@/lib/time-range";
 /**
  * The bucket key a row falls into, as ClickHouse SQL.
  *
- * Both the rounding and the formatting are pinned to UTC. `Timestamp` and
- * `TimestampTime` carry no timezone, so on a server whose timezone is not UTC
- * these functions would round and format in local time while still writing a
- * literal `Z`. The keys would then miss every entry in `bucketGrid`, and each
- * series would come back fully zero-filled.
+ * The rounding and the formatting both follow the server timezone, matching
+ * `cost-analysis/server.ts`. `Timestamp` and `TimestampTime` carry no
+ * timezone, and `bucketGrid` builds its keys in UTC, so both modules assume a
+ * ClickHouse server set to UTC. On a server set to anything else the keys here
+ * would carry local time under a literal `Z`, miss every entry in
+ * `bucketGrid`, and zero-fill each series.
  */
 export function bucketExpr(
   column: string,
   granularity: BucketGranularity,
 ): string {
   return granularity === "hour"
-    ? `formatDateTime(toStartOfHour(${column}, 'UTC'), '%Y-%m-%dT%H:00:00Z', 'UTC')`
-    : `formatDateTime(toStartOfDay(${column}, 'UTC'), '%Y-%m-%dT00:00:00Z', 'UTC')`;
+    ? `formatDateTime(toStartOfHour(${column}), '%Y-%m-%dT%H:00:00Z')`
+    : `formatDateTime(toStartOfDay(${column}), '%Y-%m-%dT00:00:00Z')`;
 }
 
 /**
  * Every bucket key in the range, in order, so a series can be zero-filled
- * where the query returned no row at all. Keys match `bucketExpr` exactly.
+ * where the query returned no row at all. Keys match `bucketExpr` on a
+ * ClickHouse server set to UTC.
  */
 export function bucketGrid(
   fromDate: Date,

--- a/packages/app/src/data/home/options.ts
+++ b/packages/app/src/data/home/options.ts
@@ -1,0 +1,9 @@
+import { queryOptions } from "@tanstack/react-query";
+import type { TimeRangeInput } from "@/data/analytics/schemas";
+import { getHomeOverview } from "./server";
+
+export const homeOverviewOptions = (input: TimeRangeInput) =>
+  queryOptions({
+    queryKey: ["home", "overview", input],
+    queryFn: () => getHomeOverview({ data: input }),
+  });

--- a/packages/app/src/data/home/server.ts
+++ b/packages/app/src/data/home/server.ts
@@ -142,6 +142,13 @@ export const getHomeOverview = createAuthenticatedServerFn({ method: "GET" })
      * boundary would then be counted one bucket early, or fall off the end of
      * the grid entirely. The result is pulled up with `max` and filtered
      * afterwards, which keeps the same set of runs.
+     *
+     * The time filter is the one predicate that stays ahead of the group, and
+     * it defines what a run means here: the spans it has inside the selected
+     * range. A run still going at the range end is therefore counted at its
+     * last span inside the range, not at the span that closes it. Moving the
+     * time filter after the group would read the whole table on every load,
+     * since nothing would be left to prune partitions or the primary index on.
      */
     const ciSql = `
       SELECT

--- a/packages/app/src/data/home/server.ts
+++ b/packages/app/src/data/home/server.ts
@@ -123,19 +123,32 @@ export const getHomeOverview = createAuthenticatedServerFn({ method: "GET" })
       GROUP BY service
     `;
 
+    /**
+     * The task result lives on its own spans of a run, so it cannot be
+     * filtered before the rows are grouped into runs. Filtering first would
+     * leave `lastTimestamp` as the last result bearing span rather than the
+     * last span of the run, and a run whose closing span crosses a bucket
+     * boundary would then be counted one bucket early, or fall off the end of
+     * the grid entirely. The result is pulled up with `max` and filtered
+     * afterwards, which keeps the same set of runs.
+     */
     const ciSql = `
       SELECT
         ${bucketExpr("lastTimestamp", granularity)} AS bucket,
         count() AS runCount
       FROM (
-        SELECT
-          ${resourceAttribute("cicd.pipeline.run.id")} AS run_id,
-          max(Timestamp) AS lastTimestamp
-        FROM traces
-        WHERE ${timeFilter}
-          AND ${nonEmptyResourceAttribute("cicd.pipeline.run.id")}
-          AND ${nonEmptyResourceAttribute("cicd.pipeline.task.run.result")}
-        GROUP BY run_id
+        SELECT run_id, lastTimestamp
+        FROM (
+          SELECT
+            ${resourceAttribute("cicd.pipeline.run.id")} AS run_id,
+            max(${resourceAttribute("cicd.pipeline.task.run.result")}) AS result,
+            max(Timestamp) AS lastTimestamp
+          FROM traces
+          WHERE ${timeFilter}
+            AND ${nonEmptyResourceAttribute("cicd.pipeline.run.id")}
+          GROUP BY run_id
+        )
+        WHERE result != ''
       )
       GROUP BY bucket WITH ROLLUP
     `;

--- a/packages/app/src/data/home/server.ts
+++ b/packages/app/src/data/home/server.ts
@@ -1,7 +1,4 @@
-import {
-  ERROR_FINGERPRINT_SQL,
-  EXCEPTION_LOG_FILTER_SQL,
-} from "@everr/telemetry-explorer/errors";
+import { errorIssueCountExpr } from "@everr/telemetry-explorer/errors";
 import { resolveTimeRange } from "@everr/ui/lib/time-range";
 import { TimeRangeInputSchema } from "@/data/analytics/schemas";
 import {
@@ -29,12 +26,12 @@ interface HomeOverview {
 
 const MAX_SERVICES = 10;
 
-function fillSeries<Row extends { bucket: string }>(
+function fillSeries<Key extends string>(
   grid: string[],
-  rows: Row[],
-  value: (row: Row) => string,
+  rows: ({ bucket: string } & Record<Key, string>)[],
+  key: Key,
 ): number[] {
-  const byBucket = new Map(rows.map((r) => [r.bucket, Number(value(r))]));
+  const byBucket = new Map(rows.map((r) => [r.bucket, Number(r[key])]));
   return grid.map((bucket) => byBucket.get(bucket) ?? 0);
 }
 
@@ -45,6 +42,12 @@ function fillSeries<Row extends { bucket: string }>(
  * with, so it doubles as the marker for "this is the total row".
  */
 const ROLLUP_TOTAL_BUCKET = "";
+
+function rollupTotal<Row extends { bucket: string }>(
+  rows: Row[],
+): Row | undefined {
+  return rows.find((r) => r.bucket === ROLLUP_TOTAL_BUCKET);
+}
 
 /**
  * The services worth showing, ranked on both signals rather than on their sum.
@@ -63,14 +66,11 @@ function topServices(
 
   const picked: HomeService[] = [];
   const seen = new Set<string>();
-  for (let i = 0; i < all.length && picked.length < limit; i++) {
-    for (const ranking of [byLogs, byTraces]) {
-      const candidate = ranking[i];
-      if (!candidate || seen.has(candidate.name)) continue;
-      if (picked.length === limit) break;
-      seen.add(candidate.name);
-      picked.push(candidate);
-    }
+  for (const service of byLogs.flatMap((s, i) => [s, byTraces[i]])) {
+    if (picked.length === limit) break;
+    if (seen.has(service.name)) continue;
+    seen.add(service.name);
+    picked.push(service);
   }
   return picked;
 }
@@ -89,7 +89,7 @@ export const getHomeOverview = createAuthenticatedServerFn({ method: "GET" })
       SELECT
         ${bucketExpr("TimestampTime", granularity)} AS bucket,
         count() AS logCount,
-        uniqIf(${ERROR_FINGERPRINT_SQL}, ${EXCEPTION_LOG_FILTER_SQL}) AS issueCount
+        ${errorIssueCountExpr()} AS issueCount
       FROM logs
       WHERE ${logsTimeFilter}
       GROUP BY bucket WITH ROLLUP
@@ -117,7 +117,7 @@ export const getHomeOverview = createAuthenticatedServerFn({ method: "GET" })
       SELECT
         ServiceName AS service,
         count() AS logCount,
-        uniqIf(${ERROR_FINGERPRINT_SQL}, ${EXCEPTION_LOG_FILTER_SQL}) AS errorCount
+        ${errorIssueCountExpr()} AS errorCount
       FROM logs
       WHERE ${logsTimeFilter} AND ServiceName != ''
       GROUP BY service
@@ -197,28 +197,22 @@ export const getHomeOverview = createAuthenticatedServerFn({ method: "GET" })
       clickhouse.query<{ prMedianTotalTimeMs: string }>(prTimeSql, params),
     ]);
 
-    const rollupTotal = <Row extends { bucket: string }>(rows: Row[]) =>
-      rows.find((r) => r.bucket === ROLLUP_TOTAL_BUCKET);
-
     const services = new Map<string, HomeService>();
+    const service = (name: string): HomeService => {
+      let entry = services.get(name);
+      if (!entry) {
+        entry = { name, logCount: 0, traceCount: 0, errorCount: 0 };
+        services.set(name, entry);
+      }
+      return entry;
+    };
     for (const row of traceServiceRows) {
-      services.set(row.service, {
-        name: row.service,
-        logCount: 0,
-        traceCount: Number(row.traceCount),
-        errorCount: 0,
-      });
+      service(row.service).traceCount = Number(row.traceCount);
     }
     for (const row of logServiceRows) {
-      const entry = services.get(row.service) ?? {
-        name: row.service,
-        logCount: 0,
-        traceCount: 0,
-        errorCount: 0,
-      };
+      const entry = service(row.service);
       entry.logCount = Number(row.logCount);
       entry.errorCount = Number(row.errorCount);
-      services.set(row.service, entry);
     }
 
     const serviceList = topServices(services.values(), MAX_SERVICES);
@@ -229,21 +223,21 @@ export const getHomeOverview = createAuthenticatedServerFn({ method: "GET" })
     return {
       logs: {
         total: Number(logsTotal?.logCount ?? 0),
-        series: fillSeries(grid, logsRows, (r) => r.logCount),
+        series: fillSeries(grid, logsRows, "logCount"),
       },
       traces: {
         total: Number(rollupTotal(tracesRows)?.traceCount ?? 0),
-        series: fillSeries(grid, tracesRows, (r) => r.traceCount),
+        series: fillSeries(grid, tracesRows, "traceCount"),
       },
       services: serviceList,
       errors: {
         issues: Number(logsTotal?.issueCount ?? 0),
-        series: fillSeries(grid, logsRows, (r) => r.issueCount),
+        series: fillSeries(grid, logsRows, "issueCount"),
       },
       ci: {
         totalRuns,
         prMedianTotalTimeMs: Number(prTimeRows[0]?.prMedianTotalTimeMs ?? 0),
-        series: fillSeries(grid, ciRows, (r) => r.runCount),
+        series: fillSeries(grid, ciRows, "runCount"),
       },
     } satisfies HomeOverview;
   });

--- a/packages/app/src/data/home/server.ts
+++ b/packages/app/src/data/home/server.ts
@@ -1,0 +1,249 @@
+import {
+  ERROR_FINGERPRINT_SQL,
+  EXCEPTION_LOG_FILTER_SQL,
+} from "@everr/telemetry-explorer/errors";
+import { resolveTimeRange } from "@everr/ui/lib/time-range";
+import { TimeRangeInputSchema } from "@/data/analytics/schemas";
+import {
+  nonEmptyResourceAttribute,
+  resourceAttribute,
+} from "@/data/run-query-helpers";
+import { createAuthenticatedServerFn } from "@/lib/serverFn";
+import { getBucketGranularity } from "@/lib/time-range";
+import { bucketExpr, bucketGrid } from "./buckets";
+
+export interface HomeService {
+  name: string;
+  logCount: number;
+  traceCount: number;
+  errorCount: number;
+}
+
+interface HomeOverview {
+  logs: { total: number; series: number[] };
+  traces: { total: number; series: number[] };
+  services: HomeService[];
+  errors: { issues: number; series: number[] };
+  ci: { totalRuns: number; prMedianTotalTimeMs: number; series: number[] };
+}
+
+const MAX_SERVICES = 10;
+
+function fillSeries<Row extends { bucket: string }>(
+  grid: string[],
+  rows: Row[],
+  value: (row: Row) => string,
+): number[] {
+  const byBucket = new Map(rows.map((r) => [r.bucket, Number(value(r))]));
+  return grid.map((bucket) => byBucket.get(bucket) ?? 0);
+}
+
+/**
+ * `GROUP BY ... WITH ROLLUP` appends one extra row per query holding the
+ * range-wide total, with every grouping key defaulted. For a `String` bucket
+ * key that default is the empty string, which no real bucket key can collide
+ * with, so it doubles as the marker for "this is the total row".
+ */
+const ROLLUP_TOTAL_BUCKET = "";
+
+/**
+ * The services worth showing, ranked on both signals rather than on their sum.
+ * Log volume normally runs orders of magnitude above trace count, so adding the
+ * two would rank purely by logs and let one chatty service push out a
+ * trace-heavy one. Taking the leaders of each ranking in turn keeps both kinds
+ * of service present.
+ */
+function topServices(
+  services: Iterable<HomeService>,
+  limit: number,
+): HomeService[] {
+  const all = Array.from(services);
+  const byLogs = [...all].sort((a, b) => b.logCount - a.logCount);
+  const byTraces = [...all].sort((a, b) => b.traceCount - a.traceCount);
+
+  const picked: HomeService[] = [];
+  const seen = new Set<string>();
+  for (let i = 0; i < all.length && picked.length < limit; i++) {
+    for (const ranking of [byLogs, byTraces]) {
+      const candidate = ranking[i];
+      if (!candidate || seen.has(candidate.name)) continue;
+      if (picked.length === limit) break;
+      seen.add(candidate.name);
+      picked.push(candidate);
+    }
+  }
+  return picked;
+}
+
+export const getHomeOverview = createAuthenticatedServerFn({ method: "GET" })
+  .inputValidator(TimeRangeInputSchema)
+  .handler(async ({ data: { timeRange }, context: { clickhouse } }) => {
+    const { fromISO, toISO, fromDate, toDate } = resolveTimeRange(timeRange);
+    const granularity = getBucketGranularity(fromDate, toDate);
+    const grid = bucketGrid(fromDate, toDate, granularity);
+    const params = { fromTime: fromISO, toTime: toISO };
+    const timeFilter = `Timestamp >= parseDateTimeBestEffort({fromTime:String}) AND Timestamp <= parseDateTimeBestEffort({toTime:String})`;
+    const logsTimeFilter = `TimestampTime >= parseDateTimeBestEffort({fromTime:String}) AND TimestampTime <= parseDateTimeBestEffort({toTime:String})`;
+
+    const logsSql = `
+      SELECT
+        ${bucketExpr("TimestampTime", granularity)} AS bucket,
+        count() AS logCount,
+        uniqIf(${ERROR_FINGERPRINT_SQL}, ${EXCEPTION_LOG_FILTER_SQL}) AS issueCount
+      FROM logs
+      WHERE ${logsTimeFilter}
+      GROUP BY bucket WITH ROLLUP
+    `;
+
+    const tracesSql = `
+      SELECT
+        ${bucketExpr("Timestamp", granularity)} AS bucket,
+        uniqIf(TraceId, TraceId != '') AS traceCount
+      FROM traces
+      WHERE ${timeFilter}
+      GROUP BY bucket WITH ROLLUP
+    `;
+
+    const traceServicesSql = `
+      SELECT
+        ServiceName AS service,
+        uniqIf(TraceId, TraceId != '') AS traceCount
+      FROM traces
+      WHERE ${timeFilter} AND ServiceName != ''
+      GROUP BY service
+    `;
+
+    const logServicesSql = `
+      SELECT
+        ServiceName AS service,
+        count() AS logCount,
+        uniqIf(${ERROR_FINGERPRINT_SQL}, ${EXCEPTION_LOG_FILTER_SQL}) AS errorCount
+      FROM logs
+      WHERE ${logsTimeFilter} AND ServiceName != ''
+      GROUP BY service
+    `;
+
+    const ciSql = `
+      SELECT
+        ${bucketExpr("lastTimestamp", granularity)} AS bucket,
+        count() AS runCount
+      FROM (
+        SELECT
+          ${resourceAttribute("cicd.pipeline.run.id")} AS run_id,
+          max(Timestamp) AS lastTimestamp
+        FROM traces
+        WHERE ${timeFilter}
+          AND ${nonEmptyResourceAttribute("cicd.pipeline.run.id")}
+          AND ${nonEmptyResourceAttribute("cicd.pipeline.task.run.result")}
+        GROUP BY run_id
+      )
+      GROUP BY bucket WITH ROLLUP
+    `;
+
+    /**
+     * The PR url and the task result live on different spans of a run, so
+     * neither can be filtered before the rows are grouped into runs. Both are
+     * pulled up with `max` and filtered afterwards. Requiring a result keeps
+     * this median over the same population the run count above reports, rather
+     * than dragging it down with the partial duration of an in-flight run.
+     */
+    const prTimeSql = `
+      SELECT quantile(0.5)(prTotalMs) AS prMedianTotalTimeMs
+      FROM (
+        SELECT pr, sum(runDurationMs) AS prTotalMs
+        FROM (
+          SELECT
+            ${resourceAttribute("cicd.pipeline.run.id")} AS run_id,
+            max(${resourceAttribute("everr.git.pull_requests.url")}) AS pr,
+            max(${resourceAttribute("cicd.pipeline.task.run.result")}) AS result,
+            max(Duration) / 1000000 AS runDurationMs
+          FROM traces
+          WHERE ${timeFilter}
+            AND ${nonEmptyResourceAttribute("cicd.pipeline.run.id")}
+          GROUP BY run_id
+        )
+        WHERE pr != '' AND result != ''
+        GROUP BY pr
+      )
+    `;
+
+    const [
+      logsRows,
+      tracesRows,
+      traceServiceRows,
+      logServiceRows,
+      ciRows,
+      prTimeRows,
+    ] = await Promise.all([
+      clickhouse.query<{
+        bucket: string;
+        logCount: string;
+        issueCount: string;
+      }>(logsSql, params),
+      clickhouse.query<{ bucket: string; traceCount: string }>(
+        tracesSql,
+        params,
+      ),
+      clickhouse.query<{ service: string; traceCount: string }>(
+        traceServicesSql,
+        params,
+      ),
+      clickhouse.query<{
+        service: string;
+        logCount: string;
+        errorCount: string;
+      }>(logServicesSql, params),
+      clickhouse.query<{ bucket: string; runCount: string }>(ciSql, params),
+      clickhouse.query<{ prMedianTotalTimeMs: string }>(prTimeSql, params),
+    ]);
+
+    const rollupTotal = <Row extends { bucket: string }>(rows: Row[]) =>
+      rows.find((r) => r.bucket === ROLLUP_TOTAL_BUCKET);
+
+    const services = new Map<string, HomeService>();
+    for (const row of traceServiceRows) {
+      services.set(row.service, {
+        name: row.service,
+        logCount: 0,
+        traceCount: Number(row.traceCount),
+        errorCount: 0,
+      });
+    }
+    for (const row of logServiceRows) {
+      const entry = services.get(row.service) ?? {
+        name: row.service,
+        logCount: 0,
+        traceCount: 0,
+        errorCount: 0,
+      };
+      entry.logCount = Number(row.logCount);
+      entry.errorCount = Number(row.errorCount);
+      services.set(row.service, entry);
+    }
+
+    const serviceList = topServices(services.values(), MAX_SERVICES);
+
+    const logsTotal = rollupTotal(logsRows);
+    const totalRuns = Number(rollupTotal(ciRows)?.runCount ?? 0);
+
+    return {
+      logs: {
+        total: Number(logsTotal?.logCount ?? 0),
+        series: fillSeries(grid, logsRows, (r) => r.logCount),
+      },
+      traces: {
+        total: Number(rollupTotal(tracesRows)?.traceCount ?? 0),
+        series: fillSeries(grid, tracesRows, (r) => r.traceCount),
+      },
+      services: serviceList,
+      errors: {
+        issues: Number(logsTotal?.issueCount ?? 0),
+        series: fillSeries(grid, logsRows, (r) => r.issueCount),
+      },
+      ci: {
+        totalRuns,
+        prMedianTotalTimeMs: Number(prTimeRows[0]?.prMedianTotalTimeMs ?? 0),
+        series: fillSeries(grid, ciRows, (r) => r.runCount),
+      },
+    } satisfies HomeOverview;
+  });

--- a/packages/app/src/data/home/server.ts
+++ b/packages/app/src/data/home/server.ts
@@ -49,24 +49,35 @@ function rollupTotal<Row extends { bucket: string }>(
   return rows.find((r) => r.bucket === ROLLUP_TOTAL_BUCKET);
 }
 
+function* interleave<T>(a: readonly T[], b: readonly T[]): Generator<T> {
+  for (let i = 0; i < a.length; i++) {
+    yield a[i];
+    yield b[i];
+  }
+}
+
 /**
  * The services worth showing, ranked on both signals rather than on their sum.
  * Log volume normally runs orders of magnitude above trace count, so adding the
  * two would rank purely by logs and let one chatty service push out a
  * trace-heavy one. Taking the leaders of each ranking in turn keeps both kinds
  * of service present.
+ *
+ * The two rankings are walked lazily, so the loop stops at `limit` without
+ * building the interleaved sequence first.
  */
 function topServices(
   services: Iterable<HomeService>,
   limit: number,
 ): HomeService[] {
-  const all = Array.from(services);
-  const byLogs = [...all].sort((a, b) => b.logCount - a.logCount);
-  const byTraces = [...all].sort((a, b) => b.traceCount - a.traceCount);
+  const byLogs = Array.from(services);
+  const byTraces = [...byLogs];
+  byLogs.sort((a, b) => b.logCount - a.logCount);
+  byTraces.sort((a, b) => b.traceCount - a.traceCount);
 
   const picked: HomeService[] = [];
   const seen = new Set<string>();
-  for (const service of byLogs.flatMap((s, i) => [s, byTraces[i]])) {
+  for (const service of interleave(byLogs, byTraces)) {
     if (picked.length === limit) break;
     if (seen.has(service.name)) continue;
     seen.add(service.name);

--- a/packages/app/src/routes/_authenticated/_dashboard/_padded/index.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_padded/index.tsx
@@ -1,3 +1,5 @@
+import { serviceColor } from "@everr/telemetry-explorer/traces";
+import { Button } from "@everr/ui/components/button";
 import {
   Card,
   CardContent,
@@ -5,95 +7,286 @@ import {
   CardHeader,
   CardTitle,
 } from "@everr/ui/components/card";
-import { createFileRoute, Link } from "@tanstack/react-router";
-import {
-  Activity,
-  ChartLine,
-  ChevronRight,
-  Download,
-  FileText,
-} from "lucide-react";
-import type { ComponentType } from "react";
+import { Skeleton } from "@everr/ui/components/skeleton";
+import { Sparkline } from "@everr/ui/components/sparkline";
+import { withTimeRange } from "@everr/ui/lib/time-range";
+import { queryOptions, useQuery } from "@tanstack/react-query";
+import { createFileRoute, Link, type LinkProps } from "@tanstack/react-router";
+import { ArrowUpRight, Download, GitBranch } from "lucide-react";
+import type { ReactNode } from "react";
 import { INSTALL_COMMAND } from "@/common/install-command";
 import { InstallCommandBlock } from "@/components/install-command-block";
+import { costOverviewOptions } from "@/data/cost-analysis/options";
+import { homeOverviewOptions } from "@/data/home/options";
+import type { HomeService } from "@/data/home/server";
+import { getGithubAppInstallStatus } from "@/data/onboarding";
+import { formatCost } from "@/lib/runner-pricing";
+import { TimeRangeSearchSchema } from "@/lib/time-range";
+
+const githubInstallStatusOptions = queryOptions({
+  queryKey: ["github", "install-status"],
+  queryFn: () => getGithubAppInstallStatus(),
+  staleTime: 5 * 60_000,
+});
 
 export const Route = createFileRoute("/_authenticated/_dashboard/_padded/")({
-  staticData: { breadcrumb: "Home", hideTimeRangePicker: true },
+  staticData: { breadcrumb: "Home" },
   head: () => ({
     meta: [{ title: "Everr - Home" }],
   }),
+  validateSearch: TimeRangeSearchSchema,
+  loaderDeps: ({ search }) => withTimeRange(search),
+  loader: async ({ context: { queryClient }, deps }) => {
+    const input = { timeRange: deps.timeRange };
+    await Promise.all([
+      queryClient.prefetchQuery(homeOverviewOptions(input)),
+      queryClient.prefetchQuery(costOverviewOptions(input)),
+      queryClient.prefetchQuery(githubInstallStatusOptions),
+    ]);
+  },
   component: HomePage,
 });
 
+const compactNumber = new Intl.NumberFormat("en-US", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+
+function formatDurationLong(ms: number): string {
+  const [unit, value] =
+    ms < 1000
+      ? (["millisecond", ms] as const)
+      : ms < 60000
+        ? (["second", ms / 1000] as const)
+        : (["minute", ms / 60000] as const);
+  return new Intl.NumberFormat("en-US", {
+    style: "unit",
+    unit,
+    unitDisplay: "long",
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
 function HomePage() {
+  const { timeRange } = Route.useLoaderDeps();
+  const input = { timeRange };
+  const { data: overview } = useQuery(homeOverviewOptions(input));
+  const { data: cost } = useQuery(costOverviewOptions(input));
+  const { data: installations } = useQuery(githubInstallStatusOptions);
+
+  const githubInstalled = installations?.some((i) => i.installed) ?? true;
+
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-xl font-bold tracking-tight">Home</h1>
-        <p className="text-muted-foreground text-sm">
-          Pick up where you left off.
-        </p>
-      </div>
-
       <InstallEverrCard />
 
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        <Link
-          to="/runs"
-          search={{
-            repos: [],
-            branches: [],
-            conclusions: [],
-            workflowNames: [],
-            runId: undefined,
-          }}
-          className="block h-full"
-        >
-          <SectionCard
-            title="Runs"
-            description="Browse every workflow run"
-            icon={Activity}
-          />
-        </Link>
-        <Link to="/logs" className="block h-full">
-          <SectionCard
-            title="Logs"
-            description="Search logs across runs"
-            icon={FileText}
-          />
-        </Link>
-        <Link to="/cost-analysis" className="block h-full">
-          <SectionCard
-            title="Cost analysis"
-            description="See where CI minutes go"
-            icon={ChartLine}
-          />
-        </Link>
-      </div>
+      <StatSection label="Telemetry">
+        <StatTile
+          label="Logs"
+          to="/logs"
+          value={overview && compactNumber.format(overview.logs.total)}
+          series={overview?.logs.series}
+          color="var(--chart-2)"
+        />
+        <StatTile
+          label="Traces"
+          to="/traces"
+          value={overview && compactNumber.format(overview.traces.total)}
+          series={overview?.traces.series}
+          color="var(--chart-1)"
+        />
+        <StatTile
+          label="Error issues"
+          to="/errors"
+          value={overview && compactNumber.format(overview.errors.issues)}
+          series={overview?.errors.series}
+          color="var(--destructive)"
+        />
+      </StatSection>
+
+      <ServicesSection services={overview?.services} />
+
+      <StatSection label="CI/CD">
+        {githubInstalled ? (
+          <>
+            <StatTile
+              label="Workflow runs"
+              to="/runs"
+              value={overview && compactNumber.format(overview.ci.totalRuns)}
+              series={overview?.ci.series}
+              color="var(--chart-4)"
+            />
+            <StatTile
+              label="CI time per PR"
+              to="/runs"
+              value={
+                overview &&
+                (overview.ci.prMedianTotalTimeMs > 0
+                  ? formatDurationLong(overview.ci.prMedianTotalTimeMs)
+                  : "No PR runs")
+              }
+            />
+            <StatTile
+              label="Estimated cost"
+              to="/cost-analysis"
+              value={cost && formatCost(cost.summary.totalCost)}
+            />
+          </>
+        ) : (
+          <ConnectGithubCard />
+        )}
+      </StatSection>
     </div>
   );
 }
 
-function SectionCard({
-  title,
-  description,
-  icon: Icon,
+function StatSection({
+  label,
+  children,
 }: {
-  title: string;
-  description: string;
-  icon: ComponentType<{ className?: string }>;
+  label: string;
+  children: ReactNode;
 }) {
   return (
-    <Card className="group h-full transition-colors hover:bg-muted/30">
+    <section className="space-y-2">
+      <h2 className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
+        {label}
+      </h2>
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">{children}</div>
+    </section>
+  );
+}
+
+function StatTile({
+  label,
+  to,
+  value,
+  series,
+  color,
+}: {
+  label: string;
+  to: LinkProps["to"];
+  value: string | undefined;
+  series?: number[];
+  color?: string;
+}) {
+  return (
+    <Link to={to} className="block h-full">
+      <Card className="group relative h-full gap-2 overflow-hidden py-4 transition-colors hover:bg-muted/30">
+        {series?.some((v) => v > 0) && (
+          <Sparkline
+            data={series}
+            color={color}
+            className="pointer-events-none absolute inset-x-0 bottom-0 h-10 opacity-20 transition-opacity group-hover:opacity-35"
+          />
+        )}
+        <CardContent className="relative space-y-1 px-4">
+          <div className="flex items-center justify-between">
+            <p className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
+              {label}
+            </p>
+            <ArrowUpRight className="size-3.5 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
+          </div>
+          {value === undefined ? (
+            <Skeleton className="h-8 w-16" />
+          ) : (
+            <p className="text-2xl font-semibold tabular-nums leading-8">
+              {value}
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}
+
+function ServicesSection({
+  services,
+}: {
+  services: HomeService[] | undefined;
+}) {
+  if (services && services.length === 0) return null;
+  return (
+    <section className="space-y-2">
+      <h2 className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
+        Services
+      </h2>
+      <Card className="divide-border gap-0 divide-y py-0">
+        {services === undefined
+          ? Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-3 px-4 py-3">
+                <Skeleton className="size-2 rounded-full" />
+                <Skeleton className="h-4 w-40" />
+              </div>
+            ))
+          : services.map((service) => (
+              <Link
+                key={service.name}
+                to="/traces"
+                search={{ service: [service.name] }}
+                className="hover:bg-muted/30 flex items-center gap-3 px-4 py-3 transition-colors"
+              >
+                <span
+                  aria-hidden
+                  className="size-2 shrink-0 rounded-full"
+                  style={{ backgroundColor: serviceColor(service.name) }}
+                />
+                <span className="truncate text-sm font-medium">
+                  {service.name}
+                </span>
+                <span className="flex-1" />
+                <ServiceStat
+                  value={compactNumber.format(service.logCount)}
+                  label="logs"
+                />
+                <ServiceStat
+                  value={compactNumber.format(service.traceCount)}
+                  label="traces"
+                />
+                <ServiceStat
+                  value={compactNumber.format(service.errorCount)}
+                  label="errors"
+                />
+              </Link>
+            ))}
+      </Card>
+    </section>
+  );
+}
+
+function ServiceStat({ value, label }: { value: string; label: string }) {
+  return (
+    <span className="w-20 text-right">
+      <span className="block text-sm tabular-nums">{value}</span>
+      <span className="text-muted-foreground block text-[10px] uppercase tracking-wider">
+        {label}
+      </span>
+    </span>
+  );
+}
+
+function ConnectGithubCard() {
+  return (
+    <Card className="sm:col-span-2 lg:col-span-3">
       <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <Icon className="size-4 text-primary" />
-          {title}
+        <CardTitle className="flex items-center gap-2 text-base">
+          <GitBranch className="size-4 text-primary" />
+          Connect GitHub
         </CardTitle>
-        <CardDescription>{description}</CardDescription>
+        <CardDescription>
+          Install the Everr GitHub app to track workflow runs, test results, and
+          CI cost for your repositories.
+        </CardDescription>
       </CardHeader>
-      <CardContent className="mt-auto flex items-center justify-end pt-2">
-        <ChevronRight className="size-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+      <CardContent>
+        <Button
+          render={
+            <a href="/api/github/install/start" target="_blank" rel="noopener">
+              Install GitHub app
+              <ArrowUpRight className="size-4" />
+            </a>
+          }
+        />
       </CardContent>
     </Card>
   );

--- a/packages/app/src/routes/_authenticated/_dashboard/_padded/index.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_padded/index.tsx
@@ -1,24 +1,14 @@
-import { serviceColor } from "@everr/telemetry-explorer/traces";
-import { Button } from "@everr/ui/components/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@everr/ui/components/card";
-import { Skeleton } from "@everr/ui/components/skeleton";
-import { Sparkline } from "@everr/ui/components/sparkline";
 import { withTimeRange } from "@everr/ui/lib/time-range";
 import { queryOptions, useQuery } from "@tanstack/react-query";
-import { createFileRoute, Link, type LinkProps } from "@tanstack/react-router";
-import { ArrowUpRight, Download, GitBranch } from "lucide-react";
-import type { ReactNode } from "react";
-import { INSTALL_COMMAND } from "@/common/install-command";
-import { InstallCommandBlock } from "@/components/install-command-block";
+import { createFileRoute } from "@tanstack/react-router";
+import { ServicesSection } from "@/components/home/services-section";
+import {
+  ConnectGithubCard,
+  InstallEverrCard,
+} from "@/components/home/setup-cards";
+import { StatSection, StatTile } from "@/components/home/stat-tile";
 import { costOverviewOptions } from "@/data/cost-analysis/options";
 import { homeOverviewOptions } from "@/data/home/options";
-import type { HomeService } from "@/data/home/server";
 import { getGithubAppInstallStatus } from "@/data/onboarding";
 import { formatCost } from "@/lib/runner-pricing";
 import { TimeRangeSearchSchema } from "@/lib/time-range";
@@ -52,6 +42,11 @@ const compactNumber = new Intl.NumberFormat("en-US", {
   maximumFractionDigits: 1,
 });
 
+/**
+ * A duration in whichever single unit reads best, spelled out: "970
+ * milliseconds", "6.2 minutes". The tile has room for words, and the compact
+ * `6m 12s` form used in dense run and span lists reads oddly on its own.
+ */
 function formatDurationLong(ms: number): string {
   const [unit, value] =
     ms < 1000
@@ -137,177 +132,5 @@ function HomePage() {
         )}
       </StatSection>
     </div>
-  );
-}
-
-function StatSection({
-  label,
-  children,
-}: {
-  label: string;
-  children: ReactNode;
-}) {
-  return (
-    <section className="space-y-2">
-      <h2 className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
-        {label}
-      </h2>
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">{children}</div>
-    </section>
-  );
-}
-
-function StatTile({
-  label,
-  to,
-  value,
-  series,
-  color,
-}: {
-  label: string;
-  to: LinkProps["to"];
-  value: string | undefined;
-  series?: number[];
-  color?: string;
-}) {
-  return (
-    <Link to={to} className="block h-full">
-      <Card className="group relative h-full gap-2 overflow-hidden py-4 transition-colors hover:bg-muted/30">
-        {series?.some((v) => v > 0) && (
-          <Sparkline
-            data={series}
-            color={color}
-            className="pointer-events-none absolute inset-x-0 bottom-0 h-10 opacity-20 transition-opacity group-hover:opacity-35"
-          />
-        )}
-        <CardContent className="relative space-y-1 px-4">
-          <div className="flex items-center justify-between">
-            <p className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
-              {label}
-            </p>
-            <ArrowUpRight className="size-3.5 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
-          </div>
-          {value === undefined ? (
-            <Skeleton className="h-8 w-16" />
-          ) : (
-            <p className="text-2xl font-semibold tabular-nums leading-8">
-              {value}
-            </p>
-          )}
-        </CardContent>
-      </Card>
-    </Link>
-  );
-}
-
-function ServicesSection({
-  services,
-}: {
-  services: HomeService[] | undefined;
-}) {
-  if (services && services.length === 0) return null;
-  return (
-    <section className="space-y-2">
-      <h2 className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
-        Services
-      </h2>
-      <Card className="divide-border gap-0 divide-y py-0">
-        {services === undefined
-          ? Array.from({ length: 3 }).map((_, i) => (
-              <div key={i} className="flex items-center gap-3 px-4 py-3">
-                <Skeleton className="size-2 rounded-full" />
-                <Skeleton className="h-4 w-40" />
-              </div>
-            ))
-          : services.map((service) => (
-              <Link
-                key={service.name}
-                to="/traces"
-                search={{ service: [service.name] }}
-                className="hover:bg-muted/30 flex items-center gap-3 px-4 py-3 transition-colors"
-              >
-                <span
-                  aria-hidden
-                  className="size-2 shrink-0 rounded-full"
-                  style={{ backgroundColor: serviceColor(service.name) }}
-                />
-                <span className="truncate text-sm font-medium">
-                  {service.name}
-                </span>
-                <span className="flex-1" />
-                <ServiceStat
-                  value={compactNumber.format(service.logCount)}
-                  label="logs"
-                />
-                <ServiceStat
-                  value={compactNumber.format(service.traceCount)}
-                  label="traces"
-                />
-                <ServiceStat
-                  value={compactNumber.format(service.errorCount)}
-                  label="errors"
-                />
-              </Link>
-            ))}
-      </Card>
-    </section>
-  );
-}
-
-function ServiceStat({ value, label }: { value: string; label: string }) {
-  return (
-    <span className="w-20 text-right">
-      <span className="block text-sm tabular-nums">{value}</span>
-      <span className="text-muted-foreground block text-[10px] uppercase tracking-wider">
-        {label}
-      </span>
-    </span>
-  );
-}
-
-function ConnectGithubCard() {
-  return (
-    <Card className="sm:col-span-2 lg:col-span-3">
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-base">
-          <GitBranch className="size-4 text-primary" />
-          Connect GitHub
-        </CardTitle>
-        <CardDescription>
-          Install the Everr GitHub app to track workflow runs, test results, and
-          CI cost for your repositories.
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <Button
-          render={
-            <a href="/api/github/install/start" target="_blank" rel="noopener">
-              Install GitHub app
-              <ArrowUpRight className="size-4" />
-            </a>
-          }
-        />
-      </CardContent>
-    </Card>
-  );
-}
-
-function InstallEverrCard() {
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-base">
-          <Download className="size-4 text-primary" />
-          Install Everr
-        </CardTitle>
-        <CardDescription>
-          Get notified when CI fails, run queries from your terminal, and
-          integrate with your coding assistant.
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <InstallCommandBlock command={INSTALL_COMMAND} />
-      </CardContent>
-    </Card>
   );
 }

--- a/packages/app/src/telemetry/server-fn-runtime.ts
+++ b/packages/app/src/telemetry/server-fn-runtime.ts
@@ -42,14 +42,29 @@ export async function instrumentServerFunction<T>(
   );
 }
 
+/**
+ * The RPC semantic conventions, in their current spelling. `rpc.system`,
+ * `rpc.service` and `rpc.grpc.status_code` are all deprecated: the system
+ * became `rpc.system.name`, and `rpc.service` was absorbed into `rpc.method`,
+ * which now carries the fully-qualified `{service}/{method}` name.
+ * https://opentelemetry.io/docs/specs/semconv/non-normative/rpc-migration/
+ *
+ * The span stays INTERNAL rather than SERVER, which the conventions would ask
+ * of an RPC server span. Every one of these nests inside the framework's own
+ * `POST /_serverFn/:id` SERVER span, so promoting it would make one inbound
+ * request count as two on every panel that splits traffic by span kind.
+ */
+const RPC_SERVICE = "server_function";
+
 function serverFunctionAttributes(
   request: Request | undefined,
   serverFnMeta: ServerFunctionMeta | undefined,
 ): Attributes {
   return {
-    ...(serverFnMeta ? { "rpc.method": serverFnMeta.name } : {}),
-    "rpc.service": "server_function",
-    "rpc.system": "tanstack-start",
+    ...(serverFnMeta
+      ? { "rpc.method": `${RPC_SERVICE}/${serverFnMeta.name}` }
+      : {}),
+    "rpc.system.name": "tanstack-start",
     ...(request ? { "url.path": parameterizeServerFunctionPath(request) } : {}),
   };
 }

--- a/packages/app/src/telemetry/server-fn.test.ts
+++ b/packages/app/src/telemetry/server-fn.test.ts
@@ -72,18 +72,16 @@ describe("instrumentServerFunction", () => {
 
     expect(telemetryMocks.captureError).toHaveBeenCalledWith(error, {
       "everr.error.source": "server_fn",
-      "rpc.method": "getActiveOrganization",
-      "rpc.service": "server_function",
-      "rpc.system": "tanstack-start",
+      "rpc.method": "server_function/getActiveOrganization",
+      "rpc.system.name": "tanstack-start",
       "url.path": "/_serverFn/:id",
     });
     expect(telemetryMocks.startActiveSpan).toHaveBeenCalledWith(
       "tanstack.server_fn",
       {
         attributes: {
-          "rpc.method": "getActiveOrganization",
-          "rpc.service": "server_function",
-          "rpc.system": "tanstack-start",
+          "rpc.method": "server_function/getActiveOrganization",
+          "rpc.system.name": "tanstack-start",
           "url.path": "/_serverFn/:id",
         },
         kind: 0,
@@ -133,9 +131,8 @@ describe("instrumentServerFunction", () => {
       "tanstack.server_fn",
       {
         attributes: {
-          "rpc.method": "getSession",
-          "rpc.service": "server_function",
-          "rpc.system": "tanstack-start",
+          "rpc.method": "server_function/getSession",
+          "rpc.system.name": "tanstack-start",
           "url.path": "/_serverFn/:id",
         },
         kind: 0,

--- a/packages/telemetry-explorer/src/errors/index.ts
+++ b/packages/telemetry-explorer/src/errors/index.ts
@@ -7,10 +7,7 @@ export {
 } from "./data/repository";
 export * from "./data/schemas";
 export * from "./data/types";
-export {
-  ERROR_FINGERPRINT_SQL,
-  EXCEPTION_LOG_FILTER_SQL,
-} from "./sql/fingerprint";
+export { errorIssueCountExpr } from "./sql/fingerprint";
 export { ErrorDetail, type ErrorDetailProps } from "./ui/error-detail";
 export {
   ErrorIssues,

--- a/packages/telemetry-explorer/src/errors/index.ts
+++ b/packages/telemetry-explorer/src/errors/index.ts
@@ -7,6 +7,10 @@ export {
 } from "./data/repository";
 export * from "./data/schemas";
 export * from "./data/types";
+export {
+  ERROR_FINGERPRINT_SQL,
+  EXCEPTION_LOG_FILTER_SQL,
+} from "./sql/fingerprint";
 export { ErrorDetail, type ErrorDetailProps } from "./ui/error-detail";
 export {
   ErrorIssues,

--- a/packages/telemetry-explorer/src/errors/sql/fingerprint.ts
+++ b/packages/telemetry-explorer/src/errors/sql/fingerprint.ts
@@ -15,3 +15,17 @@ export const EXCEPTION_LOG_FILTER_SQL = `
     OR mapContains(LogAttributes, 'exception.message')
   )
 `;
+
+/**
+ * How many distinct Errors a set of log rows holds, as a ClickHouse aggregate.
+ *
+ * Which rows count as an Error and what makes two of them the same Error are
+ * both this module's rules, so callers get the composed aggregate rather than
+ * the two halves to combine themselves. Add it to any `SELECT` over `logs`;
+ * being a `uniq`, it counts distinct Errors across whatever the query groups
+ * by, so a `WITH ROLLUP` total is the range-wide figure and not the sum of the
+ * per-group counts.
+ */
+export function errorIssueCountExpr(): string {
+  return `uniqIf(${ERROR_FINGERPRINT_SQL}, ${EXCEPTION_LOG_FILTER_SQL})`;
+}

--- a/packages/telemetry-explorer/src/traces/index.ts
+++ b/packages/telemetry-explorer/src/traces/index.ts
@@ -9,6 +9,7 @@ export * from "./data/schemas";
 export * from "./data/types";
 export * from "./data/window";
 export { TimeRangeSearchSchema } from "./time-range";
+export { serviceColor } from "./ui/shared/service-color";
 export type {
   TraceDetailProps,
   TraceDetailSearch,

--- a/packages/telemetry-explorer/src/traces/ui/shared/service-color.test.ts
+++ b/packages/telemetry-explorer/src/traces/ui/shared/service-color.test.ts
@@ -2,34 +2,28 @@ import { describe, expect, it } from "vitest";
 import { serviceColor } from "./service-color";
 
 describe("serviceColor", () => {
-  it("returns a stable color for the same (namespace, name)", () => {
-    const first = serviceColor("github", "actions-runner");
+  it("returns a stable color for the same name", () => {
+    const first = serviceColor("actions-runner");
     for (let i = 0; i < 100; i++) {
-      expect(serviceColor("github", "actions-runner")).toBe(first);
+      expect(serviceColor("actions-runner")).toBe(first);
     }
   });
 
-  it("differentiates namespace from name", () => {
-    const a = serviceColor("github", "actions");
-    const b = serviceColor("", "github/actions");
-    expect(a).not.toBe(b);
-  });
-
   it("spreads across multiple palette slots on a small set", () => {
-    const services: Array<[string, string]> = [
-      ["github", "actions-runner"],
-      ["github", "scheduler"],
-      ["app", "api"],
-      ["app", "worker"],
-      ["everr", "ingest"],
-      ["everr", "query"],
-      ["", "lonely"],
+    const services = [
+      "actions-runner",
+      "scheduler",
+      "api",
+      "worker",
+      "ingest",
+      "query",
+      "lonely",
     ];
-    const colors = new Set(services.map(([ns, n]) => serviceColor(ns, n)));
+    const colors = new Set(services.map((n) => serviceColor(n)));
     expect(colors.size).toBeGreaterThanOrEqual(2);
   });
 
   it("returns a CSS variable reference", () => {
-    expect(serviceColor("ns", "svc")).toMatch(/^var\(--trace-service-\d\)$/);
+    expect(serviceColor("svc")).toMatch(/^var\(--trace-service-\d\)$/);
   });
 });

--- a/packages/telemetry-explorer/src/traces/ui/shared/service-color.ts
+++ b/packages/telemetry-explorer/src/traces/ui/shared/service-color.ts
@@ -18,8 +18,7 @@ function fnv1a(str: string): number {
   return h;
 }
 
-export function serviceColor(namespace: string, name: string): string {
-  const key = `${namespace}/${name}`;
-  const idx = fnv1a(key) % PALETTE.length;
+export function serviceColor(name: string): string {
+  const idx = fnv1a(name) % PALETTE.length;
   return `var(${PALETTE[idx]})`;
 }

--- a/packages/telemetry-explorer/src/traces/ui/timeline/span-bar.tsx
+++ b/packages/telemetry-explorer/src/traces/ui/timeline/span-bar.tsx
@@ -32,7 +32,7 @@ export function SpanBar({ span, traceStartNs, traceEndNs }: Props) {
         left: `${leftPct}%`,
         width: isZero ? undefined : `${Math.max(widthPct, 0.1)}%`,
         minWidth: isZero ? "1px" : undefined,
-        backgroundColor: serviceColor(span.serviceNamespace, span.serviceName),
+        backgroundColor: serviceColor(span.serviceName),
       }}
     >
       {isError && (

--- a/packages/telemetry-explorer/src/traces/ui/timeline/span-row.tsx
+++ b/packages/telemetry-explorer/src/traces/ui/timeline/span-row.tsx
@@ -66,10 +66,7 @@ export function SpanRow({
         <span
           className="size-2 shrink-0 rounded-full"
           style={{
-            backgroundColor: serviceColor(
-              span.serviceNamespace,
-              span.serviceName,
-            ),
+            backgroundColor: serviceColor(span.serviceName),
           }}
         />
         <span className="truncate font-medium">{span.spanName}</span>

--- a/packages/telemetry-explorer/src/traces/ui/trace-detail-page.tsx
+++ b/packages/telemetry-explorer/src/traces/ui/trace-detail-page.tsx
@@ -156,10 +156,7 @@ function TraceHeader({
       <span
         className="size-2.5 rounded-full"
         style={{
-          backgroundColor: serviceColor(
-            root.serviceNamespace,
-            root.serviceName,
-          ),
+          backgroundColor: serviceColor(root.serviceName),
         }}
       />
       <div className="min-w-0 max-w-2xl flex-1">

--- a/packages/telemetry-explorer/src/traces/ui/trace-results-list.tsx
+++ b/packages/telemetry-explorer/src/traces/ui/trace-results-list.tsx
@@ -194,7 +194,7 @@ function TraceRow({
         <span
           className="size-2 shrink-0 rounded-full"
           style={{
-            backgroundColor: serviceColor(row.rootNamespace, row.rootService),
+            backgroundColor: serviceColor(row.rootService),
           }}
         />
         <span className="min-w-0 truncate" title={row.rootService}>


### PR DESCRIPTION
Replaces the homepage's static navigation cards with a live overview. The Install Everr card stays on top; everything below follows the global time range picker, now enabled on this route.

Split out of the combined branch so the overview can be reviewed on its own. #372 (`serviceColor` by name), which the services list depends on, has merged. Kept narrow: `cost-analysis/server.ts` and `lib/time-range.ts` are untouched. The only change outside the home module is a new `errorIssueCountExpr()` in `telemetry-explorer/src/errors`.

## What changed

- **Telemetry tiles**: logs, traces, and error issue counts with sparkline backdrops; each links into its section.
- **Services list**: one row per service with log / trace / error-issue counts, dotted in the shared trace service palette, deep-linking to `/traces` filtered by that service.
- **CI row**: workflow runs, median total CI time per PR in full units ("7.9 minutes"), and estimated cost. Becomes a Connect GitHub card when no installation is active.
- **New-user state**: zeroed tiles plus the connect card, services hidden, no dead ends.

## Data layer

One authenticated serverFn (`src/data/home/server.ts`) runs the queries in parallel:

- logs filter on `TimestampTime` and traces on a parsed `Timestamp`, so partition and primary-index pruning stay engaged on both;
- series and range-wide totals share a scan via `GROUP BY ... WITH ROLLUP`. This matters for the error-issue count: the total is the distinct fingerprints over the whole range, not the sum of the per-bucket counts, which double-count an issue recurring across buckets;
- services are ranked on log count and trace count **separately** and then interleaved. Log volume normally runs orders of magnitude above trace count, so summing the two would rank purely by logs and let one chatty service push out a trace-heavy one;
- both CI queries group whole runs before filtering, since the PR url and the task result live on different spans of a run. Filtering the result first would leave the run count's `lastTimestamp` on the last result bearing span rather than the last span of the run, bucketing a run that closes across a boundary one bucket early;
- CI filters use the `run-query-helpers` attribute helpers, where `mapContains` keeps the bloom skip index effective.

Bucket helpers live in `src/data/home/buckets.ts` rather than a shared lib, and match how `cost-analysis/server.ts` handles timezones. Both build their key grid in JS with UTC methods and leave the SQL side to the server timezone, so both assume a ClickHouse server set to UTC.

## Testing

No unit tests: the previous ones dispatched mock rows by SQL substring, which only worked because of branch ordering. Verified against the dev ClickHouse instead, cross-checking every tile against direct queries.

| Tile | UI | Direct query |
| --- | --- | --- |
| Logs (7d) | 589.8K | 589,834 |
| Error issues (7d) | 37 | 37 |
| Workflow runs (7d) | 382 | 382 |
| CI time per PR (7d) | 7.9 minutes | 473,000 ms = 7.883 min |
| Logs (24h) | 236.8K | 236,814 |
| Error issues (24h) | 5 | 5 |

Also checked: ROLLUP totals equal their bucket sums exactly (logs 210,388; runs 372); a day with no runs is absent from the result set and correctly zero-filled; granularity switches to daily past 36h; time-range switching updates the URL and every tile; all tile and service links carry the range through; and the fresh-workspace state via a newly registered account.

Typecheck clean, full app suite passes (1283 tests).

One note for the reviewer: while loading, `githubInstalled` defaults to `true`, so a fresh workspace briefly shows three CI tiles before they swap for the Connect card. Left as-is deliberately.

The CI run grouping fix is not observable on dev data: over 7 days both the old and new query forms return 511 runs and no run's `lastTimestamp` moves.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a home dashboard overview with telemetry, service, and CI/CD metrics.
  * Added selectable time ranges, loading states, trend visualizations, and estimated CI costs.
  * Added service rankings with log, trace, and distinct error counts.
  * Added setup cards for installing Everr and connecting GitHub for CI insights.
  * Added compact metric formatting and long-form duration displays.
* **Bug Fixes**
  * Improved dashboard charts by filling missing time buckets with zero values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
