### PR TITLE
refactor(telemetry): describe server functions with everr.server_function attributes

### DIFF
--- a/crates/everr-core/assets/skills/everr-setup-telemetry/SKILL.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/SKILL.md
@@ -90,6 +90,16 @@ When OpenTelemetry is missing:
 
 Do not make high-volume runtime traces or debug logs print to stdout/stderr just so they can be inspected. Export them to Everr and query them.
 
+## Server Function Convention
+
+Framework server functions (TanStack Start server functions, Next.js server actions, and similar) are not RPCs: do not describe them with the `rpc.*` conventions. Instrument each invocation as one span:
+
+- Span name: `serverFn {name}`, falling back to `serverFn` when the framework provides no name.
+- `everr.server_function.name`: the framework's own identifier for the function, verbatim (for example `getActiveOrganization`). Do not rename, prefix, or namespace it.
+- `everr.server_function.transport`: `http` when the invocation arrived as its own request, `in-process` otherwise.
+
+Reserve `rpc.*` for actual RPC systems (gRPC, JSON-RPC, and similar). Span kind and framework-specific wiring live in the runtime rules (`spans`, `tanstack-start`, `nextjs`).
+
 ## Debug Telemetry
 
 Use debug telemetry when normal telemetry does not explain local behavior yet.

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/SKILL.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/SKILL.md
@@ -92,13 +92,11 @@ Do not make high-volume runtime traces or debug logs print to stdout/stderr just
 
 ## Server Function Convention
 
-Framework server functions (TanStack Start server functions, Next.js server actions, and similar) are not RPCs: do not describe them with the `rpc.*` conventions. Instrument each invocation as one span:
+Instrument each framework server function invocation (TanStack Start server functions, Next.js server actions, and similar) as one span:
 
 - Span name: `serverFn {name}`, falling back to `serverFn` when the framework provides no name.
 - `everr.server_function.name`: the framework's own identifier for the function, verbatim (for example `getActiveOrganization`). Do not rename, prefix, or namespace it.
 - `everr.server_function.transport`: `http` when the invocation arrived as its own request, `in-process` otherwise.
