### PR TITLE
fix(app): polish the sidebar collapse animation

### DIFF
--- a/packages/app/src/components/app-sidebar.tsx
+++ b/packages/app/src/components/app-sidebar.tsx
@@ -24,9 +24,11 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
               <div className="bg-sidebar-primary text-sidebar-primary-foreground flex aspect-square size-8 items-center justify-center rounded-lg">
                 <Citrus />
               </div>
-              <div className="grid flex-1 text-left text-sm leading-tight">
-                <span className="truncate font-semibold">Everr</span>
-                <span className="truncate text-xs">
+              <div className="grid flex-1 text-left text-sm leading-tight transition-opacity duration-200 ease-sidebar motion-reduce:transition-none group-data-[collapsible=icon]:opacity-0">
+                <span className="overflow-hidden whitespace-nowrap font-semibold">
+                  Everr
+                </span>
+                <span className="overflow-hidden whitespace-nowrap text-xs">
                   Observability made simple
                 </span>
               </div>

--- a/packages/app/src/components/nav-user.tsx
+++ b/packages/app/src/components/nav-user.tsx
@@ -91,9 +91,13 @@ export function NavUser() {
                 initials
               )}
             </div>
-            <div className="grid flex-1 text-left text-sm leading-tight">
-              <span className="truncate font-medium">{fullName}</span>
-              <span className="truncate text-xs">{activeOrg?.name ?? " "}</span>
+            <div className="grid flex-1 text-left text-sm leading-tight transition-opacity duration-200 ease-sidebar motion-reduce:transition-none group-data-[collapsible=icon]:opacity-0">
+              <span className="overflow-hidden whitespace-nowrap font-medium">
+                {fullName}
+              </span>
+              <span className="overflow-hidden whitespace-nowrap text-xs">
+                {activeOrg?.name ?? " "}
+              </span>
             </div>
             <ChevronsUpDown className="ml-auto size-4" />
           </DropdownMenuTrigger>

--- a/packages/app/src/lib/sidebar-tracked-left.ts
+++ b/packages/app/src/lib/sidebar-tracked-left.ts
@@ -5,4 +5,4 @@
 // transition without a `useSidebar()` re-render mid-collapse. Below `md` the
 // sidebar is offcanvas, so chrome spans from the viewport edge.
 export const SIDEBAR_TRACKED_LEFT =
