### PR TITLE
feat(alerts): everr alerts manages silences and delivery channels

### DIFF
--- a/crates/everr-core/assets/skills/everr-setup-resources/SKILL.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: everr-setup-resources
-description: Use when creating, editing, applying, or inspecting Everr as-code resources (dashboards, runbooks, alert rules), Perses-format dashboard YAML, panels, ClickHouse queries, ```panel blocks, AlertRule YAML, or the `everr apply` and `everr resources` CLIs.
+description: Use when creating, editing, applying, or inspecting Everr as-code resources (dashboards, runbooks, alert rules), Perses-format dashboard YAML, panels, ClickHouse queries, ```panel blocks, AlertRule YAML, alert channels or silences, or the `everr apply`, `everr resources`, and `everr alerts` CLIs.
 ---
 
 ## Startup Access
@@ -77,6 +77,10 @@ everr resources adopt <kind> <slug> [--yes]                    # take ownership 
 ```
 
 `--project` defaults to `default`. `list --repoid ""` shows UI-created resources. Use `delete` and `adopt` only for resources outside your apply tree (UI-created, or owned by another repo); anything in your tree is managed by `everr apply`.
+
+## Live Alerting State
+
+Alert channels and silences are not as-code: a channel holds a credential, and a silence is an operational decision made at a moment in time. Manage them with `everr alerts channels` and `everr alerts silences`, which also need a login session. A channel secret is never a flag value; it comes from a file, an environment variable, or a hidden prompt. See `rules/alerts.md` for the full surface.
 
 ## Previews
 

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/alerts.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/alerts.md
@@ -240,6 +240,103 @@ condition: { operator: gt, threshold: 100 }
 1. Test the query using `everr cloud query` and confirm the result set stays far below 1,000 rows. Check both healthy and breaching values against the configured condition.
 2. Run `everr apply ./everr --preview` and confirm the summary shows the expected creates/updates, then open the printed `Preview:` link and check the alert's firing/ok state (preview alerts evaluate but never notify).
 
+## Live Alerting State
+
+Channels and silences are not as-code. A channel holds a credential, and a
+silence is an operational decision made at a moment in time, so neither belongs
+in a file that a repository applies, and `everr apply` never touches them.
+
+They live on the Notifications and Silences pages. `everr alerts` does the same
+work from a terminal, which is what a script or an agent needs. It requires an
+`everr cloud login` session (API keys are not accepted).
+
+### Channels
+
+```sh
+everr alerts channels list [--json]
+everr alerts channels create --name <name> --type webhook|slack|discord|telegram
+everr alerts channels edit <name> [--rename <new>] [--type <type>]
+everr alerts channels delete <name> [--yes]
+```
+
+The name is what a rule's `spec.notifications.channels` refers to, so create the
+channel before, or after, the rule that names it: delivery resolves the name at
+send time.
+
+**Secrets never travel as a flag value.** A webhook URL and a Telegram bot token
+are both bearer credentials, and a flag would leave one in the shell history of
+everybody who ran the command. Give the secret in one of three ways, tried in
+this order:
+
+```sh
+# a file, or `-` to read stdin
+everr alerts channels create --name oncall --type slack --url-file ./hook.txt
+
+# an environment variable, for CI
+EVERR_CHANNEL_URL=$SLACK_HOOK everr alerts channels create --name oncall --type slack
+
+# nothing: an interactive terminal prompts, with the input hidden
+everr alerts channels create --name oncall --type slack
+```
+
+Telegram takes `--bot-token-file` (or `$EVERR_CHANNEL_BOT_TOKEN`) and one
+`--chat-id` per chat.
+
+A read never returns a stored secret: `list` shows `***`. An edit that does not
+supply a new secret keeps the stored one, so renaming is safe. Changing `--type`
+does need a new secret, because a credential belongs to the transport it was
+made for.
+
+A delete is refused while notifications are still sending to that channel. Those
+drain in minutes; retry once they settle. Rules naming a deleted channel keep the
+name and deliver again as soon as a channel with that name exists.
+
+### Silences
+
+A silence withholds delivery for the alerts its matchers select. The alerts still
+fire and stay visible; nobody is paged.
+
+```sh
+everr alerts silences list [--from TIME] [--to TIME] [--limit 20] [--offset 0] [--json]
+everr alerts silences create --matcher <label>=<value> --for <duration> [--comment <why>]
+everr alerts silences expire <id> [--yes]
+```
+
+Matching is exact: `label=value` or `label!=value`, never a pattern. Repeat
+`--matcher` to require several, and pass at least one.
+
+`--for` starts the window now (`2h`, `30m`, `7d`). For a window that starts
+later, pass `--starts-at` with `--ends-at`; both take a timestamp or date math
+such as `now+1h`.
+
+`list` shows the silences a page at a time, newest first (20 by default, 100 at
+most). Closed windows are included: retention keeps them for 90 days, and the
+STATE column tells them apart. When another page exists, the command prints the
+`--limit` and `--offset` to rerun with.
+
+`--from` and `--to` select the silences whose own window overlaps the one you
+name, which is what to ask when a page did not arrive:
+
+```sh
+# what was silencing during the incident
+everr alerts silences list --from 2026-08-20T03:00:00Z --to 2026-08-20T04:00:00Z
+
+# silencing right now
+everr alerts silences list --from now --to now
+
+# not closed yet: active and scheduled
+everr alerts silences list --from now
+```
+
+Both take a timestamp or date math, and each stands alone: `--from` on its own
+means "had not closed by then", `--to` on its own means "had already started by
+then". The comparison is half-open at both ends, so a silence that ended exactly
+when the window opened did not cover it.
+
+Expiring closes the window now and re-checks every alert the silence was
+holding. The row stays: alert history records which silence withheld a
+notification, so the record outlives the silence itself.
+
 ## Common Mistakes
 
 | Mistake | Fix |
@@ -254,7 +351,7 @@ condition: { operator: gt, threshold: 100 }
 | Alerting on mean latency | Prefer p95/p99 or another tail-latency signal |
 | Template variable `${Foo}` but the label column is `foo` (case mismatch) | Match column names exactly |
 | Alert flaps on gappy data | Raise `resolveAfter` (and consider `for`) instead of loosening the query |
-| A rule names a channel that does not exist | Create the channel with that exact name on the Notifications page, or fix the name in `spec.notifications.channels`: an unresolved name delivers to nobody |
+| A rule names a channel that does not exist | Create the channel with that exact name, on the Notifications page or with `everr alerts channels create`, or fix the name in `spec.notifications.channels`: an unresolved name delivers to nobody |
 | Expecting re-notification on every evaluation | Notifications fire on transitions, not every tick |
 | `maxInterval` shorter than `evaluationInterval` | Raise `maxInterval` to at least `evaluationInterval`, or drop it to use the default |
 | `annotations` key rejected at apply time | Rename it: `everr.*` and the exact keys `summary`, `description`, `link.alert`, `link.runbook` are reserved for generated annotations |

--- a/crates/everr-core/src/api.rs
+++ b/crates/everr-core/src/api.rs
@@ -402,6 +402,108 @@ impl ApiClient {
             .context("failed to decode adopt response")
     }
 
+    /// One page of the org's alert silences, newest first.
+    pub async fn list_silences(&self, query: &SilenceQuery<'_>) -> Result<Vec<Silence>> {
+        let mut params = vec![
+            ("limit", query.limit.to_string()),
+            ("offset", query.offset.to_string()),
+        ];
+        if let Some(from) = query.from {
+            params.push(("from", from.to_string()));
+        }
+        if let Some(to) = query.to {
+            params.push(("to", to.to_string()));
+        }
+        let request = self
+            .http
+            .get(self.alerts_url(&["silences"])?)
+            .query(&params);
+        self.send_json(request, "list silences").await
+    }
+
+    pub async fn create_silence(&self, input: &SilenceInput) -> Result<Silence> {
+        let request = self.http.post(self.alerts_url(&["silences"])?).json(input);
+        self.send_json(request, "create silence").await
+    }
+
+    /// Close a silence's window. Expiring one that is already closed is not an
+    /// error: the outcome reports that nothing changed.
+    pub async fn expire_silence(&self, id: &str) -> Result<ExpireOutcome> {
+        let url = self.alerts_url(&["silences", id, "expire"])?;
+        let request = self.http.post(url);
+        self.send_json(request, "expire silence").await
+    }
+
+    /// The org's delivery channels. Secrets come back redacted as `***`.
+    pub async fn list_channels(&self) -> Result<Vec<Channel>> {
+        let request = self.http.get(self.alerts_url(&["channels"])?);
+        self.send_json(request, "list channels").await
+    }
+
+    pub async fn create_channel(&self, name: &str, config: &ChannelConfig) -> Result<Channel> {
+        let body = ChannelWrite {
+            name: Some(name),
+            config: Some(config),
+        };
+        let request = self.http.post(self.alerts_url(&["channels"])?).json(&body);
+        self.send_json(request, "create channel").await
+    }
+
+    /// Update a channel, naming only what changes. Omitting the config leaves
+    /// the stored credential alone; sending one whose secret is the redaction
+    /// marker does the same, for an edit that changes the rest of it.
+    pub async fn update_channel(
+        &self,
+        name: &str,
+        rename: Option<&str>,
+        config: Option<&ChannelConfig>,
+    ) -> Result<Channel> {
+        let body = ChannelWrite {
+            name: rename,
+            config,
+        };
+        let url = self.alerts_url(&["channels", name])?;
+        let request = self.http.patch(url).json(&body);
+        self.send_json(request, "update channel").await
+    }
+
+    pub async fn delete_channel(&self, name: &str) -> Result<DeleteOutcome> {
+        let url = self.alerts_url(&["channels", name])?;
+        let request = self.http.delete(url);
+        self.send_json(request, "delete channel").await
+    }
+
+    /// An /api/cli/alerts URL whose trailing segments are values, not literals:
+    /// a channel name or a silence id goes through `push`, which percent-encodes
+    /// it, so a name holding a slash or a space still addresses one channel.
+    fn alerts_url(&self, segments: &[&str]) -> Result<reqwest::Url> {
+        let mut url = reqwest::Url::parse(&format!("{}/alerts", self.base_endpoint))
+            .context("CLI API endpoint is not a valid URL")?;
+        {
+            let mut path = url
+                .path_segments_mut()
+                .map_err(|()| anyhow::anyhow!("CLI API endpoint cannot have path segments"))?;
+            for segment in segments {
+                path.push(segment);
+            }
+        }
+        Ok(url)
+    }
+
+    /// `send_checked` plus decoding the body, for the routes that answer with
+    /// JSON rather than an empty 2xx.
+    async fn send_json<T: DeserializeOwned>(
+        &self,
+        request: reqwest::RequestBuilder,
+        context: &'static str,
+    ) -> Result<T> {
+        let response = self.send_checked(request, context).await?;
+        response
+            .json()
+            .await
+            .with_context(|| format!("failed to decode {context} response"))
+    }
+
     /// Calls POST /api/cli/import and returns once the server acknowledges the import has started.
     pub async fn start_import_repos(&self, repos: &[String]) -> Result<()> {
         let response = self
@@ -485,12 +587,25 @@ fn current_trace_headers() -> HeaderMap {
     headers
 }
 
+/// The reason a refusal gave, unwrapped from its envelope.
+///
+/// Every /api/cli route answers a refusal with `{ "error": ... }` (the alerting
+/// ones add a `code`). Printing the envelope would put JSON in front of the
+/// sentence the user needs to read. A body in any other shape, such as apply's
+/// plain-text validation output, is passed through untouched.
+fn refusal_text(text: String) -> String {
+    serde_json::from_str::<serde_json::Value>(&text)
+        .ok()
+        .and_then(|body| Some(body.get("error")?.as_str()?.to_string()))
+        .unwrap_or(text)
+}
+
 fn http_status_error(status: StatusCode, text: String, context: &str) -> anyhow::Error {
     if status == StatusCode::UNAUTHORIZED {
         return anyhow::Error::new(ReauthenticationRequired);
     }
 
-    anyhow::anyhow!("{context} failed with {status}: {text}")
+    anyhow::anyhow!("{context} failed with {status}: {}", refusal_text(text))
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -643,6 +758,104 @@ pub struct ResourceSummary {
     pub slug: String,
     pub repoid: String,
     pub updated_at: String,
+}
+
+/// A matcher selects the alerts a silence withholds. Matching is exact only:
+/// `eq` or `ne`, never a pattern.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Matcher {
+    pub label: String,
+    pub op: MatchOp,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum MatchOp {
+    Eq,
+    Ne,
+}
+
+/// What a create sends. The author is not here: the server stamps it from the
+/// authenticated principal, so a caller cannot name somebody else.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct SilenceInput {
+    pub matchers: Vec<Matcher>,
+    pub starts_at: String,
+    pub ends_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+/// Which page of silences to read, and which window they must overlap.
+///
+/// `from` and `to` are absolute timestamps: date math is resolved before it
+/// gets here, so the request says exactly what it asked for.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SilenceQuery<'a> {
+    pub limit: u32,
+    pub offset: u32,
+    pub from: Option<&'a str>,
+    pub to: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Silence {
+    pub id: String,
+    pub matchers: Vec<Matcher>,
+    pub starts_at: String,
+    pub ends_at: String,
+    pub comment: String,
+    pub author: String,
+    pub created_at: String,
+    pub canceled_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+pub struct ExpireOutcome {
+    pub expired: bool,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+pub struct DeleteOutcome {
+    pub deleted: bool,
+}
+
+/// A delivery channel's transport and its credentials. On read the secret half
+/// is `***`; sending that back keeps whatever is stored.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum ChannelConfig {
+    Webhook {
+        url: String,
+    },
+    Slack {
+        url: String,
+    },
+    Discord {
+        url: String,
+    },
+    Telegram {
+        bot_token: String,
+        chat_ids: Vec<String>,
+    },
+}
+
+/// The body a create or an update sends. Both halves are optional because an
+/// update names only what changes; a create fills in both.
+#[derive(Debug, Serialize)]
+struct ChannelWrite<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    config: Option<&'a ChannelConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Channel {
+    pub id: String,
+    pub name: String,
+    pub config: ChannelConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1079,7 +1292,14 @@ data: {"tenantId":1,"traceId":"trace-1","runId":"42","sha":"deadbeef","repo":"ev
             .delete_resource("dashboard", "default", "nope")
             .await
             .unwrap_err();
-        assert!(err.to_string().contains("404"), "got: {err}");
+        let message = err.to_string();
+        assert!(message.contains("404"), "got: {message}");
+        // The reason, not the envelope it arrived in.
+        assert!(
+            message.contains("resource not found: dashboard/default/nope"),
+            "got: {message}"
+        );
+        assert!(!message.contains('{'), "got: {message}");
         mock.assert_async().await;
     }
 
@@ -1105,6 +1325,167 @@ data: {"tenantId":1,"traceId":"trace-1","runId":"42","sha":"deadbeef","repo":"ev
 
         assert_eq!(outcome.repoid, "github.com/acme/app");
         assert!(!outcome.already_owned);
+        mock.assert_async().await;
+    }
+    #[tokio::test]
+    async fn list_silences_decodes_the_stored_window_and_matchers() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/api/cli/alerts/silences")
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("limit".into(), "20".into()),
+                mockito::Matcher::UrlEncoded("offset".into(), "0".into()),
+            ]))
+            .with_body(
+                r#"[{"id":"s-1","tenant":"org-1","matchers":[{"label":"service","op":"eq","value":"api"}],"starts_at":"2026-08-20T09:00:00.000Z","ends_at":"2026-08-20T11:00:00.000Z","comment":"deploy","author":"Ada","created_at":"2026-08-20T08:00:00.000Z","canceled_at":null}]"#,
+            )
+            .create_async()
+            .await;
+
+        let client = ApiClient::from_session(&make_session(&server.url())).unwrap();
+        let silences = client
+            .list_silences(&SilenceQuery {
+                limit: 20,
+                offset: 0,
+                ..SilenceQuery::default()
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(silences.len(), 1);
+        assert_eq!(silences[0].matchers[0].op, MatchOp::Eq);
+        assert_eq!(silences[0].author, "Ada");
+        assert_eq!(silences[0].canceled_at, None);
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn create_silence_omits_a_comment_nobody_gave() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/api/cli/alerts/silences")
+            .match_body(mockito::Matcher::JsonString(
+                r#"{"matchers":[{"label":"service","op":"ne","value":"api"}],"starts_at":"2026-08-20T09:00:00.000Z","ends_at":"2026-08-20T11:00:00.000Z"}"#
+                    .to_string(),
+            ))
+            .with_body(
+                r#"{"id":"s-1","tenant":"org-1","matchers":[],"starts_at":"2026-08-20T09:00:00.000Z","ends_at":"2026-08-20T11:00:00.000Z","comment":"","author":"Ada","created_at":"2026-08-20T08:00:00.000Z","canceled_at":null}"#,
+            )
+            .create_async()
+            .await;
+
+        let client = ApiClient::from_session(&make_session(&server.url())).unwrap();
+        client
+            .create_silence(&SilenceInput {
+                matchers: vec![Matcher {
+                    label: "service".to_string(),
+                    op: MatchOp::Ne,
+                    value: "api".to_string(),
+                }],
+                starts_at: "2026-08-20T09:00:00.000Z".to_string(),
+                ends_at: "2026-08-20T11:00:00.000Z".to_string(),
+                comment: None,
+            })
+            .await
+            .unwrap();
+
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn create_channel_sends_the_name_beside_its_tagged_config() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/api/cli/alerts/channels")
+            .match_body(mockito::Matcher::JsonString(
+                r#"{"name":"oncall","config":{"type":"telegram","bot_token":"tok","chat_ids":["1","2"]}}"#
+                    .to_string(),
+            ))
+            .with_body(
+                r#"{"id":"c-1","tenant":"org-1","name":"oncall","config":{"type":"telegram","bot_token":"***","chat_ids":["1","2"]}}"#,
+            )
+            .create_async()
+            .await;
+
+        let client = ApiClient::from_session(&make_session(&server.url())).unwrap();
+        let channel = client
+            .create_channel(
+                "oncall",
+                &ChannelConfig::Telegram {
+                    bot_token: "tok".to_string(),
+                    chat_ids: vec!["1".to_string(), "2".to_string()],
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            channel.config,
+            ChannelConfig::Telegram {
+                bot_token: "***".to_string(),
+                chat_ids: vec!["1".to_string(), "2".to_string()],
+            }
+        );
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn an_update_sends_only_the_half_that_changes() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("PATCH", "/api/cli/alerts/channels/oncall")
+            .match_body(mockito::Matcher::JsonString(
+                r#"{"name":"primary-oncall"}"#.to_string(),
+            ))
+            .with_body(
+                r#"{"id":"c-1","tenant":"org-1","name":"primary-oncall","config":{"type":"slack","url":"***"}}"#,
+            )
+            .create_async()
+            .await;
+
+        let client = ApiClient::from_session(&make_session(&server.url())).unwrap();
+        client
+            .update_channel("oncall", Some("primary-oncall"), None)
+            .await
+            .unwrap();
+
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn a_channel_name_needing_escaping_still_addresses_one_channel() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("DELETE", "/api/cli/alerts/channels/team%2Foncall")
+            .with_body(r#"{"deleted":true}"#)
+            .create_async()
+            .await;
+
+        let client = ApiClient::from_session(&make_session(&server.url())).unwrap();
+        let outcome = client.delete_channel("team/oncall").await.unwrap();
+
+        assert!(outcome.deleted);
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn a_refusal_reports_its_reason_not_its_envelope() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("DELETE", "/api/cli/alerts/channels/oncall")
+            .with_status(409)
+            .with_body(
+                r#"{"error":"Channel has 2 notifications still sending; retry once they settle","code":"conflict"}"#,
+            )
+            .create_async()
+            .await;
+
+        let client = ApiClient::from_session(&make_session(&server.url())).unwrap();
+        let error = client.delete_channel("oncall").await.unwrap_err();
+
+        let message = error.to_string();
+        assert!(message.contains("still sending"), "got: {message}");
+        assert!(!message.contains("\"code\""), "got: {message}");
         mock.assert_async().await;
     }
 }

--- a/packages/app/src/routeTree.gen.ts
+++ b/packages/app/src/routeTree.gen.ts
@@ -58,6 +58,8 @@ import { Route as AuthenticatedDashboardPaddedUsersManagementRouteImport } from 
 import { Route as AuthenticatedDashboardPreviewableAlertsRouteImport } from './routes/_authenticated/_dashboard/_previewable/alerts'
 import { Route as AuthenticatedDashboardRunsIndexRouteImport } from './routes/_authenticated/_dashboard/runs/index'
 import { Route as AuthenticatedDashboardRunsTraceIdRouteRouteImport } from './routes/_authenticated/_dashboard/runs/$traceId/route'
+import { Route as ApiCliAlertsChannelsRouteImport } from './routes/api/cli/alerts/channels'
+import { Route as ApiCliAlertsSilencesRouteImport } from './routes/api/cli/alerts/silences'
 import { Route as ApiCliOrgNameRouteImport } from './routes/api/cli/org/name'
 import { Route as ApiCliRunsTraceIdRouteImport } from './routes/api/cli/runs/$traceId'
 import { Route as ApiCliRunsFilterOptionsRouteImport } from './routes/api/cli/runs/filter-options'
@@ -76,11 +78,13 @@ import { Route as AuthenticatedDashboardPreviewableDashboardsIndexRouteImport } 
 import { Route as AuthenticatedDashboardPreviewableRunbooksIndexRouteImport } from './routes/_authenticated/_dashboard/_previewable/runbooks/index'
 import { Route as AuthenticatedDashboardRunsTraceIdIndexRouteImport } from './routes/_authenticated/_dashboard/runs/$traceId/index'
 import { Route as AuthenticatedDashboardRunsTraceIdTraceRouteImport } from './routes/_authenticated/_dashboard/runs/$traceId/trace'
+import { Route as ApiCliAlertsChannelsNameRouteImport } from './routes/api/cli/alerts/channels/$name'
 import { Route as ApiCliRunsTraceIdLogsRouteImport } from './routes/api/cli/runs/$traceId/logs'
 import { Route as AuthenticatedDashboardExploreErrorsFingerprintModalRouteImport } from './routes/_authenticated/_dashboard/_explore/errors/$fingerprint/modal'
 import { Route as AuthenticatedDashboardExploreTracesTraceIdModalRouteImport } from './routes/_authenticated/_dashboard/_explore/traces/$traceId/modal'
 import { Route as AuthenticatedDashboardPaddedWorkflowsRepoWorkflowNameRouteImport } from './routes/_authenticated/_dashboard/_padded/workflows/$repo/$workflowName'
 import { Route as AuthenticatedDashboardPreviewableDashboardsProjectSlugRouteImport } from './routes/_authenticated/_dashboard/_previewable/dashboards/$project.$slug'
+import { Route as ApiCliAlertsSilencesIdExpireRouteImport } from './routes/api/cli/alerts/silences/$id/expire'
 import { Route as ApiCliResourcesKindProjectSlugRouteImport } from './routes/api/cli/resources/$kind/$project/$slug'
 import { Route as AuthenticatedDashboardPreviewableAlertsRulesProjectSlugRouteImport } from './routes/_authenticated/_dashboard/_previewable/alerts/rules_.$project.$slug'
 import { Route as AuthenticatedDashboardPreviewableRunbooksProjectSlugIndexRouteImport } from './routes/_authenticated/_dashboard/_previewable/runbooks/$project.$slug.index'
@@ -349,6 +353,16 @@ const AuthenticatedDashboardRunsTraceIdRouteRoute =
     path: '/$traceId',
     getParentRoute: () => AuthenticatedDashboardRunsRoute,
   } as any)
+const ApiCliAlertsChannelsRoute = ApiCliAlertsChannelsRouteImport.update({
+  id: '/alerts/channels',
+  path: '/alerts/channels',
+  getParentRoute: () => ApiCliRoute,
+} as any)
+const ApiCliAlertsSilencesRoute = ApiCliAlertsSilencesRouteImport.update({
+  id: '/alerts/silences',
+  path: '/alerts/silences',
+  getParentRoute: () => ApiCliRoute,
+} as any)
 const ApiCliOrgNameRoute = ApiCliOrgNameRouteImport.update({
   id: '/name',
   path: '/name',
@@ -451,6 +465,12 @@ const AuthenticatedDashboardRunsTraceIdTraceRoute =
     path: '/trace',
     getParentRoute: () => AuthenticatedDashboardRunsTraceIdRouteRoute,
   } as any)
+const ApiCliAlertsChannelsNameRoute =
+  ApiCliAlertsChannelsNameRouteImport.update({
+    id: '/$name',
+    path: '/$name',
+    getParentRoute: () => ApiCliAlertsChannelsRoute,
+  } as any)
 const ApiCliRunsTraceIdLogsRoute = ApiCliRunsTraceIdLogsRouteImport.update({
   id: '/logs',
   path: '/logs',
@@ -479,6 +499,12 @@ const AuthenticatedDashboardPreviewableDashboardsProjectSlugRoute =
     id: '/dashboards/$project/$slug',
     path: '/dashboards/$project/$slug',
     getParentRoute: () => AuthenticatedDashboardPreviewableRoute,
+  } as any)
+const ApiCliAlertsSilencesIdExpireRoute =
+  ApiCliAlertsSilencesIdExpireRouteImport.update({
+    id: '/$id/expire',
+    path: '/$id/expire',
+    getParentRoute: () => ApiCliAlertsSilencesRoute,
   } as any)
 const ApiCliResourcesKindProjectSlugRoute =
   ApiCliResourcesKindProjectSlugRouteImport.update({
@@ -565,6 +591,8 @@ export interface FileRoutesByFullPath {
   '/repos': typeof AuthenticatedDashboardPaddedReposRoute
   '/users-management': typeof AuthenticatedDashboardPaddedUsersManagementRoute
   '/alerts': typeof AuthenticatedDashboardPreviewableAlertsRouteWithChildren
+  '/api/cli/alerts/channels': typeof ApiCliAlertsChannelsRouteWithChildren
+  '/api/cli/alerts/silences': typeof ApiCliAlertsSilencesRouteWithChildren
   '/api/cli/org/name': typeof ApiCliOrgNameRoute
   '/api/cli/runs/$traceId': typeof ApiCliRunsTraceIdRouteWithChildren
   '/api/cli/runs/filter-options': typeof ApiCliRunsFilterOptionsRoute
@@ -580,6 +608,7 @@ export interface FileRoutesByFullPath {
   '/alerts/rules': typeof AuthenticatedDashboardPreviewableAlertsRulesRoute
   '/alerts/silences': typeof AuthenticatedDashboardPreviewableAlertsSilencesRoute
   '/runs/$traceId/trace': typeof AuthenticatedDashboardRunsTraceIdTraceRoute
+  '/api/cli/alerts/channels/$name': typeof ApiCliAlertsChannelsNameRoute
   '/api/cli/runs/$traceId/logs': typeof ApiCliRunsTraceIdLogsRoute
   '/alerts/': typeof AuthenticatedDashboardPreviewableAlertsIndexRoute
   '/dashboards/': typeof AuthenticatedDashboardPreviewableDashboardsIndexRoute
@@ -589,6 +618,7 @@ export interface FileRoutesByFullPath {
   '/traces/$traceId/modal': typeof AuthenticatedDashboardExploreTracesTraceIdModalRoute
   '/workflows/$repo/$workflowName': typeof AuthenticatedDashboardPaddedWorkflowsRepoWorkflowNameRoute
   '/dashboards/$project/$slug': typeof AuthenticatedDashboardPreviewableDashboardsProjectSlugRoute
+  '/api/cli/alerts/silences/$id/expire': typeof ApiCliAlertsSilencesIdExpireRoute
   '/api/cli/resources/$kind/$project/$slug': typeof ApiCliResourcesKindProjectSlugRouteWithChildren
   '/alerts/rules/$project/$slug': typeof AuthenticatedDashboardPreviewableAlertsRulesProjectSlugRoute
   '/runbooks/$project/$slug/$': typeof AuthenticatedDashboardPreviewableRunbooksProjectSlugSplatRoute
@@ -636,6 +666,8 @@ export interface FileRoutesByTo {
   '/cost-analysis': typeof AuthenticatedDashboardPaddedCostAnalysisRoute
   '/repos': typeof AuthenticatedDashboardPaddedReposRoute
   '/users-management': typeof AuthenticatedDashboardPaddedUsersManagementRoute
+  '/api/cli/alerts/channels': typeof ApiCliAlertsChannelsRouteWithChildren
+  '/api/cli/alerts/silences': typeof ApiCliAlertsSilencesRouteWithChildren
   '/api/cli/org/name': typeof ApiCliOrgNameRoute
   '/api/cli/runs/$traceId': typeof ApiCliRunsTraceIdRouteWithChildren
   '/api/cli/runs/filter-options': typeof ApiCliRunsFilterOptionsRoute
@@ -651,6 +683,7 @@ export interface FileRoutesByTo {
   '/alerts/rules': typeof AuthenticatedDashboardPreviewableAlertsRulesRoute
   '/alerts/silences': typeof AuthenticatedDashboardPreviewableAlertsSilencesRoute
   '/runs/$traceId/trace': typeof AuthenticatedDashboardRunsTraceIdTraceRoute
+  '/api/cli/alerts/channels/$name': typeof ApiCliAlertsChannelsNameRoute
   '/api/cli/runs/$traceId/logs': typeof ApiCliRunsTraceIdLogsRoute
   '/alerts': typeof AuthenticatedDashboardPreviewableAlertsIndexRoute
   '/dashboards': typeof AuthenticatedDashboardPreviewableDashboardsIndexRoute
@@ -660,6 +693,7 @@ export interface FileRoutesByTo {
   '/traces/$traceId/modal': typeof AuthenticatedDashboardExploreTracesTraceIdModalRoute
   '/workflows/$repo/$workflowName': typeof AuthenticatedDashboardPaddedWorkflowsRepoWorkflowNameRoute
   '/dashboards/$project/$slug': typeof AuthenticatedDashboardPreviewableDashboardsProjectSlugRoute
+  '/api/cli/alerts/silences/$id/expire': typeof ApiCliAlertsSilencesIdExpireRoute
   '/api/cli/resources/$kind/$project/$slug': typeof ApiCliResourcesKindProjectSlugRouteWithChildren
   '/alerts/rules/$project/$slug': typeof AuthenticatedDashboardPreviewableAlertsRulesProjectSlugRoute
   '/runbooks/$project/$slug/$': typeof AuthenticatedDashboardPreviewableRunbooksProjectSlugSplatRoute
@@ -717,6 +751,8 @@ export interface FileRoutesById {
   '/_authenticated/_dashboard/_padded/repos': typeof AuthenticatedDashboardPaddedReposRoute
   '/_authenticated/_dashboard/_padded/users-management': typeof AuthenticatedDashboardPaddedUsersManagementRoute
   '/_authenticated/_dashboard/_previewable/alerts': typeof AuthenticatedDashboardPreviewableAlertsRouteWithChildren
+  '/api/cli/alerts/channels': typeof ApiCliAlertsChannelsRouteWithChildren
+  '/api/cli/alerts/silences': typeof ApiCliAlertsSilencesRouteWithChildren
   '/api/cli/org/name': typeof ApiCliOrgNameRoute
   '/api/cli/runs/$traceId': typeof ApiCliRunsTraceIdRouteWithChildren
   '/api/cli/runs/filter-options': typeof ApiCliRunsFilterOptionsRoute
@@ -733,6 +769,7 @@ export interface FileRoutesById {
   '/_authenticated/_dashboard/_previewable/alerts/rules': typeof AuthenticatedDashboardPreviewableAlertsRulesRoute
   '/_authenticated/_dashboard/_previewable/alerts/silences': typeof AuthenticatedDashboardPreviewableAlertsSilencesRoute
   '/_authenticated/_dashboard/runs/$traceId/trace': typeof AuthenticatedDashboardRunsTraceIdTraceRoute
+  '/api/cli/alerts/channels/$name': typeof ApiCliAlertsChannelsNameRoute
   '/api/cli/runs/$traceId/logs': typeof ApiCliRunsTraceIdLogsRoute
   '/_authenticated/_dashboard/_previewable/alerts/': typeof AuthenticatedDashboardPreviewableAlertsIndexRoute
   '/_authenticated/_dashboard/_previewable/dashboards/': typeof AuthenticatedDashboardPreviewableDashboardsIndexRoute
@@ -742,6 +779,7 @@ export interface FileRoutesById {
   '/_authenticated/_dashboard/_explore/traces/$traceId/modal': typeof AuthenticatedDashboardExploreTracesTraceIdModalRoute
   '/_authenticated/_dashboard/_padded/workflows/$repo/$workflowName': typeof AuthenticatedDashboardPaddedWorkflowsRepoWorkflowNameRoute
   '/_authenticated/_dashboard/_previewable/dashboards/$project/$slug': typeof AuthenticatedDashboardPreviewableDashboardsProjectSlugRoute
+  '/api/cli/alerts/silences/$id/expire': typeof ApiCliAlertsSilencesIdExpireRoute
   '/api/cli/resources/$kind/$project/$slug': typeof ApiCliResourcesKindProjectSlugRouteWithChildren
   '/_authenticated/_dashboard/_previewable/alerts/rules_/$project/$slug': typeof AuthenticatedDashboardPreviewableAlertsRulesProjectSlugRoute
   '/_authenticated/_dashboard/_previewable/runbooks/$project/$slug/$': typeof AuthenticatedDashboardPreviewableRunbooksProjectSlugSplatRoute
@@ -794,6 +832,8 @@ export interface FileRouteTypes {
     | '/repos'
     | '/users-management'
     | '/alerts'
+    | '/api/cli/alerts/channels'
+    | '/api/cli/alerts/silences'
     | '/api/cli/org/name'
     | '/api/cli/runs/$traceId'
     | '/api/cli/runs/filter-options'
@@ -809,6 +849,7 @@ export interface FileRouteTypes {
     | '/alerts/rules'
     | '/alerts/silences'
     | '/runs/$traceId/trace'
+    | '/api/cli/alerts/channels/$name'
     | '/api/cli/runs/$traceId/logs'
     | '/alerts/'
     | '/dashboards/'
@@ -818,6 +859,7 @@ export interface FileRouteTypes {
     | '/traces/$traceId/modal'
     | '/workflows/$repo/$workflowName'
     | '/dashboards/$project/$slug'
+    | '/api/cli/alerts/silences/$id/expire'
     | '/api/cli/resources/$kind/$project/$slug'
     | '/alerts/rules/$project/$slug'
     | '/runbooks/$project/$slug/$'
@@ -865,6 +907,8 @@ export interface FileRouteTypes {
     | '/cost-analysis'
     | '/repos'
     | '/users-management'
+    | '/api/cli/alerts/channels'
+    | '/api/cli/alerts/silences'
     | '/api/cli/org/name'
     | '/api/cli/runs/$traceId'
     | '/api/cli/runs/filter-options'
@@ -880,6 +924,7 @@ export interface FileRouteTypes {
     | '/alerts/rules'
     | '/alerts/silences'
     | '/runs/$traceId/trace'
+    | '/api/cli/alerts/channels/$name'
     | '/api/cli/runs/$traceId/logs'
     | '/alerts'
     | '/dashboards'
@@ -889,6 +934,7 @@ export interface FileRouteTypes {
     | '/traces/$traceId/modal'
     | '/workflows/$repo/$workflowName'
     | '/dashboards/$project/$slug'
+    | '/api/cli/alerts/silences/$id/expire'
     | '/api/cli/resources/$kind/$project/$slug'
     | '/alerts/rules/$project/$slug'
     | '/runbooks/$project/$slug/$'
@@ -945,6 +991,8 @@ export interface FileRouteTypes {
     | '/_authenticated/_dashboard/_padded/repos'
     | '/_authenticated/_dashboard/_padded/users-management'
     | '/_authenticated/_dashboard/_previewable/alerts'
+    | '/api/cli/alerts/channels'
+    | '/api/cli/alerts/silences'
     | '/api/cli/org/name'
     | '/api/cli/runs/$traceId'
     | '/api/cli/runs/filter-options'
@@ -961,6 +1009,7 @@ export interface FileRouteTypes {
     | '/_authenticated/_dashboard/_previewable/alerts/rules'
     | '/_authenticated/_dashboard/_previewable/alerts/silences'
     | '/_authenticated/_dashboard/runs/$traceId/trace'
+    | '/api/cli/alerts/channels/$name'
     | '/api/cli/runs/$traceId/logs'
     | '/_authenticated/_dashboard/_previewable/alerts/'
     | '/_authenticated/_dashboard/_previewable/dashboards/'
@@ -970,6 +1019,7 @@ export interface FileRouteTypes {
     | '/_authenticated/_dashboard/_explore/traces/$traceId/modal'
     | '/_authenticated/_dashboard/_padded/workflows/$repo/$workflowName'
     | '/_authenticated/_dashboard/_previewable/dashboards/$project/$slug'
+    | '/api/cli/alerts/silences/$id/expire'
     | '/api/cli/resources/$kind/$project/$slug'
     | '/_authenticated/_dashboard/_previewable/alerts/rules_/$project/$slug'
     | '/_authenticated/_dashboard/_previewable/runbooks/$project/$slug/$'
@@ -1343,6 +1393,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedDashboardRunsTraceIdRouteRouteImport
       parentRoute: typeof AuthenticatedDashboardRunsRoute
     }
+    '/api/cli/alerts/channels': {
+      id: '/api/cli/alerts/channels'
+      path: '/alerts/channels'
+      fullPath: '/api/cli/alerts/channels'
+      preLoaderRoute: typeof ApiCliAlertsChannelsRouteImport
+      parentRoute: typeof ApiCliRoute
+    }
+    '/api/cli/alerts/silences': {
+      id: '/api/cli/alerts/silences'
+      path: '/alerts/silences'
+      fullPath: '/api/cli/alerts/silences'
+      preLoaderRoute: typeof ApiCliAlertsSilencesRouteImport
+      parentRoute: typeof ApiCliRoute
+    }
     '/api/cli/org/name': {
       id: '/api/cli/org/name'
       path: '/name'
@@ -1469,6 +1533,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedDashboardRunsTraceIdTraceRouteImport
       parentRoute: typeof AuthenticatedDashboardRunsTraceIdRouteRoute
     }
+    '/api/cli/alerts/channels/$name': {
+      id: '/api/cli/alerts/channels/$name'
+      path: '/$name'
+      fullPath: '/api/cli/alerts/channels/$name'
+      preLoaderRoute: typeof ApiCliAlertsChannelsNameRouteImport
+      parentRoute: typeof ApiCliAlertsChannelsRoute
+    }
     '/api/cli/runs/$traceId/logs': {
       id: '/api/cli/runs/$traceId/logs'
       path: '/logs'
@@ -1503,6 +1574,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/dashboards/$project/$slug'
       preLoaderRoute: typeof AuthenticatedDashboardPreviewableDashboardsProjectSlugRouteImport
       parentRoute: typeof AuthenticatedDashboardPreviewableRoute
+    }
+    '/api/cli/alerts/silences/$id/expire': {
+      id: '/api/cli/alerts/silences/$id/expire'
+      path: '/$id/expire'
+      fullPath: '/api/cli/alerts/silences/$id/expire'
+      preLoaderRoute: typeof ApiCliAlertsSilencesIdExpireRouteImport
+      parentRoute: typeof ApiCliAlertsSilencesRoute
     }
     '/api/cli/resources/$kind/$project/$slug': {
       id: '/api/cli/resources/$kind/$project/$slug'
@@ -1904,6 +1982,28 @@ const ApiCliRunsRouteWithChildren = ApiCliRunsRoute._addFileChildren(
   ApiCliRunsRouteChildren,
 )
 
+interface ApiCliAlertsChannelsRouteChildren {
+  ApiCliAlertsChannelsNameRoute: typeof ApiCliAlertsChannelsNameRoute
+}
+
+const ApiCliAlertsChannelsRouteChildren: ApiCliAlertsChannelsRouteChildren = {
+  ApiCliAlertsChannelsNameRoute: ApiCliAlertsChannelsNameRoute,
+}
+
+const ApiCliAlertsChannelsRouteWithChildren =
+  ApiCliAlertsChannelsRoute._addFileChildren(ApiCliAlertsChannelsRouteChildren)
+
+interface ApiCliAlertsSilencesRouteChildren {
+  ApiCliAlertsSilencesIdExpireRoute: typeof ApiCliAlertsSilencesIdExpireRoute
+}
+
+const ApiCliAlertsSilencesRouteChildren: ApiCliAlertsSilencesRouteChildren = {
+  ApiCliAlertsSilencesIdExpireRoute: ApiCliAlertsSilencesIdExpireRoute,
+}
+
+const ApiCliAlertsSilencesRouteWithChildren =
+  ApiCliAlertsSilencesRoute._addFileChildren(ApiCliAlertsSilencesRouteChildren)
+
 interface ApiCliRouteChildren {
   ApiCliImportRoute: typeof ApiCliImportRoute
   ApiCliMeRoute: typeof ApiCliMeRoute
@@ -1913,6 +2013,8 @@ interface ApiCliRouteChildren {
   ApiCliResourcesRoute: typeof ApiCliResourcesRouteWithChildren
   ApiCliRunsRoute: typeof ApiCliRunsRouteWithChildren
   ApiCliSqlRoute: typeof ApiCliSqlRoute
+  ApiCliAlertsChannelsRoute: typeof ApiCliAlertsChannelsRouteWithChildren
+  ApiCliAlertsSilencesRoute: typeof ApiCliAlertsSilencesRouteWithChildren
 }
 
 const ApiCliRouteChildren: ApiCliRouteChildren = {
@@ -1924,6 +2026,8 @@ const ApiCliRouteChildren: ApiCliRouteChildren = {
   ApiCliResourcesRoute: ApiCliResourcesRouteWithChildren,
   ApiCliRunsRoute: ApiCliRunsRouteWithChildren,
   ApiCliSqlRoute: ApiCliSqlRoute,
+  ApiCliAlertsChannelsRoute: ApiCliAlertsChannelsRouteWithChildren,
+  ApiCliAlertsSilencesRoute: ApiCliAlertsSilencesRouteWithChildren,
 }
 
 const ApiCliRouteWithChildren =

--- a/packages/app/src/routes/api/cli/-test-utils.ts
+++ b/packages/app/src/routes/api/cli/-test-utils.ts
@@ -50,15 +50,32 @@ export function getRouteHandler<T>(
   return handler;
 }
 
+/**
+ * What a CLI route handler is called with. `P` is the route's path params.
+ * `request` and `params` are optional so a test passes only what the handler
+ * under test actually reads.
+ */
+export type CliRouteHandler<P = never> = (args: {
+  request?: Request;
+  params?: P;
+  context: ReturnType<typeof cliSessionContext>;
+}) => Promise<Response>;
+
 /** Default organization id used across CLI route tests. */
 export const CLI_TEST_ORG_ID = "org-42";
 
 /**
  * Builds the minimal `context` object that CLI route handlers expect after
  * the auth middleware has populated the active session.
+ *
+ * The user is here because a route that mutates derives the acting principal
+ * from the session rather than from the request body.
  */
 export function cliSessionContext(organizationId: string = CLI_TEST_ORG_ID) {
   return {
-    session: { session: { activeOrganizationId: organizationId } },
+    session: {
+      session: { activeOrganizationId: organizationId },
+      user: { id: "user-1", name: "Ada", email: "ada@example.com" },
+    },
   };
 }

--- a/packages/app/src/routes/api/cli/alerts/-responses.test.ts
+++ b/packages/app/src/routes/api/cli/alerts/-responses.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { AlertingError } from "@/data/alerting/errors";
+import { alertingJson, readJsonBody } from "./-responses";
+
+function jsonRequest(body: string): Request {
+  return new Request("http://localhost/api/cli/alerts/silences", {
+    method: "POST",
+    body,
+  });
+}
+
+describe("alertingJson", () => {
+  it("answers with what the operation returned", async () => {
+    const res = await alertingJson(async () => ({ id: "s-1" }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ id: "s-1" });
+  });
+
+  it("answers a refusal with the status and code it carries", async () => {
+    const res = await alertingJson(async () => {
+      throw new AlertingError(409, "conflict", "still sending");
+    });
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({
+      error: "still sending",
+      code: "conflict",
+    });
+  });
+
+  it("leaves anything else to the error reporter as a 500", async () => {
+    // A ZodError from reading stored data says the server is broken, not the
+    // request, so it must not be flattened into a 422 the caller cannot act on.
+    await expect(
+      alertingJson(async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+  });
+});
+
+describe("readJsonBody", () => {
+  it("returns the object a request carries", async () => {
+    expect(await readJsonBody(jsonRequest('{"comment":"deploy"}'))).toEqual({
+      comment: "deploy",
+    });
+  });
+
+  it("refuses a body that is not JSON", async () => {
+    await expect(readJsonBody(jsonRequest("not json"))).rejects.toMatchObject({
+      status: 400,
+      code: "validation",
+    });
+  });
+
+  it("refuses a body that is not an object", async () => {
+    await expect(readJsonBody(jsonRequest("[1,2]"))).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+});

--- a/packages/app/src/routes/api/cli/alerts/-responses.ts
+++ b/packages/app/src/routes/api/cli/alerts/-responses.ts
@@ -1,0 +1,50 @@
+import { AlertingError, alertingErrorInfo } from "@/data/alerting/errors";
+
+/**
+ * Run an alerting operation and answer with what it returned, or with the
+ * refusal it raised.
+ *
+ * A refusal is an `AlertingError`, which carries the status it means: 422 for
+ * input a schema rejected, 404 for an unknown channel, 409 for one still
+ * sending. Anything else is a bug and stays an unhandled 500, so it reaches
+ * the error reporter rather than being flattened into a message the caller
+ * cannot act on. That includes a `ZodError` from reading stored data, which
+ * says the server is broken, not the request.
+ */
+export async function alertingJson(
+  operation: () => Promise<unknown>,
+): Promise<Response> {
+  try {
+    return Response.json(await operation());
+  } catch (cause) {
+    const info = alertingErrorInfo(cause);
+    if (info) {
+      return Response.json(
+        { error: info.message, code: info.code },
+        { status: info.status },
+      );
+    }
+    throw cause;
+  }
+}
+
+/**
+ * The JSON object a request carries. Raises rather than returning null, so a
+ * handler reads it inside `alertingJson` and never repeats a guard.
+ */
+export async function readJsonBody(request: Request): Promise<unknown> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    throw new AlertingError(400, "validation", "request body is not JSON");
+  }
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    throw new AlertingError(
+      400,
+      "validation",
+      "request body must be a JSON object",
+    );
+  }
+  return body;
+}

--- a/packages/app/src/routes/api/cli/alerts/channels.test.ts
+++ b/packages/app/src/routes/api/cli/alerts/channels.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createChannel,
+  listChannels,
+} from "@/data/alerting/delivery/repository";
+import {
+  CLI_TEST_ORG_ID,
+  type CliRouteHandler,
+  cliSessionContext,
+  getRouteHandler,
+} from "../-test-utils";
+import { Route } from "./channels";
+
+vi.mock("@/data/alerting/delivery/repository", () => ({
+  listChannels: vi.fn(),
+  createChannel: vi.fn(),
+}));
+
+const mockedList = vi.mocked(listChannels);
+const mockedCreate = vi.mocked(createChannel);
+
+type Handler = CliRouteHandler;
+
+const context = cliSessionContext();
+
+function post(body: unknown): Promise<Response> {
+  const handler = getRouteHandler<Handler>(
+    Route,
+    "POST",
+    "/api/cli/alerts/channels",
+  );
+  return handler({
+    request: new Request("http://localhost/api/cli/alerts/channels", {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+    context,
+  });
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("GET /api/cli/alerts/channels", () => {
+  it("returns the org's channels with secrets redacted", async () => {
+    mockedList.mockResolvedValueOnce([
+      {
+        id: "c-1",
+        tenant: CLI_TEST_ORG_ID,
+        name: "oncall",
+        config: { type: "slack", url: "***" },
+      },
+    ]);
+
+    const handler = getRouteHandler<Handler>(Route, "GET");
+    const res = await handler({
+      request: new Request("http://localhost/api/cli/alerts/channels"),
+      context,
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([
+      {
+        id: "c-1",
+        tenant: CLI_TEST_ORG_ID,
+        name: "oncall",
+        config: { type: "slack", url: "***" },
+      },
+    ]);
+    expect(mockedList).toHaveBeenCalledWith(CLI_TEST_ORG_ID);
+  });
+});
+
+describe("POST /api/cli/alerts/channels", () => {
+  it("creates the channel", async () => {
+    mockedCreate.mockResolvedValueOnce({ id: "c-1" } as never);
+
+    const res = await post({
+      name: "oncall",
+      config: { type: "slack", url: "https://hooks.slack.test/abc" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockedCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ organizationId: CLI_TEST_ORG_ID }),
+      {
+        name: "oncall",
+        config: { type: "slack", url: "https://hooks.slack.test/abc" },
+      },
+    );
+  });
+});

--- a/packages/app/src/routes/api/cli/alerts/channels.ts
+++ b/packages/app/src/routes/api/cli/alerts/channels.ts
@@ -1,0 +1,29 @@
+import { createFileRoute } from "@tanstack/react-router";
+import {
+  createChannel,
+  listChannels,
+} from "@/data/alerting/delivery/repository";
+import { alertingMutationScope } from "@/data/alerting/session";
+import { alertingJson, readJsonBody } from "./-responses";
+
+// Auth + org context comes from the parent `/api/cli` route
+// (requireOrgMiddleware); these are session-authenticated CLI endpoints.
+export const Route = createFileRoute("/api/cli/alerts/channels")({
+  server: {
+    handlers: {
+      // Secrets come back redacted, so a list never returns a usable webhook
+      // URL or bot token.
+      GET: ({ context }) =>
+        alertingJson(() =>
+          listChannels(context.session.session.activeOrganizationId),
+        ),
+      POST: ({ request, context }) =>
+        alertingJson(async () =>
+          createChannel(
+            alertingMutationScope(context.session),
+            await readJsonBody(request),
+          ),
+        ),
+    },
+  },
+});

--- a/packages/app/src/routes/api/cli/alerts/channels/$name.test.ts
+++ b/packages/app/src/routes/api/cli/alerts/channels/$name.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  deleteChannel,
+  updateChannel,
+} from "@/data/alerting/delivery/repository";
+import {
+  CLI_TEST_ORG_ID,
+  type CliRouteHandler,
+  cliSessionContext,
+  getRouteHandler,
+} from "../../-test-utils";
+import { Route } from "./$name";
+
+vi.mock("@/data/alerting/delivery/repository", () => ({
+  updateChannel: vi.fn(),
+  deleteChannel: vi.fn(),
+}));
+
+const mockedUpdate = vi.mocked(updateChannel);
+const mockedDelete = vi.mocked(deleteChannel);
+
+type Handler = CliRouteHandler<{ name: string }>;
+
+const context = cliSessionContext();
+
+function patch(name: string, body: unknown): Promise<Response> {
+  const handler = getRouteHandler<Handler>(
+    Route,
+    "PATCH",
+    "/api/cli/alerts/channels/$name",
+  );
+  return handler({
+    params: { name },
+    request: new Request(`http://localhost/api/cli/alerts/channels/${name}`, {
+      method: "PATCH",
+      body: JSON.stringify(body),
+    }),
+    context,
+  });
+}
+
+function remove(name: string): Promise<Response> {
+  const handler = getRouteHandler<Handler>(Route, "DELETE");
+  return handler({
+    params: { name },
+    request: new Request(`http://localhost/api/cli/alerts/channels/${name}`, {
+      method: "DELETE",
+    }),
+    context,
+  });
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("PATCH /api/cli/alerts/channels/$name", () => {
+  it("updates the channel named in the path", async () => {
+    mockedUpdate.mockResolvedValueOnce({ id: "c-1" } as never);
+
+    const res = await patch("oncall", {
+      config: { type: "slack", url: "https://hooks.slack.test/new" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockedUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ organizationId: CLI_TEST_ORG_ID }),
+      "oncall",
+      { config: { type: "slack", url: "https://hooks.slack.test/new" } },
+    );
+  });
+
+  it("passes a redacted secret through so the stored one is kept", async () => {
+    mockedUpdate.mockResolvedValueOnce({ id: "c-1" } as never);
+
+    await patch("oncall", {
+      name: "primary-oncall",
+      config: { type: "slack", url: "***" },
+    });
+
+    expect(mockedUpdate.mock.calls[0]?.[2]).toEqual({
+      name: "primary-oncall",
+      config: { type: "slack", url: "***" },
+    });
+  });
+});
+
+describe("DELETE /api/cli/alerts/channels/$name", () => {
+  it("deletes the channel named in the path", async () => {
+    mockedDelete.mockResolvedValueOnce({ deleted: true });
+
+    const res = await remove("oncall");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ deleted: true });
+    expect(mockedDelete).toHaveBeenCalledWith(
+      expect.objectContaining({ organizationId: CLI_TEST_ORG_ID }),
+      "oncall",
+    );
+  });
+});

