### PR TITLE
fix(otel-web): escape naming attribute values in element selectors

### DIFF
--- a/packages/otel-web/src/instrumentations/element.test.ts
+++ b/packages/otel-web/src/instrumentations/element.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { selectorOf } from "./element.js";
+
+describe("selectorOf", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("escapes a backslash in a naming attribute", () => {
+    const label = "path\\to\\thing";
+    document.body.innerHTML = `<div><button aria-label="${label}"></button><button></button></div>`;
+    const el = document.querySelector("button") as Element;
+
+    const sel = selectorOf(el);
+
+    expect(sel).toBe(`button[aria-label="${CSS.escape(label)}"]`);
+    expect(document.querySelectorAll(sel)).toHaveLength(1);
+    expect(document.querySelector(sel)).toBe(el);
+  });
+
+  it("escapes a line break in a naming attribute", () => {
+    const label = "first\nsecond";
+    const button = document.createElement("button");
+    button.setAttribute("aria-label", label);
+    document.body.append(button, document.createElement("button"));
+
+    const sel = selectorOf(button);
+
+    expect(sel).toBe(`button[aria-label="${CSS.escape(label)}"]`);
+    expect(document.querySelectorAll(sel)).toHaveLength(1);
+    expect(document.querySelector(sel)).toBe(button);
+  });
+
+  it("keeps a plain naming attribute readable", () => {
+    document.body.innerHTML =
+      '<div><button aria-label="Close"></button><button></button></div>';
+    expect(selectorOf(document.querySelector("button") as Element)).toBe(
+      'button[aria-label="Close"]',
+    );
+  });
+});

--- a/packages/otel-web/src/instrumentations/element.ts
+++ b/packages/otel-web/src/instrumentations/element.ts
@@ -79,7 +79,7 @@ export function selectorOf(el: Element): string {
       for (const name of NAME_ATTRS) {
         const value = node.getAttribute(name);
         if (value) {
-          part += `[${name}="${value.replace(/"/g, '\\"')}"]`;
+          part += `[${name}="${CSS.escape(value)}"]`;
           break;
         }
       }

--- a/packages/otel-web/src/test-setup.ts
+++ b/packages/otel-web/src/test-setup.ts
@@ -1,0 +1,45 @@
+// jsdom declares no CSS namespace, so the tests get the escape function of the
+// CSSOM specification. It is the same algorithm as the browsers use:
+// https://drafts.csswg.org/cssom/#the-css.escape()-method
+// The control characters and the lone NULL become hexadecimal escapes, which a
+// selector can carry where the raw character cannot.
+function cssEscape(value: string): string {
+  const str = String(value);
+  let out = "";
+  for (let i = 0; i < str.length; i++) {
+    const code = str.charCodeAt(i);
+    if (code === 0) {
+      out += "�";
+    } else if (
+      (code >= 0x1 && code <= 0x1f) ||
+      code === 0x7f ||
+      (i === 0 && code >= 0x30 && code <= 0x39) ||
+      (i === 1 && code >= 0x30 && code <= 0x39 && str.charCodeAt(0) === 0x2d)
+    ) {
+      out += `\\${code.toString(16)} `;
+    } else if (i === 0 && code === 0x2d && str.length === 1) {
+      out += `\\${str[i]}`;
+    } else if (
+      code >= 0x80 ||
+      code === 0x2d ||
+      code === 0x5f ||
+      (code >= 0x30 && code <= 0x39) ||
+      (code >= 0x41 && code <= 0x5a) ||
+      (code >= 0x61 && code <= 0x7a)
+    ) {
+      out += str[i];
+    } else {
+      out += `\\${str[i]}`;
+    }
+  }
+  return out;
+}
+
+if (typeof globalThis.CSS === "undefined") {
+  Object.defineProperty(globalThis, "CSS", {
+    value: { escape: cssEscape },
+    writable: true,
+  });
+} else if (typeof globalThis.CSS.escape !== "function") {
+  globalThis.CSS.escape = cssEscape;
+}

--- a/packages/otel-web/vitest.config.ts
+++ b/packages/otel-web/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
   test: {
     reporters: ["verbose"],
     environment: "jsdom",
+    setupFiles: ["./src/test-setup.ts"],
     coverage: {
       provider: "v8",
       include: ["src/**"],


### PR DESCRIPTION
A raw backslash or line break in a naming attribute made the built selector invalid, so `document.querySelectorAll(sel)` could throw or fail to match. Attribute values now go through the native `CSS.escape`, which costs nothing in the bundle.

- `element.ts`: replace the quote-only `replace` with `CSS.escape(value)`.
- `element.test.ts`: regression coverage for a backslash value and a line-break value. Each asserts the emitted selector and that it resolves back to exactly that one element. Both fail against the old escaping.
- `test-setup.ts`: jsdom ships no `CSS` namespace, so the tests get the CSSOM escape algorithm as a vitest setup file. It encodes the control characters as CSS hexadecimal escapes.

Full suite: 352 tests pass. `pnpm size` unchanged, all limits green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of special characters in accessibility label selectors, including backslashes, line breaks, and other CSS-sensitive values.
  - Enhanced selector reliability for elements with unusual attribute content.

- **Tests**
  - Added coverage for selector generation and matching across standard and edge-case accessibility labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->