### PR TITLE
Emit the current RPC semconv on server function spans

### DIFF
--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/metrics.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/metrics.md
@@ -33,7 +33,7 @@ When these instrumentations are present, expect metrics in these domains before 
 | HTTP client | `http.client.request.duration` |
 | Database client | `db.client.operation.duration` |
 | Messaging | `messaging.process.duration`, `messaging.publish.duration` |
-| RPC | `rpc.server.duration`, `rpc.client.duration` |
+| RPC | `rpc.server.call.duration`, `rpc.client.call.duration` (both seconds; the retired names were `rpc.server.duration` and `rpc.client.duration`, in milliseconds) |
 | Runtime/process | `process.runtime.*`, `process.cpu.*`, `process.memory.*` |
 
 Exact names can vary by SDK version and semantic convention stability setting. If a service depends on a metric for alerts or dashboards, test the emitted shape instead of assuming the library uses the current stable name.

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/spans.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/spans.md
@@ -18,7 +18,7 @@ Common formats:
 - HTTP server: `{method} {http.route}`
 - HTTP client: `{method} {url.template}` or `{method}` when no safe template exists
 - Database: `{db.operation.name} {db.collection.name}`
-- RPC: `{rpc.service}/{rpc.method}`
+- RPC: `{rpc.method}`, which is already the fully-qualified `{service}/{method}`
 - Messaging: `{operation} {destination}`
 - Domain work: `{verb} {object}`, such as `process order`
 
@@ -62,6 +62,21 @@ Avoid attributes containing request bodies, raw URLs with query params, serializ
 
 Add business attributes to auto-instrumented spans by retrieving the active span; do not create a redundant child span solely to add attributes.
 
+## RPC Attributes
+
+The RPC conventions moved. Emit the current spelling, not the retired one.
+
+| Retired | Current | Note |
+| --- | --- | --- |
+| `rpc.system` | `rpc.system.name` | Well-known values: `grpc`, `dubbo`, `connectrpc`, `jsonrpc`. Other systems may use their own value. |
+| `rpc.service` | (none) | Absorbed into `rpc.method`. |
+| `rpc.method` | `rpc.method` | Now the fully-qualified `{service}/{method}`, such as `com.example.ExampleService/exampleMethod`. |
+| `rpc.grpc.status_code` | `rpc.response.status_code` | Also changed type: the integer `0` is now the string `OK`. |
+| `rpc.grpc.request.metadata.<key>` | `rpc.request.metadata.<key>` | Same for the response side. |
+| `rpc.message.*` | (none) | Deprecated with no replacement. |
+
+Set `error.type` on a failed call. Auto-instrumentation still emits the retired spelling by default; `OTEL_SEMCONV_STABILITY_OPT_IN=rpc` switches it to the current one, and `rpc/dup` emits both during a migration. Do not read both spellings in a query: the two are not interchangeable, because the old method key needs `rpc.service` concatenated onto it and the two status codes do not even share a type.
+
 ## Headless Work
 
 Cron jobs, background workers, CLI commands, startup tasks, and batch jobs often have no inbound request span. Wrap the unit of work in a manual root span so outbound database or HTTP spans do not become root `CLIENT` spans.