-  "left-0 transition-[left] duration-200 ease-linear md:left-(--sidebar-width) md:group-has-data-[collapsible=icon]/sidebar-wrapper:left-(--sidebar-width-icon)";
+  "left-0 transition-[left] duration-200 ease-sidebar motion-reduce:transition-none md:left-(--sidebar-width) md:group-has-data-[collapsible=icon]/sidebar-wrapper:left-(--sidebar-width-icon)";

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -371,7 +371,7 @@ function Sidebar({
       <div
         data-slot="sidebar-gap"
         className={cn(
-          "transition-[width] duration-200 ease-linear relative w-(--sidebar-width) bg-transparent",
+          "transition-[width] duration-200 ease-sidebar motion-reduce:transition-none relative w-(--sidebar-width) bg-transparent",
           "group-data-[collapsible=offcanvas]:w-0",
           "group-data-[side=right]:rotate-180",
           variant === "floating" || variant === "inset"
@@ -383,7 +383,7 @@ function Sidebar({
         data-slot="sidebar-container"
         data-side={side}
         className={cn(
-          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex",
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-sidebar motion-reduce:transition-none data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex",
           // Adjust the padding for floating and inset variants.
           variant === "floating" || variant === "inset"
             ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
@@ -556,7 +556,7 @@ function SidebarGroupLabel({
     props: mergeProps<"div">(
       {
         className: cn(
-          "text-sidebar-foreground/70 ring-primary ring-offset-background h-8 rounded-md px-2 text-xs transition-[margin,opacity,outline,outline-offset,box-shadow] duration-200 ease-[cubic-bezier(0.19,1,0.22,1)] group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 outline-2 outline-dotted outline-transparent outline-offset-2 focus-visible:ring-2 focus-visible:ring-offset-[3px] [&>svg]:size-4 flex shrink-0 items-center [&>svg]:shrink-0",
+          "text-sidebar-foreground/70 ring-primary ring-offset-background h-8 overflow-hidden whitespace-nowrap rounded-md px-2 text-xs transition-[margin,opacity,outline,outline-offset,box-shadow] duration-200 ease-sidebar motion-reduce:transition-none group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 group-data-[collapsible=icon]:[transition-duration:200ms,75ms,200ms,200ms,200ms] outline-2 outline-dotted outline-transparent outline-offset-2 focus-visible:ring-2 focus-visible:ring-offset-[3px] [&>svg]:size-4 flex shrink-0 items-center [&>svg]:shrink-0",
           className,
         ),
       },
@@ -580,7 +580,7 @@ function SidebarGroupAction({
     props: mergeProps<"button">(
       {
         className: cn(
-          "text-sidebar-foreground ring-primary ring-offset-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-3 w-5 rounded-md p-0 outline-2 outline-dotted outline-transparent outline-offset-2 focus-visible:ring-2 focus-visible:ring-offset-[3px] [&>svg]:size-4 flex aspect-square items-center justify-center transition-[transform,outline,outline-offset,box-shadow] duration-200 ease-[cubic-bezier(0.19,1,0.22,1)] [&>svg]:shrink-0 after:absolute after:-inset-2 md:after:hidden group-data-[collapsible=icon]:hidden",
+          "text-sidebar-foreground ring-primary ring-offset-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-3 w-5 rounded-md p-0 outline-2 outline-dotted outline-transparent outline-offset-2 focus-visible:ring-2 focus-visible:ring-offset-[3px] [&>svg]:size-4 flex aspect-square items-center justify-center transition-[transform,outline,outline-offset,box-shadow] duration-200 ease-sidebar [&>svg]:shrink-0 after:absolute after:-inset-2 md:after:hidden group-data-[collapsible=icon]:hidden",
           className,
         ),
       },
@@ -631,7 +631,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  "ring-primary ring-offset-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground gap-2 rounded-[calc(var(--radius-sm)+2px)] p-2 text-left text-xs transition-[width,height,padding,outline,outline-offset,box-shadow] duration-200 ease-[cubic-bezier(0.19,1,0.22,1)] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! outline-2 outline-dotted outline-transparent outline-offset-2 focus-visible:ring-2 focus-visible:ring-offset-[3px] data-active:font-medium peer/menu-button flex w-full items-center overflow-hidden group/menu-button disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&_svg]:size-4 [&_svg]:shrink-0",
+  "ring-primary ring-offset-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground gap-2 rounded-[calc(var(--radius-sm)+2px)] p-2 text-left text-xs transition-[width,height,padding,outline,outline-offset,box-shadow] duration-200 ease-sidebar motion-reduce:transition-none group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! outline-2 outline-dotted outline-transparent outline-offset-2 focus-visible:ring-2 focus-visible:ring-offset-[3px] data-active:font-medium peer/menu-button flex w-full items-center overflow-hidden group/menu-button disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:overflow-hidden [&>span:last-child]:whitespace-nowrap [&>span:last-child]:transition-opacity [&>span:last-child]:duration-200 [&>span:last-child]:ease-sidebar motion-reduce:[&>span:last-child]:transition-none group-data-[collapsible=icon]:[&>span:last-child]:opacity-0 [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -713,7 +713,7 @@ function SidebarMenuAction({
     props: mergeProps<"button">(
       {
         className: cn(
-          "text-sidebar-foreground ring-primary ring-offset-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 right-1 aspect-square w-5 rounded-[calc(var(--radius-sm)-2px)] p-0 peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 outline-2 outline-dotted outline-transparent outline-offset-2 focus-visible:ring-2 focus-visible:ring-offset-[3px] [&>svg]:size-4 flex items-center justify-center transition-[transform,outline,outline-offset,box-shadow] duration-200 ease-[cubic-bezier(0.19,1,0.22,1)] group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 md:after:hidden [&>svg]:shrink-0",
+          "text-sidebar-foreground ring-primary ring-offset-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 right-1 aspect-square w-5 rounded-[calc(var(--radius-sm)-2px)] p-0 peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 outline-2 outline-dotted outline-transparent outline-offset-2 focus-visible:ring-2 focus-visible:ring-offset-[3px] [&>svg]:size-4 flex items-center justify-center transition-[transform,outline,outline-offset,box-shadow] duration-200 ease-sidebar group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 md:after:hidden [&>svg]:shrink-0",
           showOnHover &&
             "peer-data-active/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-open:opacity-100 md:opacity-0",
           className,
@@ -828,7 +828,7 @@ function SidebarMenuSubButton({
     props: mergeProps<"a">(
       {
         className: cn(
-          "text-sidebar-foreground ring-primary ring-offset-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground h-7 gap-2 rounded-md px-2 outline-2 outline-dotted outline-transparent outline-offset-2 focus-visible:ring-2 focus-visible:ring-offset-[3px] transition-[outline,outline-offset,box-shadow] duration-200 ease-[cubic-bezier(0.19,1,0.22,1)] data-[size=md]:text-xs data-[size=sm]:text-xs [&>svg]:size-4 flex min-w-0 -translate-x-px items-center overflow-hidden group-data-[collapsible=icon]:hidden disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:shrink-0",
+          "text-sidebar-foreground ring-primary ring-offset-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground h-7 gap-2 rounded-md px-2 outline-2 outline-dotted outline-transparent outline-offset-2 focus-visible:ring-2 focus-visible:ring-offset-[3px] transition-[outline,outline-offset,box-shadow] duration-200 ease-sidebar data-[size=md]:text-xs data-[size=sm]:text-xs [&>svg]:size-4 flex min-w-0 -translate-x-px items-center overflow-hidden group-data-[collapsible=icon]:hidden disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:shrink-0",
           className,
         ),
       },

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -14,6 +14,7 @@
   --radius-3xl: calc(var(--radius) + 12px);
   --radius-4xl: calc(var(--radius) + 16px);
   --animate-highlight-fade: highlight-fade 1.5s ease-out forwards;
+  --ease-sidebar: cubic-bezier(0.19, 1, 0.22, 1);
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);


### PR DESCRIPTION
## What

The sidebar collapse/expand ran on two different physics at once and the labels glitched during the motion. This unifies the whole gesture:

- **One easing curve.** New `--ease-sidebar` token (`cubic-bezier(0.19, 1, 0.22, 1)`) in the `@theme` block. The rail width, the tracked chrome (`SIDEBAR_TRACKED_LEFT`), and the sidebar's inner elements all move on it, replacing a `ease-linear` rail fighting expo-out contents. The five hand-typed cubic-bezier literals in `sidebar.tsx` now reference the token.
- **No ellipsis churn.** Labels inside collapsing buttons (menu items, the header text, the user button) swap `truncate` for `overflow-hidden whitespace-nowrap` plus an opacity fade in icon mode, so the shrinking edge wipes over stationary text instead of re-truncating it every frame ("Dashbo…" → "Da…" → "…"). Ellipsis stays where it belongs: inside the user dropdown, which never collapses.
- **Group labels exit cleanly.** `SidebarGroupLabel` now clips like the items, and in the collapsed state its opacity transition runs at 75ms so the text is gone before the `-mt-8` slide-up crosses the icons above. Expanding keeps the base 200ms fade-in at the settled position. Note: the duration list maps positionally onto `transition-[margin,opacity,…]`; if the property list changes, move the durations with it.
- **Reduced motion.** Every collapse-related transition gains `motion-reduce:transition-none`: the toggle snaps instantly, focus-ring feedback is preserved.

## Demo

Two collapse/expand cycles recorded on the branch (10fps capture, cropped to the rail):

![Sidebar collapse/expand animation](https://raw.githubusercontent.com/everr-labs/everr/assets/sidebar-collapse-animation/sidebar-collapse.gif)

## Feel check

Verified in the browser with mid-animation frame captures: rail, chrome, and labels move as one decelerating body; no ellipsis at any frame in either direction; group headers never overlap icons; collapsed-state restore on reload still doesn't animate (`data-restoring` guard untouched); reduced-motion emulation snaps.

Both package typechecks pass. The `SidebarRail` hover strip keeps its `transition-all ease-linear` — it's the hover affordance, not the collapse motion.

## Tradeoff

A label longer than the expanded rail now hard-clips without "…" in the steady state. Nav labels are short static words; a consumer needing ellipsis can put `truncate` on its own inner element.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved sidebar expand and collapse animations for smoother transitions.
  * Added support for reduced-motion preferences.
  * Preserved full sidebar brand, user, organization, and menu text without truncation.
  * Improved text visibility and overflow handling across sidebar controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
