### PR TITLE
fix(app): keep pivoted series in query order instead of sorting

### DIFF
--- a/packages/app/src/components/dashboards/visualizations/bar-chart/bar-chart-data.test.ts
+++ b/packages/app/src/components/dashboards/visualizations/bar-chart/bar-chart-data.test.ts
@@ -67,14 +67,15 @@ describe("buildBarChartModel", () => {
       ],
     ]);
     expect(model.valueKeys).toEqual(["s0", "s1"]);
-    // Pivoted series labels are sorted.
-    expect(model.chartConfig.s0?.label).toBe("error");
-    expect(model.chartConfig.s1?.label).toBe("ok");
+    // Pivoted series keep the order the rows arrived in, so a query's
+    // ORDER BY decides which series stacks at the bottom.
+    expect(model.chartConfig.s0?.label).toBe("ok");
+    expect(model.chartConfig.s1?.label).toBe("error");
     expect(model.chartData).toHaveLength(2);
-    expect(model.chartData[0]?.s0).toBe(2);
-    expect(model.chartData[0]?.s1).toBe(8);
+    expect(model.chartData[0]?.s0).toBe(8);
+    expect(model.chartData[0]?.s1).toBe(2);
     // "no bar here" stays absent, not 0.
-    expect(model.chartData[1]?.s0).toBeUndefined();
+    expect(model.chartData[1]?.s1).toBeUndefined();
   });
 
   it("pivots remaining string columns on a category axis", () => {

--- a/packages/app/src/components/dashboards/visualizations/data-utils.ts
+++ b/packages/app/src/components/dashboards/visualizations/data-utils.ts
@@ -175,7 +175,12 @@ export function pivotByGroup(
     entry[group] = value;
   }
 
-  const seriesKeys = [...seriesSet].sort();
+  // First-seen order, not alphabetical: a stacked chart stacks its series in
+  // this order, so the author's `ORDER BY` is the only way to say which band
+  // sits at the bottom (a phase breakdown reads bottom-up in time order).
+  // Every query that pivots already carries an ORDER BY, so this is as stable
+  // across refreshes as sorting was.
+  const seriesKeys = [...seriesSet];
   const pivoted = [...byAxis.values()];
   return { pivoted, seriesKeys };
 }

--- a/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-data.test.ts
+++ b/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-data.test.ts
@@ -105,7 +105,7 @@ describe("buildChartModel", () => {
       ],
       WIDE,
     );
-    // One opaque key per group value, in sorted group order (a, b).
+    // One opaque key per group value, in the order the rows arrived (a, b).
     expect(model.valueKeys).toEqual(["s0", "s1"]);
     expect(model.chartConfig.s0?.label).toBe("a");
     expect(model.chartConfig.s1?.label).toBe("b");
@@ -134,9 +134,9 @@ describe("buildChartModel", () => {
     // neither series overwrites the other.
     expect(model.valueKeys).toEqual(["s0", "s1"]);
     const labels = model.valueKeys.map((k) => model.chartConfig[k]?.label);
-    expect(labels).toEqual(["a b", "a-b"]); // sorted group order
-    expect(model.chartData[0]?.s0).toBe(2); // "a b"
-    expect(model.chartData[0]?.s1).toBe(1); // "a-b"
+    expect(labels).toEqual(["a-b", "a b"]); // first-seen group order
+    expect(model.chartData[0]?.s0).toBe(1); // "a-b"
+    expect(model.chartData[0]?.s1).toBe(2); // "a b"
   });
 
   it("keeps non-identifier column names as the label without mangling the key", () => {


### PR DESCRIPTION
Pivoted series used to be sorted alphabetically, which broke stacking order: the author's `ORDER BY` is the only way to say which band sits at the bottom of a stacked chart. Series now keep first-seen (query) order, which is just as stable across refreshes since every pivoting query already carries an ORDER BY.

Split out of the built-in dashboards branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the original order of grouped and pivoted chart series based on when they first appear in the data.
  * Improved handling of similarly named series so their values remain associated with the correct series.
  * Ensured missing series values continue to display correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->