--- a/packages/app/src/routes/api/cli/alerts/channels/$name.ts
+++ b/packages/app/src/routes/api/cli/alerts/channels/$name.ts
@@ -1,0 +1,30 @@
+import { createFileRoute } from "@tanstack/react-router";
+import {
+  deleteChannel,
+  updateChannel,
+} from "@/data/alerting/delivery/repository";
+import { alertingMutationScope } from "@/data/alerting/session";
+import { alertingJson, readJsonBody } from "../-responses";
+
+// Channels are addressed by name: it is what a rule's `notifications.channels`
+// names and what delivery resolves at flush, so the id never leaves the server.
+export const Route = createFileRoute("/api/cli/alerts/channels/$name")({
+  server: {
+    handlers: {
+      // A config whose secret arrives as "***" keeps the stored one, so an edit
+      // that only renames never re-sends the secret in clear.
+      PATCH: ({ params, request, context }) =>
+        alertingJson(async () =>
+          updateChannel(
+            alertingMutationScope(context.session),
+            params.name,
+            await readJsonBody(request),
+          ),
+        ),
+      DELETE: ({ params, context }) =>
+        alertingJson(() =>
+          deleteChannel(alertingMutationScope(context.session), params.name),
+        ),
+    },
+  },
+});

--- a/packages/app/src/routes/api/cli/alerts/silences.test.ts
+++ b/packages/app/src/routes/api/cli/alerts/silences.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createSilence,
+  listSilences,
+} from "@/data/alerting/silences/repository";
+import {
+  CLI_TEST_ORG_ID,
+  type CliRouteHandler,
+  cliSessionContext,
+  getRouteHandler,
+} from "../-test-utils";
+import { Route } from "./silences";
+
+vi.mock("@/data/alerting/silences/repository", () => ({
+  listSilences: vi.fn(),
+  createSilence: vi.fn(),
+}));
+
+const mockedList = vi.mocked(listSilences);
+const mockedCreate = vi.mocked(createSilence);
+
+type Handler = CliRouteHandler;
+
+const context = cliSessionContext();
+
+function post(body: unknown): Promise<Response> {
+  const handler = getRouteHandler<Handler>(
+    Route,
+    "POST",
+    "/api/cli/alerts/silences",
+  );
+  return handler({
+    request: new Request("http://localhost/api/cli/alerts/silences", {
+      method: "POST",
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    }),
+    context,
+  });
+}
+
+const validInput = {
+  matchers: [{ label: "service", op: "eq", value: "api" }],
+  starts_at: "2026-08-20T09:00:00.000Z",
+  ends_at: "2026-08-20T11:00:00.000Z",
+  comment: "deploy window",
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("GET /api/cli/alerts/silences", () => {
+  async function get(query = ""): Promise<Response> {
+    const handler = getRouteHandler<Handler>(Route, "GET");
+    return handler({
+      request: new Request(`http://localhost/api/cli/alerts/silences${query}`),
+      context,
+    });
+  }
+
+  it("bounds a request that named no page", async () => {
+    mockedList.mockResolvedValueOnce([{ id: "s-1" }] as never);
+
+    const res = await get();
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([{ id: "s-1" }]);
+    expect(mockedList).toHaveBeenCalledWith(CLI_TEST_ORG_ID, {
+      limit: 20,
+      offset: 0,
+    });
+  });
+
+  it("passes the page it was given through to the query", async () => {
+    mockedList.mockResolvedValueOnce([] as never);
+
+    await get("?limit=21&offset=20");
+
+    expect(mockedList).toHaveBeenCalledWith(CLI_TEST_ORG_ID, {
+      limit: 21,
+      offset: 20,
+    });
+  });
+
+  it("hands the window over as instants, not as text", async () => {
+    mockedList.mockResolvedValueOnce([] as never);
+
+    await get("?from=2026-08-20T08:00:00.000Z&to=2026-08-20T10:00:00.000Z");
+
+    expect(mockedList).toHaveBeenCalledWith(CLI_TEST_ORG_ID, {
+      limit: 20,
+      offset: 0,
+      from: new Date("2026-08-20T08:00:00.000Z"),
+      to: new Date("2026-08-20T10:00:00.000Z"),
+    });
+  });
+
+  it("refuses a bound that is not a timestamp", async () => {
+    const res = await get("?from=now-1d");
+
+    expect(res.status).toBe(422);
+    expect(mockedList).not.toHaveBeenCalled();
+  });
+
+  it("refuses a page size the query would not bound", async () => {
+    const res = await get("?limit=5000");
+
+    expect(res.status).toBe(422);
+    expect(mockedList).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/cli/alerts/silences", () => {
+  it("creates the silence attributed to the session's user", async () => {
+    mockedCreate.mockResolvedValueOnce({ id: "s-1" } as never);
+
+    const res = await post(validInput);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ id: "s-1" });
+    expect(mockedCreate).toHaveBeenCalledWith(
+      {
+        organizationId: CLI_TEST_ORG_ID,
+        actor: { kind: "user", id: "user-1", display: "Ada" },
+      },
+      expect.objectContaining({ comment: "deploy window" }),
+    );
+  });
+
+  it("hands the body to the repository, which owns the schema", async () => {
+    mockedCreate.mockResolvedValueOnce({ id: "s-1" } as never);
+
+    await post(validInput);
+
+    expect(mockedCreate.mock.calls[0]?.[1]).toEqual(validInput);
+  });
+});

--- a/packages/app/src/routes/api/cli/alerts/silences.ts
+++ b/packages/app/src/routes/api/cli/alerts/silences.ts
@@ -1,0 +1,57 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+import { parseAlertingInput } from "@/data/alerting/persistence";
+import { alertingMutationScope } from "@/data/alerting/session";
+import {
+  createSilence,
+  listSilences,
+} from "@/data/alerting/silences/repository";
+import { alertingJson, readJsonBody } from "./-responses";
+
+const DEFAULT_PAGE_SIZE = 20;
+
+/** An absolute instant. Date math is resolved by the caller, not here. */
+const QueryInstant = z
+  .string()
+  .datetime()
+  .transform((value) => new Date(value));
+
+const SilencesQuerySchema = z.strictObject({
+  // A silence matches when its own window overlaps this one.
+  from: QueryInstant.optional(),
+  to: QueryInstant.optional(),
+  // 101, not 100, so a caller can request one more row than it means to show
+  // and learn whether another page exists without a second count query.
+  limit: z.coerce.number().int().min(1).max(101).default(DEFAULT_PAGE_SIZE),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+// Auth + org context comes from the parent `/api/cli` route
+// (requireOrgMiddleware); these are session-authenticated CLI endpoints.
+export const Route = createFileRoute("/api/cli/alerts/silences")({
+  server: {
+    handlers: {
+      GET: ({ request, context }) =>
+        alertingJson(() => {
+          const url = new URL(request.url);
+          const query = parseAlertingInput(
+            SilencesQuerySchema,
+            Object.fromEntries(url.searchParams),
+          );
+          return listSilences(
+            context.session.session.activeOrganizationId,
+            query,
+          );
+        }),
+      // The scope carries the authenticated principal, so the stored author is
+      // who the session says it is, not whoever the body names.
+      POST: ({ request, context }) =>
+        alertingJson(async () =>
+          createSilence(
+            alertingMutationScope(context.session),
+            await readJsonBody(request),
+          ),
+        ),
+    },
+  },
+});

--- a/packages/app/src/routes/api/cli/alerts/silences/$id/expire.test.ts
+++ b/packages/app/src/routes/api/cli/alerts/silences/$id/expire.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { expireSilence } from "@/data/alerting/silences/repository";
+import {
+  CLI_TEST_ORG_ID,
+  type CliRouteHandler,
+  cliSessionContext,
+  getRouteHandler,
+} from "../../../-test-utils";
+import { Route } from "./expire";
+
+vi.mock("@/data/alerting/silences/repository", () => ({
+  expireSilence: vi.fn(),
+}));
+
+const mockedExpire = vi.mocked(expireSilence);
+
+type Handler = CliRouteHandler<{ id: string }>;
+
+function expire(id: string): Promise<Response> {
+  const handler = getRouteHandler<Handler>(
+    Route,
+    "POST",
+    "/api/cli/alerts/silences/$id/expire",
+  );
+  return handler({ params: { id }, context: cliSessionContext() });
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("POST /api/cli/alerts/silences/$id/expire", () => {
+  it("closes the silence's window", async () => {
+    mockedExpire.mockResolvedValueOnce({ expired: true });
+
+    const res = await expire("s-1");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ expired: true });
+    expect(mockedExpire).toHaveBeenCalledWith(
+      expect.objectContaining({ organizationId: CLI_TEST_ORG_ID }),
+      "s-1",
+    );
+  });
+
+  it("reports an already-closed silence rather than failing", async () => {
+    mockedExpire.mockResolvedValueOnce({ expired: false });
+
+    const res = await expire("s-1");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ expired: false });
+  });
+});