@@ -82,6 +97,7 @@ await tracer.startActiveSpan('process daily orders', async (span) => {
 - `CLIENT` and `PRODUCER` spans should have a parent that explains why the outbound work happened.
 - Every child span should have a parent span in the same trace.
 - Keep `INTERNAL` spans sparse; avoid tracing tight loops.
+- A span that carries RPC attributes but nests inside a `SERVER` span that already covers the same request stays `INTERNAL`. The conventions ask an RPC server span to be `SERVER`, but promoting a nested one makes a single inbound request count twice on every panel that splits traffic by span kind.
 - Replace per-item spans with one batch span plus `batch.size`.
 - Use logs for lightweight annotations.
 - Keep application SDK sampling at the default unless the project has an explicit collector-side sampling plan. Application-side head sampling drops evidence before outcome is known.

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/tanstack-start.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/tanstack-start.md
@@ -106,6 +106,8 @@ export const startInstance = createStart(() => ({
 
 The middleware (`createMiddleware({ type: "function" })`) starts an INTERNAL span per invocation with the function id, name, and filename from `serverFnMeta` as attributes (prefix non-semconv attributes with `everr.`). It nests under the request's SERVER span automatically because the fetch wrapper's context is active.
 
+A server function call is an RPC, so describe it with the RPC conventions in `spans.md`: `rpc.system.name` for the framework and a fully-qualified `rpc.method`. Keep the span INTERNAL even though the conventions ask an RPC server span to be SERVER, because the request already has one and a second would double every inbound count.
+
 TanStack Start signals control flow with throwables: `redirect()` and `notFound()` surface as thrown values inside server functions. Filter those out before calling `captureError`, or every redirect becomes a phantom error.
 
 ## Validation

--- a/packages/app/src/telemetry/server-fn-runtime.ts
+++ b/packages/app/src/telemetry/server-fn-runtime.ts
@@ -42,14 +42,29 @@ export async function instrumentServerFunction<T>(
   );
 }
 
+/**
+ * The RPC semantic conventions, in their current spelling. `rpc.system`,
+ * `rpc.service` and `rpc.grpc.status_code` are all deprecated: the system
+ * became `rpc.system.name`, and `rpc.service` was absorbed into `rpc.method`,
+ * which now carries the fully-qualified `{service}/{method}` name.
+ * https://opentelemetry.io/docs/specs/semconv/non-normative/rpc-migration/
+ *
+ * The span stays INTERNAL rather than SERVER, which the conventions would ask
+ * of an RPC server span. Every one of these nests inside the framework's own
+ * `POST /_serverFn/:id` SERVER span, so promoting it would make one inbound
+ * request count as two on every panel that splits traffic by span kind.
+ */
+const RPC_SERVICE = "server_function";
+
 function serverFunctionAttributes(
   request: Request | undefined,
   serverFnMeta: ServerFunctionMeta | undefined,
 ): Attributes {
   return {
-    ...(serverFnMeta ? { "rpc.method": serverFnMeta.name } : {}),
-    "rpc.service": "server_function",
-    "rpc.system": "tanstack-start",
+    ...(serverFnMeta
+      ? { "rpc.method": `${RPC_SERVICE}/${serverFnMeta.name}` }
+      : {}),
+    "rpc.system.name": "tanstack-start",
     ...(request ? { "url.path": parameterizeServerFunctionPath(request) } : {}),
   };
 }

--- a/packages/app/src/telemetry/server-fn.test.ts
+++ b/packages/app/src/telemetry/server-fn.test.ts
@@ -72,18 +72,16 @@ describe("instrumentServerFunction", () => {
 
     expect(telemetryMocks.captureError).toHaveBeenCalledWith(error, {
       "everr.error.source": "server_fn",
-      "rpc.method": "getActiveOrganization",
-      "rpc.service": "server_function",
-      "rpc.system": "tanstack-start",
+      "rpc.method": "server_function/getActiveOrganization",
+      "rpc.system.name": "tanstack-start",
       "url.path": "/_serverFn/:id",
     });
     expect(telemetryMocks.startActiveSpan).toHaveBeenCalledWith(
       "tanstack.server_fn",
       {
         attributes: {
-          "rpc.method": "getActiveOrganization",
-          "rpc.service": "server_function",
-          "rpc.system": "tanstack-start",
+          "rpc.method": "server_function/getActiveOrganization",
+          "rpc.system.name": "tanstack-start",
           "url.path": "/_serverFn/:id",
         },
         kind: 0,
@@ -133,9 +131,8 @@ describe("instrumentServerFunction", () => {
       "tanstack.server_fn",
       {
         attributes: {
-          "rpc.method": "getSession",
-          "rpc.service": "server_function",
-          "rpc.system": "tanstack-start",
+          "rpc.method": "server_function/getSession",
+          "rpc.system.name": "tanstack-start",
           "url.path": "/_serverFn/:id",
         },
         kind: 0,


### PR DESCRIPTION
Extracted from #370 so it can land on its own.

## What changes

- `server-fn-runtime.ts` emits the current RPC spelling: `rpc.system.name` instead of the retired `rpc.system`, and a fully-qualified `rpc.method` (`server_function/<name>`) that absorbs the retired `rpc.service`. See the [OTel RPC migration guide](https://opentelemetry.io/docs/specs/semconv/non-normative/rpc-migration/).
- The span stays `INTERNAL` rather than the `SERVER` the conventions ask of an RPC server span: each one nests inside the framework's own `POST /_serverFn/:id` SERVER span, so promoting it would make one inbound request count twice on every panel that splits traffic by span kind.
- Telemetry skill rules record the migration: the attribute table and `OTEL_SEMCONV_STABILITY_OPT_IN` in `spans.md`, the metric rename (`rpc.server.duration` to `rpc.server.call.duration`, milliseconds to seconds) in `metrics.md`, and the server-function guidance in `tanstack-start.md`.

Queries that read `rpc.service` or `rpc.system` on server function spans need updating; #370 carries the dashboard that reads the new spelling.

## Testing

- `vitest src/telemetry/server-fn.test.ts` passes (5 tests).
- Verified ingestion against a dev app running this branch: the traces attribute filter offers `rpc.system.name` with value `tanstack-start`, and a fresh span reads

```
Kind             Internal
rpc.method       server_function/getTraceAttributeValues
rpc.system.name  tanstack-start
url.path         /_serverFn/:id
```

  nested under its `GET /_serverFn/:id` SERVER span, so the inbound request is still counted once.