### PR TITLE
refactor(app): align the Runs layout with Logs and Traces

### DIFF
--- a/packages/telemetry-explorer/src/runs/ui/runs-explorer.tsx
+++ b/packages/telemetry-explorer/src/runs/ui/runs-explorer.tsx
@@ -4,13 +4,9 @@ import {
   useInfiniteQuery,
   useQuery,
 } from "@tanstack/react-query";
-import { FolderGit2 } from "lucide-react";
 import { useMemo } from "react";
-import { ExploreFilterPill } from "../../filters/ui/explore-filter-pill";
-import { FilterSearchBar } from "../../filters/ui/filter-search-bar";
 import {
   runsExplorerInfiniteOptions,
-  runsFilterOptions,
   runsHistogramOptions,
 } from "../data/options";
 import type { RunsRepositoryLike } from "../data/repository";
@@ -134,40 +130,18 @@ export function RunsExplorer({
   return (
     <div className="min-h-0 flex-1 overflow-hidden">
       <section className="bg-background text-foreground flex h-full min-h-0 flex-col overflow-hidden">
-        {/* Repository sits in the topbar — same slot (and h-11 height) as the
-            Service/Environment filter bar on the logs/traces/errors explorers —
-            rather than the sidebar. */}
-        <div className="flex h-11 shrink-0 items-center gap-1.5 border-b bg-muted/10 px-3">
-          <ExploreFilterPill
-            label="Repository"
-            icon={FolderGit2}
-            values={repos}
-            onChange={(next) => onSearchChange({ repos: next })}
-            options={{
-              ...runsFilterOptions(repo, { timeRange }),
-              select: (data) => data.repos,
-            }}
-            placeholder="All repositories"
-            searchPlaceholder="Search repositories..."
-            countNoun="repositories"
-          />
-        </div>
-
-        <div className="border-b bg-muted/10 px-3 py-2">
-          <FilterSearchBar
-            id="runs-search"
-            label="Search runs by ID"
-            value={runId ?? ""}
-            onChange={(value) => onSearchChange({ runId: value || undefined })}
-            placeholder="Search by run ID"
-          />
-        </div>
-
         <div className="grid min-h-0 flex-1 grid-cols-1 grid-rows-[auto_minmax(0,1fr)] lg:grid-cols-[260px_minmax(0,1fr)] lg:grid-rows-[minmax(0,1fr)]">
           <RunsFilters
             repo={repo}
             timeRange={timeRange}
-            value={{ branches, conclusions, workflowNames, onlyMine }}
+            value={{
+              runId,
+              repos,
+              branches,
+              conclusions,
+              workflowNames,
+              onlyMine,
+            }}
             showMineFilter={showMineFilter}
             onChange={onSearchChange}
           />

--- a/packages/telemetry-explorer/src/runs/ui/runs-filters.tsx
+++ b/packages/telemetry-explorer/src/runs/ui/runs-filters.tsx
@@ -1,10 +1,12 @@
 import { FilterCombobox } from "@everr/ui/components/filter-combobox";
+import { Label } from "@everr/ui/components/label";
 import { Separator } from "@everr/ui/components/separator";
 import { Switch } from "@everr/ui/components/switch";
 import type { TimeRange } from "@everr/ui/lib/time-range";
 import { cn } from "@everr/ui/lib/utils";
 import { User } from "lucide-react";
-import { FilterSidebar } from "../../filters/ui/filter-sidebar";
+import { ExploreFilterRail } from "../../filters/ui/explore-filter-rail";
+import { FilterSearchBar } from "../../filters/ui/filter-search-bar";
 import { runsFilterOptions } from "../data/options";
 import type { RunsRepositoryLike } from "../data/repository";
 import { RUN_STATUS_FILTERS, type RunStatusFilter } from "../schemas";
@@ -12,6 +14,8 @@ import { ConclusionIcon } from "./conclusion-icon";
 import { RUN_CONCLUSION_META } from "./run-conclusion-meta";
 
 export interface RunsFiltersValue {
+  runId: string | undefined;
+  repos: string[];
   branches: string[];
   conclusions: RunStatusFilter[];
   workflowNames: string[];
@@ -34,7 +38,8 @@ export function RunsFilters({
   showMineFilter = false,
   onChange,
 }: RunsFiltersProps) {
-  const { branches, conclusions, workflowNames, onlyMine } = value;
+  const { runId, repos, branches, conclusions, workflowNames, onlyMine } =
+    value;
 
   const toggleStatus = (status: RunStatusFilter) => {
     onChange({
@@ -46,17 +51,31 @@ export function RunsFilters({
 
   const baseOptions = runsFilterOptions(repo, { timeRange });
 
-  // "Your runs" is owned by its dedicated switch, so it doesn't count toward
-  // hasActiveFilters nor get reset by "Clear all".
-  const hasActiveFilters =
-    branches.length > 0 || conclusions.length > 0 || workflowNames.length > 0;
+  // The count for the "Filters" button that replaces the rail in a narrow
+  // window. Each control counts one time, whatever number of values it holds,
+  // so the badge means the same thing here as on Logs and Traces.
+  //
+  // "Your runs" is owned by its dedicated switch, so it counts toward neither
+  // this badge nor "Clear page filters".
+  const pageFilterCount =
+    (runId !== undefined ? 1 : 0) +
+    (repos.length > 0 ? 1 : 0) +
+    (conclusions.length > 0 ? 1 : 0) +
+    (branches.length > 0 ? 1 : 0) +
+    (workflowNames.length > 0 ? 1 : 0);
 
   return (
-    <FilterSidebar
+    <ExploreFilterRail
       label="Run filters"
-      hasActiveFilters={hasActiveFilters}
+      // Runs has no top zone: `repos` is a Runs search param, not one of the
+      // filters that stay set across the Explore pages, so it belongs to the
+      // page zone and "Clear page filters" resets it with the rest.
+      persistentFilterCount={0}
+      pageFilterCount={pageFilterCount}
       onClear={() =>
         onChange({
+          runId: undefined,
+          repos: [],
           branches: [],
           conclusions: [],
           workflowNames: [],
@@ -80,28 +99,48 @@ export function RunsFilters({
         </>
       ) : null}
 
-      <div className="space-y-1">
-        {RUN_STATUS_FILTERS.map((status) => (
-          <button
-            key={status}
-            type="button"
-            aria-pressed={conclusions.includes(status)}
-            className={cn(
-              "flex h-8 w-full items-center gap-2 rounded-md px-2 text-left text-xs transition-colors hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30",
-              conclusions.includes(status) &&
-                "bg-background font-medium shadow-xs ring-1 ring-border",
-            )}
-            onClick={() => toggleStatus(status)}
-          >
-            <ConclusionIcon conclusion={status} className="size-3.5" />
-            <span className="truncate">
-              {RUN_CONCLUSION_META[status].label}
-            </span>
-          </button>
-        ))}
-      </div>
+      <FilterSearchBar
+        id="runs-search"
+        label="Search"
+        showLabel
+        value={runId ?? ""}
+        onChange={(next) => onChange({ runId: next || undefined })}
+        placeholder="Search by run ID"
+      />
 
-      <Separator />
+      <FilterCombobox
+        label="Repository"
+        values={repos}
+        onChange={(next) => onChange({ repos: next })}
+        options={{ ...baseOptions, select: (data) => data.repos }}
+        placeholder="All repositories"
+        searchPlaceholder="Search repositories..."
+        className="w-full"
+      />
+
+      <div className="flex flex-col gap-1">
+        <Label className="text-muted-foreground text-xs">Status</Label>
+        <div className="space-y-1">
+          {RUN_STATUS_FILTERS.map((status) => (
+            <button
+              key={status}
+              type="button"
+              aria-pressed={conclusions.includes(status)}
+              className={cn(
+                "flex h-8 w-full items-center gap-2 rounded-md px-2 text-left text-xs transition-colors hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30",
+                conclusions.includes(status) &&
+                  "bg-background font-medium shadow-xs ring-1 ring-border",
+              )}
+              onClick={() => toggleStatus(status)}
+            >
+              <ConclusionIcon conclusion={status} className="size-3.5" />
+              <span className="truncate">
+                {RUN_CONCLUSION_META[status].label}
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
 
       <FilterCombobox
         label="Branch"
@@ -122,6 +161,6 @@ export function RunsFilters({
         searchPlaceholder="Search workflows..."
         className="w-full"
       />
-    </FilterSidebar>
+    </ExploreFilterRail>
   );
 }


### PR DESCRIPTION
Runs kept its filters in two stacked bars above the results: a topbar for Repository and a full-width bar for the run ID search. Logs and Traces put both in the filter rail, so Runs read as a different kind of page and lost the vertical space of two bars.

## What changed

- The rail now holds **Search, Repository, Status, Branch, Workflow**, in the order the other explorers use, and the page starts at the histogram like they do.
- Runs used `FilterSidebar` directly, so it had no narrow-window behaviour. It now uses `ExploreFilterRail`, which gives it the "Filters" button and sheet below 1024px, plus the count badge.
- The status group gained a "Status" label, matching "Severity" on Logs.

Repository stays in the page zone rather than the rail's top zone: it is a Runs search param, not one of the filters that stay set between the Explore pages, so "Clear page filters" resets it with the rest.

## Verified

Manually, against the dev app:

- Desktop (1440px): rail order and spacing match /logs.
- Narrow (900px): "Filters" button opens the sheet with all five controls.
- Badge counts one per control (status only → 1; repo + run ID → 2).
- "Clear page filters" resets repository and the run ID search along with status, branch and workflow.

`tsc --noEmit` clean in `telemetry-explorer` and `app`. The desktop app's CI page consumes `RunsExplorer`, whose props are unchanged, so it picks up the same rail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added run ID search and repository filtering to the runs explorer filter panel.
  * Grouped status controls into a clearly labeled section.
  * Updated filter clearing to reset run ID, repositories, and other page filters together.

* **UI Improvements**
  * Consolidated filtering into the explorer’s filter rail for a more consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->