### PR TITLE
refactor(telemetry-explorer): errors service badge uses shared serviceColor

### DIFF
--- a/packages/telemetry-explorer/src/errors/ui/error-service-badge.tsx
+++ b/packages/telemetry-explorer/src/errors/ui/error-service-badge.tsx
@@ -1,25 +1,5 @@
 import { Badge } from "@everr/ui/components/badge";
-import { cn } from "@everr/ui/lib/utils";
-
-const serviceDotClassNames = [
-  "bg-chart-1",
-  "bg-chart-2",
-  "bg-chart-3",
-  "bg-chart-4",
-  "bg-chart-5",
-] as const;
-
-function serviceDotClassName(serviceName: string): string {
-  let hash = 0;
-
-  for (const char of serviceName) {
-    hash = (hash * 31 + char.charCodeAt(0)) >>> 0;
-  }
-
-  return (
-    serviceDotClassNames[hash % serviceDotClassNames.length] ?? "bg-chart-1"
-  );
-}
+import { serviceColor } from "../../traces/ui/shared/service-color";
 
 export function ErrorServiceBadge({ serviceName }: { serviceName: string }) {
   const label = serviceName || "unknown-service";
@@ -28,10 +8,8 @@ export function ErrorServiceBadge({ serviceName }: { serviceName: string }) {
     <Badge variant="outline" className="max-w-52 justify-start" title={label}>
       <span
         aria-hidden="true"
-        className={cn(
-          "size-2 shrink-0 rounded-full",
-          serviceDotClassName(label),
-        )}
+        className="size-2 shrink-0 rounded-full"
+        style={{ backgroundColor: serviceColor(label) }}
       />
       <span className="truncate">{label}</span>
     </Badge>


### PR DESCRIPTION
The errors service badge had its own hash-and-`bg-chart-*` color calculator, so a service could show one color in the errors list and a different one in traces or on home.

It now uses the shared `serviceColor()` helper (FNV-1a over the eight `--trace-service-*` vars) that traces and home already use, so the dot color is consistent everywhere.

Tests: `pnpm vitest run src/errors src/traces` in packages/telemetry-explorer, 111 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved service indicators by applying consistent colors to error badges.
  * Removed inconsistent color-generation behavior, resulting in more reliable visual identification of services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->