### PR TITLE
Seat the dashboard variables in a toolbar strip

### DIFF
--- a/packages/app/src/components/dashboards/dashboard-grid.tsx
+++ b/packages/app/src/components/dashboards/dashboard-grid.tsx
@@ -1,16 +1,24 @@
-import { useMemo } from "react";
+import { type ReactNode, useMemo } from "react";
 import type { LayoutItem } from "react-grid-layout";
 import { GridLayout, noCompactor, useContainerWidth } from "react-grid-layout";
 import { persesToRGL } from "@/data/dashboards/convert";
+import { GRID_COLS } from "@/data/dashboards/schema";
 import { DashboardPanel } from "./dashboard-panel";
 import { useDashboard } from "./use-dashboard";
-import { VariableBar } from "./variable-bar";
+import { useHasVisibleVariables, VariableBar } from "./variable-bar";
 
-const GRID_COLS = 24;
 const ROW_HEIGHT = 30;
 
-export function DashboardGrid() {
+/**
+ * `actions` share one bordered toolbar with the variable pickers instead of
+ * getting a row of their own. Two controls separated by whitespace read as
+ * unowned chrome floating above the grid; one strip with a divider is a single
+ * object that belongs to the grid beneath it, and it keeps its shape on the
+ * many dashboards that declare no variables at all.
+ */
+export function DashboardGrid({ actions }: { actions?: ReactNode } = {}) {
   const dashboard = useDashboard();
+  const hasVariables = useHasVisibleVariables();
   const { width, containerRef } = useContainerWidth({
     measureBeforeMount: true,
   });
@@ -23,13 +31,32 @@ export function DashboardGrid() {
 
   return (
     <div>
-      <VariableBar />
+      {(hasVariables || actions) && (
+        <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-2 rounded-lg border bg-card/40 px-2.5 py-2">
+          <VariableBar className="mb-0" layout="inline" />
+          {hasVariables && actions && (
+            <div aria-hidden className="h-5 w-px self-center bg-border" />
+          )}
+          {actions && (
+            <div className="ml-auto flex items-center gap-2">{actions}</div>
+          )}
+        </div>
+      )}
       <div ref={containerRef}>
         <GridLayout
           width={width}
           className="layout"
           layout={layout}
-          gridConfig={{ cols: GRID_COLS, rowHeight: ROW_HEIGHT }}
+          gridConfig={{
+            cols: GRID_COLS,
+            rowHeight: ROW_HEIGHT,
+            // `containerPadding` defaults to `margin`, which insets the whole
+            // grid by 10px and leaves the panels narrower than everything
+            // stacked above them — the toolbar, the breadcrumb, the page. Zero
+            // it so the panel block starts and ends on the page's own column;
+            // `margin` still spaces the panels from each other.
+            containerPadding: [0, 0],
+          }}
           dragConfig={{ enabled: false }}
           resizeConfig={{ enabled: false }}
           // No compaction: render panels at their authored x/y so intentional

--- a/packages/app/src/components/dashboards/variable-bar.tsx
+++ b/packages/app/src/components/dashboards/variable-bar.tsx
@@ -24,6 +24,9 @@ import {
   type VariableOptionsState,
 } from "./use-dashboard-variables";
 
+const fieldClass = (layout: VariableBarLayout) =>
+  layout === "inline" ? "flex items-center gap-2" : "flex flex-col gap-1";
+
 function variableLabel(variable: Variable): string {
   return variable.spec.display?.name ?? variable.spec.name;
 }
@@ -35,7 +38,30 @@ function isVisible(variable: Variable): boolean {
   return true;
 }
 
-export function VariableBar() {
+/**
+ * Whether this dashboard shows any pickers at all. A container that seats the
+ * variable bar next to other controls has to know before it renders: with no
+ * pickers there is no left half, so there is nothing to divide.
+ */
+export function useHasVisibleVariables(): boolean {
+  return useDashboardVariables().variables.some(isVisible);
+}
+
+/**
+ * `inline` puts each label beside its control instead of above it, so every
+ * item in the row shares one control-height baseline. The dashboard toolbar
+ * needs that to align its actions against; the runbook viewer renders this as a
+ * standalone block, where the stacked label reads better, and keeps the default.
+ */
+export type VariableBarLayout = "stacked" | "inline";
+
+export function VariableBar({
+  className,
+  layout = "stacked",
+}: {
+  className?: string;
+  layout?: VariableBarLayout;
+} = {}) {
   const navigate = useNavigate();
   const { variables, values, optionsState } = useDashboardVariables();
 
@@ -60,12 +86,19 @@ export function VariableBar() {
   if (visible.length === 0) return null;
 
   return (
-    <div className="mb-3 flex flex-wrap items-end gap-3">
+    <div
+      className={cn(
+        "mb-3 flex flex-wrap gap-3",
+        layout === "inline" ? "items-center" : "items-end",
+        className,
+      )}
+    >
       {visible.map((variable) =>
         variable.kind === "TextVariable" ? (
           <TextVariableField
             key={variable.spec.name}
             variable={variable}
+            layout={layout}
             value={
               typeof values[variable.spec.name] === "string"
                 ? (values[variable.spec.name] as string)
@@ -77,6 +110,7 @@ export function VariableBar() {
           <ListVariableField
             key={variable.spec.name}
             variable={variable}
+            layout={layout}
             value={values[variable.spec.name]}
             optionsState={optionsState[variable.spec.name]}
             onChange={(value) => setValue(variable.spec.name, value)}
@@ -89,16 +123,18 @@ export function VariableBar() {
 
 function TextVariableField({
   variable,
+  layout,
   value,
   onCommit,
 }: {
   variable: TextVariable;
+  layout: VariableBarLayout;
   value: string;
   onCommit: (value: string) => void;
 }) {
   const name = variable.spec.name;
   return (
-    <div className="flex flex-col gap-1">
+    <div className={fieldClass(layout)}>
       <Label htmlFor={`var-${name}`} className="text-xs text-muted-foreground">
         {variableLabel(variable)}
       </Label>
@@ -120,11 +156,13 @@ function TextVariableField({
 
 function ListVariableField({
   variable,
+  layout,
   value,
   optionsState,
   onChange,
 }: {
   variable: ListVariable;
+  layout: VariableBarLayout;
   value: string | string[] | undefined;
   optionsState: VariableOptionsState | undefined;
   onChange: (value: string | string[]) => void;
@@ -162,7 +200,7 @@ function ListVariableField({
   };
 
   return (
-    <div className="flex flex-col gap-1">
+    <div className={fieldClass(layout)}>
       <Label htmlFor={`var-${name}`} className="text-xs text-muted-foreground">
         {variableLabel(variable)}
       </Label>

--- a/packages/app/src/data/dashboards/schema.ts
+++ b/packages/app/src/data/dashboards/schema.ts
@@ -55,6 +55,9 @@ export const panel = z.object({
   }),
 });
 
+/** Columns every dashboard grid is measured in, layout and renderer alike. */
+export const GRID_COLS = 24;
+
 /** Prefix every layout `content.$ref` must use to point at a panel key. */
 export const PANEL_REF_PREFIX = "#/spec/panels/";
 


### PR DESCRIPTION

Before
<img width="1280" height="577" alt="before" src="https://github.com/user-attachments/assets/4f036f14-a8f5-4f90-9c19-ed13f1b2c686" />

After
<img width="1280" height="577" alt="after" src="https://github.com/user-attachments/assets/e5f0aa90-8991-441e-89bf-64fdedf6f825" />