--- a/packages/app/src/routes/api/cli/alerts/silences/$id/expire.ts
+++ b/packages/app/src/routes/api/cli/alerts/silences/$id/expire.ts
@@ -1,0 +1,17 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { alertingMutationScope } from "@/data/alerting/session";
+import { expireSilence } from "@/data/alerting/silences/repository";
+import { alertingJson } from "../../-responses";
+
+// Expire, not delete: alert history references the silence that withheld a
+// notification, so the row outlives its window. See `expireSilence`.
+export const Route = createFileRoute("/api/cli/alerts/silences/$id/expire")({
+  server: {
+    handlers: {
+      POST: ({ params, context }) =>
+        alertingJson(() =>
+          expireSilence(alertingMutationScope(context.session), params.id),
+        ),
+    },
+  },
+});

--- a/packages/desktop-app/src-cli/src/alerts.rs
+++ b/packages/desktop-app/src-cli/src/alerts.rs
@@ -1,0 +1,1065 @@
+use std::borrow::Cow;
+use std::fmt::Write as _;
+use std::io::{IsTerminal, Read};
+use std::time::SystemTime;
+
+use anyhow::{Context, Result, bail};
+use chrono::{DateTime, SecondsFormat, Utc};
+use everr_core::api::{
+    ApiClient, Channel, ChannelConfig, MatchOp, Matcher, Silence, SilenceInput, SilenceQuery,
+};
+
+use crate::cli::{
+    AlertsSubcommand, ChannelSecretArgs, ChannelTypeArg, ChannelsCreateArgs, ChannelsDeleteArgs,
+    ChannelsEditArgs, ChannelsListArgs, ChannelsSubcommand, SilencesCreateArgs, SilencesExpireArgs,
+    SilencesListArgs, SilencesSubcommand,
+};
+use crate::core::confirm_action;
+
+/// The marker a read puts where a secret was. Sending it back keeps whatever
+/// the server has stored.
+const REDACTED: &str = "***";
+
+const URL_ENV: &str = "EVERR_CHANNEL_URL";
+const BOT_TOKEN_ENV: &str = "EVERR_CHANNEL_BOT_TOKEN";
+
+pub async fn run_alerts(cmd: AlertsSubcommand) -> Result<()> {
+    // Like `everr resources`, these target the session-authenticated /api/cli
+    // routes, which have no API-key path.
+    let session = crate::auth::require_session_with_refresh().await?;
+    let client = ApiClient::from_session(&session)?;
+    match cmd {
+        AlertsSubcommand::Silences(args) => match args.command {
+            SilencesSubcommand::List(args) => silences_list(&client, args).await,
+            SilencesSubcommand::Create(args) => silences_create(&client, args).await,
+            SilencesSubcommand::Expire(args) => silences_expire(&client, args).await,
+        },
+        AlertsSubcommand::Channels(args) => match args.command {
+            ChannelsSubcommand::List(args) => channels_list(&client, args).await,
+            ChannelsSubcommand::Create(args) => channels_create(&client, args).await,
+            ChannelsSubcommand::Edit(args) => channels_edit(&client, args).await,
+            ChannelsSubcommand::Delete(args) => channels_delete(&client, args).await,
+        },
+    }
+}
+
+// ---------------------------------------------------------------- silences
+
+async fn silences_list(client: &ApiClient, args: SilencesListArgs) -> Result<()> {
+    let now = SystemTime::now();
+    let from = resolve_bound(args.from.as_deref(), now, "--from")?;
+    let to = resolve_bound(args.to.as_deref(), now, "--to")?;
+    // Both are RFC 3339 in UTC with a fixed width, so ordering them as text
+    // orders them as instants.
+    if let (Some(from), Some(to)) = (&from, &to)
+        && from > to
+    {
+        bail!("--from is after --to, so no silence could overlap the window");
+    }
+    // One row more than we mean to show: if it comes back, another page exists,
+    // and the count that answers that costs nothing extra.
+    let probe = args.limit.saturating_add(1);
+    let mut silences = client
+        .list_silences(&SilenceQuery {
+            limit: probe,
+            offset: args.offset,
+            from: from.as_deref(),
+            to: to.as_deref(),
+        })
+        .await?;
+    let has_more = silences.len() > args.limit as usize;
+    silences.truncate(args.limit as usize);
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&silences)?);
+        return Ok(());
+    }
+    print!("{}", render_silences(&silences, Utc::now()));
+    if has_more {
+        println!(
+            "\nMore silences available. Rerun with --limit {} --offset {} to continue.",
+            args.limit,
+            args.offset.saturating_add(args.limit)
+        );
+    }
+    Ok(())
+}
+
+/// The silence table, as text. Separate from printing it so what a reader sees
+/// can be asserted without a terminal.
+fn render_silences(silences: &[Silence], now: DateTime<Utc>) -> String {
+    if silences.is_empty() {
+        return "No silences.\n".to_string();
+    }
+    let mut out = format!(
+        "{:<38}  {:<10}  {:<24}  {:<18}  MATCHERS\n",
+        "ID", "STATE", "ENDS", "AUTHOR"
+    );
+    for silence in silences {
+        let state = silence_state(silence, now);
+        let _ = writeln!(
+            out,
+            "{:<38}  {:<10}  {:<24}  {:<18}  {}",
+            silence.id,
+            state,
+            silence.ends_at,
+            truncate(&silence.author, 18),
+            format_matchers(&silence.matchers)
+        );
+    }
+    out
+}
+
+async fn silences_create(client: &ApiClient, args: SilencesCreateArgs) -> Result<()> {
+    let matchers = args
+        .matchers
+        .iter()
+        .map(|raw| parse_matcher(raw))
+        .collect::<Result<Vec<_>>>()?;
+    let (starts_at, ends_at) = resolve_window(
+        args.duration.as_deref(),
+        args.starts_at.as_deref(),
+        args.ends_at.as_deref(),
+        SystemTime::now(),
+    )?;
+    let silence = client
+        .create_silence(&SilenceInput {
+            matchers,
+            starts_at,
+            ends_at,
+            comment: args.comment,
+        })
+        .await?;
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&silence)?);
+        return Ok(());
+    }
+    println!(
+        "Created silence {} for {}.",
+        silence.id,
+        format_matchers(&silence.matchers)
+    );
+    println!("Window: {} to {}.", silence.starts_at, silence.ends_at);
+    println!("Matching alerts stay visible; they are not delivered.");
+    Ok(())
+}
+
+async fn silences_expire(client: &ApiClient, args: SilencesExpireArgs) -> Result<()> {
+    if !confirm_action(
+        format!("Expire silence {}?", args.id),
+        args.yes,
+        false,
+        "refusing to proceed without confirmation; re-run with --yes".into(),
+    )? {
+        println!("Aborted.");
+        return Ok(());
+    }
+    let outcome = client.expire_silence(&args.id).await?;
+    if outcome.expired {
+        println!("Expired silence {}.", args.id);
+        println!("Alerts it was withholding are re-checked now.");
+    } else {
+        println!("Silence {} was already closed. Nothing to do.", args.id);
+    }
+    Ok(())
+}
+
+/// A closed window withholds nothing any more.
+const EXPIRED: &str = "expired";
+
+fn silence_state(silence: &Silence, now: DateTime<Utc>) -> &'static str {
+    if parse_timestamp(&silence.ends_at).is_some_and(|ends| ends <= now) {
+        return EXPIRED;
+    }
+    match parse_timestamp(&silence.starts_at) {
+        Some(starts) if starts > now => "scheduled",
+        _ => "active",
+    }
+}
+
+fn parse_timestamp(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|t| t.with_timezone(&Utc))
+}
+
+/// Parse `label=value` or `label!=value`.
+///
+/// `!=` is tested first: `env!=staging` also contains `=`, and splitting on
+/// that would silence `env!` instead of everything but staging.
+fn parse_matcher(raw: &str) -> Result<Matcher> {
+    let (label, op, value) = match raw.split_once("!=") {
+        Some((label, value)) => (label, MatchOp::Ne, value),
+        None => match raw.split_once('=') {
+            Some((label, value)) => (label, MatchOp::Eq, value),
+            None => {
+                bail!("matcher `{raw}` needs an operator: write `label=value` or `label!=value`")
+            }
+        },
+    };
+    if label.trim().is_empty() {
+        bail!("matcher `{raw}` has no label");
+    }
+    Ok(Matcher {
+        label: label.trim().to_string(),
+        op,
+        value: value.to_string(),
+    })
+}
+
+/// The window to silence, as the two timestamps the API takes.
+///
+/// `--for` is the common case and means "starting now". The explicit pair is
+/// for a window that starts later. Both go through date math, so `--ends-at
+/// now+30m` works as well as an absolute timestamp.
+fn resolve_window(
+    duration: Option<&str>,
+    starts_at: Option<&str>,
+    ends_at: Option<&str>,
+    now: SystemTime,
+) -> Result<(String, String)> {
+    let start = match starts_at {
+        Some(expression) => resolve_time(expression, now, "--starts-at")?,
+        None => now,
+    };
+    let end = match (duration, ends_at) {
+        (Some(duration), _) => resolve_time(&format!("now+{duration}"), now, "--for")?,
+        (None, Some(expression)) => resolve_time(expression, now, "--ends-at")?,
+        (None, None) => bail!("pass --for to silence from now, or --starts-at with --ends-at"),
+    };
+    if end <= start {
+        bail!("the silence would end before it starts");
+    }
+    Ok((format_timestamp(start), format_timestamp(end)))
+}
+
+/// A filter bound, resolved to an absolute timestamp so the request says what
+/// it asked for rather than deferring `now` to the server.
+fn resolve_bound(expression: Option<&str>, now: SystemTime, flag: &str) -> Result<Option<String>> {
+    expression
+        .map(|value| resolve_time(value, now, flag).map(format_timestamp))
+        .transpose()
+}
+
+fn resolve_time(expression: &str, now: SystemTime, flag: &str) -> Result<SystemTime> {
+    everr_core::datemath::resolve(expression, now)
+        .with_context(|| format!("{flag} is not a time or a duration: {expression}"))
+}
+
+fn format_timestamp(time: SystemTime) -> String {
+    DateTime::<Utc>::from(time).to_rfc3339_opts(SecondsFormat::Millis, true)
+}
+
+fn format_matchers(matchers: &[Matcher]) -> String {
+    let mut out = String::new();
+    for (index, matcher) in matchers.iter().enumerate() {
+        if index > 0 {
+            out.push_str(", ");
+        }
+        out.push_str(&matcher.label);
+        out.push_str(match matcher.op {
+            MatchOp::Eq => "=",
+            MatchOp::Ne => "!=",
+        });
+        out.push_str(&matcher.value);
+    }
+    out
+}
+
+// ---------------------------------------------------------------- channels
+
+async fn channels_list(client: &ApiClient, args: ChannelsListArgs) -> Result<()> {
+    let channels = client.list_channels().await?;
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&channels)?);
+        return Ok(());
+    }
+    print!("{}", render_channels(&channels));
+    Ok(())
+}
+
+/// The channel table, as text. See `render_silences`.
+fn render_channels(channels: &[Channel]) -> String {
+    if channels.is_empty() {
+        return "No channels.\n".to_string();
+    }
+    let mut out = format!("{:<28}  {:<10}  DESTINATION\n", "NAME", "TYPE");
+    for channel in channels {
+        let _ = writeln!(
+            out,
+            "{:<28}  {:<10}  {}",
+            channel.name,
+            channel_type_name(&channel.config),
+            channel_destination(&channel.config)
+        );
+    }
+    out.push_str("\nSecrets are stored encrypted and are never returned.\n");
+    out
+}
+
+async fn channels_create(client: &ApiClient, args: ChannelsCreateArgs) -> Result<()> {
+    let config = build_config(args.channel_type, &args.secret, None)?;
+    let channel = client.create_channel(&args.name, &config).await?;
+    report_channel("Created", &channel, args.json)
+}
+
+async fn channels_edit(client: &ApiClient, args: ChannelsEditArgs) -> Result<()> {
+    // A rename says nothing about the credential or the transport, so it needs
+    // neither the stored config nor the round trip that would read it back.
+    if args.channel_type.is_none() && !args.secret.is_given() {
+        let Some(rename) = args.rename.as_deref() else {
+            bail!("nothing to change: pass --rename, --type, or a secret to set");
+        };
+        let channel = client
+            .update_channel(&args.name, Some(rename), None)
+            .await?;
+        return report_channel("Updated", &channel, args.json);
+    }
+    let current = find_channel(client, &args.name).await?;
+    let channel_type = args
+        .channel_type
+        .unwrap_or_else(|| channel_type_of(&current.config));
+    // A stored secret belongs to the transport it was made for, so a type
+    // change cannot carry it over. The server would store the redaction marker
+    // verbatim, leaving a channel that delivers nowhere.
+    let previous = if channel_type == channel_type_of(&current.config) {
+        Some(&current.config)
+    } else {
+        None
+    };
+    let config = build_config(channel_type, &args.secret, previous)?;
+    let channel = client
+        .update_channel(&args.name, args.rename.as_deref(), Some(&config))
+        .await?;
+    report_channel("Updated", &channel, args.json)
+}
+
+async fn channels_delete(client: &ApiClient, args: ChannelsDeleteArgs) -> Result<()> {
+    if !confirm_action(
+        format!("Delete channel «{}»?", args.name),
+        args.yes,
+        true,
+        "refusing to proceed without confirmation; re-run with --yes".into(),
+    )? {
+        println!("Aborted.");
+        return Ok(());
+    }
+    client.delete_channel(&args.name).await?;
+    println!("Deleted channel «{}».", args.name);
+    println!(
+        "note: rules naming it keep the name, and deliver again once a channel with that name exists."
+    );
+    Ok(())
+}
+
+async fn find_channel(client: &ApiClient, name: &str) -> Result<Channel> {
+    let channels = client.list_channels().await?;
+    channels
+        .into_iter()
+        .find(|channel| channel.name == name)
+        .with_context(|| format!("Channel not found: {name}"))
+}
+
+/// Assemble the config to send.
+///
+/// `previous` is the channel's current config when an edit keeps its type: its
+/// redacted secret goes back untouched, which is how an edit that changes only
+/// the name leaves the credential alone.
+fn build_config(
+    channel_type: ChannelTypeArg,
+    secret: &ChannelSecretArgs,
+    previous: Option<&ChannelConfig>,
+) -> Result<ChannelConfig> {
+    reject_inapplicable_flags(channel_type, secret)?;
+    let webhook_url = |label| {
+        resolve_secret(
+            secret.url_file.as_deref(),
+            URL_ENV,
+            label,
+            previous.is_some(),
+        )
+    };
+    Ok(match channel_type {
+        ChannelTypeArg::Telegram => {
+            let bot_token = resolve_secret(
+                secret.bot_token_file.as_deref(),
+                BOT_TOKEN_ENV,
+                "Telegram bot token",
+                previous.is_some(),
+            )?;
+            let chat_ids = if secret.chat_ids.is_empty() {
+                match previous {
+                    Some(ChannelConfig::Telegram { chat_ids, .. }) => chat_ids.clone(),
+                    _ => bail!("--chat-id names the chat to deliver to; pass at least one"),
+                }
+            } else {
+                secret.chat_ids.clone()
+            };
+            ChannelConfig::Telegram {
+                bot_token,
+                chat_ids,
+            }
+        }
+        ChannelTypeArg::Slack => ChannelConfig::Slack {
+            url: webhook_url("Slack webhook URL")?,
+        },
+        ChannelTypeArg::Discord => ChannelConfig::Discord {
+            url: webhook_url("Discord webhook URL")?,
+        },
+        ChannelTypeArg::Webhook => ChannelConfig::Webhook {
+            url: webhook_url("Webhook URL")?,
+        },
+    })
+}
+
+/// Refuse a secret flag that belongs to another transport, rather than
+/// silently ignoring it and storing a channel the caller did not describe.
+fn reject_inapplicable_flags(
+    channel_type: ChannelTypeArg,
+    secret: &ChannelSecretArgs,
+) -> Result<()> {
+    if channel_type == ChannelTypeArg::Telegram {
+        if secret.url_file.is_some() {
+            bail!("--url-file does not apply to a telegram channel; use --bot-token-file");
+        }
+        return Ok(());
+    }
+    if secret.bot_token_file.is_some() {
+        bail!("--bot-token-file only applies to a telegram channel; use --url-file");
+    }
+    if !secret.chat_ids.is_empty() {
+        bail!("--chat-id only applies to a telegram channel");
+    }
+    Ok(())
+}
+
+/// The secret to send, from a file, the environment, or a hidden prompt.
+///
+/// `keep_stored` is set when the channel already has a secret of this kind: the
+/// caller may be editing something else entirely, so the redaction marker goes
+/// back and the stored secret stays. Without one, a value has to come from
+/// somewhere, and a non-interactive shell is told where.
+fn resolve_secret(
+    file: Option<&str>,
+    env_var: &str,
+    label: &str,
+    keep_stored: bool,
+) -> Result<String> {
+    if let Some(path) = file {
+        return read_secret_file(path, label);
+    }
+    if let Ok(value) = std::env::var(env_var)
+        && !value.trim().is_empty()
+    {
+        return Ok(value.trim().to_string());
+    }
+    if keep_stored {
+        return Ok(REDACTED.to_string());
+    }
+    if !(std::io::stdin().is_terminal() && std::io::stdout().is_terminal()) {
+        bail!(
+            "no {label} given: set ${env_var}, or pass the file holding it \
+             (`-` reads stdin). It is deliberately not a flag, so it stays out \
+             of your shell history."
+        );
+    }
+    let value = cliclack::password(format!("{label}:")).interact()?;
+    if value.trim().is_empty() {
+        bail!("no {label} given");
+    }
+    Ok(value.trim().to_string())
+}
+
+fn read_secret_file(path: &str, label: &str) -> Result<String> {
+    let contents = if path == "-" {
+        let mut buffer = String::new();
+        std::io::stdin()
+            .read_to_string(&mut buffer)
+            .context("failed to read the secret from stdin")?;
+        buffer
+    } else {
+        std::fs::read_to_string(path).with_context(|| format!("failed to read {path}"))?
+    };
+    let value = contents.trim();
+    if value.is_empty() {
+        bail!("{label} is empty");
+    }
+    Ok(value.to_string())
+}
+
+fn channel_type_of(config: &ChannelConfig) -> ChannelTypeArg {
+    match config {
+        ChannelConfig::Webhook { .. } => ChannelTypeArg::Webhook,
+        ChannelConfig::Slack { .. } => ChannelTypeArg::Slack,
+        ChannelConfig::Discord { .. } => ChannelTypeArg::Discord,
+        ChannelConfig::Telegram { .. } => ChannelTypeArg::Telegram,
+    }
+}
+
+fn channel_type_name(config: &ChannelConfig) -> &'static str {
+    match config {
+        ChannelConfig::Webhook { .. } => "webhook",
+        ChannelConfig::Slack { .. } => "slack",
+        ChannelConfig::Discord { .. } => "discord",
+        ChannelConfig::Telegram { .. } => "telegram",
+    }
+}
+
+/// What a list can say about where a channel delivers. The URL is redacted, so
+/// only a Telegram channel has anything to show: its chat ids are not secret.
+fn channel_destination(config: &ChannelConfig) -> Cow<'static, str> {
+    match config {
+        ChannelConfig::Telegram { chat_ids, .. } => {
+            Cow::Owned(format!("chats {}", chat_ids.join(", ")))
+        }
+        _ => Cow::Borrowed(REDACTED),
+    }
+}
+
+fn report_channel(verb: &str, channel: &Channel, json: bool) -> Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(channel)?);
+        return Ok(());
+    }
+    println!(
+        "{verb} channel «{}» ({}).",
+        channel.name,
+        channel_type_name(&channel.config)
+    );
+    Ok(())
+}
+
+/// `value` shortened to `width` characters, with an ellipsis standing for what
+/// was cut. Borrows when it already fits, which is the usual case.
+fn truncate(value: &str, width: usize) -> Cow<'_, str> {
+    // `nth(width)` stops at the first character past the limit, so a value that
+    // fits is never walked further than the limit itself.
+    if value.char_indices().nth(width).is_none() {
+        return Cow::Borrowed(value);
+    }
+    let end = value
+        .char_indices()
+        .nth(width.saturating_sub(1))
+        .map_or(value.len(), |(index, _)| index);
+    Cow::Owned(format!("{}…", &value[..end]))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, UNIX_EPOCH};
+
+    use super::*;
+    use crate::test_support::ENV_LOCK;
+
+    /// 2026-08-20T09:00:00Z, so the expected windows read as timestamps.
+    fn fixed_now() -> SystemTime {
+        UNIX_EPOCH + Duration::from_secs(1_787_216_400)
+    }
+
+    fn no_secret_flags() -> ChannelSecretArgs {
+        ChannelSecretArgs {
+            url_file: None,
+            bot_token_file: None,
+            chat_ids: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn a_matcher_reads_its_operator() {
+        assert_eq!(
+            parse_matcher("service=api").unwrap(),
+            Matcher {
+                label: "service".to_string(),
+                op: MatchOp::Eq,
+                value: "api".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn a_negated_matcher_keeps_its_label_whole() {
+        let matcher = parse_matcher("env!=staging").unwrap();
+
+        assert_eq!(matcher.label, "env");
+        assert_eq!(matcher.op, MatchOp::Ne);
+        assert_eq!(matcher.value, "staging");
+    }
+
+    #[test]
+    fn a_value_may_contain_the_operator_character() {
+        assert_eq!(parse_matcher("url=a=b").unwrap().value, "a=b");
+    }
+
+    #[test]
+    fn a_matcher_without_an_operator_is_refused() {
+        let error = parse_matcher("service").unwrap_err().to_string();
+
+        assert!(error.contains("label=value"), "got: {error}");
+    }
+
+    #[test]
+    fn a_matcher_without_a_label_is_refused() {
+        assert!(parse_matcher("=api").is_err());
+    }
+
+    #[test]
+    fn a_duration_silences_from_now() {
+        let (starts_at, ends_at) = resolve_window(Some("2h"), None, None, fixed_now()).unwrap();
+
+        assert_eq!(starts_at, "2026-08-20T09:00:00.000Z");
+        assert_eq!(ends_at, "2026-08-20T11:00:00.000Z");
+    }
+
+    #[test]
+    fn an_explicit_pair_schedules_a_later_window() {
+        let (starts_at, ends_at) = resolve_window(
+            None,
+            Some("2026-08-21T09:00:00Z"),
+            Some("2026-08-21T11:00:00Z"),
+            fixed_now(),
+        )
+        .unwrap();
+
+        assert_eq!(starts_at, "2026-08-21T09:00:00.000Z");
+        assert_eq!(ends_at, "2026-08-21T11:00:00.000Z");
+    }
+
+    #[test]
+    fn a_window_with_no_end_is_refused() {
+        let error = resolve_window(None, None, None, fixed_now())
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("--for"), "got: {error}");
+    }
+
+    #[test]
+    fn a_window_that_ends_before_it_starts_is_refused() {
+        let error = resolve_window(
+            None,
+            Some("2026-08-21T11:00:00Z"),
+            Some("2026-08-21T09:00:00Z"),
+            fixed_now(),
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("before it starts"), "got: {error}");
+    }
+
+    #[test]
+    fn an_expired_silence_is_told_apart_from_a_scheduled_one() {
+        let now = DateTime::<Utc>::from(fixed_now());
+        let silence = |starts_at: &str, ends_at: &str| Silence {
+            id: "s-1".to_string(),
+            matchers: Vec::new(),
+            starts_at: starts_at.to_string(),
+            ends_at: ends_at.to_string(),
+            comment: String::new(),
+            author: "Ada".to_string(),
+            created_at: "2026-08-20T08:00:00Z".to_string(),
+            canceled_at: None,
+        };
+
+        assert_eq!(
+            silence_state(
+                &silence("2026-08-20T06:00:00Z", "2026-08-20T08:00:00Z"),
+                now
+            ),
+            "expired"
+        );
+        assert_eq!(
+            silence_state(
+                &silence("2026-08-20T08:00:00Z", "2026-08-20T10:00:00Z"),
+                now
+            ),
+            "active"
+        );
+        assert_eq!(
+            silence_state(
+                &silence("2026-08-20T10:00:00Z", "2026-08-20T12:00:00Z"),
+                now
+            ),
+            "scheduled"
+        );
+    }
+
+    #[test]
+    fn a_url_flag_is_refused_on_a_telegram_channel() {
+        let secret = ChannelSecretArgs {
+            url_file: Some("hook.txt".to_string()),
+            ..no_secret_flags()
+        };
+
+        let error = reject_inapplicable_flags(ChannelTypeArg::Telegram, &secret)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("--bot-token-file"), "got: {error}");
+    }
+
+    #[test]
+    fn a_chat_id_is_refused_on_a_webhook_channel() {
+        let secret = ChannelSecretArgs {
+            chat_ids: vec!["1".to_string()],
+            ..no_secret_flags()
+        };
+
+        assert!(reject_inapplicable_flags(ChannelTypeArg::Slack, &secret).is_err());
+    }
+
+    #[test]
+    fn an_edit_that_touches_no_secret_sends_the_marker_back() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        unsafe { std::env::remove_var(URL_ENV) };
+        let previous = ChannelConfig::Slack {
+            url: REDACTED.to_string(),
+        };
+
+        let config = build_config(ChannelTypeArg::Slack, &no_secret_flags(), Some(&previous))
+            .expect("keeps the stored secret");
+
+        assert_eq!(
+            config,
+            ChannelConfig::Slack {
+                url: REDACTED.to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn an_edit_keeps_the_chat_ids_it_does_not_change() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        unsafe { std::env::remove_var(BOT_TOKEN_ENV) };
+        let previous = ChannelConfig::Telegram {
+            bot_token: REDACTED.to_string(),
+            chat_ids: vec!["1".to_string(), "2".to_string()],
+        };
+
+        let config = build_config(
+            ChannelTypeArg::Telegram,
+            &no_secret_flags(),
+            Some(&previous),
+        )
+        .expect("keeps the stored chats");
+
+        assert_eq!(
+            config,
+            ChannelConfig::Telegram {
+                bot_token: REDACTED.to_string(),
+                chat_ids: vec!["1".to_string(), "2".to_string()],
+            }
+        );
+    }
+
+    #[test]
+    fn the_environment_supplies_the_secret_when_no_file_does() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        unsafe { std::env::set_var(URL_ENV, "https://hooks.slack.test/abc\n") };
+
+        let config = build_config(ChannelTypeArg::Slack, &no_secret_flags(), None)
+            .expect("reads the environment");
+
+        unsafe { std::env::remove_var(URL_ENV) };
+        assert_eq!(
+            config,
+            ChannelConfig::Slack {
+                url: "https://hooks.slack.test/abc".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn a_file_outranks_the_environment() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        unsafe { std::env::set_var(URL_ENV, "https://hooks.slack.test/from-env") };
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("hook.txt");
+        std::fs::write(&path, "https://hooks.slack.test/from-file\n").expect("write");
+        let secret = ChannelSecretArgs {
+            url_file: Some(path.to_string_lossy().into_owned()),
+            ..no_secret_flags()
+        };
+
+        let config = build_config(ChannelTypeArg::Slack, &secret, None).expect("reads the file");
+
+        unsafe { std::env::remove_var(URL_ENV) };
+        assert_eq!(
+            config,
+            ChannelConfig::Slack {
+                url: "https://hooks.slack.test/from-file".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn a_type_change_will_not_carry_the_old_secret_over() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        unsafe { std::env::remove_var(BOT_TOKEN_ENV) };
+
+        // `previous` is None whenever the type changes, which is what makes the
+        // marker unavailable and forces a real token.
+        let error = build_config(ChannelTypeArg::Telegram, &no_secret_flags(), None)
+            .expect_err("a new transport needs its own credential");
+
+        assert!(error.to_string().contains(BOT_TOKEN_ENV), "got: {error}");
+    }
+    fn silence_at(id: &str, starts_at: &str, ends_at: &str) -> Silence {
+        Silence {
+            id: id.to_string(),
+            matchers: vec![Matcher {
+                label: "service".to_string(),
+                op: MatchOp::Eq,
+                value: "api".to_string(),
+            }],
+            starts_at: starts_at.to_string(),
+            ends_at: ends_at.to_string(),
+            comment: String::new(),
+            author: "Ada".to_string(),
+            created_at: "2026-08-20T08:00:00Z".to_string(),
+            canceled_at: None,
+        }
+    }
+
+    #[test]
+    fn the_silence_table_shows_every_row_the_page_returned() {
+        // The page is the query's decision, so the renderer states each row's
+        // state rather than deciding what to hide.
+        let now = DateTime::<Utc>::from(fixed_now());
+        let silences = vec![silence_at(
+            "s-1",
+            "2026-08-20T06:00:00Z",
+            "2026-08-20T08:00:00Z",
+        )];
+
+        let out = render_silences(&silences, now);
+
+        assert!(out.contains("s-1"), "got: {out}");
+        assert!(out.contains(EXPIRED), "got: {out}");
+    }
+
+    #[test]
+    fn an_empty_page_says_so() {
+        assert_eq!(
+            render_silences(&[], DateTime::<Utc>::from(fixed_now())),
+            "No silences.\n"
+        );
+    }
+
+    #[test]
+    fn the_silence_table_prints_the_matchers_it_was_created_with() {
+        let now = DateTime::<Utc>::from(fixed_now());
+        let silences = vec![silence_at(
+            "s-1",
+            "2026-08-20T08:00:00Z",
+            "2026-08-20T10:00:00Z",
+        )];
+
+        let out = render_silences(&silences, now);
+
+        assert!(out.contains("service=api"), "got: {out}");
+        assert!(out.contains("Ada"), "got: {out}");
+        assert!(out.contains("active"), "got: {out}");
+    }
+
+    #[test]
+    fn the_channel_table_never_shows_a_secret() {
+        let channels = vec![
+            Channel {
+                id: "c-1".to_string(),
+                name: "oncall".to_string(),
+                config: ChannelConfig::Slack {
+                    url: REDACTED.to_string(),
+                },
+            },
+            Channel {
+                id: "c-2".to_string(),
+                name: "tg".to_string(),
+                config: ChannelConfig::Telegram {
+                    bot_token: REDACTED.to_string(),
+                    chat_ids: vec!["1".to_string(), "2".to_string()],
+                },
+            },
+        ];
+
+        let out = render_channels(&channels);
+
+        assert!(out.contains("oncall"), "got: {out}");
+        assert!(out.contains("slack"), "got: {out}");
+        // Chat ids are not secret, so they are the one destination worth showing.
+        assert!(out.contains("chats 1, 2"), "got: {out}");
+        assert!(out.contains("never returned"), "got: {out}");
+    }
+
+    #[test]
+    fn an_empty_channel_list_says_so() {
+        assert_eq!(render_channels(&[]), "No channels.\n");
+    }
+
+    #[test]
+    fn a_long_author_is_truncated_to_fit_its_column() {
+        assert_eq!(truncate("abcdefghij", 5), "abcd\u{2026}");
+        assert_eq!(truncate("abc", 5), "abc");
+    }
+
+    fn edit_args(name: &str) -> ChannelsEditArgs {
+        ChannelsEditArgs {
+            name: name.to_string(),
+            rename: None,
+            channel_type: None,
+            secret: no_secret_flags(),
+            json: false,
+        }
+    }
+
+    fn test_client(base_url: &str) -> ApiClient {
+        ApiClient::from_session(&everr_core::state::Session {
+            api_base_url: base_url.to_string(),
+            token: "test-token".to_string(),
+        })
+        .expect("client")
+    }
+
+    #[tokio::test]
+    async fn a_full_page_asks_for_one_more_row_and_says_another_page_exists() {
+        let mut server = mockito::Server::new_async().await;
+        // Two rows come back for a page of one: the extra is the probe.
+        let list = server
+            .mock("GET", "/api/cli/alerts/silences")
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("limit".into(), "2".into()),
+                mockito::Matcher::UrlEncoded("offset".into(), "0".into()),
+            ]))
+            .with_body(
+                serde_json::to_string(&[
+                    silence_at("s-1", "2026-08-20T08:00:00Z", "2026-08-20T10:00:00Z"),
+                    silence_at("s-2", "2026-08-20T08:00:00Z", "2026-08-20T10:00:00Z"),
+                ])
+                .expect("fixture"),
+            )
+            .create_async()
+            .await;
+        let client = test_client(&server.url());
+
+        silences_list(
+            &client,
+            SilencesListArgs {
+                from: None,
+                to: None,
+                limit: 1,
+                offset: 0,
+                json: false,
+            },
+        )
+        .await
+        .expect("listed");
+
+        list.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn a_window_is_resolved_before_it_is_asked_for() {
+        let mut server = mockito::Server::new_async().await;
+        // Date math never reaches the server: the request names two instants.
+        let list = server
+            .mock("GET", "/api/cli/alerts/silences")
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("limit".into(), "21".into()),
+                mockito::Matcher::UrlEncoded("offset".into(), "0".into()),
+                mockito::Matcher::Regex("from=2026-08".into()),
+                mockito::Matcher::Regex("to=2026-08".into()),
+            ]))
+            .with_body("[]")
+            .create_async()
+            .await;
+        let client = test_client(&server.url());
+
+        silences_list(
+            &client,
+            SilencesListArgs {
+                from: Some("now-1d".to_string()),
+                to: Some("now".to_string()),
+                limit: 20,
+                offset: 0,
+                json: false,
+            },
+        )
+        .await
+        .expect("listed");
+
+        list.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn a_window_that_starts_after_it_ends_is_refused() {
+        // No mock: the refusal has to come before any request.
+        let server = mockito::Server::new_async().await;
+        let client = test_client(&server.url());
+
+        let error = silences_list(
+            &client,
+            SilencesListArgs {
+                from: Some("now".to_string()),
+                to: Some("now-1h".to_string()),
+                limit: 20,
+                offset: 0,
+                json: false,
+            },
+        )
+        .await
+        .expect_err("an inverted window overlaps nothing");
+
+        assert!(
+            error.to_string().contains("--from is after --to"),
+            "got: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_edit_that_names_nothing_to_change_is_refused() {
+        let server = mockito::Server::new_async().await;
+        let client = test_client(&server.url());
+
+        let error = channels_edit(&client, edit_args("oncall"))
+            .await
+            .expect_err("nothing was asked for");
+
+        assert!(error.to_string().contains("--rename"), "got: {error}");
+        // Refused before any request: the mock has no expectations to match.
+    }
+
+    #[tokio::test]
+    async fn a_rename_reaches_the_server_without_reading_the_channel_back() {
+        let mut server = mockito::Server::new_async().await;
+        // No GET is mocked, so a fetch of the channel list would fail the call.
+        let patch = server
+            .mock("PATCH", "/api/cli/alerts/channels/oncall")
+            .match_body(mockito::Matcher::JsonString(
+                r#"{"name":"primary-oncall"}"#.to_string(),
+            ))
+            .with_body(
+                r#"{"id":"c-1","tenant":"org-1","name":"primary-oncall","config":{"type":"slack","url":"***"}}"#,
+            )
+            .create_async()
+            .await;
+        let client = test_client(&server.url());
+
+        let args = ChannelsEditArgs {
+            rename: Some("primary-oncall".to_string()),
+            ..edit_args("oncall")
+        };
+        channels_edit(&client, args).await.expect("renamed");
+
+        patch.assert_async().await;
+    }
+}

--- a/packages/desktop-app/src-cli/src/cli.rs
+++ b/packages/desktop-app/src-cli/src/cli.rs
@@ -7,6 +7,8 @@ const VERSION_OUTPUT: &str = concat!(env!("EVERR_VERSION"), " (debug build)");
 const VERSION_OUTPUT: &str = concat!(env!("EVERR_VERSION"), " (release build)");
 
 pub const DEFAULT_LOG_PAGE_SIZE: u32 = 1000;
+pub const DEFAULT_SILENCE_PAGE_SIZE: u32 = 20;
+pub const MAX_SILENCE_PAGE_SIZE: u32 = 100;
 pub const MAX_LOG_PAGE_SIZE: u32 = 5000;
 
 #[derive(Parser, Debug)]
@@ -47,6 +49,8 @@ pub enum Commands {
     Apply(ApplyArgs),
     /// Inspect and manage live Cloud resources (dashboards, runbooks, alerts)
     Resources(ResourcesArgs),
+    /// Manage live alerting state (silences and delivery channels)
+    Alerts(AlertsArgs),
 }
 
 impl Cli {
@@ -69,6 +73,7 @@ impl Commands {
             Commands::Skills(_) => true,
             Commands::Apply(_) => true,
             Commands::Resources(args) => args.command.prints_human_stdout(stdout_is_terminal),
+            Commands::Alerts(args) => args.command.prints_human_stdout(stdout_is_terminal),
         }
     }
 }
@@ -544,6 +549,212 @@ pub struct ResourcesTargetArgs {
     /// Project namespace
     #[arg(long, default_value = "default")]
     pub project: String,
+    /// Skip the confirmation prompt (required in non-interactive contexts)
+    #[arg(long, short = 'y')]
+    pub yes: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct AlertsArgs {
+    #[command(subcommand)]
+    pub command: AlertsSubcommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum AlertsSubcommand {
+    /// Inspect and manage alert silences
+    Silences(SilencesArgs),
+    /// Inspect and manage alert delivery channels
+    Channels(ChannelsArgs),
+}
+
+impl AlertsSubcommand {
+    fn prints_human_stdout(&self, _stdout_is_terminal: bool) -> bool {
+        match self {
+            AlertsSubcommand::Silences(args) => match &args.command {
+                SilencesSubcommand::List(args) => !args.json,
+                SilencesSubcommand::Create(args) => !args.json,
+                SilencesSubcommand::Expire(_) => true,
+            },
+            AlertsSubcommand::Channels(args) => match &args.command {
+                ChannelsSubcommand::List(args) => !args.json,
+                ChannelsSubcommand::Create(args) => !args.json,
+                ChannelsSubcommand::Edit(args) => !args.json,
+                ChannelsSubcommand::Delete(_) => true,
+            },
+        }
+    }
+}
+
+#[derive(Args, Debug)]
+pub struct SilencesArgs {
+    #[command(subcommand)]
+    pub command: SilencesSubcommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SilencesSubcommand {
+    /// List the organization's silences, newest first
+    List(SilencesListArgs),
+    /// Silence the alerts a set of matchers selects
+    Create(SilencesCreateArgs),
+    /// Close a silence's window now
+    Expire(SilencesExpireArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct SilencesListArgs {
+    /// Only silences still open at this time, as a timestamp or date math.
+    /// With --to, only the ones whose window overlaps the two.
+    #[arg(long, value_name = "TIME")]
+    pub from: Option<String>,
+    /// Only silences that had already started by this time, as a timestamp or
+    /// date math
+    #[arg(long, value_name = "TIME")]
+    pub to: Option<String>,
+    /// How many to show
+    #[arg(long, default_value_t = DEFAULT_SILENCE_PAGE_SIZE, value_parser = clap::value_parser!(u32).range(1..=MAX_SILENCE_PAGE_SIZE as i64))]
+    pub limit: u32,
+    /// Skip this many before printing
+    #[arg(long, default_value_t = 0)]
+    pub offset: u32,
+    /// Output raw JSON instead of a table
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct SilencesCreateArgs {
+    /// A label to match, as `label=value` or `label!=value`. Repeatable.
+    /// Matching is exact: patterns are not accepted.
+    #[arg(long = "matcher", value_name = "LABEL=VALUE", required = true)]
+    pub matchers: Vec<String>,
+    /// How long the silence lasts, starting now (for example `2h`, `30m`, `7d`)
+    #[arg(long = "for", value_name = "DURATION", conflicts_with_all = ["starts_at", "ends_at"])]
+    pub duration: Option<String>,
+    /// When the silence starts, as a timestamp or date math (default: now)
+    #[arg(long, value_name = "TIME", requires = "ends_at")]
+    pub starts_at: Option<String>,
+    /// When the silence ends, as a timestamp or date math
+    #[arg(long, value_name = "TIME")]
+    pub ends_at: Option<String>,
+    /// Why the alerts are silenced. Frozen onto every notification withheld.
+    #[arg(long)]
+    pub comment: Option<String>,
+    /// Output raw JSON instead of a summary
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct SilencesExpireArgs {
+    /// The silence's id, as `silences list` prints it
+    pub id: String,
+    /// Skip the confirmation prompt (required in non-interactive contexts)
+    #[arg(long, short = 'y')]
+    pub yes: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct ChannelsArgs {
+    #[command(subcommand)]
+    pub command: ChannelsSubcommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ChannelsSubcommand {
+    /// List the organization's delivery channels
+    List(ChannelsListArgs),
+    /// Create a delivery channel
+    Create(ChannelsCreateArgs),
+    /// Change a delivery channel's name or configuration
+    Edit(ChannelsEditArgs),
+    /// Delete a delivery channel
+    Delete(ChannelsDeleteArgs),
+}
+
+/// The transports a channel can deliver over.
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+#[value(rename_all = "lower")]
+pub enum ChannelTypeArg {
+    Webhook,
+    Slack,
+    Discord,
+    Telegram,
+}
+
+#[derive(Args, Debug)]
+pub struct ChannelsListArgs {
+    /// Output raw JSON instead of a table
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// Where a channel's secret comes from.
+///
+/// There is deliberately no flag carrying the value: a webhook URL and a bot
+/// token are both bearer credentials, and a flag would leave one in the shell
+/// history of everybody who ran the command. A file, an environment variable,
+/// or a hidden prompt all keep it out.
+#[derive(Args, Debug)]
+pub struct ChannelSecretArgs {
+    /// Read the webhook URL from this file, or from stdin when given `-`.
+    /// Falls back to $EVERR_CHANNEL_URL, then to a hidden prompt.
+    #[arg(long, value_name = "FILE")]
+    pub url_file: Option<String>,
+    /// Read the Telegram bot token from this file, or from stdin when given
+    /// `-`. Falls back to $EVERR_CHANNEL_BOT_TOKEN, then to a hidden prompt.
+    #[arg(long, value_name = "FILE")]
+    pub bot_token_file: Option<String>,
+    /// A Telegram chat to deliver to. Repeatable.
+    #[arg(long = "chat-id", value_name = "ID")]
+    pub chat_ids: Vec<String>,
+}
+
+impl ChannelSecretArgs {
+    /// Whether the caller named anything that describes a destination. An edit
+    /// that did not can leave the stored one untouched.
+    pub fn is_given(&self) -> bool {
+        self.url_file.is_some() || self.bot_token_file.is_some() || !self.chat_ids.is_empty()
+    }
+}
+
+#[derive(Args, Debug)]
+pub struct ChannelsCreateArgs {
+    /// The channel's name, as a rule's `notifications.channels` names it
+    #[arg(long)]
+    pub name: String,
+    /// The transport to deliver over
+    #[arg(long = "type", value_enum)]
+    pub channel_type: ChannelTypeArg,
+    #[command(flatten)]
+    pub secret: ChannelSecretArgs,
+    /// Output raw JSON instead of a summary
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct ChannelsEditArgs {
+    /// The channel to change
+    pub name: String,
+    /// A new name for the channel
+    #[arg(long)]
+    pub rename: Option<String>,
+    /// The transport to deliver over (default: the channel's current one)
+    #[arg(long = "type", value_enum)]
+    pub channel_type: Option<ChannelTypeArg>,
+    #[command(flatten)]
+    pub secret: ChannelSecretArgs,
+    /// Output raw JSON instead of a summary
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct ChannelsDeleteArgs {
+    /// The channel to delete
+    pub name: String,
     /// Skip the confirmation prompt (required in non-interactive contexts)
     #[arg(long, short = 'y')]
     pub yes: bool,

--- a/packages/desktop-app/src-cli/src/command_telemetry.rs
+++ b/packages/desktop-app/src-cli/src/command_telemetry.rs
@@ -16,8 +16,8 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
 use crate::cli::{
-    CiSubcommand, Cli, CloudSubcommand, Commands, LocalSubcommand, ResourcesSubcommand,
-    SkillsSubcommand,
+    AlertsSubcommand, ChannelsSubcommand, CiSubcommand, Cli, CloudSubcommand, Commands,
+    LocalSubcommand, ResourcesSubcommand, SilencesSubcommand, SkillsSubcommand,
 };
 
 const SERVICE_NAME: &str = "everr-cli";
@@ -316,6 +316,22 @@ impl CommandTelemetry {
                     ResourcesSubcommand::Show(_) => "show",
                     ResourcesSubcommand::Delete(_) => "delete",
                     ResourcesSubcommand::Adopt(_) => "adopt",
+                }),
+            ),
+            Commands::Alerts(args) => (
+                "alerts",
+                Some(match &args.command {
+                    AlertsSubcommand::Silences(args) => match &args.command {
+                        SilencesSubcommand::List(_) => "silences.list",
+                        SilencesSubcommand::Create(_) => "silences.create",
+                        SilencesSubcommand::Expire(_) => "silences.expire",
+                    },
+                    AlertsSubcommand::Channels(args) => match &args.command {
+                        ChannelsSubcommand::List(_) => "channels.list",
+                        ChannelsSubcommand::Create(_) => "channels.create",
+                        ChannelsSubcommand::Edit(_) => "channels.edit",
+                        ChannelsSubcommand::Delete(_) => "channels.delete",
+                    },
                 }),
             ),
         };

--- a/packages/desktop-app/src-cli/src/core.rs
+++ b/packages/desktop-app/src-cli/src/core.rs
@@ -790,7 +790,7 @@ async fn resources_adopt(
 /// Gate a destructive action behind confirmation: `--yes` skips the prompt,
 /// interactive terminals ask (warning-styled when `warn`), and non-interactive
 /// contexts refuse with `refusal`.
-fn confirm_action(
+pub(crate) fn confirm_action(
     question: String,
     yes: bool,
     warn: bool,

--- a/packages/desktop-app/src-cli/src/main.rs
+++ b/packages/desktop-app/src-cli/src/main.rs
@@ -1,3 +1,4 @@
+mod alerts;
 mod api;
 mod auth;
 mod banner;
@@ -72,6 +73,7 @@ async fn run_command(command: Commands) -> Result<()> {
         Commands::Skills(args) => skills::run(args)?,
         Commands::Apply(args) => core::run_apply(args).await?,
         Commands::Resources(args) => core::run_resources(args.command).await?,
+        Commands::Alerts(args) => alerts::run_alerts(args.command).await?,
     }
 
     Ok(())


### PR DESCRIPTION
> **Stacked on #343.** The shared data layer this needs (a paginated `listSilences` with the window filter, the channel input schemas, `parseAlertingInput`, the silence-id guard) lands there, because it changes code the pages already use. This PR is the CLI and the routes that serve it, reviewable on its own.

Silences and channels can only be managed from a browser today. This adds a CLI surface for both.

## Why a new command and not `everr resources`

`everr resources` is the as-code kinds: addressed by project and slug, recreated by the next `everr apply`. Silences and channels are neither. A channel holds a credential; a silence is an operational decision made at a moment in time. Neither belongs in a file a repository applies, and the verbs do not fit (a silence has no slug, and a channel is never applied). They get `everr alerts` instead, which also gives future live-state operations a home.

The pages keep doing what they do. This is for the callers that have no browser: a script, a CI job, an agent.

## Commands

All of them need an `everr cloud login` session. `EVERR_API_KEY` is not accepted, because the routes they call are session-authenticated.

### `everr alerts silences`

| Command | Argument | Options | What it does |
| --- | --- | --- | --- |
| `list` | | `--from`, `--to`, `--limit`, `--offset`, `--json` | One page of the org's silences, newest first. Columns: id, state (`active` / `scheduled` / `expired`), ends, author, matchers. |
| `create` | | `--matcher` (required, repeatable), `--for`, `--starts-at`, `--ends-at`, `--comment`, `--json` | Withholds delivery for the alerts the matchers select. The alerts still fire and stay visible; nobody is paged. |
| `expire` | `<ID>` | `-y`, `--yes` | Closes the window now and re-checks every alert the silence was holding. Prompts unless `--yes`. |

| Option | Value | Notes |
| --- | --- | --- |
| `--matcher` | `label=value` or `label!=value` | Repeatable, at least one required. Matching is exact: patterns are refused, because a user regex would reach the native RegExp engine. `!=` is read before `=`, so `env!=staging` matches the label `env`, not `env!`. |
| `--for` | duration (`2h`, `30m`, `7d`) | Window starts now. Conflicts with `--ends-at`. |
| `--starts-at` | timestamp or date math | Defaults to now. Requires `--ends-at`. |
| `--ends-at` | timestamp or date math | `now+30m` works beside an absolute timestamp. |
| `--comment` | text | Frozen onto every notification the silence withholds. |
| `--from` | timestamp or date math | Silences whose window had not closed by then. |
| `--to` | timestamp or date math | Silences whose window had already started by then. |
| `--limit` | 1 to 100, default 20 | Page size, matching `everr ci runs`. When another page exists the command prints the `--limit` and `--offset` to rerun with, so the cap is never silent. |
| `--offset` | default 0 | Skip this many before printing. |
| `--json` | flag | Raw JSON instead of a table or summary. |

`--from` and `--to` together select the silences whose own window **overlaps** the one you name, which is the question somebody has when a page did not arrive: what was silencing at the time.

```sh
everr alerts silences list --from 2026-08-20T03:00:00Z --to 2026-08-20T04:00:00Z  # during the incident
everr alerts silences list --from now --to now                                     # silencing right now
everr alerts silences list --from now                                              # active and scheduled
```

The match is `starts_at < to AND ends_at > from`, half-open at both ends, so a silence that ended exactly when the window opened did not cover it. Each bound stands alone, which is why one flag pair covers "right now", "not closed yet", and any past window without a separate state filter. Date math is resolved by the CLI, so the request names two instants and the API contract stays plain timestamps.

Expire is not delete. The row survives, because alert history records the `silence_id` that withheld a notification, and deleting it would strand every one of those references.

### `everr alerts channels`

| Command | Argument | Options | What it does |
| --- | --- | --- | --- |
| `list` | | `--json` | The org's channels: name, type, destination. Secrets come back redacted as `***` and are never printed. |
| `create` | | `--name` (required), `--type` (required), a secret source, `--chat-id`, `--json` | Creates a delivery channel. The first channel in an org also becomes its default destination. |
| `edit` | `<NAME>` | `--rename`, `--type`, a secret source, `--chat-id`, `--json` | Changes a channel's name, transport, or credential. Needs at least one of them. |
| `delete` | `<NAME>` | `-y`, `--yes` | Deletes the channel. Refused while any notification is still sending to it. Prompts unless `--yes`. |

| Option | Value | Notes |
| --- | --- | --- |
| `--name` | text | What a rule's `spec.notifications.channels` refers to. Trimmed, 1 to 128 characters. |
| `--type` | `webhook`, `slack`, `discord`, `telegram` | On `edit`, defaults to the channel's current transport. Changing it requires a new secret. |
| `--url-file` | path, or `-` for stdin | Webhook, Slack, and Discord only. |
| `--bot-token-file` | path, or `-` for stdin | Telegram only. |
| `--chat-id` | id | Telegram only, repeatable. Required on create, kept as-is on edit when not given. |
| `--rename` | text | A new name. On its own it sends no config at all, so it costs one request and never touches the credential. |
| `--json` | flag | Raw JSON instead of a table or summary. |

**Secrets never travel as a flag value.** A webhook URL and a bot token are both bearer credentials, and a flag would leave one in the shell history of everybody who ran the command. The value resolves in this order, and there is deliberately no `--url` flag:

1. `--url-file` / `--bot-token-file` (`-` reads stdin)
2. `$EVERR_CHANNEL_URL` / `$EVERR_CHANNEL_BOT_TOKEN`
3. a hidden prompt, when stdin is a terminal
4. otherwise the command fails, naming the two non-interactive options

```sh
everr alerts channels create --name oncall --type slack --url-file ./hook.txt
EVERR_CHANNEL_URL=$SLACK_HOOK everr alerts channels create --name oncall --type slack
everr alerts channels create --name oncall --type slack   # prompts, input hidden
```

## Routes

All under the existing `/api/cli` parent, so they inherit its auth and org middleware. Mutations derive the acting principal from the session, never from the body.

| Method | Path | Request | Returns |
| --- | --- | --- | --- |
| `GET` | `/api/cli/alerts/silences` | query: `from`, `to` (RFC 3339), `limit` (1 to 101, default 20), `offset` (default 0) | `Silence[]`, newest first |
| `POST` | `/api/cli/alerts/silences` | `{ matchers[], starts_at, ends_at, comment? }` | the created `Silence` |
| `POST` | `/api/cli/alerts/silences/$id/expire` | | `{ expired: boolean }` |
| `GET` | `/api/cli/alerts/channels` | | `Channel[]`, secrets redacted |
| `POST` | `/api/cli/alerts/channels` | `{ name, config }` | the created `Channel` |
| `PATCH` | `/api/cli/alerts/channels/$name` | `{ name?, config? }` | the updated `Channel` |
| `DELETE` | `/api/cli/alerts/channels/$name` | | `{ deleted: true }` |

Shapes:

| Type | Fields |
| --- | --- |
| `Silence` | `id`, `tenant`, `matchers[]`, `starts_at`, `ends_at`, `comment`, `author`, `created_at`, `canceled_at` |
| `Matcher` | `label`, `op` (`eq` or `ne`), `value` |
| `Channel` | `id`, `tenant`, `name`, `config` |
| `ChannelConfig` | `{ type: "webhook" \| "slack" \| "discord", url }` or `{ type: "telegram", bot_token, chat_ids[] }` |

The page and the window are bounded by the route's own schema, and `listSilences` (in #343) has no unbounded form to fall back to. `limit` caps at 101 rather than 100 so a caller can request one row more than it means to show and learn whether another page exists without a second count query.

`expired: false` means the window was already closed, not that anything failed. `PATCH` omitting `config` keeps the stored credential; sending one whose secret is `***` does the same, for an edit that changes the rest of it.

Statuses:

| Status | When |
| --- | --- |
| `400` | body is not JSON, or not a JSON object |
| `404` | no channel by that name |
| `409` | channel name already taken, or notifications still sending to a channel being deleted |
| `422` | a schema rejected the input: a malformed silence id, a window ending before it starts, a `limit` above the cap, or a `from` / `to` that is not RFC 3339 |
| `500` | a bug. Reaches the error reporter rather than being flattened into a message the caller cannot act on. |

Refusals answer `{ error, code }`. The CLI prints the reason, not the envelope, and it now does so for every command: the unwrapping moved into the one function every client call reports through, so `everr resources delete` on a missing resource stops printing braces at the user.

## Where validation lives

Nowhere in these routes. The repositories own it and the domain carries the status a refusal means, so a handler is one expression: read the body, call the repository, answer what it returned. That is why the route tests assert wiring rather than rejections, and why the error contract is stated once against `alertingJson` and `readJsonBody` instead of being restated through each route with a different repository mocked.

## Testing

- App suite green at 1728 passed / 217 files on this branch. What this PR adds is the route layer: the shared error contract, and one wiring test per handler. The data-layer coverage (overlap at every edge, the page, the secret surviving a rename, the alert-rule resource list) went to #343 with the code it tests.
- `cargo test -p everr-cli -p everr-core` green, with 28 CLI unit tests and 24 API-client tests. Clippy and rustfmt clean.
- Ran the built binary to confirm the help text and the flag constraints (`--for` conflicts with `--ends-at`; `--starts-at` requires `--ends-at`).
- Not run end to end: no dev server was started, so the HTTP layer is covered by tests only. Route registration and the real session shape are the untested part.

The `everr-setup-resources` skill documents both command groups, and says plainly that neither kind is as-code: the pages own them, apply never touches them, and the CLI is the same work without a browser.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `everr alerts` commands for managing notification channels and alert silences.
  - List, create, edit, expire, and delete supported resources.
  - Added JSON and table output, filtering, pagination, expiration controls, and confirmation prompts.
  - Sensitive channel credentials can be provided securely and are redacted in displayed results.
  - Added authenticated alert-management API endpoints with organization-scoped operations.

- **Documentation**
  - Added guidance for live alerting operations, channel configuration, credential handling, and silence management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->