### PR TITLE
fix(app): register CSRF middleware for server functions

### DIFF
--- a/packages/app/src/start.test.ts
+++ b/packages/app/src/start.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, it, vi } from "vitest";
 
+type CsrfOptions = {
+  filter: (ctx: { handlerType: string }) => boolean;
+};
+
 const startMocks = vi.hoisted(() => ({
   createStart: vi.fn((factory: () => unknown) => factory()),
+  createCsrfMiddleware: vi.fn((_options: CsrfOptions) => ({ name: "csrf" })),
   serverFnTelemetryMiddleware: { name: "server-fn-telemetry" },
 }));
 
 vi.mock("@tanstack/react-start", () => ({
   createStart: startMocks.createStart,
+  createCsrfMiddleware: startMocks.createCsrfMiddleware,
 }));
 
 vi.mock("@/telemetry/server-fn", () => ({
@@ -14,11 +20,21 @@ vi.mock("@/telemetry/server-fn", () => ({
 }));
 
 describe("startInstance", () => {
-  it("registers telemetry server function middleware", async () => {
+  it("registers CSRF and telemetry middleware", async () => {
     const { startInstance } = await import("./start");
 
     expect(startInstance).toEqual({
+      requestMiddleware: [{ name: "csrf" }],
       functionMiddleware: [startMocks.serverFnTelemetryMiddleware],
     });
+  });
+
+  it("scopes CSRF protection to server functions", async () => {
+    await import("./start");
+
+    const { filter } = startMocks.createCsrfMiddleware.mock.calls[0][0];
+
+    expect(filter({ handlerType: "serverFn" })).toBe(true);
+    expect(filter({ handlerType: "request" })).toBe(false);
   });
 });

--- a/packages/app/src/start.ts
+++ b/packages/app/src/start.ts
@@ -1,6 +1,14 @@
-import { createStart } from "@tanstack/react-start";
+import { createCsrfMiddleware, createStart } from "@tanstack/react-start";
 import { serverFnTelemetryMiddleware } from "@/telemetry/server-fn";
 
+// Start only auto-installs CSRF protection when there is no custom start.ts.
+// Since we have one, register it ourselves. Scoped to server functions so the
+// API routes (CLI apply, MCP, webhooks) keep accepting cross-origin callers.
+const csrfMiddleware = createCsrfMiddleware({
+  filter: (ctx) => ctx.handlerType === "serverFn",
+});
+
 export const startInstance = createStart(() => ({
+  requestMiddleware: [csrfMiddleware],
   functionMiddleware: [serverFnTelemetryMiddleware],
 }));


### PR DESCRIPTION
TanStack Start only auto-installs its CSRF middleware when there is no custom `src/start.ts`. We have one, so server functions ran unprotected and dev printed a warning on every server function request. See https://tanstack.com/start/latest/docs/framework/react/guide/middleware#csrf-middleware

The middleware is scoped to `handlerType === "serverFn"` on purpose: the non-browser API routes (CLI `/api/apply`, MCP, GitHub webhooks) authenticate with their own credentials and must keep accepting cross-origin callers.

## Verification

Dev server on a spare port:

- server fn with `Sec-Fetch-Site: cross-site` -> `403 Forbidden`
- server fn same-origin -> passes CSRF, reaches auth middleware (500 unauthenticated, expected without a session)
- `POST /api/apply` cross-site -> `401 Missing credential`, unchanged
- no CSRF warning in the dev log
- `tsc --noEmit` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request security for server functions by adding CSRF protection.
  * Preserved cross-origin access for API routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->