### PR TITLE
feat(app): add per-series colors option to BarChart

### DIFF
--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/barchart.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/barchart.md
@@ -1,6 +1,6 @@
 # BarChart
 
-A bar chart over time **or** over categories. It infers its structure from the columns you `SELECT` — there is no axis, color, or per-series configuration.
+A bar chart over time **or** over categories. It infers its structure from the columns you `SELECT` — there is no axis or per-series configuration beyond pinning colors by series name.
 
 ## Options (`plugin.spec`)
 
@@ -11,14 +11,21 @@ A bar chart over time **or** over categories. It infers its structure from the c
 | `stacking` | string | `none` | `none`, `stacked`, `percent` | `none` draws series side by side; `stacked` piles them into one bar per x value; `percent` additionally normalizes each stack to 100% — the value axis becomes percentages while tooltips keep raw values. |
 | `orientation` | string | `vertical` | `vertical`, `horizontal` | `vertical` draws bars bottom-up; `horizontal` draws them left-to-right with categories on the y-axis — prefer it for categorical data with long labels. |
 | `showValues` | boolean | `false` | `true` | Draw each bar's value: on top (vertical) / to the right (horizontal) of grouped bars, centered inside stacked segments. |
+| `colors` | map | `{}` | series name to CSS color | Pin a series to a fixed color. Use it when the series name carries a meaning a rotating palette would lose (`good` / `poor`, `pass` / `fail`). Unlisted series keep their palette color. |
 
 ```yaml
 plugin:
   kind: BarChart
-  spec: { unit: req, showLegend: true, stacking: stacked, orientation: vertical, showValues: false }
+  spec:
+    unit: req
+    showLegend: true
+    stacking: stacked
+    orientation: vertical
+    showValues: false
+    colors: { good: "#0cce6b", poor: "#ff4e42" } # optional
 ```
 
-These five are the complete set. There is **no** `yAxis` / `min` / `max`, `barWidth`, `legend` object, `thresholds`, `decimals`, or per-series color. Series colors come from a fixed 6-color palette assigned by order (wrapping after 6) and are not configurable.
+These six are the complete set. There is **no** `yAxis` / `min` / `max`, `barWidth`, `legend` object, `thresholds`, or `decimals`. A series that `colors` does not name takes its color from a fixed 6-color palette assigned by order (wrapping after 6).
 
 ## Data shape
 

--- a/packages/app/src/components/dashboards/visualizations/bar-chart/bar-chart-data.ts
+++ b/packages/app/src/components/dashboards/visualizations/bar-chart/bar-chart-data.ts
@@ -33,9 +33,13 @@ export interface BarChartModel {
  * per label, exactly like the time-series chart.
  *
  * A time axis is sorted ascending; categories keep first-seen (query) order.
+ * `colors` pins a series to a fixed color by name; the rest cycle the palette
+ * in first-seen order (a pinned series still consumes its palette slot, so
+ * pinning one series never reshuffles the others).
  */
 export function buildBarChartModel(
   dataSets: QueryResultRow[][],
+  colors: Record<string, string> = {},
 ): BarChartModel {
   const chartConfig: ChartConfig = {};
   const valueKeys: string[] = [];
@@ -93,7 +97,8 @@ export function buildBarChartModel(
       valueKeys.push(renderKey);
       chartConfig[renderKey] = {
         label: name,
-        color: SERIES_COLORS[seriesIndex % SERIES_COLORS.length],
+        color:
+          colors[name] ?? SERIES_COLORS[seriesIndex % SERIES_COLORS.length],
       };
       seriesIndex++;
     }

--- a/packages/app/src/components/dashboards/visualizations/bar-chart/bar-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/bar-chart/bar-chart-visualization.tsx
@@ -111,11 +111,11 @@ export function BarChartVisualization({
   spec,
   data,
 }: VisualizationProps<BarChartSpec>) {
-  const { unit, showLegend, stacking, orientation, showValues } = spec;
+  const { unit, showLegend, stacking, orientation, showValues, colors } = spec;
 
   const { chartData, valueKeys, chartConfig, isTimeAxis } = useMemo(
-    () => buildBarChartModel(data ?? []),
-    [data],
+    () => buildBarChartModel(data ?? [], colors),
+    [data, colors],
   );
 
   // recharts naming: layout "vertical" = horizontal bars.

--- a/packages/app/src/components/dashboards/visualizations/bar-chart/spec.ts
+++ b/packages/app/src/components/dashboards/visualizations/bar-chart/spec.ts
@@ -14,6 +14,10 @@ export const barChartSpec = z.looseObject({
   /** `horizontal` draws bars left-to-right with categories on the y-axis. */
   orientation: z.enum(["vertical", "horizontal"]).default("vertical"),
   showValues: z.boolean().default(false),
+  /** Fixed series name → CSS color mapping; unmapped series cycle the shared
+   * palette. Use it when the series names carry a meaning of their own (a
+   * good/poor rating, a pass/fail outcome) that a rotating palette would lose. */
+  colors: z.record(z.string(), z.string()).default({}),
 });
 
 export type BarChartSpec = z.infer<typeof barChartSpec>;


### PR DESCRIPTION
Adds an optional `colors` map to the BarChart spec that pins a series name to a fixed CSS color. Unlisted series keep their palette slot, so pinning one series never reshuffles the others. Updates the barchart skill rule accordingly.

Split out of the built-in dashboards branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for assigning fixed colors to individual bar chart series.
  * Series colors can be configured by name using the chart’s `colors` option.
  * Unconfigured series continue using the existing color palette.

* **Documentation**
  * Updated BarChart configuration guidance and examples to include per-series colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->