-
-Reserve `rpc.*` for actual RPC systems (gRPC, JSON-RPC, and similar). Span kind and framework-specific wiring live in the runtime rules (`spans`, `tanstack-start`, `nextjs`).
 
 ## Debug Telemetry
 

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/spans.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/spans.md
@@ -97,7 +97,7 @@ await tracer.startActiveSpan('process daily orders', async (span) => {
 - `CLIENT` and `PRODUCER` spans should have a parent that explains why the outbound work happened.
 - Every child span should have a parent span in the same trace.
 - Keep `INTERNAL` spans sparse; avoid tracing tight loops.
-- A span that carries RPC attributes but nests inside a `SERVER` span that already covers the same request stays `INTERNAL`. The conventions ask an RPC server span to be `SERVER`, but promoting a nested one makes a single inbound request count twice on every panel that splits traffic by span kind.
+- Reserve `rpc.*` and the `SERVER` kind it demands for actual RPC systems (gRPC, JSON-RPC, and friends). A framework server-function invocation is not an RPC: describe it with `everr.server_function.*` and keep it `INTERNAL`, nested under the transport's `SERVER` span when it arrives over HTTP. Promoting it would make one inbound request count twice on every panel that splits traffic by span kind.
 - Replace per-item spans with one batch span plus `batch.size`.
 - Use logs for lightweight annotations.
 - Keep application SDK sampling at the default unless the project has an explicit collector-side sampling plan. Application-side head sampling drops evidence before outcome is known.

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/tanstack-start.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/tanstack-start.md
@@ -106,7 +106,7 @@ export const startInstance = createStart(() => ({
 
 The middleware (`createMiddleware({ type: "function" })`) starts an INTERNAL span per invocation, named `serverFn {name}` from `serverFnMeta`. It nests under the request's SERVER span automatically because the fetch wrapper's context is active.
 
-A server function call is not an RPC, so it does not use the `rpc.*` conventions. Describe it with the server-function convention from the skill root: `everr.server_function.name` carries the function's own identifier verbatim, and `everr.server_function.transport` is `http` when the call arrived over `/_serverFn/` and `in-process` when it ran during SSR. The span stays INTERNAL: over HTTP the transport's SERVER span already counts the inbound request, and in-process there is no inbound request at all.
+Describe it with the server-function convention from the skill root: `everr.server_function.name` carries the function's own identifier verbatim, and `everr.server_function.transport` is `http` when the call arrived over `/_serverFn/` and `in-process` when it ran during SSR. The span stays INTERNAL: over HTTP the transport's SERVER span already counts the inbound request, and in-process there is no inbound request at all.
 
 The transport span for a server function request only knows the opaque `/_serverFn/<id>` path, so the middleware reports the function name back to the fetch wrapper (an app-owned AsyncLocalStorage holder around the handler). After the response settles, the wrapper renames its SERVER span and the `x-everr-route` echo to `/_serverFn/{name}`, falling back to `/_serverFn/:id` when the middleware never ran. The browser's client span picks the name up from the echo, so all three spans of one call read as the same function.
 

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/tanstack-start.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/tanstack-start.md
@@ -108,8 +108,10 @@ The middleware (`createMiddleware({ type: "function" })`) starts an INTERNAL spa
 
 A server function call is not an RPC, so it does not use the `rpc.*` conventions. Describe it with the server-function convention from the skill root: `everr.server_function.name` carries the function's own identifier verbatim, and `everr.server_function.transport` is `http` when the call arrived over `/_serverFn/` and `in-process` when it ran during SSR. The span stays INTERNAL: over HTTP the transport's SERVER span already counts the inbound request, and in-process there is no inbound request at all.
 
+The transport span for a server function request only knows the opaque `/_serverFn/<id>` path, so the middleware reports the function name back to the fetch wrapper (an app-owned AsyncLocalStorage holder around the handler). After the response settles, the wrapper renames its SERVER span and the `x-everr-route` echo to `/_serverFn/{name}`, falling back to `/_serverFn/:id` when the middleware never ran. The browser's client span picks the name up from the echo, so all three spans of one call read as the same function.
+
 TanStack Start signals control flow with throwables: `redirect()` and `notFound()` surface as thrown values inside server functions. Filter those out before calling `captureError`, or every redirect becomes a phantom error.
 
 ## Validation
 
-Run the seam validation from `vite-ssr.md`. Additionally trigger one server function from the browser and verify its `serverFn {name}` INTERNAL span shares a `TraceId` with the browser request and the transport's SERVER span, and carries `everr.server_function.transport: http`.
+Run the seam validation from `vite-ssr.md`. Additionally trigger one server function from the browser and verify its `serverFn {name}` INTERNAL span shares a `TraceId` with the browser request and the transport's `POST /_serverFn/{name}` SERVER span, and carries `everr.server_function.transport: http`.

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/tanstack-start.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/tanstack-start.md
@@ -104,12 +104,12 @@ export const startInstance = createStart(() => ({
 }));
 ```
 
-The middleware (`createMiddleware({ type: "function" })`) starts an INTERNAL span per invocation with the function id, name, and filename from `serverFnMeta` as attributes (prefix non-semconv attributes with `everr.`). It nests under the request's SERVER span automatically because the fetch wrapper's context is active.
+The middleware (`createMiddleware({ type: "function" })`) starts an INTERNAL span per invocation, named `serverFn {name}` from `serverFnMeta`. It nests under the request's SERVER span automatically because the fetch wrapper's context is active.
 
-A server function call is an RPC, so describe it with the RPC conventions in `spans.md`: `rpc.system.name` for the framework and a fully-qualified `rpc.method`. Keep the span INTERNAL even though the conventions ask an RPC server span to be SERVER, because the request already has one and a second would double every inbound count.
+A server function call is not an RPC, so it does not use the `rpc.*` conventions. Describe it with the server-function convention from the skill root: `everr.server_function.name` carries the function's own identifier verbatim, and `everr.server_function.transport` is `http` when the call arrived over `/_serverFn/` and `in-process` when it ran during SSR. The span stays INTERNAL: over HTTP the transport's SERVER span already counts the inbound request, and in-process there is no inbound request at all.
 
 TanStack Start signals control flow with throwables: `redirect()` and `notFound()` surface as thrown values inside server functions. Filter those out before calling `captureError`, or every redirect becomes a phantom error.
 
 ## Validation
 
-Run the seam validation from `vite-ssr.md`. Additionally trigger one server function from the browser and verify its INTERNAL span shares a `TraceId` with the browser request and the SERVER span.
+Run the seam validation from `vite-ssr.md`. Additionally trigger one server function from the browser and verify its `serverFn {name}` INTERNAL span shares a `TraceId` with the browser request and the transport's SERVER span, and carries `everr.server_function.transport: http`.

--- a/packages/app/src/telemetry/server-fn-name.ts
+++ b/packages/app/src/telemetry/server-fn-name.ts
@@ -1,0 +1,29 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/**
+ * Bridges the server-function middleware back to the transport wrapper: the
+ * wrapper only sees the opaque `/_serverFn/<id>` path, while the middleware
+ * holds the function's name. The wrapper runs the handler inside a mutable
+ * holder, the middleware fills it, and the wrapper reads it after the
+ * response to rename its span and the `x-everr-route` echo to
+ * `/_serverFn/{name}`.
+ *
+ * App-owned AsyncLocalStorage rather than the OTel context: the OTel context
+ * manager is only registered once the NodeSDK boots, and this bridge must not
+ * depend on that ordering.
+ */
+export type ServerFunctionName = { name?: string };
+
+const storage = new AsyncLocalStorage<ServerFunctionName>();
+
+export function runWithServerFunctionName<T>(
+  holder: ServerFunctionName,
+  run: () => T,
+): T {
+  return storage.run(holder, run);
+}
+
+export function recordServerFunctionName(name: string): void {
+  const holder = storage.getStore();
+  if (holder) holder.name = name;
+}

--- a/packages/app/src/telemetry/server-fn-runtime.ts
+++ b/packages/app/src/telemetry/server-fn-runtime.ts
@@ -1,7 +1,6 @@
 import type { Attributes } from "@opentelemetry/api";
 import { isExpectedServerFunctionError } from "./expected-errors";
 import { captureError, getTelemetryTracer, SpanKind } from "./node";
-import { serverRouteTemplate } from "./server-router";
 
 const tracer = getTelemetryTracer("everr-app.server_fn");
 
@@ -19,7 +18,7 @@ export async function instrumentServerFunction<T>(
   const attributes = serverFunctionAttributes(request, serverFnMeta);
 
   return tracer.startActiveSpan(
-    "tanstack.server_fn",
+    serverFnMeta ? `serverFn ${serverFnMeta.name}` : "serverFn",
     {
       attributes,
       kind: SpanKind.INTERNAL,
@@ -43,33 +42,21 @@ export async function instrumentServerFunction<T>(
 }
 
 /**
- * The RPC semantic conventions, in their current spelling. `rpc.system`,
- * `rpc.service` and `rpc.grpc.status_code` are all deprecated: the system
- * became `rpc.system.name`, and `rpc.service` was absorbed into `rpc.method`,
- * which now carries the fully-qualified `{service}/{method}` name.
- * https://opentelemetry.io/docs/specs/semconv/non-normative/rpc-migration/
- *
- * The span stays INTERNAL rather than SERVER, which the conventions would ask
- * of an RPC server span. Every one of these nests inside the framework's own
- * `POST /_serverFn/:id` SERVER span, so promoting it would make one inbound
- * request count as two on every panel that splits traffic by span kind.
+ * A server function invocation is not an RPC, so it does not borrow the
+ * `rpc.*` conventions: it describes itself under `everr.server_function.*`.
+ * The span stays INTERNAL — over HTTP it nests inside the framework's
+ * `POST /_serverFn/:id` SERVER span, which already counts the inbound
+ * request, and in-process it is a plain function call with no request of
+ * its own. `transport` records that split explicitly.
  */
-const RPC_SERVICE = "server_function";
-
 function serverFunctionAttributes(
   request: Request | undefined,
   serverFnMeta: ServerFunctionMeta | undefined,
 ): Attributes {
   return {
     ...(serverFnMeta
-      ? { "rpc.method": `${RPC_SERVICE}/${serverFnMeta.name}` }
+      ? { "everr.server_function.name": serverFnMeta.name }
       : {}),
-    "rpc.system.name": "tanstack-start",
-    ...(request ? { "url.path": parameterizeServerFunctionPath(request) } : {}),
+    "everr.server_function.transport": request ? "http" : "in-process",
   };
-}
-
-function parameterizeServerFunctionPath(request: Request) {
-  const pathname = new URL(request.url).pathname;
-  return serverRouteTemplate(pathname) ?? pathname;
 }

--- a/packages/app/src/telemetry/server-fn-runtime.ts
+++ b/packages/app/src/telemetry/server-fn-runtime.ts
@@ -1,6 +1,7 @@
 import type { Attributes } from "@opentelemetry/api";
 import { isExpectedServerFunctionError } from "./expected-errors";
 import { captureError, getTelemetryTracer, SpanKind } from "./node";
+import { recordServerFunctionName } from "./server-fn-name";
 
 const tracer = getTelemetryTracer("everr-app.server_fn");
 
@@ -15,6 +16,11 @@ export async function instrumentServerFunction<T>(
   serverFnMeta: ServerFunctionMeta | undefined,
   run: () => T | Promise<T>,
 ) {
+  // Report the name to the transport wrapper, which only sees the opaque
+  // /_serverFn/<id> path: it renames its SERVER span and the x-everr-route
+  // echo to `/_serverFn/{name}` once the response settles.
+  if (serverFnMeta) recordServerFunctionName(serverFnMeta.name);
+
   const attributes = serverFunctionAttributes(request, serverFnMeta);
 
   return tracer.startActiveSpan(

--- a/packages/app/src/telemetry/server-fn.test.ts
+++ b/packages/app/src/telemetry/server-fn.test.ts
@@ -30,19 +30,6 @@ vi.mock("./node", () => ({
   SpanKind: { INTERNAL: 0 },
 }));
 
-// The real matcher pulls the whole generated route tree (and the server env
-// with it) into the test environment; server function paths only exercise the
-// /_serverFn prefix rule, which needs no tree.
-vi.mock("./server-router", async () => {
-  const { routeTemplate } = await import("./route-template");
-  const matcher = {
-    matchRoutes: () => [{ routeId: "__root__", fullPath: "/" }],
-  };
-  return {
-    serverRouteTemplate: (pathname: string) => routeTemplate(matcher, pathname),
-  };
-});
-
 import { instrumentServerFunction } from "./server-fn-runtime";
 
 describe("instrumentServerFunction", () => {
@@ -72,17 +59,15 @@ describe("instrumentServerFunction", () => {
 
     expect(telemetryMocks.captureError).toHaveBeenCalledWith(error, {
       "everr.error.source": "server_fn",
-      "rpc.method": "server_function/getActiveOrganization",
-      "rpc.system.name": "tanstack-start",
-      "url.path": "/_serverFn/:id",
+      "everr.server_function.name": "getActiveOrganization",
+      "everr.server_function.transport": "http",
     });
     expect(telemetryMocks.startActiveSpan).toHaveBeenCalledWith(
-      "tanstack.server_fn",
+      "serverFn getActiveOrganization",
       {
         attributes: {
-          "rpc.method": "server_function/getActiveOrganization",
-          "rpc.system.name": "tanstack-start",
-          "url.path": "/_serverFn/:id",
+          "everr.server_function.name": "getActiveOrganization",
+          "everr.server_function.transport": "http",
         },
         kind: 0,
       },
@@ -114,7 +99,7 @@ describe("instrumentServerFunction", () => {
     expect(telemetryMocks.span.end).toHaveBeenCalledOnce();
   });
 
-  it("parameterizes TanStack dev serverFn IDs in serverFn span attributes", async () => {
+  it("names the span after the function", async () => {
     await instrumentServerFunction(
       new Request(
         "http://localhost/_serverFn/eyJmaWxlIjoiL3NyYy9yb3V0ZXMvX19yb290LnRzeD90c3Mtc2VydmVyZm4tc3BsaXQiLCJleHBvcnQiOiJnZXRTZXNzaW9uX2NyZWF0ZVNlcnZlckZuX2hhbmRsZXIifQ",
@@ -128,12 +113,11 @@ describe("instrumentServerFunction", () => {
     );
 
     expect(telemetryMocks.startActiveSpan).toHaveBeenCalledWith(
-      "tanstack.server_fn",
+      "serverFn getSession",
       {
         attributes: {
-          "rpc.method": "server_function/getSession",
-          "rpc.system.name": "tanstack-start",
-          "url.path": "/_serverFn/:id",
+          "everr.server_function.name": "getSession",
+          "everr.server_function.transport": "http",
         },
         kind: 0,
       },

--- a/packages/app/src/telemetry/server.test.ts
+++ b/packages/app/src/telemetry/server.test.ts
@@ -4,6 +4,7 @@ const telemetryMocks = vi.hoisted(() => {
   const span = {
     end: vi.fn(),
     setAttribute: vi.fn(),
+    updateName: vi.fn(),
   };
 
   return {
@@ -51,6 +52,7 @@ vi.mock("./server-router", async () => {
 });
 
 import { instrumentServerFetch } from "./server";
+import { recordServerFunctionName } from "./server-fn-name";
 
 describe("instrumentServerFetch", () => {
   beforeEach(() => {
@@ -58,6 +60,7 @@ describe("instrumentServerFetch", () => {
     telemetryMocks.startActiveSpan.mockClear();
     telemetryMocks.span.end.mockClear();
     telemetryMocks.span.setAttribute.mockClear();
+    telemetryMocks.span.updateName.mockClear();
   });
 
   it("records 5xx responses as server response errors", async () => {
@@ -126,5 +129,38 @@ describe("instrumentServerFetch", () => {
       expect.anything(),
       expect.any(Function),
     );
+  });
+
+  it("renames the span and the route echo after the middleware reports the function name", async () => {
+    const response = await instrumentServerFetch(
+      new Request("http://localhost/_serverFn/c4d3d0c28997f144965eeaca", {
+        method: "POST",
+      }),
+      () => {
+        // The middleware runs inside the wrapper's context and reports the
+        // name it read from serverFnMeta.
+        recordServerFunctionName("getSession");
+        return new Response("{}", { status: 200 });
+      },
+    );
+
+    expect(telemetryMocks.span.updateName).toHaveBeenCalledWith(
+      "POST /_serverFn/getSession",
+    );
+    expect(telemetryMocks.span.setAttribute).toHaveBeenCalledWith(
+      "http.route",
+      "/_serverFn/getSession",
+    );
+    expect(response.headers.get("x-everr-route")).toBe("/_serverFn/getSession");
+  });
+
+  it("keeps the /_serverFn/:id fallback when no name is reported", async () => {
+    const response = await instrumentServerFetch(
+      new Request("http://localhost/_serverFn/c4d3d0c28997f144965eeaca"),
+      () => new Response("{}", { status: 200 }),
+    );
+
+    expect(telemetryMocks.span.updateName).not.toHaveBeenCalled();
+    expect(response.headers.get("x-everr-route")).toBe("/_serverFn/:id");
   });
 });

--- a/packages/app/src/telemetry/server.ts
+++ b/packages/app/src/telemetry/server.ts
@@ -1,6 +1,10 @@
 import type { Attributes, TextMapGetter } from "@opentelemetry/api";
 import { context, propagation } from "@opentelemetry/api";
 import { captureError, getTelemetryTracer, SpanKind } from "./node";
+import {
+  runWithServerFunctionName,
+  type ServerFunctionName,
+} from "./server-fn-name";
 import { serverRouteTemplate } from "./server-router";
 
 const tracer = getTelemetryTracer();
@@ -19,6 +23,15 @@ export async function instrumentServerFetch(
   const route = serverRouteTemplate(pathname);
   const method = request.method.toUpperCase();
 
+  // For server function requests the path only carries the opaque id; the
+  // middleware knows the function's name and reports it into this holder, so
+  // the span and the route echo can say `/_serverFn/{name}` instead.
+  const serverFn: ServerFunctionName | undefined = pathname.startsWith(
+    "/_serverFn/",
+  )
+    ? {}
+    : undefined;
+
   // Continue a trace started by a first-party client (e.g. the CLI, which
   // injects `traceparent`) instead of starting a fresh root. Requests without
   // the header extract to an empty context, so this span roots itself as before.
@@ -36,15 +49,22 @@ export async function instrumentServerFetch(
     },
     parentContext,
     async (span) => {
+      // The middleware fills the holder mid-flight, so the route is only
+      // final after `run` settles (or throws past the middleware).
+      const resolvedRoute = () =>
+        serverFn?.name ? `/_serverFn/${serverFn.name}` : route;
       try {
-        const response = await run();
+        const response = await (serverFn
+          ? runWithServerFunctionName(serverFn, run)
+          : run());
 
+        const finalRoute = resolvedRoute();
         // Echo the derived route so the browser SDK can stamp url.template on
         // its client span: the client route tree has no server-only routes, so
         // this header is the browser's only exact source for API templates.
-        if (route !== undefined) {
+        if (finalRoute !== undefined) {
           try {
-            response.headers.set("x-everr-route", route);
+            response.headers.set("x-everr-route", finalRoute);
           } catch {
             // A response with immutable headers keeps them; the span is
             // unaffected.
@@ -57,21 +77,27 @@ export async function instrumentServerFetch(
             "everr.error.source": "server.response",
             "http.request.method": method,
             "http.response.status_code": response.status,
-            ...(route === undefined ? {} : { "http.route": route }),
+            ...(finalRoute === undefined ? {} : { "http.route": finalRoute }),
             "url.path": pathname,
           });
         }
 
         return response;
       } catch (error) {
+        const finalRoute = resolvedRoute();
         captureError(error, {
           "everr.error.source": "server.fetch",
           "http.request.method": method,
-          ...(route === undefined ? {} : { "http.route": route }),
+          ...(finalRoute === undefined ? {} : { "http.route": finalRoute }),
           "url.path": pathname,
         });
         throw error;
       } finally {
+        const finalRoute = resolvedRoute();
+        if (finalRoute !== undefined && finalRoute !== route) {
+          span.updateName(`${method} ${finalRoute}`);
+          span.setAttribute("http.route", finalRoute);
+        }
         span.end();
       }
     },


### PR DESCRIPTION
A server function invocation is not an RPC, so it stops borrowing the `rpc.*` conventions. Each invocation is now one INTERNAL span named `serverFn {name}` carrying:

- `everr.server_function.name`: the framework's own identifier for the function, verbatim.
- `everr.server_function.transport`: `http` when the call arrived as its own request over `/_serverFn/`, `in-process` when it ran during SSR.

The span stays INTERNAL: over HTTP the transport's SERVER span already counts the inbound request, and in-process there is no inbound request at all. `rpc.*` stays reserved for actual RPC systems.

The transport span also stops hiding behind the opaque id: the middleware reports the function name back to the fetch wrapper through an app-owned AsyncLocalStorage holder, and the wrapper renames its SERVER span and the `x-everr-route` echo to `/_serverFn/{name}` (falling back to `/_serverFn/:id` when the middleware never ran). The browser's client span picks the name up from the echo with no SDK change, so all three spans of one call read as the same function.

The setup skill gains a root-level server function convention guide, and the `spans` and `tanstack-start` rules are updated to match.

Split out of the built-in dashboards branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Improved server-function telemetry naming and transport classification.
  - HTTP traces now preserve server-function names across browser, transport, and server execution.
  - Server-function routes and error details remain accurate, including when execution fails.

- **Documentation**
  - Clarified the distinction between server functions and actual RPC systems.

- **Tests**
  - Expanded validation for trace continuity, span naming, route propagation, error handling, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->