### PR TITLE
feat(storybook): a gallery for every @everr/ui component

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -29,6 +29,10 @@
     "packages/otel-web/.size-limit.cjs",
     // On-demand skill eval runner, invoked directly with `node`.
     "evals/setup-telemetry/run.mjs",
+    // Storybook loads its config and every story file by glob, never by import.
+    "packages/storybook/.storybook/*.{ts,tsx}",
+    "packages/storybook/src/**/*.stories.tsx",
+    "packages/storybook/src/**/*.mdx",
   ],
   // The two @opentelemetry/* entries are imported only by the OTel web SDK
   // sample in content/docs/guides/browser-telemetry.mdx (the reader
@@ -53,6 +57,12 @@
       // Child-process fixtures intentionally import built package output, which
       // does not exist during CI's pre-build dead-code scan.
       "files": ["packages/otel-errors/test/fixtures/*.mjs"],
+      "rules": { "unresolved-imports": "off" }
+    },
+    {
+      // The Vite alias for @everr/ui points at a source directory, which is a
+      // path rather than a resolvable module.
+      "files": ["packages/storybook/.storybook/main.ts"],
       "rules": { "unresolved-imports": "off" }
     },
     {

--- a/biome.json
+++ b/biome.json
@@ -22,6 +22,9 @@
 
       "packages/telemetry-explorer/**/src/**/*",
 
+      "packages/storybook/**/src/**/*",
+      "packages/storybook/.storybook/**/*",
+
       "packages/otel-web/**/src/**/*",
 
       "packages/otel-errors/**/src/**/*",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev:desktop": "pnpm --filter @everr/desktop-app dev",
     "dev:cli": "pnpm --filter @everr/desktop-app build:cli:debug",
     "dev:docs": "pnpm --filter @everr/docs dev",
+    "dev:storybook": "pnpm --filter @everr/storybook storybook",
     "build:desktop": "pnpm --filter @everr/desktop-app build:desktop",
     "build:desktop:ci": "pnpm --filter @everr/desktop-app build:desktop:ci",
     "check": "biome check",

--- a/packages/storybook/.gitignore
+++ b/packages/storybook/.gitignore
@@ -1,0 +1,1 @@
+storybook-static

--- a/packages/storybook/.storybook/main.ts
+++ b/packages/storybook/.storybook/main.ts
@@ -1,0 +1,25 @@
+import { fileURLToPath } from "node:url";
+import type { StorybookConfig } from "@storybook/react-vite";
+import tailwindcss from "@tailwindcss/vite";
+
+const config: StorybookConfig = {
+  stories: ["../src/**/*.mdx", "../src/**/*.stories.@(ts|tsx)"],
+  addons: ["@storybook/addon-docs"],
+  framework: {
+    name: "@storybook/react-vite",
+    options: {},
+  },
+  viteFinal: (config) => ({
+    ...config,
+    plugins: [...(config.plugins ?? []), tailwindcss()],
+    resolve: {
+      ...config.resolve,
+      alias: {
+        ...config.resolve?.alias,
+        "@everr/ui": fileURLToPath(new URL("../../ui/src", import.meta.url)),
+      },
+    },
+  }),
+};
+
+export default config;

--- a/packages/storybook/.storybook/preview.tsx
+++ b/packages/storybook/.storybook/preview.tsx
@@ -1,0 +1,28 @@
+import { TooltipProvider } from "@everr/ui/components/tooltip";
+import type { Decorator, Preview } from "@storybook/react-vite";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import "./theme.css";
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
+
+const withProviders: Decorator = (Story) => (
+  <QueryClientProvider client={queryClient}>
+    <TooltipProvider>
+      <div className="bg-background text-foreground p-6">
+        <Story />
+      </div>
+    </TooltipProvider>
+  </QueryClientProvider>
+);
+
+const preview: Preview = {
+  decorators: [withProviders],
+  parameters: {
+    layout: "fullscreen",
+    controls: { expanded: true },
+  },
+};
+
+export default preview;

--- a/packages/storybook/.storybook/theme.css
+++ b/packages/storybook/.storybook/theme.css
@@ -1,0 +1,6 @@
+@import "@everr/ui/styles/global.css";
+
+/* Tailwind detects its sources from this file's package, so the component
+   classes and the story classes both have to be registered by hand. */
+@source "../src";
+@source "../../ui/src";

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@everr/storybook",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "storybook": "storybook dev -p 6006 --no-open",
+    "build": "storybook build",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@everr/ui": "workspace:*",
+    "@tanstack/react-query": "catalog:",
+    "lucide-react": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "recharts": "catalog:",
+    "sonner": "^2.0.7"
+  },
+  "devDependencies": {
+    "@storybook/addon-docs": "^9.1.13",
+    "@storybook/react-vite": "^9.1.13",
+    "@tailwindcss/vite": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "catalog:",
+    "storybook": "^9.1.13",
+    "tailwindcss": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:"
+  }
+}

--- a/packages/storybook/src/stories/alert-dialog.stories.tsx
+++ b/packages/storybook/src/stories/alert-dialog.stories.tsx
@@ -1,0 +1,116 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@everr/ui/components/alert-dialog";
+import { Button } from "@everr/ui/components/button";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { TriangleAlertIcon } from "lucide-react";
+
+const meta = {
+  title: "Overlays/AlertDialog",
+  component: AlertDialog,
+} satisfies Meta<typeof AlertDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <AlertDialog defaultOpen>
+      <AlertDialogTrigger render={<Button variant="outline" />}>
+        Delete rule
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete this alert rule?</AlertDialogTitle>
+          <AlertDialogDescription>
+            The rule stops evaluating immediately. The history of its instances
+            stays available.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction variant="destructive">Delete</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  ),
+};
+
+export const WithMedia: Story = {
+  render: () => (
+    <AlertDialog defaultOpen>
+      <AlertDialogTrigger render={<Button variant="outline" />}>
+        Revoke token
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogMedia>
+            <TriangleAlertIcon />
+          </AlertDialogMedia>
+          <AlertDialogTitle>Revoke this API token?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Every client that uses this token stops sending data until you give
+            it a new token.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Keep token</AlertDialogCancel>
+          <AlertDialogAction variant="destructive">Revoke</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  ),
+};
+
+export const Small: Story = {
+  render: () => (
+    <AlertDialog defaultOpen>
+      <AlertDialogTrigger render={<Button variant="outline" />}>
+        Discard draft
+      </AlertDialogTrigger>
+      <AlertDialogContent size="sm">
+        <AlertDialogHeader>
+          <AlertDialogTitle>Discard the draft?</AlertDialogTitle>
+          <AlertDialogDescription>
+            The changes are not saved.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel size="sm">Keep</AlertDialogCancel>
+          <AlertDialogAction size="sm" variant="destructive">
+            Discard
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  ),
+};
+
+export const ClosedUntilTriggered: Story = {
+  render: () => (
+    <AlertDialog>
+      <AlertDialogTrigger render={<Button />}>Open alert</AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Stop the ingestion?</AlertDialogTitle>
+          <AlertDialogDescription>
+            New telemetry is refused until you start the ingestion again.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction>Stop</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  ),
+};

--- a/packages/storybook/src/stories/avatar.stories.tsx
+++ b/packages/storybook/src/stories/avatar.stories.tsx
@@ -1,0 +1,125 @@
+import {
+  Avatar,
+  AvatarBadge,
+  AvatarFallback,
+  AvatarGroup,
+  AvatarGroupCount,
+  AvatarImage,
+} from "@everr/ui/components/avatar";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { CheckIcon } from "lucide-react";
+
+const portrait = (hue: number) =>
+  `data:image/svg+xml;utf8,${encodeURIComponent(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80"><rect width="80" height="80" fill="hsl(${hue} 60% 45%)"/><circle cx="40" cy="32" r="14" fill="hsl(${hue} 60% 80%)"/><circle cx="40" cy="78" r="26" fill="hsl(${hue} 60% 80%)"/></svg>`,
+  )}`;
+
+const meta = {
+  title: "Data/Avatar",
+  component: Avatar,
+  render: (args) => (
+    <Avatar {...args}>
+      <AvatarImage src={portrait(210)} alt="Ada Lovelace" />
+      <AvatarFallback>AL</AvatarFallback>
+    </Avatar>
+  ),
+} satisfies Meta<typeof Avatar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex items-end gap-3">
+      {(["xs", "sm", "default", "lg"] as const).map((size) => (
+        <Avatar key={size} size={size}>
+          <AvatarImage src={portrait(160)} alt="Grace Hopper" />
+          <AvatarFallback>GH</AvatarFallback>
+        </Avatar>
+      ))}
+    </div>
+  ),
+};
+
+export const Fallback: Story = {
+  render: () => (
+    <div className="flex items-end gap-3">
+      <Avatar size="sm">
+        <AvatarFallback>GR</AvatarFallback>
+      </Avatar>
+      <Avatar>
+        <AvatarFallback>GR</AvatarFallback>
+      </Avatar>
+      <Avatar size="lg">
+        <AvatarFallback>GR</AvatarFallback>
+      </Avatar>
+    </div>
+  ),
+};
+
+export const BrokenImage: Story = {
+  render: () => (
+    <Avatar>
+      <AvatarImage src="/missing-portrait.png" alt="Missing" />
+      <AvatarFallback>MP</AvatarFallback>
+    </Avatar>
+  ),
+};
+
+export const WithBadge: Story = {
+  render: () => (
+    <div className="flex items-end gap-3">
+      <Avatar size="sm">
+        <AvatarImage src={portrait(120)} alt="Online user" />
+        <AvatarFallback>ON</AvatarFallback>
+        <AvatarBadge className="bg-emerald-500" />
+      </Avatar>
+      <Avatar>
+        <AvatarImage src={portrait(120)} alt="Online user" />
+        <AvatarFallback>ON</AvatarFallback>
+        <AvatarBadge className="bg-emerald-500" />
+      </Avatar>
+      <Avatar size="lg">
+        <AvatarImage src={portrait(120)} alt="Verified user" />
+        <AvatarFallback>VU</AvatarFallback>
+        <AvatarBadge>
+          <CheckIcon />
+        </AvatarBadge>
+      </Avatar>
+    </div>
+  ),
+};
+
+export const Group: Story = {
+  render: () => (
+    <AvatarGroup>
+      {[10, 90, 200, 300].map((hue) => (
+        <Avatar key={hue}>
+          <AvatarImage src={portrait(hue)} alt={`On-call engineer ${hue}`} />
+          <AvatarFallback>EN</AvatarFallback>
+        </Avatar>
+      ))}
+      <AvatarGroupCount>+7</AvatarGroupCount>
+    </AvatarGroup>
+  ),
+};
+
+export const GroupSizes: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      {(["sm", "default", "lg"] as const).map((size) => (
+        <AvatarGroup key={size}>
+          {[20, 140, 260].map((hue) => (
+            <Avatar key={hue} size={size}>
+              <AvatarImage src={portrait(hue)} alt="Team member" />
+              <AvatarFallback>TM</AvatarFallback>
+            </Avatar>
+          ))}
+          <AvatarGroupCount>+3</AvatarGroupCount>
+        </AvatarGroup>
+      ))}
+    </div>
+  ),
+};

--- a/packages/storybook/src/stories/badge.stories.tsx
+++ b/packages/storybook/src/stories/badge.stories.tsx
@@ -1,0 +1,84 @@
+import { Badge } from "@everr/ui/components/badge";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { AlertTriangleIcon, CheckIcon } from "lucide-react";
+
+const meta = {
+  title: "Data/Badge",
+  component: Badge,
+  args: { children: "Badge" },
+} satisfies Meta<typeof Badge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Secondary: Story = {
+  args: { variant: "secondary", children: "Secondary" },
+};
+
+export const Destructive: Story = {
+  args: { variant: "destructive", children: "Firing" },
+};
+
+export const Outline: Story = {
+  args: { variant: "outline", children: "checkout-api" },
+};
+
+export const Ghost: Story = {
+  args: { variant: "ghost", children: "Ghost" },
+};
+
+export const Link: Story = {
+  args: { variant: "link", children: "View rule" },
+};
+
+export const DiffTones: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-center gap-2">
+      <Badge variant="added">Added</Badge>
+      <Badge variant="changed">Changed</Badge>
+      <Badge variant="conflict">Conflict</Badge>
+      <Badge variant="removed">Removed</Badge>
+    </div>
+  ),
+};
+
+export const WithIcon: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-center gap-2">
+      <Badge variant="added">
+        <CheckIcon data-icon="inline-start" />
+        Healthy
+      </Badge>
+      <Badge variant="destructive">
+        <AlertTriangleIcon data-icon="inline-start" />3 firing
+      </Badge>
+    </div>
+  ),
+};
+
+export const AsLink: Story = {
+  args: {
+    variant: "outline",
+    children: "payments-worker",
+    render: <a href="#services">payments-worker</a>,
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-center gap-2">
+      <Badge>default</Badge>
+      <Badge variant="secondary">secondary</Badge>
+      <Badge variant="destructive">destructive</Badge>
+      <Badge variant="outline">outline</Badge>
+      <Badge variant="ghost">ghost</Badge>
+      <Badge variant="link">link</Badge>
+      <Badge variant="added">added</Badge>
+      <Badge variant="changed">changed</Badge>
+      <Badge variant="conflict">conflict</Badge>
+      <Badge variant="removed">removed</Badge>
+    </div>
+  ),
+};

--- a/packages/storybook/src/stories/banner.stories.tsx
+++ b/packages/storybook/src/stories/banner.stories.tsx
@@ -1,0 +1,105 @@
+import {
+  Banner,
+  BannerActions,
+  BannerContent,
+  bannerFrameVariants,
+} from "@everr/ui/components/banner";
+import { Button } from "@everr/ui/components/button";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { InfoIcon, XIcon } from "lucide-react";
+
+const variants = ["neutral", "info", "success", "warning", "danger"] as const;
+
+const meta = {
+  title: "Data/Banner",
+  component: Banner,
+  args: {
+    variant: "info",
+    className: "w-full justify-between py-1 pl-3.5 pr-1.5",
+  },
+  render: (args) => (
+    <Banner {...args}>
+      <div className="flex min-w-0 items-center gap-2">
+        <InfoIcon className="size-3.5 shrink-0" />
+        <BannerContent className="truncate">
+          You are viewing a preview of the alerting rules.
+        </BannerContent>
+      </div>
+      <BannerActions>
+        <Button variant="ghost" size="sm">
+          Apply
+        </Button>
+        <Button variant="ghost" size="icon-sm" aria-label="Dismiss">
+          <XIcon />
+        </Button>
+      </BannerActions>
+    </Banner>
+  ),
+} satisfies Meta<typeof Banner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Info: Story = {};
+
+export const Neutral: Story = { args: { variant: "neutral" } };
+
+export const Success: Story = { args: { variant: "success" } };
+
+export const Warning: Story = { args: { variant: "warning" } };
+
+export const Danger: Story = { args: { variant: "danger" } };
+
+export const MessageOnly: Story = {
+  render: (args) => (
+    <Banner {...args} className="w-full py-1 pl-3.5 pr-3.5">
+      <BannerContent>Data is delayed by about 40 seconds.</BannerContent>
+    </Banner>
+  ),
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex w-full flex-col gap-3">
+      {variants.map((variant) => (
+        <Banner
+          key={variant}
+          variant={variant}
+          className="w-full justify-between py-1 pl-3.5 pr-1.5"
+        >
+          <BannerContent className="truncate">{variant}</BannerContent>
+          <BannerActions>
+            <Button variant="ghost" size="icon-sm" aria-label="Dismiss">
+              <XIcon />
+            </Button>
+          </BannerActions>
+        </Banner>
+      ))}
+    </div>
+  ),
+};
+
+export const InsideFrame: Story = {
+  render: () => (
+    <div className="flex w-full flex-col gap-4">
+      {variants.map((variant) => (
+        <div
+          key={variant}
+          className={bannerFrameVariants({ variant, className: "rounded-lg" })}
+        >
+          <Banner
+            variant={variant}
+            className="w-full justify-between py-1 pl-3.5 pr-1.5"
+          >
+            <BannerContent className="truncate">
+              The frame ring matches the {variant} banner.
+            </BannerContent>
+          </Banner>
+          <div className="p-4 text-xs text-muted-foreground">
+            Framed content goes here.
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/packages/storybook/src/stories/breadcrumb.stories.tsx
+++ b/packages/storybook/src/stories/breadcrumb.stories.tsx
@@ -1,0 +1,99 @@
+import {
+  Breadcrumb,
+  BreadcrumbEllipsis,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@everr/ui/components/breadcrumb";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SlashIcon } from "lucide-react";
+
+const meta = {
+  title: "Layout/Breadcrumb",
+  component: Breadcrumb,
+} satisfies Meta<typeof Breadcrumb>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <Breadcrumb {...args}>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Services</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">checkout-api</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Traces</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  ),
+};
+
+export const WithEllipsis: Story = {
+  render: (args) => (
+    <Breadcrumb {...args}>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbEllipsis />
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Alerts</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Queue depth</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  ),
+};
+
+export const CustomSeparator: Story = {
+  render: (args) => (
+    <Breadcrumb {...args}>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Dashboards</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator>
+          <SlashIcon />
+        </BreadcrumbSeparator>
+        <BreadcrumbItem>
+          <BreadcrumbPage>Ingest overview</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  ),
+};
+
+export const CustomLinkRender: Story = {
+  render: (args) => (
+    <Breadcrumb {...args}>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink render={<button type="button" />}>
+            Workspace
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Settings</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  ),
+};

--- a/packages/storybook/src/stories/button.stories.tsx
+++ b/packages/storybook/src/stories/button.stories.tsx
@@ -1,0 +1,159 @@
+import { Button } from "@everr/ui/components/button";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ArrowRightIcon, PlusIcon, TrashIcon } from "lucide-react";
+
+const meta = {
+  title: "Controls/Button",
+  component: Button,
+  args: { children: "Button" },
+  argTypes: {
+    variant: {
+      control: "select",
+      options: [
+        "default",
+        "outline",
+        "secondary",
+        "ghost",
+        "destructive",
+        "link",
+        "cta",
+      ],
+    },
+    size: {
+      control: "select",
+      options: [
+        "default",
+        "xs",
+        "sm",
+        "lg",
+        "xl",
+        "icon",
+        "icon-xs",
+        "icon-sm",
+        "icon-lg",
+      ],
+    },
+    disabled: { control: "boolean" },
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Variants: Story = {
+  render: (args) => (
+    <div className="flex flex-wrap items-center gap-2">
+      <Button {...args} variant="default">
+        Default
+      </Button>
+      <Button {...args} variant="outline">
+        Outline
+      </Button>
+      <Button {...args} variant="secondary">
+        Secondary
+      </Button>
+      <Button {...args} variant="ghost">
+        Ghost
+      </Button>
+      <Button {...args} variant="destructive">
+        Destructive
+      </Button>
+      <Button {...args} variant="link">
+        Link
+      </Button>
+      <Button {...args} variant="cta">
+        Call to action
+      </Button>
+    </div>
+  ),
+};
+
+export const Sizes: Story = {
+  render: (args) => (
+    <div className="flex flex-wrap items-center gap-2">
+      <Button {...args} size="xs">
+        Extra small
+      </Button>
+      <Button {...args} size="sm">
+        Small
+      </Button>
+      <Button {...args} size="default">
+        Default
+      </Button>
+      <Button {...args} size="lg">
+        Large
+      </Button>
+      <Button {...args} size="xl">
+        Extra large
+      </Button>
+    </div>
+  ),
+};
+
+export const IconSizes: Story = {
+  render: (args) => (
+    <div className="flex flex-wrap items-center gap-2">
+      <Button {...args} size="icon-xs" aria-label="Add">
+        <PlusIcon />
+      </Button>
+      <Button {...args} size="icon-sm" aria-label="Add">
+        <PlusIcon />
+      </Button>
+      <Button {...args} size="icon" aria-label="Add">
+        <PlusIcon />
+      </Button>
+      <Button {...args} size="icon-lg" aria-label="Add">
+        <PlusIcon />
+      </Button>
+    </div>
+  ),
+};
+
+export const WithIcons: Story = {
+  render: (args) => (
+    <div className="flex flex-wrap items-center gap-2">
+      <Button {...args}>
+        <PlusIcon data-icon="inline-start" />
+        Create rule
+      </Button>
+      <Button {...args} variant="outline">
+        Continue
+        <ArrowRightIcon data-icon="inline-end" />
+      </Button>
+      <Button {...args} variant="destructive">
+        <TrashIcon data-icon="inline-start" />
+        Delete
+      </Button>
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  render: (args) => (
+    <div className="flex flex-wrap items-center gap-2">
+      <Button {...args} disabled>
+        Default
+      </Button>
+      <Button {...args} variant="outline" disabled>
+        Outline
+      </Button>
+      <Button {...args} variant="destructive" disabled>
+        Destructive
+      </Button>
+    </div>
+  ),
+};
+
+export const Invalid: Story = {
+  args: { "aria-invalid": true, children: "Invalid" },
+};
+
+export const AsLink: Story = {
+  args: {
+    variant: "link",
+    children: "Open the docs",
+    render: <a href="https://example.com">Open the docs</a>,
+  },
+};

--- a/packages/storybook/src/stories/card.stories.tsx
+++ b/packages/storybook/src/stories/card.stories.tsx
@@ -1,0 +1,112 @@
+import { Button } from "@everr/ui/components/button";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@everr/ui/components/card";
+import { Separator } from "@everr/ui/components/separator";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Layout/Card",
+  component: Card,
+} satisfies Meta<typeof Card>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <Card {...args} className="w-80">
+      <CardHeader>
+        <CardTitle>Checkout latency</CardTitle>
+        <CardDescription>p95 over the last 24 hours</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p className="text-2xl font-medium tabular-nums">412 ms</p>
+      </CardContent>
+    </Card>
+  ),
+};
+
+export const WithAction: Story = {
+  render: (args) => (
+    <Card {...args} className="w-80">
+      <CardHeader>
+        <CardTitle>Error budget</CardTitle>
+        <CardDescription>28 days remaining in the window</CardDescription>
+        <CardAction>
+          <Button variant="ghost" size="sm">
+            Details
+          </Button>
+        </CardAction>
+      </CardHeader>
+      <CardContent>
+        <p className="text-muted-foreground">61% of the budget is left.</p>
+      </CardContent>
+    </Card>
+  ),
+};
+
+export const WithFooter: Story = {
+  render: (args) => (
+    <Card {...args} className="w-80">
+      <CardHeader>
+        <CardTitle>Deploy 4f21ac</CardTitle>
+        <CardDescription>Promoted 12 minutes ago</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p className="text-muted-foreground">
+          All checks passed on the release pipeline.
+        </p>
+      </CardContent>
+      <Separator />
+      <CardFooter className="justify-end gap-2 pt-3">
+        <Button variant="ghost" size="sm">
+          Roll back
+        </Button>
+        <Button size="sm">Open run</Button>
+      </CardFooter>
+    </Card>
+  ),
+};
+
+export const Small: Story = {
+  args: { size: "sm" },
+  render: (args) => (
+    <Card {...args} className="w-64">
+      <CardHeader>
+        <CardTitle>Ingest rate</CardTitle>
+        <CardDescription>Spans per second</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p className="text-lg font-medium tabular-nums">18.4k</p>
+      </CardContent>
+    </Card>
+  ),
+};
+
+export const FlushContent: Story = {
+  args: { inset: "flush-content" },
+  render: (args) => (
+    <Card {...args} className="w-80">
+      <CardHeader>
+        <CardTitle>Recent alerts</CardTitle>
+        <CardDescription>Firing instances by rule</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ul className="divide-border divide-y border-t">
+          {["Checkout p95", "Queue depth", "Auth error rate"].map((rule) => (
+            <li key={rule} className="px-3 py-2">
+              {rule}
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  ),
+};

--- a/packages/storybook/src/stories/chart-helpers.stories.tsx
+++ b/packages/storybook/src/stories/chart-helpers.stories.tsx
@@ -1,0 +1,126 @@
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@everr/ui/components/chart";
+import {
+  ChartEmptyState,
+  chartTooltipLabelFormatter,
+  createChartTooltipFormatter,
+  createLegendFormatter,
+  formatChartDate,
+} from "@everr/ui/components/chart-helpers";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
+
+const requestRate = [1240, 1180, 1310, 1490, 1720, 1980, 2140];
+const p95Latency = [182, 176, 191, 214, 268, 342, 401];
+
+const series = requestRate.map((requests, index) => ({
+  date: `2026-08-${String(index + 10).padStart(2, "0")}T00:00:00Z`,
+  requests,
+  latency: p95Latency[index],
+}));
+
+const config = {
+  requests: { label: "Requests / s", color: "var(--chart-1)" },
+  latency: { label: "p95 latency (ms)", color: "var(--chart-2)" },
+} satisfies ChartConfig;
+
+const meta = {
+  title: "Charts/ChartHelpers",
+  component: ChartEmptyState,
+  args: { message: "No data for the selected time range" },
+} satisfies Meta<typeof ChartEmptyState>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const EmptyState: Story = {};
+
+export const EmptyStateAfterFilter: Story = {
+  args: { message: "No series match the current filters" },
+};
+
+export const FormatChartDate: Story = {
+  render: () => (
+    <ul className="text-sm font-mono">
+      {series.map((point) => (
+        <li key={point.date}>
+          {point.date} → {formatChartDate(point.date)}
+        </li>
+      ))}
+    </ul>
+  ),
+};
+
+export const TooltipFormatters: Story = {
+  render: () => (
+    <ChartContainer config={config} className="aspect-auto h-[300px] w-[640px]">
+      <BarChart data={series}>
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="date"
+          tickLine={false}
+          axisLine={false}
+          tickFormatter={formatChartDate}
+        />
+        <YAxis tickLine={false} axisLine={false} width={44} />
+        <ChartTooltip
+          labelFormatter={chartTooltipLabelFormatter}
+          content={
+            <ChartTooltipContent
+              formatter={createChartTooltipFormatter(config, (value, name) =>
+                name === "latency"
+                  ? `${value} ms`
+                  : `${value.toLocaleString()} rps`,
+              )}
+            />
+          }
+        />
+        <Bar
+          dataKey="requests"
+          fill="var(--color-requests)"
+          radius={4}
+          isAnimationActive={false}
+        />
+        <Bar
+          dataKey="latency"
+          fill="var(--color-latency)"
+          radius={4}
+          isAnimationActive={false}
+        />
+      </BarChart>
+    </ChartContainer>
+  ),
+};
+
+export const LegendFormatter: Story = {
+  render: () => (
+    <ChartContainer config={config} className="aspect-auto h-[300px] w-[640px]">
+      <BarChart data={series}>
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="date"
+          tickLine={false}
+          axisLine={false}
+          tickFormatter={formatChartDate}
+        />
+        <YAxis tickLine={false} axisLine={false} width={44} />
+        <ChartLegend
+          formatter={createLegendFormatter(config)}
+          content={<ChartLegendContent />}
+        />
+        <Bar
+          dataKey="requests"
+          fill="var(--color-requests)"
+          radius={4}
+          isAnimationActive={false}
+        />
+      </BarChart>
+    </ChartContainer>
+  ),
+};

--- a/packages/storybook/src/stories/chart.stories.tsx
+++ b/packages/storybook/src/stories/chart.stories.tsx
@@ -1,0 +1,218 @@
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartStyle,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@everr/ui/components/chart";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Line,
+  LineChart,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+const requestRate = [
+  1240, 1180, 1310, 1490, 1720, 1980, 2140, 2060, 1890, 1650, 1420, 1290,
+];
+const p95Latency = [182, 176, 191, 214, 268, 342, 401, 377, 310, 254, 208, 190];
+const errorRate = [0.4, 0.3, 0.5, 0.8, 1.4, 2.6, 3.9, 3.1, 1.9, 1.1, 0.6, 0.4];
+
+const series = requestRate.map((requests, index) => ({
+  time: `${String(index * 2).padStart(2, "0")}:00`,
+  requests,
+  latency: p95Latency[index],
+  errors: errorRate[index],
+}));
+
+const config = {
+  requests: { label: "Requests / s", color: "var(--chart-1)" },
+  latency: { label: "p95 latency (ms)", color: "var(--chart-2)" },
+  errors: { label: "Error rate (%)", color: "var(--chart-3)" },
+} satisfies ChartConfig;
+
+const meta = {
+  title: "Charts/Chart",
+  component: ChartContainer,
+  args: {
+    config,
+    className: "aspect-auto h-[300px] w-[640px]",
+    children: (
+      <LineChart data={series}>
+        <CartesianGrid vertical={false} />
+        <XAxis dataKey="time" tickLine={false} axisLine={false} />
+        <YAxis tickLine={false} axisLine={false} width={40} />
+        <ChartTooltip content={<ChartTooltipContent />} />
+        <Line
+          dataKey="requests"
+          stroke="var(--color-requests)"
+          strokeWidth={2}
+          dot={false}
+          isAnimationActive={false}
+        />
+      </LineChart>
+    ),
+  },
+} satisfies Meta<typeof ChartContainer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Line_: Story = { name: "Line" };
+
+export const Bars: Story = {
+  args: {
+    children: (
+      <BarChart data={series}>
+        <CartesianGrid vertical={false} />
+        <XAxis dataKey="time" tickLine={false} axisLine={false} />
+        <YAxis tickLine={false} axisLine={false} width={40} />
+        <ChartTooltip content={<ChartTooltipContent />} />
+        <Bar
+          dataKey="latency"
+          fill="var(--color-latency)"
+          radius={4}
+          isAnimationActive={false}
+        />
+      </BarChart>
+    ),
+  },
+};
+
+export const StackedArea: Story = {
+  args: {
+    children: (
+      <AreaChart data={series}>
+        <CartesianGrid vertical={false} />
+        <XAxis dataKey="time" tickLine={false} axisLine={false} />
+        <YAxis tickLine={false} axisLine={false} width={40} />
+        <ChartTooltip content={<ChartTooltipContent indicator="line" />} />
+        <Area
+          dataKey="requests"
+          stackId="a"
+          stroke="var(--color-requests)"
+          fill="var(--color-requests)"
+          fillOpacity={0.3}
+          isAnimationActive={false}
+        />
+        <Area
+          dataKey="latency"
+          stackId="a"
+          stroke="var(--color-latency)"
+          fill="var(--color-latency)"
+          fillOpacity={0.3}
+          isAnimationActive={false}
+        />
+      </AreaChart>
+    ),
+  },
+};
+
+export const WithLegend: Story = {
+  args: {
+    children: (
+      <LineChart data={series}>
+        <CartesianGrid vertical={false} />
+        <XAxis dataKey="time" tickLine={false} axisLine={false} />
+        <YAxis tickLine={false} axisLine={false} width={40} />
+        <ChartTooltip content={<ChartTooltipContent />} />
+        <ChartLegend content={<ChartLegendContent />} />
+        <Line
+          dataKey="requests"
+          stroke="var(--color-requests)"
+          strokeWidth={2}
+          dot={false}
+          isAnimationActive={false}
+        />
+        <Line
+          dataKey="latency"
+          stroke="var(--color-latency)"
+          strokeWidth={2}
+          dot={false}
+          isAnimationActive={false}
+        />
+      </LineChart>
+    ),
+  },
+};
+
+export const LegendOnTop: Story = {
+  args: {
+    children: (
+      <BarChart data={series}>
+        <CartesianGrid vertical={false} />
+        <XAxis dataKey="time" tickLine={false} axisLine={false} />
+        <YAxis tickLine={false} axisLine={false} width={40} />
+        <ChartTooltip content={<ChartTooltipContent hideLabel />} />
+        <ChartLegend
+          verticalAlign="top"
+          content={<ChartLegendContent verticalAlign="top" />}
+        />
+        <Bar
+          dataKey="errors"
+          fill="var(--color-errors)"
+          radius={4}
+          isAnimationActive={false}
+        />
+      </BarChart>
+    ),
+  },
+};
+
+export const TooltipIndicators: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6">
+      {(["dot", "line", "dashed"] as const).map((indicator) => (
+        <div key={indicator} className="flex flex-col gap-2">
+          <span className="text-muted-foreground text-xs">{indicator}</span>
+          <ChartContainer
+            config={config}
+            className="aspect-auto h-[160px] w-[640px]"
+          >
+            <LineChart data={series}>
+              <CartesianGrid vertical={false} />
+              <XAxis dataKey="time" tickLine={false} axisLine={false} />
+              <ChartTooltip
+                defaultIndex={5}
+                active
+                content={<ChartTooltipContent indicator={indicator} />}
+              />
+              <Line
+                dataKey="requests"
+                stroke="var(--color-requests)"
+                strokeWidth={2}
+                dot={false}
+                isAnimationActive={false}
+              />
+            </LineChart>
+          </ChartContainer>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+export const ChartStyleOnly: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3" data-chart="chart-style-demo">
+      <ChartStyle id="chart-style-demo" config={config} />
+      {Object.entries(config).map(([key, item]) => (
+        <div key={key} className="flex items-center gap-2 text-sm">
+          <span
+            className="size-3 rounded-[2px]"
+            style={{ backgroundColor: `var(--color-${key})` }}
+          />
+          {item.label}
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/packages/storybook/src/stories/collapsible.stories.tsx
+++ b/packages/storybook/src/stories/collapsible.stories.tsx
@@ -1,0 +1,115 @@
+import { Button } from "@everr/ui/components/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@everr/ui/components/collapsible";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ChevronsUpDownIcon } from "lucide-react";
+import { useState } from "react";
+
+const meta = {
+  title: "Layout/Collapsible",
+  component: Collapsible,
+} satisfies Meta<typeof Collapsible>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const attributes = [
+  "service.name = checkout-api",
+  "deployment.environment = production",
+  "http.route = /cart/checkout",
+];
+
+export const Default: Story = {
+  render: (args) => (
+    <Collapsible {...args} className="w-80">
+      <CollapsibleTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full justify-between"
+          />
+        }
+      >
+        Resource attributes
+        <ChevronsUpDownIcon />
+      </CollapsibleTrigger>
+      <CollapsibleContent className="text-muted-foreground grid gap-1 px-2 pt-2 font-mono">
+        {attributes.map((attribute) => (
+          <span key={attribute}>{attribute}</span>
+        ))}
+      </CollapsibleContent>
+    </Collapsible>
+  ),
+};
+
+export const OpenByDefault: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Collapsible {...args} className="w-80">
+      <CollapsibleTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full justify-between"
+          />
+        }
+      >
+        Resource attributes
+        <ChevronsUpDownIcon />
+      </CollapsibleTrigger>
+      <CollapsibleContent className="text-muted-foreground grid gap-1 px-2 pt-2 font-mono">
+        {attributes.map((attribute) => (
+          <span key={attribute}>{attribute}</span>
+        ))}
+      </CollapsibleContent>
+    </Collapsible>
+  ),
+};
+
+export const Controlled: Story = {
+  render: function Controlled(args) {
+    const [open, setOpen] = useState(false);
+    return (
+      <div className="w-80 grid gap-2">
+        <Button variant="outline" size="sm" onClick={() => setOpen(!open)}>
+          {open ? "Hide" : "Show"} attributes
+        </Button>
+        <Collapsible {...args} open={open} onOpenChange={setOpen}>
+          <CollapsibleContent className="text-muted-foreground grid gap-1 font-mono">
+            {attributes.map((attribute) => (
+              <span key={attribute}>{attribute}</span>
+            ))}
+          </CollapsibleContent>
+        </Collapsible>
+      </div>
+    );
+  },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+  render: (args) => (
+    <Collapsible {...args} className="w-80">
+      <CollapsibleTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full justify-between"
+          />
+        }
+      >
+        Resource attributes
+        <ChevronsUpDownIcon />
+      </CollapsibleTrigger>
+      <CollapsibleContent className="text-muted-foreground px-2 pt-2">
+        Not reachable while disabled.
+      </CollapsibleContent>
+    </Collapsible>
+  ),
+};

--- a/packages/storybook/src/stories/command.stories.tsx
+++ b/packages/storybook/src/stories/command.stories.tsx
@@ -1,0 +1,132 @@
+import { Button } from "@everr/ui/components/button";
+import {
+  Command,
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+  CommandShortcut,
+} from "@everr/ui/components/command";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { BellIcon, GaugeIcon, SearchIcon, SettingsIcon } from "lucide-react";
+import { useState } from "react";
+
+const meta = {
+  title: "Overlays/Command",
+  component: Command,
+} satisfies Meta<typeof Command>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function CommandBody() {
+  return (
+    <>
+      <CommandInput placeholder="Search for a command..." />
+      <CommandList>
+        <CommandEmpty>No command matches that search.</CommandEmpty>
+        <CommandGroup heading="Navigate">
+          <CommandItem>
+            <GaugeIcon />
+            Dashboards
+            <CommandShortcut>⌘D</CommandShortcut>
+          </CommandItem>
+          <CommandItem>
+            <BellIcon />
+            Alerts
+            <CommandShortcut>⌘A</CommandShortcut>
+          </CommandItem>
+          <CommandItem>
+            <SearchIcon />
+            Traces
+          </CommandItem>
+        </CommandGroup>
+        <CommandSeparator />
+        <CommandGroup heading="Settings">
+          <CommandItem>
+            <SettingsIcon />
+            Organization settings
+          </CommandItem>
+          <CommandItem disabled>Billing</CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </>
+  );
+}
+
+export const Inline: Story = {
+  render: () => (
+    <div className="ring-foreground/10 mx-auto max-w-md rounded-xl ring-1">
+      <Command>
+        <CommandBody />
+      </Command>
+    </div>
+  ),
+};
+
+export const Empty: Story = {
+  render: () => (
+    <div className="ring-foreground/10 mx-auto max-w-md rounded-xl ring-1">
+      <Command>
+        <CommandInput
+          placeholder="Search for a command..."
+          value="unknown command"
+          onValueChange={() => {}}
+        />
+        <CommandList>
+          <CommandEmpty>No command matches that search.</CommandEmpty>
+          <CommandGroup heading="Navigate">
+            <CommandItem>Dashboards</CommandItem>
+          </CommandGroup>
+        </CommandList>
+      </Command>
+    </div>
+  ),
+};
+
+export const AsDialog: Story = {
+  render: function AsDialogStory() {
+    const [open, setOpen] = useState(true);
+
+    return (
+      <>
+        <Button variant="outline" onClick={() => setOpen(true)}>
+          Open command palette
+        </Button>
+        <CommandDialog open={open} onOpenChange={setOpen}>
+          <Command>
+            <CommandBody />
+          </Command>
+        </CommandDialog>
+      </>
+    );
+  },
+};
+
+export const AsDialogWithCloseButton: Story = {
+  render: function AsDialogWithCloseButtonStory() {
+    const [open, setOpen] = useState(true);
+
+    return (
+      <>
+        <Button variant="outline" onClick={() => setOpen(true)}>
+          Open command palette
+        </Button>
+        <CommandDialog
+          open={open}
+          onOpenChange={setOpen}
+          showCloseButton
+          title="Jump to"
+          description="Type the name of a page or an action."
+        >
+          <Command>
+            <CommandBody />
+          </Command>
+        </CommandDialog>
+      </>
+    );
+  },
+};

--- a/packages/storybook/src/stories/consent-banner.stories.tsx
+++ b/packages/storybook/src/stories/consent-banner.stories.tsx
@@ -1,0 +1,114 @@
+import { Button } from "@everr/ui/components/button";
+import { ConsentBanner } from "@everr/ui/components/consent-banner";
+import { ConsentSettingsDialog } from "@everr/ui/components/consent-settings-dialog";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+
+const meta = {
+  title: "Overlays/ConsentBanner",
+  component: ConsentBanner,
+  args: {
+    open: true,
+    onAcceptAll: () => {},
+    onDeny: () => {},
+  },
+} satisfies Meta<typeof ConsentBanner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <div className="min-h-72">
+      <ConsentBanner {...args} />
+    </div>
+  ),
+};
+
+export const WithSettingsButton: Story = {
+  args: { onOpenSettings: () => {} },
+  render: (args) => (
+    <div className="min-h-72">
+      <ConsentBanner {...args} />
+    </div>
+  ),
+};
+
+export const CustomCopy: Story = {
+  args: {
+    title: "Help us improve Everr",
+    description:
+      "We store anonymous usage data in your browser. It tells us which parts of the product are used. You can change this at any time.",
+  },
+  render: (args) => (
+    <div className="min-h-72">
+      <ConsentBanner {...args} />
+    </div>
+  ),
+};
+
+export const Closed: Story = {
+  args: { open: false },
+  render: (args) => (
+    <div className="text-muted-foreground min-h-24">
+      <p>The banner shows nothing when `open` is false.</p>
+      <ConsentBanner {...args} />
+    </div>
+  ),
+};
+
+export const WithSettingsDialog: Story = {
+  render: function WithSettingsDialogStory() {
+    const [decided, setDecided] = useState(false);
+    const [settingsOpen, setSettingsOpen] = useState(false);
+    const [analyticsEnabled, setAnalyticsEnabled] = useState(false);
+
+    return (
+      <div className="min-h-72">
+        {decided && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              setDecided(false);
+            }}
+          >
+            Ask again
+          </Button>
+        )}
+        <ConsentBanner
+          open={!decided}
+          onAcceptAll={() => {
+            setAnalyticsEnabled(true);
+            setDecided(true);
+          }}
+          onDeny={() => {
+            setAnalyticsEnabled(false);
+            setDecided(true);
+          }}
+          onOpenSettings={() => setSettingsOpen(true)}
+        />
+        <ConsentSettingsDialog
+          open={settingsOpen}
+          onOpenChange={setSettingsOpen}
+          analyticsEnabled={analyticsEnabled}
+          onAnalyticsChange={setAnalyticsEnabled}
+          onDeny={() => {
+            setAnalyticsEnabled(false);
+            setSettingsOpen(false);
+            setDecided(true);
+          }}
+          onAcceptAll={() => {
+            setAnalyticsEnabled(true);
+            setSettingsOpen(false);
+            setDecided(true);
+          }}
+          onSave={() => {
+            setSettingsOpen(false);
+            setDecided(true);
+          }}
+        />
+      </div>
+    );
+  },
+};

--- a/packages/storybook/src/stories/consent-settings-dialog.stories.tsx
+++ b/packages/storybook/src/stories/consent-settings-dialog.stories.tsx
@@ -1,0 +1,78 @@
+import { Button } from "@everr/ui/components/button";
+import { ConsentSettingsDialog } from "@everr/ui/components/consent-settings-dialog";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+
+const meta = {
+  title: "Overlays/ConsentSettingsDialog",
+  component: ConsentSettingsDialog,
+  args: {
+    open: true,
+    onOpenChange: () => {},
+    analyticsEnabled: false,
+    onAnalyticsChange: () => {},
+    onDeny: () => {},
+    onAcceptAll: () => {},
+    onSave: () => {},
+  },
+} satisfies Meta<typeof ConsentSettingsDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const AnalyticsEnabled: Story = {
+  args: { analyticsEnabled: true },
+};
+
+export const WithPrivacyPolicy: Story = {
+  args: { privacyPolicyHref: "https://example.com/privacy" },
+};
+
+export const CustomDescription: Story = {
+  args: {
+    description:
+      "Everr stores a small amount of usage data in your browser. Select the categories you accept.",
+  },
+};
+
+export const Interactive: Story = {
+  render: function InteractiveStory(args) {
+    const [open, setOpen] = useState(true);
+    const [analyticsEnabled, setAnalyticsEnabled] = useState(false);
+    const [saved, setSaved] = useState<string | null>(null);
+
+    return (
+      <div className="flex flex-col items-start gap-3">
+        <Button variant="outline" onClick={() => setOpen(true)}>
+          Open consent settings
+        </Button>
+        {saved && <p className="text-muted-foreground text-xs">{saved}</p>}
+        <ConsentSettingsDialog
+          {...args}
+          open={open}
+          onOpenChange={setOpen}
+          analyticsEnabled={analyticsEnabled}
+          onAnalyticsChange={setAnalyticsEnabled}
+          onDeny={() => {
+            setAnalyticsEnabled(false);
+            setSaved("Analytics denied");
+            setOpen(false);
+          }}
+          onAcceptAll={() => {
+            setAnalyticsEnabled(true);
+            setSaved("Analytics accepted");
+            setOpen(false);
+          }}
+          onSave={() => {
+            setSaved(
+              analyticsEnabled ? "Analytics accepted" : "Analytics denied",
+            );
+            setOpen(false);
+          }}
+        />
+      </div>
+    );
+  },
+};

--- a/packages/storybook/src/stories/data-table.stories.tsx
+++ b/packages/storybook/src/stories/data-table.stories.tsx
@@ -1,0 +1,187 @@
+import { Badge } from "@everr/ui/components/badge";
+import { type Column, DataTable } from "@everr/ui/components/data-table";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@everr/ui/components/empty";
+import { Skeleton } from "@everr/ui/components/skeleton";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SearchXIcon } from "lucide-react";
+
+interface ServiceRow {
+  service: string;
+  environment: string;
+  requests: number;
+  errors: number;
+  p95Ms: number;
+  status: "healthy" | "degraded" | "firing";
+}
+
+const services: ServiceRow[] = [
+  {
+    service: "checkout-api",
+    environment: "production",
+    requests: 1_284_310,
+    errors: 4128,
+    p95Ms: 842,
+    status: "firing",
+  },
+  {
+    service: "payments-worker",
+    environment: "production",
+    requests: 402_887,
+    errors: 311,
+    p95Ms: 219,
+    status: "degraded",
+  },
+  {
+    service: "search-indexer",
+    environment: "production",
+    requests: 96_540,
+    errors: 12,
+    p95Ms: 143,
+    status: "healthy",
+  },
+  {
+    service: "edge-gateway",
+    environment: "production",
+    requests: 3_110_774,
+    errors: 890,
+    p95Ms: 61,
+    status: "healthy",
+  },
+  {
+    service: "notification-fanout",
+    environment: "staging",
+    requests: 18_204,
+    errors: 0,
+    p95Ms: 88,
+    status: "healthy",
+  },
+];
+
+const numberFormat = new Intl.NumberFormat("en-US");
+
+const statusVariant = {
+  healthy: "added",
+  degraded: "changed",
+  firing: "removed",
+} as const;
+
+const columns: Column<ServiceRow>[] = [
+  {
+    header: "Service",
+    cell: (row) => <span className="font-medium">{row.service}</span>,
+  },
+  {
+    header: "Environment",
+    cell: (row) => (
+      <span className="text-muted-foreground">{row.environment}</span>
+    ),
+  },
+  {
+    header: "Requests",
+    cell: (row) => numberFormat.format(row.requests),
+  },
+  {
+    header: "Errors",
+    cell: (row) => numberFormat.format(row.errors),
+  },
+  {
+    header: "p95",
+    cell: (row) => `${row.p95Ms} ms`,
+  },
+  {
+    header: "Status",
+    cell: (row) => (
+      <Badge variant={statusVariant[row.status]}>{row.status}</Badge>
+    ),
+  },
+];
+
+const ServiceTable = DataTable<ServiceRow>;
+
+const meta = {
+  title: "Data/DataTable",
+  component: ServiceTable,
+  args: {
+    data: services,
+    columns,
+    rowKey: (row: ServiceRow) => row.service,
+  },
+} satisfies Meta<typeof ServiceTable>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Bordered: Story = {
+  args: {
+    bordered: true,
+    containerClassName: "rounded-lg border border-border overflow-hidden",
+  },
+};
+
+export const StickyHeader: Story = {
+  args: {
+    data: [
+      ...services,
+      ...services.map((row) => ({ ...row, environment: "staging" })),
+    ],
+    rowKey: (row: ServiceRow) => `${row.service}-${row.environment}`,
+    stickyHeader: true,
+    containerClassName: "h-56 overflow-auto rounded-lg border border-border",
+  },
+};
+
+export const HighlightedRows: Story = {
+  args: {
+    rowClassName: (row: ServiceRow) =>
+      row.status === "firing" ? "bg-red-500/10" : undefined,
+  },
+};
+
+export const Clickable: Story = {
+  args: {
+    onRowClick: (row: ServiceRow) => {
+      window.alert(`Open ${row.service}`);
+    },
+  },
+};
+
+export const EmptyState: Story = {
+  args: {
+    data: [],
+    emptyState: (
+      <Empty className="border">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <SearchXIcon />
+          </EmptyMedia>
+          <EmptyTitle>No services reported data</EmptyTitle>
+          <EmptyDescription>
+            Widen the time range or remove a filter.
+          </EmptyDescription>
+        </EmptyHeader>
+      </Empty>
+    ),
+  },
+};
+
+export const NoRowsWithoutEmptyState: Story = {
+  args: { data: [] },
+};
+
+export const Loading: Story = {
+  args: {
+    data: services,
+    columns: columns.map((column) => ({
+      ...column,
+      cell: () => <Skeleton className="h-4 w-20" />,
+    })),
+  },
+};

--- a/packages/storybook/src/stories/detail-panel.stories.tsx
+++ b/packages/storybook/src/stories/detail-panel.stories.tsx
@@ -1,0 +1,114 @@
+import {
+  AttributeMap,
+  CopyValueButton,
+  DetailItem,
+  DetailSection,
+} from "@everr/ui/components/detail-panel";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ClockIcon, ServerIcon, TagIcon } from "lucide-react";
+
+const meta = {
+  title: "Layout/DetailPanel",
+  component: DetailSection,
+} satisfies Meta<typeof DetailSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Section: Story = {
+  args: { title: "Span", children: null },
+  render: (args) => (
+    <div className="w-80">
+      <DetailSection {...args}>
+        <DetailItem
+          icon={<ServerIcon />}
+          label="service.name"
+          value="checkout-api"
+          mono
+        />
+        <DetailItem icon={<ClockIcon />} label="Duration" value="412 ms" />
+      </DetailSection>
+    </div>
+  ),
+};
+
+export const ItemStates: Story = {
+  args: { title: "Item states", children: null },
+  render: (args) => (
+    <div className="w-80">
+      <DetailSection {...args}>
+        <DetailItem label="Plain value" value="checkout-api" />
+        <DetailItem
+          label="Monospaced value"
+          value="4f21ac9e0b1d47c8a3f5"
+          mono
+        />
+        <DetailItem icon={<TagIcon />} label="With icon" value="production" />
+        <DetailItem label="Missing value" />
+        <DetailItem
+          label="Long value"
+          value="https://app.example.com/traces/4f21ac9e0b1d47c8a3f5e6b7c8d9e0f1"
+          mono
+        />
+      </DetailSection>
+    </div>
+  ),
+};
+
+export const Attributes: Story = {
+  args: { title: "Attributes", children: null },
+  render: () => (
+    <div className="w-80">
+      <AttributeMap
+        title="Resource attributes"
+        map={{
+          "service.name": "checkout-api",
+          "service.version": "2.14.0",
+          "deployment.environment": "production",
+          "host.name": "ip-10-0-3-51",
+        }}
+      />
+    </div>
+  ),
+};
+
+export const CopyButton: Story = {
+  args: { title: "Copy", children: null },
+  render: () => (
+    <div className="group bg-card w-64 rounded-md border px-2.5 py-2">
+      <span className="flex items-center justify-between">
+        trace_id
+        <CopyValueButton value="4f21ac9e0b1d47c8a3f5e6b7c8d9e0f1" />
+      </span>
+    </div>
+  ),
+};
+
+export const FullPanel: Story = {
+  args: { title: "Full panel", children: null },
+  render: () => (
+    <div className="bg-card h-[28rem] w-80 overflow-y-auto rounded-lg border p-3">
+      <DetailSection title="Span">
+        <DetailItem icon={<ServerIcon />} label="Name" value="POST /checkout" />
+        <DetailItem icon={<ClockIcon />} label="Duration" value="412 ms" />
+        <DetailItem label="Status" value="OK" />
+      </DetailSection>
+      <AttributeMap
+        title="Span attributes"
+        map={{
+          "http.request.method": "POST",
+          "http.response.status_code": "200",
+          "http.route": "/checkout",
+          "url.path": "/checkout",
+        }}
+      />
+      <AttributeMap
+        title="Resource attributes"
+        map={{
+          "service.name": "checkout-api",
+          "deployment.environment": "production",
+        }}
+      />
+    </div>
+  ),
+};

--- a/packages/storybook/src/stories/dialog.stories.tsx
+++ b/packages/storybook/src/stories/dialog.stories.tsx
@@ -1,0 +1,104 @@
+import { Button } from "@everr/ui/components/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@everr/ui/components/dialog";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Overlays/Dialog",
+  component: Dialog,
+} satisfies Meta<typeof Dialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <Dialog defaultOpen>
+      <DialogTrigger render={<Button variant="outline" />}>
+        Open dialog
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Rename service</DialogTitle>
+          <DialogDescription>
+            The new name is used everywhere the service appears.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose render={<Button variant="outline" />}>
+            Cancel
+          </DialogClose>
+          <Button>Save</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  ),
+};
+
+export const WithFooterCloseButton: Story = {
+  render: () => (
+    <Dialog defaultOpen>
+      <DialogTrigger render={<Button variant="outline" />}>
+        Open dialog
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Export finished</DialogTitle>
+          <DialogDescription>
+            The export is ready. It stays available for seven days.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter showCloseButton />
+      </DialogContent>
+    </Dialog>
+  ),
+};
+
+export const WithoutCloseButton: Story = {
+  render: () => (
+    <Dialog defaultOpen>
+      <DialogTrigger render={<Button variant="outline" />}>
+        Open dialog
+      </DialogTrigger>
+      <DialogContent showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>Confirm the change</DialogTitle>
+          <DialogDescription>
+            You must select an answer. There is no close button.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose render={<Button variant="outline" />}>
+            Cancel
+          </DialogClose>
+          <DialogClose render={<Button />}>Confirm</DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  ),
+};
+
+export const ClosedUntilTriggered: Story = {
+  render: () => (
+    <Dialog>
+      <DialogTrigger render={<Button />}>Open dialog</DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Trigger opened this dialog</DialogTitle>
+          <DialogDescription>
+            The dialog starts closed, and the trigger button opens it.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter showCloseButton />
+      </DialogContent>
+    </Dialog>
+  ),
+};

--- a/packages/storybook/src/stories/dropdown-menu.stories.tsx
+++ b/packages/storybook/src/stories/dropdown-menu.stories.tsx
@@ -1,0 +1,176 @@
+import { Button } from "@everr/ui/components/button";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuLinkItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@everr/ui/components/dropdown-menu";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { CopyIcon, PencilIcon, Trash2Icon } from "lucide-react";
+import { useState } from "react";
+
+const meta = {
+  title: "Overlays/DropdownMenu",
+  component: DropdownMenu,
+} satisfies Meta<typeof DropdownMenu>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="flex min-h-80 items-start justify-center pt-4">
+      <DropdownMenu defaultOpen>
+        <DropdownMenuTrigger render={<Button variant="outline" />}>
+          Actions
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="w-56">
+          <DropdownMenuGroup>
+            <DropdownMenuLabel>Rule</DropdownMenuLabel>
+            <DropdownMenuItem>
+              <PencilIcon />
+              Edit
+              <DropdownMenuShortcut>⌘E</DropdownMenuShortcut>
+            </DropdownMenuItem>
+            <DropdownMenuItem>
+              <CopyIcon />
+              Copy YAML
+              <DropdownMenuShortcut>⌘C</DropdownMenuShortcut>
+            </DropdownMenuItem>
+            <DropdownMenuItem disabled>Adopt rule</DropdownMenuItem>
+          </DropdownMenuGroup>
+          <DropdownMenuSeparator />
+          <DropdownMenuLinkItem href="https://example.com/docs">
+            Open the docs
+          </DropdownMenuLinkItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem variant="destructive">
+            <Trash2Icon />
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  ),
+};
+
+export const WithSubmenu: Story = {
+  render: () => (
+    <div className="flex min-h-80 items-start justify-center pt-4">
+      <DropdownMenu defaultOpen>
+        <DropdownMenuTrigger render={<Button variant="outline" />}>
+          Export
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="w-56">
+          <DropdownMenuItem>Export now</DropdownMenuItem>
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>Export as</DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              <DropdownMenuItem>CSV</DropdownMenuItem>
+              <DropdownMenuItem>JSON</DropdownMenuItem>
+              <DropdownMenuItem>Parquet</DropdownMenuItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  ),
+};
+
+export const WithCheckboxItems: Story = {
+  render: function WithCheckboxItemsStory() {
+    const [columns, setColumns] = useState({
+      service: true,
+      severity: true,
+      duration: false,
+    });
+
+    return (
+      <div className="flex min-h-80 items-start justify-center pt-4">
+        <DropdownMenu defaultOpen>
+          <DropdownMenuTrigger render={<Button variant="outline" />}>
+            Columns
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="w-56">
+            <DropdownMenuGroup>
+              <DropdownMenuLabel>Visible columns</DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              {(["service", "severity", "duration"] as const).map((column) => (
+                <DropdownMenuCheckboxItem
+                  key={column}
+                  checked={columns[column]}
+                  closeOnClick={false}
+                  onCheckedChange={(checked) =>
+                    setColumns((current) => ({ ...current, [column]: checked }))
+                  }
+                >
+                  {column}
+                </DropdownMenuCheckboxItem>
+              ))}
+            </DropdownMenuGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    );
+  },
+};
+
+export const WithRadioItems: Story = {
+  render: function WithRadioItemsStory() {
+    const [range, setRange] = useState("1h");
+
+    return (
+      <div className="flex min-h-80 items-start justify-center pt-4">
+        <DropdownMenu defaultOpen>
+          <DropdownMenuTrigger render={<Button variant="outline" />}>
+            Last {range}
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="w-56">
+            <DropdownMenuGroup>
+              <DropdownMenuLabel>Time range</DropdownMenuLabel>
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuRadioGroup
+              value={range}
+              onValueChange={(value) => setRange(String(value))}
+            >
+              <DropdownMenuRadioItem value="15m">15m</DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="1h">1h</DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="24h">24h</DropdownMenuRadioItem>
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    );
+  },
+};
+
+export const InsetItems: Story = {
+  render: () => (
+    <div className="flex min-h-80 items-start justify-center pt-4">
+      <DropdownMenu defaultOpen>
+        <DropdownMenuTrigger render={<Button variant="outline" />}>
+          View
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="w-56">
+          <DropdownMenuGroup>
+            <DropdownMenuLabel inset>Layout</DropdownMenuLabel>
+            <DropdownMenuItem inset>Compact</DropdownMenuItem>
+            <DropdownMenuItem inset>Comfortable</DropdownMenuItem>
+          </DropdownMenuGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  ),
+};

--- a/packages/storybook/src/stories/empty.stories.tsx
+++ b/packages/storybook/src/stories/empty.stories.tsx
@@ -1,0 +1,105 @@
+import { Button } from "@everr/ui/components/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@everr/ui/components/empty";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { BellOffIcon, SearchIcon } from "lucide-react";
+
+const meta = {
+  title: "Data/Empty",
+  component: Empty,
+  render: () => (
+    <Empty className="border">
+      <EmptyHeader>
+        <EmptyTitle>No alerts firing</EmptyTitle>
+        <EmptyDescription>
+          Every rule in this project is healthy for the selected time range.
+        </EmptyDescription>
+      </EmptyHeader>
+    </Empty>
+  ),
+} satisfies Meta<typeof Empty>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithIconMedia: Story = {
+  render: () => (
+    <Empty className="border">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <BellOffIcon />
+        </EmptyMedia>
+        <EmptyTitle>No alerts firing</EmptyTitle>
+        <EmptyDescription>
+          Everr checks your rules every 30 seconds.
+        </EmptyDescription>
+      </EmptyHeader>
+    </Empty>
+  ),
+};
+
+export const WithPlainMedia: Story = {
+  render: () => (
+    <Empty className="border">
+      <EmptyHeader>
+        <EmptyMedia>
+          <SearchIcon className="size-8 text-muted-foreground" />
+        </EmptyMedia>
+        <EmptyTitle>No services match this filter</EmptyTitle>
+        <EmptyDescription>
+          Remove a filter or widen the time range.
+        </EmptyDescription>
+      </EmptyHeader>
+    </Empty>
+  ),
+};
+
+export const WithContentAction: Story = {
+  render: () => (
+    <Empty className="border">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <BellOffIcon />
+        </EmptyMedia>
+        <EmptyTitle as="h2">No alert rules yet</EmptyTitle>
+        <EmptyDescription>
+          Alert rules are applied as code. See the{" "}
+          <a href="#docs">alerting guide</a> to write your first one.
+        </EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent>
+        <Button size="sm" variant="outline">
+          Copy example YAML
+        </Button>
+        <EmptyDescription>
+          Then run <code>everr apply ./alerts</code>.
+        </EmptyDescription>
+      </EmptyContent>
+    </Empty>
+  ),
+};
+
+export const TitleLevels: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      {(["div", "h2", "h3"] as const).map((as) => (
+        <Empty key={as} className="border">
+          <EmptyHeader>
+            <EmptyTitle as={as}>Rendered as {as}</EmptyTitle>
+            <EmptyDescription>
+              The title element changes, the style stays the same.
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      ))}
+    </div>
+  ),
+};

--- a/packages/storybook/src/stories/filter-combobox.stories.tsx
+++ b/packages/storybook/src/stories/filter-combobox.stories.tsx
@@ -1,0 +1,143 @@
+import { FilterCombobox } from "@everr/ui/components/filter-combobox";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+
+const services = [
+  "checkout-api",
+  "payments-worker",
+  "search-indexer",
+  "edge-gateway",
+  "notification-fanout",
+  "session-store",
+];
+
+const delay = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+const fetchServices = async () => {
+  await delay(300);
+  return services;
+};
+
+const fetchSlowly = async () => {
+  await delay(1_000_000);
+  return services;
+};
+
+const fetchNothing = async () => {
+  await delay(300);
+  return [] as string[];
+};
+
+const ServiceFilter = FilterCombobox<string[]>;
+
+function StatefulFilter({
+  initialValues = [],
+  ...props
+}: Omit<Parameters<typeof ServiceFilter>[0], "values" | "onChange"> & {
+  initialValues?: string[];
+}) {
+  const [values, setValues] = useState(initialValues);
+  return <ServiceFilter {...props} values={values} onChange={setValues} />;
+}
+
+const meta = {
+  title: "Data/FilterCombobox",
+  component: ServiceFilter,
+  args: {
+    label: "Service",
+    placeholder: "All services",
+    searchPlaceholder: "Search services...",
+    values: [],
+    onChange: () => {},
+    options: {
+      queryKey: ["stories", "services"],
+      queryFn: fetchServices,
+      select: (data: string[]) => data,
+    },
+  },
+  render: ({ values, onChange, ...args }) => (
+    <div className="h-72">
+      <StatefulFilter {...args} initialValues={values} />
+    </div>
+  ),
+} satisfies Meta<typeof ServiceFilter>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const OneSelected: Story = {
+  args: { values: ["checkout-api"] },
+};
+
+export const ManySelected: Story = {
+  args: { values: ["checkout-api", "payments-worker", "edge-gateway"] },
+};
+
+export const Loading: Story = {
+  args: {
+    options: {
+      queryKey: ["stories", "services", "loading"],
+      queryFn: fetchSlowly,
+      select: (data: string[]) => data,
+    },
+  },
+};
+
+export const NoResults: Story = {
+  args: {
+    options: {
+      queryKey: ["stories", "services", "empty"],
+      queryFn: fetchNothing,
+      select: (data: string[]) => data,
+    },
+  },
+};
+
+export const Wide: Story = {
+  args: { className: "w-72" },
+};
+
+export const FilterBar: Story = {
+  render: () => (
+    <div className="flex h-72 items-start gap-3">
+      <StatefulFilter
+        label="Service"
+        placeholder="All services"
+        searchPlaceholder="Search services..."
+        options={{
+          queryKey: ["stories", "services"],
+          queryFn: fetchServices,
+          select: (data: string[]) => data,
+        }}
+      />
+      <StatefulFilter
+        label="Environment"
+        placeholder="All environments"
+        initialValues={["production"]}
+        options={{
+          queryKey: ["stories", "environments"],
+          queryFn: async () => {
+            await delay(200);
+            return ["production", "staging", "development"];
+          },
+          select: (data: string[]) => data,
+        }}
+      />
+      <StatefulFilter
+        label="Severity"
+        placeholder="All severities"
+        options={{
+          queryKey: ["stories", "severities"],
+          queryFn: async () => {
+            await delay(200);
+            return ["page", "ticket", "info"];
+          },
+          select: (data: string[]) => data,
+        }}
+      />
+    </div>
+  ),
+} satisfies Story;

--- a/packages/storybook/src/stories/input-group.stories.tsx
+++ b/packages/storybook/src/stories/input-group.stories.tsx
@@ -1,0 +1,210 @@
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+  InputGroupText,
+  InputGroupTextarea,
+} from "@everr/ui/components/input-group";
+import { Kbd } from "@everr/ui/components/kbd";
+import { Label } from "@everr/ui/components/label";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  ArrowUpIcon,
+  CopyIcon,
+  SearchIcon,
+  SendIcon,
+  XIcon,
+} from "lucide-react";
+import * as React from "react";
+
+const meta = {
+  title: "Controls/InputGroup",
+  component: InputGroup,
+  decorators: [
+    (Story) => (
+      <div className="max-w-sm">
+        <Story />
+      </div>
+    ),
+  ],
+  render: () => (
+    <InputGroup>
+      <InputGroupAddon>
+        <SearchIcon />
+      </InputGroupAddon>
+      <InputGroupInput placeholder="Search alerts" />
+    </InputGroup>
+  ),
+} satisfies Meta<typeof InputGroup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const InlineEndAddon: Story = {
+  render: () => (
+    <InputGroup>
+      <InputGroupInput placeholder="Search alerts" />
+      <InputGroupAddon align="inline-end">
+        <Kbd>/</Kbd>
+      </InputGroupAddon>
+    </InputGroup>
+  ),
+};
+
+export const BothInlineAddons: Story = {
+  render: () => (
+    <InputGroup>
+      <InputGroupAddon>
+        <InputGroupText>https://</InputGroupText>
+      </InputGroupAddon>
+      <InputGroupInput placeholder="hooks.example.com/alerts" />
+      <InputGroupAddon align="inline-end">
+        <InputGroupButton size="icon-xs" aria-label="Copy">
+          <CopyIcon />
+        </InputGroupButton>
+      </InputGroupAddon>
+    </InputGroup>
+  ),
+};
+
+export const ButtonSizes: Story = {
+  render: () => (
+    <div className="grid gap-3">
+      <InputGroup>
+        <InputGroupInput placeholder="Extra small button" />
+        <InputGroupAddon align="inline-end">
+          <InputGroupButton size="xs">Apply</InputGroupButton>
+        </InputGroupAddon>
+      </InputGroup>
+      <InputGroup>
+        <InputGroupInput placeholder="Small button" />
+        <InputGroupAddon align="inline-end">
+          <InputGroupButton size="sm" variant="outline">
+            Apply
+          </InputGroupButton>
+        </InputGroupAddon>
+      </InputGroup>
+      <InputGroup>
+        <InputGroupInput placeholder="Icon buttons" />
+        <InputGroupAddon align="inline-end">
+          <InputGroupButton size="icon-xs" aria-label="Clear">
+            <XIcon />
+          </InputGroupButton>
+          <InputGroupButton size="icon-sm" aria-label="Send">
+            <SendIcon />
+          </InputGroupButton>
+        </InputGroupAddon>
+      </InputGroup>
+    </div>
+  ),
+};
+
+export const BlockStartAddon: Story = {
+  render: () => (
+    <InputGroup>
+      <InputGroupAddon align="block-start" className="border-b">
+        <InputGroupText>Filter expression</InputGroupText>
+      </InputGroupAddon>
+      <InputGroupInput placeholder="service.name = 'checkout-api'" />
+    </InputGroup>
+  ),
+};
+
+export const BlockEndAddon: Story = {
+  render: () => (
+    <InputGroup>
+      <InputGroupInput placeholder="service.name = 'checkout-api'" />
+      <InputGroupAddon align="block-end" className="border-t">
+        <InputGroupText>Press Enter to run the query</InputGroupText>
+      </InputGroupAddon>
+    </InputGroup>
+  ),
+};
+
+export const WithTextarea: Story = {
+  render: () => (
+    <InputGroup>
+      <InputGroupTextarea placeholder="Why are you silencing this alert?" />
+      <InputGroupAddon align="block-end" className="justify-end">
+        <InputGroupButton size="icon-sm" aria-label="Send">
+          <ArrowUpIcon />
+        </InputGroupButton>
+      </InputGroupAddon>
+    </InputGroup>
+  ),
+};
+
+export const WithLabel: Story = {
+  render: () => (
+    <div className="grid gap-2">
+      <Label htmlFor="query">Query</Label>
+      <InputGroup>
+        <InputGroupAddon>
+          <SearchIcon />
+        </InputGroupAddon>
+        <InputGroupInput id="query" placeholder="Search alerts" />
+      </InputGroup>
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <InputGroup data-disabled="true">
+      <InputGroupAddon>
+        <SearchIcon />
+      </InputGroupAddon>
+      <InputGroupInput placeholder="Search alerts" disabled />
+    </InputGroup>
+  ),
+};
+
+export const Invalid: Story = {
+  render: () => (
+    <div className="grid gap-2">
+      <InputGroup>
+        <InputGroupAddon>
+          <SearchIcon />
+        </InputGroupAddon>
+        <InputGroupInput aria-invalid defaultValue="service.name =" />
+      </InputGroup>
+      <p className="text-destructive text-xs">The expression is incomplete.</p>
+    </div>
+  ),
+};
+
+export const Controlled: Story = {
+  render: () => {
+    const [value, setValue] = React.useState("checkout");
+
+    return (
+      <div className="grid gap-2">
+        <InputGroup>
+          <InputGroupAddon>
+            <SearchIcon />
+          </InputGroupAddon>
+          <InputGroupInput
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+            placeholder="Search alerts"
+          />
+          <InputGroupAddon align="inline-end">
+            <InputGroupButton
+              size="icon-xs"
+              aria-label="Clear"
+              onClick={() => setValue("")}
+            >
+              <XIcon />
+            </InputGroupButton>
+          </InputGroupAddon>
+        </InputGroup>
+        <p className="text-muted-foreground text-xs">
+          Query: {value || "None"}
+        </p>
+      </div>
+    );
+  },
+};

--- a/packages/storybook/src/stories/input.stories.tsx
+++ b/packages/storybook/src/stories/input.stories.tsx
@@ -1,0 +1,86 @@
+import { Input } from "@everr/ui/components/input";
+import { Label } from "@everr/ui/components/label";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import * as React from "react";
+
+const meta = {
+  title: "Controls/Input",
+  component: Input,
+  args: { placeholder: "service.name" },
+  argTypes: {
+    type: {
+      control: "select",
+      options: ["text", "email", "password", "number", "search", "file"],
+    },
+    disabled: { control: "boolean" },
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-xs">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Input>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithLabel: Story = {
+  render: (args) => (
+    <div className="grid gap-2">
+      <Label htmlFor="service">Service</Label>
+      <Input id="service" {...args} />
+    </div>
+  ),
+};
+
+export const Types: Story = {
+  render: (args) => (
+    <div className="grid gap-3">
+      <Input {...args} type="text" placeholder="Text" />
+      <Input {...args} type="email" placeholder="name@example.com" />
+      <Input {...args} type="password" placeholder="Password" />
+      <Input {...args} type="number" placeholder="42" />
+      <Input {...args} type="search" placeholder="Search" />
+      <Input {...args} type="file" placeholder="" />
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  args: { disabled: true, value: "Read only value" },
+};
+
+export const Invalid: Story = {
+  render: (args) => (
+    <div className="grid gap-2">
+      <Label htmlFor="threshold">Threshold</Label>
+      <Input id="threshold" {...args} aria-invalid defaultValue="-1" />
+      <p className="text-destructive text-xs">
+        The threshold must be positive.
+      </p>
+    </div>
+  ),
+};
+
+export const Controlled: Story = {
+  render: (args) => {
+    const [value, setValue] = React.useState("checkout-api");
+
+    return (
+      <div className="grid gap-2">
+        <Input
+          {...args}
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+        />
+        <p className="text-muted-foreground text-xs">
+          Value: {value || "None"}
+        </p>
+      </div>
+    );
+  },
+};

--- a/packages/storybook/src/stories/kbd.stories.tsx
+++ b/packages/storybook/src/stories/kbd.stories.tsx
@@ -1,0 +1,72 @@
+import { Button } from "@everr/ui/components/button";
+import { Kbd } from "@everr/ui/components/kbd";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@everr/ui/components/tooltip";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ArrowUpIcon, CommandIcon } from "lucide-react";
+
+const meta = {
+  title: "Controls/Kbd",
+  component: Kbd,
+  args: { children: "K" },
+} satisfies Meta<typeof Kbd>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Combination: Story = {
+  render: () => (
+    <div className="flex items-center gap-1">
+      <Kbd>
+        <CommandIcon />
+      </Kbd>
+      <Kbd>K</Kbd>
+    </div>
+  ),
+};
+
+export const WithIcon: Story = {
+  render: () => (
+    <Kbd>
+      <ArrowUpIcon />
+    </Kbd>
+  ),
+};
+
+export const WordKeys: Story = {
+  render: () => (
+    <div className="flex items-center gap-1">
+      <Kbd>Shift</Kbd>
+      <Kbd>Enter</Kbd>
+      <Kbd>Esc</Kbd>
+    </div>
+  ),
+};
+
+export const InText: Story = {
+  render: () => (
+    <p className="text-muted-foreground text-xs">
+      Press <Kbd>/</Kbd> to search, then <Kbd>Enter</Kbd> to open the result.
+    </p>
+  ),
+};
+
+export const InTooltip: Story = {
+  render: () => (
+    <Tooltip>
+      <TooltipTrigger render={<Button variant="outline">Search</Button>} />
+      <TooltipContent className="flex items-center gap-2">
+        Open the search
+        <Kbd>
+          <CommandIcon />
+        </Kbd>
+        <Kbd>K</Kbd>
+      </TooltipContent>
+    </Tooltip>
+  ),
+};

--- a/packages/storybook/src/stories/label.stories.tsx
+++ b/packages/storybook/src/stories/label.stories.tsx
@@ -1,0 +1,52 @@
+import { Input } from "@everr/ui/components/input";
+import { Label } from "@everr/ui/components/label";
+import { Switch } from "@everr/ui/components/switch";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { InfoIcon } from "lucide-react";
+
+const meta = {
+  title: "Controls/Label",
+  component: Label,
+  args: { children: "Service" },
+} satisfies Meta<typeof Label>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithInput: Story = {
+  render: (args) => (
+    <div className="grid max-w-xs gap-2">
+      <Label htmlFor="service" {...args} />
+      <Input id="service" placeholder="checkout-api" />
+    </div>
+  ),
+};
+
+export const WithIcon: Story = {
+  render: () => (
+    <Label htmlFor="budget">
+      Error budget
+      <InfoIcon className="text-muted-foreground size-3.5" />
+    </Label>
+  ),
+};
+
+export const WithDisabledControl: Story = {
+  render: () => (
+    <div className="grid max-w-xs gap-2">
+      <Input id="locked" className="peer" disabled value="Locked" />
+      <Label htmlFor="locked">This label dims with the disabled input</Label>
+    </div>
+  ),
+};
+
+export const InlineWithSwitch: Story = {
+  render: () => (
+    <Label htmlFor="notify" className="gap-2">
+      <Switch id="notify" />
+      Send a notification
+    </Label>
+  ),
+};

--- a/packages/storybook/src/stories/popover.stories.tsx
+++ b/packages/storybook/src/stories/popover.stories.tsx
@@ -1,0 +1,106 @@
+import { Button } from "@everr/ui/components/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from "@everr/ui/components/popover";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Overlays/Popover",
+  component: Popover,
+} satisfies Meta<typeof Popover>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="flex min-h-72 items-center justify-center">
+      <Popover defaultOpen>
+        <PopoverTrigger render={<Button variant="outline" />}>
+          Open popover
+        </PopoverTrigger>
+        <PopoverContent>
+          <PopoverHeader>
+            <PopoverTitle>Retention</PopoverTitle>
+            <PopoverDescription>
+              Traces stay for 7 days. Metrics stay for 90 days.
+            </PopoverDescription>
+          </PopoverHeader>
+        </PopoverContent>
+      </Popover>
+    </div>
+  ),
+};
+
+export const Sides: Story = {
+  render: () => (
+    <div className="grid min-h-96 grid-cols-2 place-items-center gap-8">
+      {(["top", "right", "bottom", "left"] as const).map((side) => (
+        <Popover key={side} defaultOpen>
+          <PopoverTrigger render={<Button variant="outline" />}>
+            {side}
+          </PopoverTrigger>
+          <PopoverContent side={side} className="w-48">
+            <PopoverHeader>
+              <PopoverTitle>Side {side}</PopoverTitle>
+              <PopoverDescription>
+                The popup is placed on the {side} of the trigger.
+              </PopoverDescription>
+            </PopoverHeader>
+          </PopoverContent>
+        </Popover>
+      ))}
+    </div>
+  ),
+};
+
+export const AlignedStart: Story = {
+  render: () => (
+    <div className="flex min-h-72 items-center justify-center">
+      <Popover defaultOpen>
+        <PopoverTrigger render={<Button variant="outline" />}>
+          Aligned to start
+        </PopoverTrigger>
+        <PopoverContent align="start" sideOffset={8}>
+          <PopoverHeader>
+            <PopoverTitle>Alignment</PopoverTitle>
+            <PopoverDescription>
+              The popup edge follows the start edge of the trigger.
+            </PopoverDescription>
+          </PopoverHeader>
+        </PopoverContent>
+      </Popover>
+    </div>
+  ),
+};
+
+export const WithActions: Story = {
+  render: () => (
+    <div className="flex min-h-72 items-center justify-center">
+      <Popover defaultOpen>
+        <PopoverTrigger render={<Button variant="outline" />}>
+          Silence rule
+        </PopoverTrigger>
+        <PopoverContent>
+          <PopoverHeader>
+            <PopoverTitle>Silence for 1 hour?</PopoverTitle>
+            <PopoverDescription>
+              The rule keeps evaluating, but it sends no notification.
+            </PopoverDescription>
+          </PopoverHeader>
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" size="sm">
+              Cancel
+            </Button>
+            <Button size="sm">Silence</Button>
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  ),
+};

--- a/packages/storybook/src/stories/preview-frame.stories.tsx
+++ b/packages/storybook/src/stories/preview-frame.stories.tsx
@@ -1,0 +1,105 @@
+import { Button } from "@everr/ui/components/button";
+import { PreviewFrame } from "@everr/ui/components/preview-frame";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { EyeIcon, TriangleAlertIcon } from "lucide-react";
+import { useState } from "react";
+
+const meta = {
+  title: "Layout/PreviewFrame",
+  component: PreviewFrame,
+  args: {
+    variant: "info",
+    icon: <EyeIcon className="size-3.5" />,
+    message: "You are viewing a preview of unapplied changes.",
+  },
+} satisfies Meta<typeof PreviewFrame>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const body = (
+  <div className="text-muted-foreground flex-1 p-4">
+    The framed page content renders below the bar.
+  </div>
+);
+
+export const Default: Story = {
+  render: (args) => (
+    <div className="h-64 w-[36rem] overflow-hidden rounded-lg">
+      <PreviewFrame {...args}>{body}</PreviewFrame>
+    </div>
+  ),
+};
+
+export const WithActions: Story = {
+  render: (args) => (
+    <div className="h-64 w-[36rem] overflow-hidden rounded-lg">
+      <PreviewFrame
+        {...args}
+        actions={
+          <Button variant="ghost" size="sm">
+            Exit preview
+          </Button>
+        }
+      >
+        {body}
+      </PreviewFrame>
+    </div>
+  ),
+};
+
+export const Dismissible: Story = {
+  render: function Dismissible(args) {
+    const [dismissed, setDismissed] = useState(false);
+    return (
+      <div className="grid gap-2">
+        <div className="h-64 w-[36rem] overflow-hidden rounded-lg">
+          <PreviewFrame
+            {...args}
+            dismissed={dismissed}
+            onDismiss={() => setDismissed(true)}
+            actions={
+              <Button variant="ghost" size="sm">
+                Exit preview
+              </Button>
+            }
+          >
+            {body}
+          </PreviewFrame>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-fit"
+          onClick={() => setDismissed(false)}
+        >
+          Restore bar
+        </Button>
+      </div>
+    );
+  },
+};
+
+export const Variants: Story = {
+  render: (args) => (
+    <div className="grid gap-3">
+      {(["neutral", "info", "success", "warning", "danger"] as const).map(
+        (variant) => (
+          <div
+            key={variant}
+            className="h-24 w-[36rem] overflow-hidden rounded-lg"
+          >
+            <PreviewFrame
+              {...args}
+              variant={variant}
+              icon={<TriangleAlertIcon className="size-3.5" />}
+              message={`Variant: ${variant}`}
+            >
+              {body}
+            </PreviewFrame>
+          </div>
+        ),
+      )}
+    </div>
+  ),
+};

--- a/packages/storybook/src/stories/refresh-picker.stories.tsx
+++ b/packages/storybook/src/stories/refresh-picker.stories.tsx
@@ -1,0 +1,65 @@
+import {
+  getRefreshIntervalMs,
+  REFRESH_INTERVALS,
+  RefreshPicker,
+} from "@everr/ui/components/refresh-picker";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+
+const meta = {
+  title: "Time/RefreshPicker",
+  component: RefreshPicker,
+  args: {
+    value: "off",
+    isFetching: false,
+    onChange: () => {},
+    onRefresh: () => {},
+  },
+  render: (args) => {
+    const [interval, setInterval] = useState(args.value);
+    const [fetchCount, setFetchCount] = useState(0);
+    return (
+      <div className="flex flex-col items-start gap-3">
+        <RefreshPicker
+          value={interval}
+          onChange={setInterval}
+          onRefresh={() => setFetchCount((count) => count + 1)}
+          isFetching={args.isFetching}
+        />
+        <code className="text-muted-foreground text-xs">
+          interval: {interval} ({getRefreshIntervalMs(interval) ?? "manual"}) ·
+          refreshes: {fetchCount}
+        </code>
+      </div>
+    );
+  },
+} satisfies Meta<typeof RefreshPicker>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Off: Story = {};
+
+export const EveryFiveSeconds: Story = {
+  args: { value: "5s" },
+};
+
+export const EveryFiveMinutes: Story = {
+  args: { value: "5m" },
+};
+
+export const Fetching: Story = {
+  args: { value: "30s", isFetching: true },
+};
+
+export const Intervals: Story = {
+  render: () => (
+    <ul className="text-sm font-mono">
+      {REFRESH_INTERVALS.map((entry) => (
+        <li key={entry.value}>
+          {entry.label}: {getRefreshIntervalMs(entry.value) ?? "no polling"}
+        </li>
+      ))}
+    </ul>
+  ),
+};

--- a/packages/storybook/src/stories/resizable.stories.tsx
+++ b/packages/storybook/src/stories/resizable.stories.tsx
@@ -1,0 +1,132 @@
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@everr/ui/components/resizable";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Layout/Resizable",
+  component: ResizablePanelGroup,
+  args: { orientation: "horizontal" },
+} satisfies Meta<typeof ResizablePanelGroup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function Pane({ label }: { label: string }) {
+  return (
+    <div className="text-muted-foreground flex h-full items-center justify-center p-3">
+      {label}
+    </div>
+  );
+}
+
+export const Horizontal: Story = {
+  render: (args) => (
+    <div className="h-64 w-[36rem] overflow-hidden rounded-lg border">
+      <ResizablePanelGroup {...args}>
+        <ResizablePanel defaultSize={35}>
+          <Pane label="Span list" />
+        </ResizablePanel>
+        <ResizableHandle />
+        <ResizablePanel>
+          <Pane label="Waterfall" />
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </div>
+  ),
+};
+
+export const Vertical: Story = {
+  args: { orientation: "vertical" },
+  render: (args) => (
+    <div className="h-64 w-[36rem] overflow-hidden rounded-lg border">
+      <ResizablePanelGroup {...args}>
+        <ResizablePanel defaultSize={60}>
+          <Pane label="Query results" />
+        </ResizablePanel>
+        <ResizableHandle />
+        <ResizablePanel>
+          <Pane label="Row detail" />
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </div>
+  ),
+};
+
+export const WithHandleGrip: Story = {
+  render: (args) => (
+    <div className="h-64 w-[36rem] overflow-hidden rounded-lg border">
+      <ResizablePanelGroup {...args}>
+        <ResizablePanel defaultSize={50}>
+          <Pane label="Left" />
+        </ResizablePanel>
+        <ResizableHandle withHandle />
+        <ResizablePanel>
+          <Pane label="Right" />
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </div>
+  ),
+};
+
+export const ThreePanels: Story = {
+  render: (args) => (
+    <div className="h-64 w-[36rem] overflow-hidden rounded-lg border">
+      <ResizablePanelGroup {...args}>
+        <ResizablePanel defaultSize={25} minSize={15}>
+          <Pane label="Filters" />
+        </ResizablePanel>
+        <ResizableHandle withHandle />
+        <ResizablePanel defaultSize={45}>
+          <Pane label="Results" />
+        </ResizablePanel>
+        <ResizableHandle withHandle />
+        <ResizablePanel minSize={15}>
+          <Pane label="Detail" />
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </div>
+  ),
+};
+
+export const NestedGroups: Story = {
+  render: (args) => (
+    <div className="h-64 w-[36rem] overflow-hidden rounded-lg border">
+      <ResizablePanelGroup {...args}>
+        <ResizablePanel defaultSize={35}>
+          <Pane label="Services" />
+        </ResizablePanel>
+        <ResizableHandle withHandle />
+        <ResizablePanel>
+          <ResizablePanelGroup orientation="vertical">
+            <ResizablePanel defaultSize={55}>
+              <Pane label="Chart" />
+            </ResizablePanel>
+            <ResizableHandle withHandle />
+            <ResizablePanel>
+              <Pane label="Table" />
+            </ResizablePanel>
+          </ResizablePanelGroup>
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </div>
+  ),
+};
+
+export const CollapsiblePanel: Story = {
+  render: (args) => (
+    <div className="h-64 w-[36rem] overflow-hidden rounded-lg border">
+      <ResizablePanelGroup {...args}>
+        <ResizablePanel collapsible collapsedSize={0} minSize={20}>
+          <Pane label="Drag me shut" />
+        </ResizablePanel>
+        <ResizableHandle withHandle />
+        <ResizablePanel>
+          <Pane label="Detail" />
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </div>
+  ),
+};

--- a/packages/storybook/src/stories/retry-error.stories.tsx
+++ b/packages/storybook/src/stories/retry-error.stories.tsx
@@ -1,0 +1,33 @@
+import { RetryError } from "@everr/ui/components/retry-error";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Data/RetryError",
+  component: RetryError,
+  args: {
+    title: "Could not load services",
+    message: "The query timed out after 30 seconds.",
+    onRetry: () => {},
+  },
+} satisfies Meta<typeof RetryError>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const LongMessage: Story = {
+  args: {
+    title: "Could not load alert instances",
+    message:
+      "ClickHouse rejected the query because the time range exceeds the retention window. Pick a shorter range and try again.",
+  },
+};
+
+export const InsideCard: Story = {
+  render: (args) => (
+    <div className="w-[28rem] rounded-xl border border-border bg-card">
+      <RetryError {...args} />
+    </div>
+  ),
+};

--- a/packages/storybook/src/stories/select.stories.tsx
+++ b/packages/storybook/src/stories/select.stories.tsx
@@ -1,0 +1,216 @@
+import { Label } from "@everr/ui/components/label";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from "@everr/ui/components/select";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ActivityIcon, BellIcon, ShieldIcon } from "lucide-react";
+import * as React from "react";
+
+const meta = {
+  title: "Controls/Select",
+  component: Select,
+  render: () => (
+    <Select>
+      <SelectTrigger className="w-56">
+        <SelectValue placeholder="Pick a severity" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectGroup>
+          <SelectItem value="page">Page</SelectItem>
+          <SelectItem value="ticket">Ticket</SelectItem>
+          <SelectItem value="info">Info</SelectItem>
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  ),
+} satisfies Meta<typeof Select>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-3">
+      <Select defaultValue="page">
+        <SelectTrigger size="sm">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="page">Page</SelectItem>
+          <SelectItem value="ticket">Ticket</SelectItem>
+        </SelectContent>
+      </Select>
+      <Select defaultValue="page">
+        <SelectTrigger size="default">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="page">Page</SelectItem>
+          <SelectItem value="ticket">Ticket</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  ),
+};
+
+export const WithLabel: Story = {
+  render: () => (
+    <div className="grid w-56 gap-2">
+      <Label htmlFor="severity">Severity</Label>
+      <Select defaultValue="ticket">
+        <SelectTrigger id="severity" className="w-full">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="page">Page</SelectItem>
+          <SelectItem value="ticket">Ticket</SelectItem>
+          <SelectItem value="info">Info</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  ),
+};
+
+export const GroupsAndSeparator: Story = {
+  render: () => (
+    <Select>
+      <SelectTrigger className="w-64">
+        <SelectValue placeholder="Pick a signal" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectGroup>
+          <SelectLabel>Availability</SelectLabel>
+          <SelectItem value="uptime">Uptime</SelectItem>
+          <SelectItem value="error-rate">Error rate</SelectItem>
+        </SelectGroup>
+        <SelectSeparator />
+        <SelectGroup>
+          <SelectLabel>Latency</SelectLabel>
+          <SelectItem value="p95">p95 latency</SelectItem>
+          <SelectItem value="p99">p99 latency</SelectItem>
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  ),
+};
+
+export const WithIcons: Story = {
+  render: () => (
+    <Select defaultValue="alerts">
+      <SelectTrigger className="w-56">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="alerts">
+          <BellIcon />
+          Alerts
+        </SelectItem>
+        <SelectItem value="slos">
+          <ActivityIcon />
+          SLOs
+        </SelectItem>
+        <SelectItem value="silences">
+          <ShieldIcon />
+          Silences
+        </SelectItem>
+      </SelectContent>
+    </Select>
+  ),
+};
+
+export const DisabledItem: Story = {
+  render: () => (
+    <Select>
+      <SelectTrigger className="w-56">
+        <SelectValue placeholder="Pick a destination" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="email">Email</SelectItem>
+        <SelectItem value="slack" disabled>
+          Slack (not connected)
+        </SelectItem>
+        <SelectItem value="webhook">Webhook</SelectItem>
+      </SelectContent>
+    </Select>
+  ),
+};
+
+export const DisabledTrigger: Story = {
+  render: () => (
+    <Select defaultValue="page" disabled>
+      <SelectTrigger className="w-56">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="page">Page</SelectItem>
+      </SelectContent>
+    </Select>
+  ),
+};
+
+export const Invalid: Story = {
+  render: () => (
+    <div className="grid w-56 gap-2">
+      <Select>
+        <SelectTrigger aria-invalid className="w-full">
+          <SelectValue placeholder="Pick a severity" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="page">Page</SelectItem>
+          <SelectItem value="ticket">Ticket</SelectItem>
+        </SelectContent>
+      </Select>
+      <p className="text-destructive text-xs">Select a severity.</p>
+    </div>
+  ),
+};
+
+export const Scrollable: Story = {
+  render: () => (
+    <Select>
+      <SelectTrigger className="w-56">
+        <SelectValue placeholder="Pick a service" />
+      </SelectTrigger>
+      <SelectContent className="max-h-48" alignItemWithTrigger={false}>
+        {Array.from({ length: 30 }, (_, index) => (
+          <SelectItem key={index} value={`service-${index}`}>
+            service-{index}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  ),
+};
+
+export const Controlled: Story = {
+  render: () => {
+    const [value, setValue] = React.useState<unknown>("ticket");
+
+    return (
+      <div className="grid w-56 gap-2">
+        <Select value={value} onValueChange={setValue}>
+          <SelectTrigger className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="page">Page</SelectItem>
+            <SelectItem value="ticket">Ticket</SelectItem>
+            <SelectItem value="info">Info</SelectItem>
+          </SelectContent>
+        </Select>
+        <p className="text-muted-foreground text-xs">
+          Selected: {String(value)}
+        </p>
+      </div>
+    );
+  },
+};

--- a/packages/storybook/src/stories/separator.stories.tsx
+++ b/packages/storybook/src/stories/separator.stories.tsx
@@ -1,0 +1,35 @@
+import { Separator } from "@everr/ui/components/separator";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Layout/Separator",
+  component: Separator,
+} satisfies Meta<typeof Separator>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Horizontal: Story = {
+  args: { orientation: "horizontal" },
+  render: (args) => (
+    <div className="w-72">
+      <p className="font-medium">Traces</p>
+      <p className="text-muted-foreground">Sampled spans by service</p>
+      <Separator {...args} className="my-3" />
+      <p className="text-muted-foreground">Retention is 7 days.</p>
+    </div>
+  ),
+};
+
+export const Vertical: Story = {
+  args: { orientation: "vertical" },
+  render: (args) => (
+    <div className="flex h-6 items-center gap-3">
+      <span>Logs</span>
+      <Separator {...args} />
+      <span>Traces</span>
+      <Separator {...args} />
+      <span>Metrics</span>
+    </div>
+  ),
+};

--- a/packages/storybook/src/stories/sheet.stories.tsx
+++ b/packages/storybook/src/stories/sheet.stories.tsx
@@ -1,0 +1,127 @@
+import { Button } from "@everr/ui/components/button";
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@everr/ui/components/sheet";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Overlays/Sheet",
+  component: Sheet,
+} satisfies Meta<typeof Sheet>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function SheetBody() {
+  return (
+    <div className="text-muted-foreground flex-1 px-6">
+      <p>
+        The sheet holds a detail view next to the page. Use it when the reader
+        must keep the context of the list behind it.
+      </p>
+    </div>
+  );
+}
+
+export const Right: Story = {
+  render: () => (
+    <Sheet defaultOpen>
+      <SheetTrigger render={<Button variant="outline" />}>
+        Open sheet
+      </SheetTrigger>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>Instance detail</SheetTitle>
+          <SheetDescription>
+            The rule fired 12 minutes ago on the checkout service.
+          </SheetDescription>
+        </SheetHeader>
+        <SheetBody />
+        <SheetFooter>
+          <Button>Acknowledge</Button>
+          <SheetClose render={<Button variant="outline" />}>Close</SheetClose>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  ),
+};
+
+export const Left: Story = {
+  render: () => (
+    <Sheet defaultOpen>
+      <SheetTrigger render={<Button variant="outline" />}>
+        Open sheet
+      </SheetTrigger>
+      <SheetContent side="left">
+        <SheetHeader>
+          <SheetTitle>Navigation</SheetTitle>
+          <SheetDescription>The sheet enters from the left.</SheetDescription>
+        </SheetHeader>
+        <SheetBody />
+      </SheetContent>
+    </Sheet>
+  ),
+};
+
+export const Top: Story = {
+  render: () => (
+    <Sheet defaultOpen>
+      <SheetTrigger render={<Button variant="outline" />}>
+        Open sheet
+      </SheetTrigger>
+      <SheetContent side="top">
+        <SheetHeader>
+          <SheetTitle>Announcement</SheetTitle>
+          <SheetDescription>The sheet enters from the top.</SheetDescription>
+        </SheetHeader>
+      </SheetContent>
+    </Sheet>
+  ),
+};
+
+export const Bottom: Story = {
+  render: () => (
+    <Sheet defaultOpen>
+      <SheetTrigger render={<Button variant="outline" />}>
+        Open sheet
+      </SheetTrigger>
+      <SheetContent side="bottom">
+        <SheetHeader>
+          <SheetTitle>Filters</SheetTitle>
+          <SheetDescription>The sheet enters from the bottom.</SheetDescription>
+        </SheetHeader>
+        <SheetFooter>
+          <SheetClose render={<Button />}>Apply</SheetClose>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  ),
+};
+
+export const WithoutCloseButton: Story = {
+  render: () => (
+    <Sheet defaultOpen>
+      <SheetTrigger render={<Button variant="outline" />}>
+        Open sheet
+      </SheetTrigger>
+      <SheetContent showCloseButton={false}>
+        <SheetHeader>
+          <SheetTitle>No close button</SheetTitle>
+          <SheetDescription>
+            The footer holds the only way to close this sheet.
+          </SheetDescription>
+        </SheetHeader>
+        <SheetFooter>
+          <SheetClose render={<Button variant="outline" />}>Close</SheetClose>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  ),
+};

--- a/packages/storybook/src/stories/sidebar.stories.tsx
+++ b/packages/storybook/src/stories/sidebar.stories.tsx
@@ -1,0 +1,253 @@
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupAction,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInput,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSkeleton,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarSeparator,
+  SidebarTrigger,
+} from "@everr/ui/components/sidebar";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  ActivityIcon,
+  BellIcon,
+  LayoutDashboardIcon,
+  ListIcon,
+  PlusIcon,
+  SettingsIcon,
+  TriangleAlertIcon,
+  WaypointsIcon,
+} from "lucide-react";
+
+const meta = {
+  title: "Layout/Sidebar",
+  component: Sidebar,
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof Sidebar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const navigation = [
+  { title: "Overview", icon: LayoutDashboardIcon },
+  { title: "Logs", icon: ListIcon },
+  { title: "Traces", icon: WaypointsIcon },
+  { title: "Metrics", icon: ActivityIcon },
+];
+
+function Nav() {
+  return (
+    <>
+      <SidebarHeader>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton size="lg" tooltip="Everr">
+              <ActivityIcon />
+              <span>Everr</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+        <SidebarInput placeholder="Search" />
+      </SidebarHeader>
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>Telemetry</SidebarGroupLabel>
+          <SidebarGroupAction title="New view">
+            <PlusIcon />
+          </SidebarGroupAction>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {navigation.map((item, index) => (
+                <SidebarMenuItem key={item.title}>
+                  <SidebarMenuButton
+                    tooltip={item.title}
+                    isActive={index === 0}
+                  >
+                    <item.icon />
+                    <span>{item.title}</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+        <SidebarSeparator />
+        <SidebarGroup>
+          <SidebarGroupLabel>Alerting</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton tooltip="Alerts">
+                  <BellIcon />
+                  <span>Alerts</span>
+                </SidebarMenuButton>
+                <SidebarMenuBadge>7</SidebarMenuBadge>
+                <SidebarMenuSub>
+                  <SidebarMenuSubItem>
+                    <SidebarMenuSubButton href="#" isActive>
+                      <span>Firing</span>
+                    </SidebarMenuSubButton>
+                  </SidebarMenuSubItem>
+                  <SidebarMenuSubItem>
+                    <SidebarMenuSubButton href="#" size="sm">
+                      <span>Silences</span>
+                    </SidebarMenuSubButton>
+                  </SidebarMenuSubItem>
+                </SidebarMenuSub>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton tooltip="SLOs">
+                  <TriangleAlertIcon />
+                  <span>SLOs</span>
+                </SidebarMenuButton>
+                <SidebarMenuAction showOnHover title="Add SLO">
+                  <PlusIcon />
+                </SidebarMenuAction>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+        <SidebarGroup>
+          <SidebarGroupLabel>Loading</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuSkeleton showIcon />
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuSkeleton showIcon />
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+      <SidebarFooter>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton variant="outline" tooltip="Settings">
+              <SettingsIcon />
+              <span>Settings</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarFooter>
+      <SidebarRail />
+    </>
+  );
+}
+
+function Page({ title }: { title: string }) {
+  return (
+    <div className="flex flex-1 flex-col gap-3 p-4">
+      <div className="flex items-center gap-2">
+        <SidebarTrigger />
+        <span className="font-medium">{title}</span>
+      </div>
+      <p className="text-muted-foreground">
+        Toggle the sidebar with the trigger, the rail, or Cmd+B.
+      </p>
+    </div>
+  );
+}
+
+export const Expanded: Story = {
+  args: { collapsible: "icon" },
+  render: (args) => (
+    <SidebarProvider open className="h-[36rem] min-h-0">
+      <Sidebar {...args}>
+        <Nav />
+      </Sidebar>
+      <Page title="Expanded" />
+    </SidebarProvider>
+  ),
+};
+
+export const CollapsedToIcons: Story = {
+  args: { collapsible: "icon" },
+  render: (args) => (
+    <SidebarProvider open={false} className="h-[36rem] min-h-0">
+      <Sidebar {...args}>
+        <Nav />
+      </Sidebar>
+      <Page title="Collapsed to icons" />
+    </SidebarProvider>
+  ),
+};
+
+export const CollapsedOffcanvas: Story = {
+  args: { collapsible: "offcanvas" },
+  render: (args) => (
+    <SidebarProvider open={false} className="h-[36rem] min-h-0">
+      <Sidebar {...args}>
+        <Nav />
+      </Sidebar>
+      <Page title="Collapsed offcanvas" />
+    </SidebarProvider>
+  ),
+};
+
+export const NotCollapsible: Story = {
+  args: { collapsible: "none" },
+  render: (args) => (
+    <SidebarProvider open className="h-[36rem] min-h-0">
+      <Sidebar {...args}>
+        <Nav />
+      </Sidebar>
+      <Page title="Always open" />
+    </SidebarProvider>
+  ),
+};
+
+export const FloatingVariant: Story = {
+  args: { variant: "floating", collapsible: "icon" },
+  render: (args) => (
+    <SidebarProvider open className="h-[36rem] min-h-0">
+      <Sidebar {...args}>
+        <Nav />
+      </Sidebar>
+      <Page title="Floating" />
+    </SidebarProvider>
+  ),
+};
+
+export const InsetVariant: Story = {
+  args: { variant: "inset", collapsible: "icon" },
+  render: (args) => (
+    <SidebarProvider open className="h-[36rem] min-h-0">
+      <Sidebar {...args}>
+        <Nav />
+      </Sidebar>
+      <SidebarInset>
+        <Page title="Inset" />
+      </SidebarInset>
+    </SidebarProvider>
+  ),
+};
+
+export const RightSide: Story = {
+  args: { side: "right", collapsible: "icon" },
+  render: (args) => (
+    <SidebarProvider open className="h-[36rem] min-h-0">
+      <Page title="Right side" />
+      <Sidebar {...args}>
+        <Nav />
+      </Sidebar>
+    </SidebarProvider>
+  ),
+};

--- a/packages/storybook/src/stories/skeleton.stories.tsx
+++ b/packages/storybook/src/stories/skeleton.stories.tsx
@@ -1,0 +1,59 @@
+import { Skeleton } from "@everr/ui/components/skeleton";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Data/Skeleton",
+  component: Skeleton,
+  args: { className: "h-4 w-48" },
+} satisfies Meta<typeof Skeleton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Circle: Story = {
+  args: { className: "size-8 rounded-full" },
+};
+
+export const TextBlock: Story = {
+  render: () => (
+    <div className="flex flex-col gap-2">
+      <Skeleton className="h-4 w-64" />
+      <Skeleton className="h-4 w-56" />
+      <Skeleton className="h-4 w-40" />
+    </div>
+  ),
+};
+
+export const CardPlaceholder: Story = {
+  render: () => (
+    <div className="flex w-80 items-center gap-3 rounded-xl border border-border p-4">
+      <Skeleton className="size-10 rounded-full" />
+      <div className="flex flex-1 flex-col gap-2">
+        <Skeleton className="h-4 w-32" />
+        <Skeleton className="h-3 w-48" />
+      </div>
+    </div>
+  ),
+};
+
+export const TablePlaceholder: Story = {
+  render: () => (
+    <div className="flex w-full max-w-2xl flex-col gap-3">
+      {[
+        "checkout-api",
+        "payments-worker",
+        "search-indexer",
+        "edge-gateway",
+      ].map((service) => (
+        <div key={service} className="flex items-center gap-4">
+          <Skeleton className="h-4 w-40" />
+          <Skeleton className="h-4 w-16" />
+          <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-6 flex-1" />
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/packages/storybook/src/stories/sonner.stories.tsx
+++ b/packages/storybook/src/stories/sonner.stories.tsx
@@ -1,0 +1,137 @@
+import { Button } from "@everr/ui/components/button";
+import { Toaster } from "@everr/ui/components/sonner";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { toast } from "sonner";
+
+const meta = {
+  title: "Overlays/Sonner",
+  component: Toaster,
+} satisfies Meta<typeof Toaster>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function saveRule(shouldFail: boolean) {
+  return new Promise<{ name: string }>((resolve, reject) => {
+    setTimeout(() => {
+      if (shouldFail) {
+        reject(new Error("The rule was refused by the server."));
+        return;
+      }
+      resolve({ name: "checkout-error-rate" });
+    }, 1500);
+  });
+}
+
+export const Default: Story = {
+  render: (args) => (
+    <div className="flex flex-wrap gap-2">
+      <Toaster {...args} />
+      <Button variant="outline" onClick={() => toast("The rule was applied.")}>
+        Default
+      </Button>
+      <Button
+        variant="outline"
+        onClick={() => toast.success("The rule was applied.")}
+      >
+        Success
+      </Button>
+      <Button
+        variant="outline"
+        onClick={() => toast.info("Two rules match this service.")}
+      >
+        Info
+      </Button>
+      <Button
+        variant="outline"
+        onClick={() => toast.warning("The rule has no destination.")}
+      >
+        Warning
+      </Button>
+      <Button
+        variant="outline"
+        onClick={() => toast.error("The rule was refused by the server.")}
+      >
+        Error
+      </Button>
+      <Button
+        variant="outline"
+        onClick={() => toast.loading("Applying the rule...")}
+      >
+        Loading
+      </Button>
+    </div>
+  ),
+};
+
+export const WithPromise: Story = {
+  render: (args) => (
+    <div className="flex flex-wrap gap-2">
+      <Toaster {...args} />
+      <Button
+        variant="outline"
+        onClick={() =>
+          toast.promise(saveRule(false), {
+            loading: "Applying the rule...",
+            success: (rule) => `${rule.name} is now active.`,
+            error: (error: Error) => error.message,
+          })
+        }
+      >
+        Promise that resolves
+      </Button>
+      <Button
+        variant="outline"
+        onClick={() =>
+          toast.promise(saveRule(true), {
+            loading: "Applying the rule...",
+            success: (rule) => `${rule.name} is now active.`,
+            error: (error: Error) => error.message,
+          })
+        }
+      >
+        Promise that rejects
+      </Button>
+    </div>
+  ),
+};
+
+export const WithDescriptionAndAction: Story = {
+  render: (args) => (
+    <div className="flex flex-wrap gap-2">
+      <Toaster {...args} />
+      <Button
+        variant="outline"
+        onClick={() =>
+          toast.error("The rule was refused by the server.", {
+            description: "The threshold must be a number above zero.",
+            action: {
+              label: "Retry",
+              onClick: () => toast.success("Applied."),
+            },
+          })
+        }
+      >
+        With description and action
+      </Button>
+      <Button variant="outline" onClick={() => toast.dismiss()}>
+        Dismiss all
+      </Button>
+    </div>
+  ),
+};
+
+export const TopCenter: Story = {
+  args: { position: "top-center" },
+  render: (args) => (
+    <div className="flex flex-wrap gap-2">
+      <Toaster {...args} />
+      <Button
+        variant="outline"
+        onClick={() => toast.success("The rule was applied.")}
+      >
+        Toast at the top
+      </Button>
+    </div>
+  ),
+};

--- a/packages/storybook/src/stories/sparkline.stories.tsx
+++ b/packages/storybook/src/stories/sparkline.stories.tsx
@@ -1,0 +1,78 @@
+import { Sparkline } from "@everr/ui/components/sparkline";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const requestRate = [
+  1240, 1180, 1310, 1490, 1720, 1980, 2140, 2060, 1890, 1650, 1420, 1290,
+];
+const p95Latency = [182, 176, 191, 214, 268, 342, 401, 377, 310, 254, 208, 190];
+const errorRate = [0.4, 0.3, 0.5, 0.8, 1.4, 2.6, 3.9, 3.1, 1.9, 1.1, 0.6, 0.4];
+
+const meta = {
+  title: "Charts/Sparkline",
+  component: Sparkline,
+  args: { data: requestRate },
+} satisfies Meta<typeof Sparkline>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Large: Story = {
+  args: { width: 320, height: 80 },
+};
+
+export const ErrorRate: Story = {
+  args: { data: errorRate, color: "var(--chart-3)" },
+};
+
+export const Latency: Story = {
+  args: { data: p95Latency, color: "var(--chart-2)" },
+};
+
+export const FixedMaxValue: Story = {
+  args: { data: errorRate, maxValue: 100, color: "var(--chart-3)" },
+};
+
+export const SinglePoint: Story = {
+  args: { data: [42] },
+};
+
+export const NoData: Story = {
+  args: { data: [] },
+};
+
+export const Stretched: Story = {
+  args: { className: "h-16 w-full" },
+  decorators: [
+    (Story) => (
+      <div className="w-[480px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const InlineWithMetric: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3">
+      {[
+        {
+          label: "Requests / s",
+          data: requestRate,
+          color: "var(--chart-1)",
+        },
+        { label: "p95 latency", data: p95Latency, color: "var(--chart-2)" },
+        { label: "Error rate", data: errorRate, color: "var(--chart-3)" },
+      ].map((row) => (
+        <div key={row.label} className="flex items-center gap-3 text-sm">
+          <span className="w-28 text-muted-foreground">{row.label}</span>
+          <Sparkline data={row.data} color={row.color} />
+          <span className="font-mono tabular-nums">
+            {row.data[row.data.length - 1]}
+          </span>
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/packages/storybook/src/stories/switch.stories.tsx
+++ b/packages/storybook/src/stories/switch.stories.tsx
@@ -1,0 +1,56 @@
+import { Label } from "@everr/ui/components/label";
+import { Switch } from "@everr/ui/components/switch";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import * as React from "react";
+
+const meta = {
+  title: "Controls/Switch",
+  component: Switch,
+  argTypes: { disabled: { control: "boolean" } },
+} satisfies Meta<typeof Switch>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Checked: Story = {
+  args: { defaultChecked: true },
+};
+
+export const Disabled: Story = {
+  render: (args) => (
+    <div className="flex items-center gap-4">
+      <Switch {...args} disabled />
+      <Switch {...args} disabled defaultChecked />
+    </div>
+  ),
+};
+
+export const WithLabel: Story = {
+  render: (args) => (
+    <Label htmlFor="polling" className="gap-2">
+      <Switch id="polling" {...args} />
+      Poll every 30 seconds
+    </Label>
+  ),
+};
+
+export const Controlled: Story = {
+  render: (args) => {
+    const [checked, setChecked] = React.useState(false);
+
+    return (
+      <div className="flex items-center gap-3">
+        <Switch {...args} checked={checked} onCheckedChange={setChecked} />
+        <span className="text-muted-foreground text-xs">
+          {checked ? "Enabled" : "Disabled"}
+        </span>
+      </div>
+    );
+  },
+};
+
+export const ReadOnly: Story = {
+  args: { readOnly: true, defaultChecked: true },
+};

--- a/packages/storybook/src/stories/tabs.stories.tsx
+++ b/packages/storybook/src/stories/tabs.stories.tsx
@@ -1,0 +1,108 @@
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@everr/ui/components/tabs";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ActivityIcon, ListIcon, WaypointsIcon } from "lucide-react";
+
+const meta = {
+  title: "Layout/Tabs",
+  component: Tabs,
+  args: { defaultValue: "logs" },
+} satisfies Meta<typeof Tabs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const panels = (
+  <>
+    <TabsContent value="logs">
+      Structured log lines for the request.
+    </TabsContent>
+    <TabsContent value="traces">
+      The span waterfall for the request.
+    </TabsContent>
+    <TabsContent value="metrics">
+      Rate, errors, and duration series.
+    </TabsContent>
+  </>
+);
+
+export const Default: Story = {
+  render: (args) => (
+    <Tabs {...args} className="w-96">
+      <TabsList>
+        <TabsTrigger value="logs">Logs</TabsTrigger>
+        <TabsTrigger value="traces">Traces</TabsTrigger>
+        <TabsTrigger value="metrics">Metrics</TabsTrigger>
+      </TabsList>
+      {panels}
+    </Tabs>
+  ),
+};
+
+export const LineVariant: Story = {
+  render: (args) => (
+    <Tabs {...args} className="w-96">
+      <TabsList variant="line">
+        <TabsTrigger value="logs">Logs</TabsTrigger>
+        <TabsTrigger value="traces">Traces</TabsTrigger>
+        <TabsTrigger value="metrics">Metrics</TabsTrigger>
+      </TabsList>
+      {panels}
+    </Tabs>
+  ),
+};
+
+export const WithIcons: Story = {
+  render: (args) => (
+    <Tabs {...args} className="w-96">
+      <TabsList>
+        <TabsTrigger value="logs">
+          <ListIcon />
+          Logs
+        </TabsTrigger>
+        <TabsTrigger value="traces">
+          <WaypointsIcon />
+          Traces
+        </TabsTrigger>
+        <TabsTrigger value="metrics">
+          <ActivityIcon />
+          Metrics
+        </TabsTrigger>
+      </TabsList>
+      {panels}
+    </Tabs>
+  ),
+};
+
+export const Vertical: Story = {
+  args: { orientation: "vertical" },
+  render: (args) => (
+    <Tabs {...args} className="w-96">
+      <TabsList>
+        <TabsTrigger value="logs">Logs</TabsTrigger>
+        <TabsTrigger value="traces">Traces</TabsTrigger>
+        <TabsTrigger value="metrics">Metrics</TabsTrigger>
+      </TabsList>
+      {panels}
+    </Tabs>
+  ),
+};
+
+export const DisabledTab: Story = {
+  render: (args) => (
+    <Tabs {...args} className="w-96">
+      <TabsList>
+        <TabsTrigger value="logs">Logs</TabsTrigger>
+        <TabsTrigger value="traces">Traces</TabsTrigger>
+        <TabsTrigger value="metrics" disabled>
+          Metrics
+        </TabsTrigger>
+      </TabsList>
+      {panels}
+    </Tabs>
+  ),
+};

--- a/packages/storybook/src/stories/textarea.stories.tsx
+++ b/packages/storybook/src/stories/textarea.stories.tsx
@@ -1,0 +1,76 @@
+import { Label } from "@everr/ui/components/label";
+import { Textarea } from "@everr/ui/components/textarea";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import * as React from "react";
+
+const meta = {
+  title: "Controls/Textarea",
+  component: Textarea,
+  args: { placeholder: "Describe what this alert means" },
+  argTypes: { disabled: { control: "boolean" } },
+  decorators: [
+    (Story) => (
+      <div className="max-w-sm">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Textarea>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithLabel: Story = {
+  render: (args) => (
+    <div className="grid gap-2">
+      <Label htmlFor="summary">Summary</Label>
+      <Textarea id="summary" {...args} />
+    </div>
+  ),
+};
+
+export const WithValue: Story = {
+  args: {
+    defaultValue:
+      "The checkout API error rate is above the budget for the last 30 minutes.",
+  },
+};
+
+export const Rows: Story = {
+  args: { rows: 8, defaultValue: "This textarea keeps eight rows of height." },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true, defaultValue: "You cannot edit this text." },
+};
+
+export const Invalid: Story = {
+  render: (args) => (
+    <div className="grid gap-2">
+      <Label htmlFor="runbook">Runbook</Label>
+      <Textarea id="runbook" {...args} aria-invalid defaultValue="" />
+      <p className="text-destructive text-xs">The runbook cannot be empty.</p>
+    </div>
+  ),
+};
+
+export const Controlled: Story = {
+  render: (args) => {
+    const [value, setValue] = React.useState("");
+
+    return (
+      <div className="grid gap-2">
+        <Textarea
+          {...args}
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+        />
+        <p className="text-muted-foreground text-xs">
+          {value.length} characters
+        </p>
+      </div>
+    );
+  },
+};

--- a/packages/storybook/src/stories/time-range-picker.stories.tsx
+++ b/packages/storybook/src/stories/time-range-picker.stories.tsx
@@ -1,0 +1,84 @@
+import {
+  DEFAULT_TIME_RANGE,
+  formatTimeRangeDisplay,
+  isValidDatemath,
+  QUICK_RANGE_GROUPS,
+  type TimeRange,
+  TimeRangePicker,
+} from "@everr/ui/components/time-range-picker";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+
+const meta = {
+  title: "Time/TimeRangePicker",
+  component: TimeRangePicker,
+  args: {
+    value: DEFAULT_TIME_RANGE,
+    onChange: () => {},
+  },
+  render: (args) => {
+    const [range, setRange] = useState<TimeRange>(args.value);
+    return (
+      <div className="flex flex-col items-start gap-3">
+        <TimeRangePicker value={range} onChange={setRange} />
+        <code className="text-muted-foreground text-xs">
+          {range.from} → {range.to}
+        </code>
+      </div>
+    );
+  },
+} satisfies Meta<typeof TimeRangePicker>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const RelativePreset: Story = {
+  args: { value: { from: "now-24h", to: "now" } },
+};
+
+export const CalendarPreset: Story = {
+  args: { value: { from: "now/d", to: "now/d" } },
+};
+
+export const CustomRange: Story = {
+  args: { value: { from: "now-3h", to: "now-30m" } },
+};
+
+export const AbsoluteRange: Story = {
+  args: { value: { from: "2026-08-01T00:00:00Z", to: "2026-08-08T00:00:00Z" } },
+};
+
+export const PresetLabels: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      {QUICK_RANGE_GROUPS.map((group) => (
+        <div key={group.label} className="flex flex-col gap-1">
+          <span className="text-muted-foreground text-xs font-medium">
+            {group.label}
+          </span>
+          {group.ranges.map((range) => (
+            <code key={range.label} className="text-xs">
+              {formatTimeRangeDisplay(range)}: {range.from} → {range.to}
+            </code>
+          ))}
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+export const DatemathValidation: Story = {
+  render: () => (
+    <ul className="text-sm font-mono">
+      {["now", "now-15m", "now/w", "now-1d/d", "yesterday", "5 minutes"].map(
+        (expr) => (
+          <li key={expr}>
+            {expr} → {isValidDatemath(expr) ? "valid" : "invalid"}
+          </li>
+        ),
+      )}
+    </ul>
+  ),
+};

--- a/packages/storybook/src/stories/toggle-group.stories.tsx
+++ b/packages/storybook/src/stories/toggle-group.stories.tsx
@@ -1,0 +1,155 @@
+import {
+  ToggleGroup,
+  ToggleGroupItem,
+} from "@everr/ui/components/toggle-group";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  AlignCenterIcon,
+  AlignLeftIcon,
+  AlignRightIcon,
+  BoldIcon,
+  ItalicIcon,
+  UnderlineIcon,
+} from "lucide-react";
+import * as React from "react";
+
+const meta = {
+  title: "Controls/ToggleGroup",
+  component: ToggleGroup,
+  argTypes: {
+    variant: { control: "select", options: ["default", "outline"] },
+    size: { control: "select", options: ["default", "sm", "lg"] },
+    orientation: {
+      control: "inline-radio",
+      options: ["horizontal", "vertical"],
+    },
+    spacing: { control: { type: "number", min: 0, max: 4 } },
+  },
+  render: (args) => (
+    <ToggleGroup {...args}>
+      <ToggleGroupItem value="left" aria-label="Align left">
+        <AlignLeftIcon />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="center" aria-label="Align center">
+        <AlignCenterIcon />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="right" aria-label="Align right">
+        <AlignRightIcon />
+      </ToggleGroupItem>
+    </ToggleGroup>
+  ),
+} satisfies Meta<typeof ToggleGroup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Outline: Story = {
+  args: { variant: "outline" },
+};
+
+export const Sizes: Story = {
+  render: (args) => (
+    <div className="flex flex-col items-start gap-3">
+      <ToggleGroup {...args} size="sm">
+        <ToggleGroupItem value="bold" aria-label="Bold">
+          <BoldIcon />
+        </ToggleGroupItem>
+        <ToggleGroupItem value="italic" aria-label="Italic">
+          <ItalicIcon />
+        </ToggleGroupItem>
+      </ToggleGroup>
+      <ToggleGroup {...args} size="default">
+        <ToggleGroupItem value="bold" aria-label="Bold">
+          <BoldIcon />
+        </ToggleGroupItem>
+        <ToggleGroupItem value="italic" aria-label="Italic">
+          <ItalicIcon />
+        </ToggleGroupItem>
+      </ToggleGroup>
+      <ToggleGroup {...args} size="lg">
+        <ToggleGroupItem value="bold" aria-label="Bold">
+          <BoldIcon />
+        </ToggleGroupItem>
+        <ToggleGroupItem value="italic" aria-label="Italic">
+          <ItalicIcon />
+        </ToggleGroupItem>
+      </ToggleGroup>
+    </div>
+  ),
+};
+
+export const WithSpacing: Story = {
+  args: { variant: "outline", spacing: 2 },
+};
+
+export const Vertical: Story = {
+  args: { variant: "outline", orientation: "vertical" },
+};
+
+export const WithText: Story = {
+  args: { variant: "outline", defaultValue: ["firing"] },
+  render: (args) => (
+    <ToggleGroup {...args}>
+      <ToggleGroupItem value="firing">Firing</ToggleGroupItem>
+      <ToggleGroupItem value="pending">Pending</ToggleGroupItem>
+      <ToggleGroupItem value="resolved">Resolved</ToggleGroupItem>
+    </ToggleGroup>
+  ),
+};
+
+export const Multiple: Story = {
+  args: { variant: "outline", multiple: true, defaultValue: ["bold"] },
+  render: (args) => (
+    <ToggleGroup {...args}>
+      <ToggleGroupItem value="bold" aria-label="Bold">
+        <BoldIcon />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="italic" aria-label="Italic">
+        <ItalicIcon />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="underline" aria-label="Underline">
+        <UnderlineIcon />
+      </ToggleGroupItem>
+    </ToggleGroup>
+  ),
+};
+
+export const DisabledItem: Story = {
+  args: { variant: "outline" },
+  render: (args) => (
+    <ToggleGroup {...args}>
+      <ToggleGroupItem value="firing">Firing</ToggleGroupItem>
+      <ToggleGroupItem value="pending" disabled>
+        Pending
+      </ToggleGroupItem>
+      <ToggleGroupItem value="resolved">Resolved</ToggleGroupItem>
+    </ToggleGroup>
+  ),
+};
+
+export const Controlled: Story = {
+  render: (args) => {
+    const [value, setValue] = React.useState<string[]>(["center"]);
+
+    return (
+      <div className="flex flex-col items-start gap-3">
+        <ToggleGroup {...args} value={value} onValueChange={setValue}>
+          <ToggleGroupItem value="left" aria-label="Align left">
+            <AlignLeftIcon />
+          </ToggleGroupItem>
+          <ToggleGroupItem value="center" aria-label="Align center">
+            <AlignCenterIcon />
+          </ToggleGroupItem>
+          <ToggleGroupItem value="right" aria-label="Align right">
+            <AlignRightIcon />
+          </ToggleGroupItem>
+        </ToggleGroup>
+        <span className="text-muted-foreground text-xs">
+          {value[0] ?? "None"}
+        </span>
+      </div>
+    );
+  },
+};

--- a/packages/storybook/src/stories/toggle.stories.tsx
+++ b/packages/storybook/src/stories/toggle.stories.tsx
@@ -1,0 +1,129 @@
+import { toggleVariants } from "@everr/ui/components/toggle";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { BoldIcon, ItalicIcon, UnderlineIcon } from "lucide-react";
+import * as React from "react";
+
+type ToggleProps = React.ComponentProps<"button"> & {
+  variant?: "default" | "outline";
+  size?: "default" | "sm" | "lg";
+  pressed?: boolean;
+  defaultPressed?: boolean;
+  onPressedChange?: (pressed: boolean) => void;
+};
+
+// The package exports only the class recipe, so the stories drive the pressed
+// state themselves.
+function Toggle({
+  className,
+  variant,
+  size,
+  pressed,
+  defaultPressed = false,
+  onPressedChange,
+  onClick,
+  ...props
+}: ToggleProps) {
+  const [uncontrolled, setUncontrolled] = React.useState(defaultPressed);
+  const isPressed = pressed ?? uncontrolled;
+
+  return (
+    <button
+      type="button"
+      data-slot="toggle"
+      aria-pressed={isPressed}
+      className={toggleVariants({ variant, size, className })}
+      onClick={(event) => {
+        onClick?.(event);
+        setUncontrolled(!isPressed);
+        onPressedChange?.(!isPressed);
+      }}
+      {...props}
+    />
+  );
+}
+
+const meta = {
+  title: "Controls/Toggle",
+  component: Toggle,
+  args: { children: <BoldIcon />, "aria-label": "Bold" },
+  argTypes: {
+    variant: { control: "select", options: ["default", "outline"] },
+    size: { control: "select", options: ["default", "sm", "lg"] },
+    disabled: { control: "boolean" },
+  },
+} satisfies Meta<typeof Toggle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Variants: Story = {
+  render: (args) => (
+    <div className="flex items-center gap-2">
+      <Toggle {...args} variant="default" />
+      <Toggle {...args} variant="outline" />
+    </div>
+  ),
+};
+
+export const Sizes: Story = {
+  render: (args) => (
+    <div className="flex items-center gap-2">
+      <Toggle {...args} size="sm" />
+      <Toggle {...args} size="default" />
+      <Toggle {...args} size="lg" />
+    </div>
+  ),
+};
+
+export const Pressed: Story = {
+  args: { defaultPressed: true },
+};
+
+export const WithText: Story = {
+  args: {
+    "aria-label": undefined,
+    children: (
+      <>
+        <ItalicIcon />
+        Italic
+      </>
+    ),
+  },
+};
+
+export const Disabled: Story = {
+  render: (args) => (
+    <div className="flex items-center gap-2">
+      <Toggle {...args} disabled />
+      <Toggle {...args} disabled defaultPressed />
+    </div>
+  ),
+};
+
+export const Invalid: Story = {
+  args: { "aria-invalid": true },
+};
+
+export const Controlled: Story = {
+  render: (args) => {
+    const [pressed, setPressed] = React.useState(false);
+
+    return (
+      <div className="flex items-center gap-3">
+        <Toggle
+          {...args}
+          aria-label="Underline"
+          pressed={pressed}
+          onPressedChange={setPressed}
+        >
+          <UnderlineIcon />
+        </Toggle>
+        <span className="text-muted-foreground text-xs">
+          {pressed ? "On" : "Off"}
+        </span>
+      </div>
+    );
+  },
+};

--- a/packages/storybook/src/stories/tooltip.stories.tsx
+++ b/packages/storybook/src/stories/tooltip.stories.tsx
@@ -1,0 +1,78 @@
+import { Button } from "@everr/ui/components/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@everr/ui/components/tooltip";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { InfoIcon } from "lucide-react";
+
+const meta = {
+  title: "Overlays/Tooltip",
+  component: Tooltip,
+} satisfies Meta<typeof Tooltip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="flex min-h-40 items-center justify-center">
+      <Tooltip open>
+        <TooltipTrigger render={<Button variant="outline" />}>
+          Hover me
+        </TooltipTrigger>
+        <TooltipContent>Refresh every 30 seconds</TooltipContent>
+      </Tooltip>
+    </div>
+  ),
+};
+
+export const Sides: Story = {
+  render: () => (
+    <div className="grid min-h-96 grid-cols-2 place-items-center gap-10">
+      {(["top", "right", "bottom", "left"] as const).map((side) => (
+        <Tooltip key={side} open>
+          <TooltipTrigger render={<Button variant="outline" />}>
+            {side}
+          </TooltipTrigger>
+          <TooltipContent side={side}>Placed on the {side}</TooltipContent>
+        </Tooltip>
+      ))}
+    </div>
+  ),
+};
+
+export const OnIconButton: Story = {
+  render: () => (
+    <div className="flex min-h-40 items-center justify-center">
+      <Tooltip open>
+        <TooltipTrigger render={<Button variant="ghost" size="icon-sm" />}>
+          <InfoIcon />
+          <span className="sr-only">About this metric</span>
+        </TooltipTrigger>
+        <TooltipContent>
+          The rate counts every request that returned 5xx.
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  ),
+};
+
+export const WithDelay: Story = {
+  render: () => (
+    <TooltipProvider delay={600}>
+      <div className="flex min-h-40 items-center justify-center">
+        <Tooltip>
+          <TooltipTrigger render={<Button variant="outline" />}>
+            Hover and wait
+          </TooltipTrigger>
+          <TooltipContent>
+            The provider delays this tooltip 600ms
+          </TooltipContent>
+        </Tooltip>
+      </div>
+    </TooltipProvider>
+  ),
+};

--- a/packages/storybook/src/welcome.mdx
+++ b/packages/storybook/src/welcome.mdx
@@ -1,0 +1,24 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Welcome" />
+
+# @everr/ui
+
+Every component of the shared UI package, with its variants and states.
+
+Components are grouped by role:
+
+- **Controls** buttons, inputs, selects and other form elements
+- **Overlays** dialogs, sheets, popovers, menus and toasts
+- **Layout** cards, tabs, sidebar, panels and separators
+- **Data** badges, tables, comboboxes, empty and error states
+- **Charts** and **Time** the chart primitives and the range pickers
+
+The stories import the components from source (`packages/ui/src`), so a change
+in the package shows here immediately.
+
+## Run it
+
+```bash
+pnpm --filter @everr/storybook dev
+```

--- a/packages/storybook/tsconfig.json
+++ b/packages/storybook/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "types": ["vite/client"],
+    "paths": {
+      "@everr/ui/*": ["../ui/src/*"]
+    }
+  },
+  "include": ["."],
+  "exclude": ["node_modules", "storybook-static"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@icons-pack/react-simple-icons':
+      specifier: ^13.13.0
+      version: 13.13.0
     '@t3-oss/env-core':
       specifier: ^0.13.11
       version: 0.13.11
@@ -42,6 +45,9 @@ catalogs:
     recharts:
       specifier: ^2.15.4
       version: 2.15.4
+    tailwindcss:
+      specifier: ^4.3.0
+      version: 4.3.0
     typescript:
       specifier: ^6.0.3
       version: 6.0.3
@@ -110,10 +116,10 @@ importers:
     dependencies:
       '@better-auth/api-key':
         specifier: ^1.6.20
-        version: 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(better-auth@1.6.20(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.11))(better-call@1.3.6(zod@4.4.3))
+        version: 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(better-auth@1.6.20(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.11)(vitest@4.1.5))(better-call@1.3.6(zod@4.4.3))
       '@better-auth/oauth-provider':
         specifier: 1.6.20
-        version: 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.20(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.11))(better-call@1.3.6(zod@4.4.3))
+        version: 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.20(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.11)(vitest@4.1.5))(better-call@1.3.6(zod@4.4.3))
       '@clickhouse/client':
         specifier: ^1.18.4
         version: 1.18.4
@@ -167,7 +173,7 @@ importers:
         version: 0.218.0(@opentelemetry/api@1.9.1)
       '@polar-sh/better-auth':
         specifier: ^1.8.4
-        version: 1.8.4(@polar-sh/sdk@0.47.1)(@stripe/react-stripe-js@4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@stripe/stripe-js@7.9.0)(better-auth@1.6.20(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.11))(react@19.2.6)(zod@4.4.3)
+        version: 1.8.4(@polar-sh/sdk@0.47.1)(@stripe/react-stripe-js@4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@stripe/stripe-js@7.9.0)(better-auth@1.6.20(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.11)(vitest@4.1.5))(react@19.2.6)(zod@4.4.3)
       '@polar-sh/sdk':
         specifier: ^0.47.1
         version: 0.47.1
@@ -179,10 +185,10 @@ importers:
         version: 0.5.20
       '@tailwindcss/vite':
         specifier: 'catalog:'
-        version: 4.3.0(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.3.0(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/react-form':
         specifier: ^1.31.0
-        version: 1.31.0(@tanstack/react-start@1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 1.31.0(@tanstack/react-start@1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.100.9(react@19.2.6)
@@ -191,13 +197,13 @@ importers:
         version: 1.170.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/react-start':
         specifier: 1.168.40
-        version: 1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       ansi-to-react:
         specifier: ^6.2.6
         version: 6.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       better-auth:
         specifier: ^1.6.20
-        version: 1.6.20(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.11)
+        version: 1.6.20(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.11)(vitest@4.1.5)
       d3-geo:
         specifier: ^3.1.1
         version: 3.1.1
@@ -273,13 +279,13 @@ importers:
     devDependencies:
       '@tanstack/devtools-vite':
         specifier: ^0.6.0
-        version: 0.6.0(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 0.6.0(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/react-devtools':
         specifier: ^0.10.2
         version: 0.10.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(csstype@3.2.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.11)
       '@tanstack/react-form-devtools':
         specifier: ^0.2.26
-        version: 0.2.26(@types/react@19.2.14)(csstype@3.2.3)(react@19.2.6)(solid-js@1.9.11)
+        version: 0.2.26(@types/react@19.2.14)(csstype@3.2.3)(preact@10.29.1)(react@19.2.6)(solid-js@1.9.11)
       '@tanstack/react-query-devtools':
         specifier: ^5.100.9
         version: 5.100.9(@tanstack/react-query@5.100.9(react@19.2.6))(react@19.2.6)
@@ -324,7 +330,7 @@ importers:
         version: 3.1.5
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 6.0.1(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -336,7 +342,7 @@ importers:
         version: 29.1.1(@noble/hashes@2.2.0)
       nitro:
         specifier: 'catalog:'
-        version: 3.0.260429-beta(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0))(jiti@2.7.0)(lru-cache@11.3.5)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 3.0.260429-beta(@azure/storage-blob@12.31.0)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0))(jiti@2.7.0)(lru-cache@11.3.5)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       smee-client:
         specifier: ^5.0.0
         version: 5.0.0
@@ -345,7 +351,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/datemath:
     devDependencies:
@@ -634,6 +640,61 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+
+  packages/storybook:
+    dependencies:
+      '@everr/ui':
+        specifier: workspace:*
+        version: link:../ui
+      '@tanstack/react-query':
+        specifier: 'catalog:'
+        version: 5.100.9(react@19.2.6)
+      lucide-react:
+        specifier: 'catalog:'
+        version: 1.14.0(react@19.2.6)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
+      recharts:
+        specifier: 'catalog:'
+        version: 2.15.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+    devDependencies:
+      '@storybook/addon-docs':
+        specifier: ^9.1.13
+        version: 9.1.20(@types/react@19.2.14)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@storybook/react-vite':
+        specifier: ^9.1.13
+        version: 9.1.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@tailwindcss/vite':
+        specifier: 'catalog:'
+        version: 4.3.0(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: 'catalog:'
+        version: 6.0.1(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      storybook:
+        specifier: ^9.1.13
+        version: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      tailwindcss:
+        specifier: 'catalog:'
+        version: 4.3.0
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/telemetry-explorer:
     dependencies:
@@ -2417,6 +2478,15 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1':
+    resolution: {integrity: sha512-J4BaTocTOYFkMHIra1JDWrMWpNmBl4EkplIwHEsV8aeUOtdWjwSnln9U7twjMFTAEB7mptNtSKyVi1Y2W9sDJw==}
+    peerDependencies:
+      typescript: '>= 4.3.x'
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -2447,6 +2517,12 @@ packages:
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
+  '@mdx-js/react@3.1.1':
+    resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
+    peerDependencies:
+      '@types/react': '>=16'
+      react: '>=16'
 
   '@modelcontextprotocol/sdk@1.26.0':
     resolution: {integrity: sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==}
@@ -3861,6 +3937,60 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@storybook/addon-docs@9.1.20':
+    resolution: {integrity: sha512-eUIOd4u/p9994Nkv8Avn6r/xmS7D+RNmhmu6KGROefN3myLe3JfhSdimal2wDFe/h/OUNZ/LVVKMZrya9oEfKQ==}
+    peerDependencies:
+      storybook: ^9.1.20
+
+  '@storybook/builder-vite@9.1.20':
+    resolution: {integrity: sha512-cdU3Q2/wEaT8h+mApFToRiF/0hYKH1eAkD0scQn67aODgp7xnkr0YHcdA+8w0Uxd2V7U8crV/cmT/HD0ELVOGw==}
+    peerDependencies:
+      storybook: ^9.1.20
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@storybook/csf-plugin@9.1.20':
+    resolution: {integrity: sha512-HHgk50YQhML7mT01Mzf9N7lNMFHWN4HwwRP90kPT9Ct+Jhx7h3LBDbdmWjI96HwujcpY7eoYdTfpB1Sw8Z7nBQ==}
+    peerDependencies:
+      storybook: ^9.1.20
+
+  '@storybook/global@5.0.0':
+    resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
+
+  '@storybook/icons@1.6.0':
+    resolution: {integrity: sha512-hcFZIjW8yQz8O8//2WTIXylm5Xsgc+lW9ISLgUk1xGmptIJQRdlhVIXCpSyLrQaaRiyhQRaVg7l3BD9S216BHw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+
+  '@storybook/react-dom-shim@9.1.20':
+    resolution: {integrity: sha512-UYdZavfPwHEqCKMqPssUOlyFVZiJExLxnSHwkICSZBmw3gxXJcp1aXWs7PvoZdWz2K4ztl3IcKErXXHeiY6w+A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      storybook: ^9.1.20
+
+  '@storybook/react-vite@9.1.20':
+    resolution: {integrity: sha512-buXeNvEJ9kp4FKbGYV7zW4sh/KS01EAjeq8Z6AVxaXOh4W2CIRTKM9maWGz+Rr+YyqQIq/Gl+RqNwxctpxeuHA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      storybook: ^9.1.20
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@storybook/react@9.1.20':
+    resolution: {integrity: sha512-TJhqzggs7HCvLhTXKfx8HodnVq9YizsB2J31s9v6olU0UCxbCY+FYaCF+XdE8qUCyefGRZgHKzGBIczJ/q9e2g==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      storybook: ^9.1.20
+      typescript: '>= 4.9.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@stripe/react-stripe-js@4.0.2':
     resolution: {integrity: sha512-l2wau+8/LOlHl+Sz8wQ1oDuLJvyw51nQCsu6/ljT6smqzTszcMHifjAJoXlnMfcou3+jK/kQyVe04u/ufyTXgg==}
     peerDependencies:
@@ -4598,6 +4728,18 @@ packages:
   '@types/aws-lambda@8.10.161':
     resolution: {integrity: sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==}
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/bunyan@1.8.11':
     resolution: {integrity: sha512-758fRH7umIMk5qt5ELmRMff4mLDlN+xyYzC+dkPTdKwbSkJFvz6xwyScrytPU0QIBbRRwbiE8/BIg8bpajerNQ==}
 
@@ -4642,6 +4784,9 @@ packages:
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/doctrine@0.0.9':
+    resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -4717,6 +4862,9 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/resolve@1.20.6':
+    resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
+
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
@@ -4776,8 +4924,22 @@ packages:
       '@vitest/browser':
         optional: true
 
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
   '@vitest/expect@4.1.5':
     resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
 
   '@vitest/mocker@4.1.5':
     resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
@@ -4790,6 +4952,9 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
   '@vitest/pretty-format@4.1.5':
     resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
 
@@ -4799,6 +4964,9 @@ packages:
   '@vitest/snapshot@4.1.5':
     resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
 
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
   '@vitest/spy@4.1.5':
     resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
 
@@ -4806,6 +4974,9 @@ packages:
     resolution: {integrity: sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==}
     peerDependencies:
       vitest: 4.1.5
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
@@ -4924,6 +5095,10 @@ packages:
   ast-kit@3.0.0-beta.1:
     resolution: {integrity: sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw==}
     engines: {node: '>=20.19.0'}
+
+  ast-types@0.16.1:
+    resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
+    engines: {node: '>=4'}
 
   ast-v8-to-istanbul@1.0.0:
     resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
@@ -5073,6 +5248,10 @@ packages:
       zod:
         optional: true
 
+  better-opn@3.0.2:
+    resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
+    engines: {node: '>=12.0.0'}
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
@@ -5160,6 +5339,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -5189,6 +5372,10 @@ packages:
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
@@ -5450,6 +5637,14 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  define-lazy-prop@2.0.0:
+    resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
+    engines: {node: '>=8'}
+
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
@@ -5491,6 +5686,10 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  doctrine@3.0.0:
+    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
+    engines: {node: '>=6.0.0'}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -5702,6 +5901,11 @@ packages:
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
 
+  esbuild-register@3.6.0:
+    resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
+    peerDependencies:
+      esbuild: '>=0.12 <1'
+
   esbuild@0.18.20:
     resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
     engines: {node: '>=12'}
@@ -5772,6 +5976,10 @@ packages:
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
 
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
@@ -5918,6 +6126,10 @@ packages:
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
+
+  find-up@7.0.0:
+    resolution: {integrity: sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==}
+    engines: {node: '>=18'}
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
@@ -6322,8 +6534,17 @@ packages:
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
+
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
+  is-docker@2.2.1:
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -6377,6 +6598,10 @@ packages:
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
+
+  is-wsl@2.2.0:
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
+    engines: {node: '>=8'}
 
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
@@ -6624,6 +6849,10 @@ packages:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
 
+  locate-path@7.2.0:
+    resolution: {integrity: sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
@@ -6645,6 +6874,9 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
@@ -7090,6 +7322,10 @@ packages:
   oniguruma-to-es@4.3.6:
     resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
+  open@8.4.2:
+    resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
+    engines: {node: '>=12'}
+
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
 
@@ -7101,9 +7337,17 @@ packages:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
 
+  p-limit@4.0.0:
+    resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
+
+  p-locate@6.0.0:
+    resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   p-map@2.1.0:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
@@ -7148,6 +7392,10 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-exists@5.0.0:
+    resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   path-expression-matcher@1.5.0:
     resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
     engines: {node: '>=14.0.0'}
@@ -7159,6 +7407,9 @@ packages:
   path-key@4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
@@ -7173,6 +7424,10 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   pg-cloudflare@1.3.0:
     resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
@@ -7346,6 +7601,15 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
+  react-docgen-typescript@2.4.0:
+    resolution: {integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==}
+    peerDependencies:
+      typescript: '>= 4.3.x'
+
+  react-docgen@8.0.3:
+    resolution: {integrity: sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w==}
+    engines: {node: ^20.9.0 || >=22}
+
   react-dom@19.2.6:
     resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
     peerDependencies:
@@ -7460,6 +7724,10 @@ packages:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
 
+  recast@0.23.21:
+    resolution: {integrity: sha512-mFAyJq9vUbSTARLZUvAEf1z3YxlvAwswbmxMx2mPA/MSm4KmpwvwvhsH/NIrZhyOuwD60Lzyw2qh83uCbgTPYw==}
+    engines: {node: '>= 4'}
+
   recharts-scale@0.4.5:
     resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
 
@@ -7565,6 +7833,11 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -7811,6 +8084,15 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
+  storybook@9.1.20:
+    resolution: {integrity: sha512-6rME2tww6PFhm96iG2Xx44yzwLDWBiDWy+kJ2ub6x90werSTOiuo+tZJ94BgCfFutR0tEfLRIq59s+Zg6YyChA==}
+    hasBin: true
+    peerDependencies:
+      prettier: ^2 || ^3
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+
   streamx@2.25.0:
     resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
 
@@ -7851,6 +8133,10 @@ packages:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
 
+  strip-indent@4.1.1:
+    resolution: {integrity: sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==}
+    engines: {node: '>=12'}
+
   strnum@2.3.0:
     resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
 
@@ -7863,6 +8149,10 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
 
   svg-parser@2.0.4:
     resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
@@ -7921,8 +8211,16 @@ packages:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
   tldts-core@7.0.30:
@@ -7971,6 +8269,14 @@ packages:
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-dedent@2.3.0:
+    resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
+    engines: {node: '>=6.10'}
+
+  tsconfig-paths@4.2.0:
+    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
+    engines: {node: '>=6'}
 
   tsdown@0.22.2:
     resolution: {integrity: sha512-VX9gsyKXsTnBZjnIM4jsHl9aRv+GfgkE/k1hQslilaBfZMlaw3JuGR+6yhiU0QxWBtOCDnTjwOSoXzgB7Rr50g==}
@@ -8084,6 +8390,10 @@ packages:
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
+  unicorn-magic@0.1.0:
+    resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
+    engines: {node: '>=18'}
+
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
@@ -8122,6 +8432,10 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  unplugin@1.16.1:
+    resolution: {integrity: sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==}
+    engines: {node: '>=14.0.0'}
 
   unplugin@3.0.0:
     resolution: {integrity: sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==}
@@ -8466,6 +8780,10 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
 
   yoctocolors@2.2.0:
     resolution: {integrity: sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==}
@@ -9027,11 +9345,11 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@better-auth/api-key@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(better-auth@1.6.20(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.11))(better-call@1.3.6(zod@4.4.3))':
+  '@better-auth/api-key@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(better-auth@1.6.20(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.11)(vitest@4.1.5))(better-call@1.3.6(zod@4.4.3))':
     dependencies:
       '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
-      better-auth: 1.6.20(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.11)
+      better-auth: 1.6.20(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.11)(vitest@4.1.5)
       better-call: 1.3.6(zod@4.4.3)
       zod: 4.4.3
 
@@ -9073,12 +9391,12 @@ snapshots:
       '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/oauth-provider@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.20(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.11))(better-call@1.3.6(zod@4.4.3))':
+  '@better-auth/oauth-provider@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.20(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.11)(vitest@4.1.5))(better-call@1.3.6(zod@4.4.3))':
     dependencies:
       '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
-      better-auth: 1.6.20(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.11)
+      better-auth: 1.6.20(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.11)(vitest@4.1.5)
       better-call: 1.3.6(zod@4.4.3)
       jose: 6.2.3
       zod: 4.4.3
@@ -9939,6 +10257,15 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@6.0.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      glob: 10.5.0
+      magic-string: 0.30.21
+      react-docgen-typescript: 2.4.0(typescript@6.0.3)
+      vite: 8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+    optionalDependencies:
+      typescript: 6.0.3
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -10007,6 +10334,12 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      '@types/mdx': 2.0.13
+      '@types/react': 19.2.14
+      react: 19.2.6
 
   '@modelcontextprotocol/sdk@1.26.0(zod@4.4.3)':
     dependencies:
@@ -10907,11 +11240,11 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@polar-sh/better-auth@1.8.4(@polar-sh/sdk@0.47.1)(@stripe/react-stripe-js@4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@stripe/stripe-js@7.9.0)(better-auth@1.6.20(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.11))(react@19.2.6)(zod@4.4.3)':
+  '@polar-sh/better-auth@1.8.4(@polar-sh/sdk@0.47.1)(@stripe/react-stripe-js@4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@stripe/stripe-js@7.9.0)(better-auth@1.6.20(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.11)(vitest@4.1.5))(react@19.2.6)(zod@4.4.3)':
     dependencies:
       '@polar-sh/checkout': 0.2.1(@stripe/react-stripe-js@4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@stripe/stripe-js@7.9.0)(react@19.2.6)
       '@polar-sh/sdk': 0.47.1
-      better-auth: 1.6.20(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.11)
+      better-auth: 1.6.20(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.11)(vitest@4.1.5)
       zod: 4.4.3
     transitivePeerDependencies:
       - '@stripe/react-stripe-js'
@@ -11581,6 +11914,74 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@storybook/addon-docs@9.1.20(@types/react@19.2.14)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))':
+    dependencies:
+      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@storybook/csf-plugin': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@storybook/icons': 1.6.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@storybook/react-dom-shim': 9.1.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      ts-dedent: 2.3.0
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@storybook/builder-vite@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@storybook/csf-plugin': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      ts-dedent: 2.3.0
+      vite: 8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+
+  '@storybook/csf-plugin@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))':
+    dependencies:
+      storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      unplugin: 1.16.1
+
+  '@storybook/global@5.0.0': {}
+
+  '@storybook/icons@1.6.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  '@storybook/react-dom-shim@9.1.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))':
+    dependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
+  '@storybook/react-vite@9.1.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@6.0.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@rollup/pluginutils': 5.3.0
+      '@storybook/builder-vite': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@storybook/react': 9.1.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)
+      find-up: 7.0.0
+      magic-string: 0.30.21
+      react: 19.2.6
+      react-docgen: 8.0.3
+      react-dom: 19.2.6(react@19.2.6)
+      resolve: 1.22.12
+      storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      tsconfig-paths: 4.2.0
+      vite: 8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+      - typescript
+
+  '@storybook/react@9.1.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/react-dom-shim': 9.1.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      storybook: 9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+    optionalDependencies:
+      typescript: 6.0.3
+
   '@stripe/react-stripe-js@4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@stripe/stripe-js': 7.9.0
@@ -11797,12 +12198,12 @@ snapshots:
     dependencies:
       postcss-selector-parser: 6.0.10
 
-  '@tailwindcss/vite@4.3.0(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@tailwindcss/vite@4.3.0(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
-      vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@tailwindcss/vite@4.3.0(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
@@ -11892,29 +12293,12 @@ snapshots:
     transitivePeerDependencies:
       - csstype
 
-  '@tanstack/devtools-utils@0.4.0(@types/react@19.2.14)(react@19.2.6)(solid-js@1.9.11)':
+  '@tanstack/devtools-utils@0.4.0(@types/react@19.2.14)(preact@10.29.1)(react@19.2.6)(solid-js@1.9.11)':
     optionalDependencies:
       '@types/react': 19.2.14
+      preact: 10.29.1
       react: 19.2.6
       solid-js: 1.9.11
-
-  '@tanstack/devtools-vite@0.6.0(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.0
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      '@tanstack/devtools-client': 0.0.6
-      '@tanstack/devtools-event-bus': 0.4.1
-      chalk: 5.6.2
-      launch-editor: 2.13.1
-      picomatch: 4.0.3
-      vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
 
   '@tanstack/devtools-vite@0.6.0(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
@@ -11956,10 +12340,10 @@ snapshots:
       '@tanstack/pacer-lite': 0.1.1
       '@tanstack/store': 0.9.3
 
-  '@tanstack/form-devtools@0.2.26(@types/react@19.2.14)(csstype@3.2.3)(react@19.2.6)(solid-js@1.9.11)':
+  '@tanstack/form-devtools@0.2.26(@types/react@19.2.14)(csstype@3.2.3)(preact@10.29.1)(react@19.2.6)(solid-js@1.9.11)':
     dependencies:
       '@tanstack/devtools-ui': 0.5.1(csstype@3.2.3)(solid-js@1.9.11)
-      '@tanstack/devtools-utils': 0.4.0(@types/react@19.2.14)(react@19.2.6)(solid-js@1.9.11)
+      '@tanstack/devtools-utils': 0.4.0(@types/react@19.2.14)(preact@10.29.1)(react@19.2.6)(solid-js@1.9.11)
       '@tanstack/form-core': 1.31.0
       clsx: 2.1.1
       dayjs: 1.11.20
@@ -11995,10 +12379,10 @@ snapshots:
       - solid-js
       - utf-8-validate
 
-  '@tanstack/react-form-devtools@0.2.26(@types/react@19.2.14)(csstype@3.2.3)(react@19.2.6)(solid-js@1.9.11)':
+  '@tanstack/react-form-devtools@0.2.26(@types/react@19.2.14)(csstype@3.2.3)(preact@10.29.1)(react@19.2.6)(solid-js@1.9.11)':
     dependencies:
-      '@tanstack/devtools-utils': 0.4.0(@types/react@19.2.14)(react@19.2.6)(solid-js@1.9.11)
-      '@tanstack/form-devtools': 0.2.26(@types/react@19.2.14)(csstype@3.2.3)(react@19.2.6)(solid-js@1.9.11)
+      '@tanstack/devtools-utils': 0.4.0(@types/react@19.2.14)(preact@10.29.1)(react@19.2.6)(solid-js@1.9.11)
+      '@tanstack/form-devtools': 0.2.26(@types/react@19.2.14)(csstype@3.2.3)(preact@10.29.1)(react@19.2.6)(solid-js@1.9.11)
       react: 19.2.6
     transitivePeerDependencies:
       - '@types/react'
@@ -12007,13 +12391,13 @@ snapshots:
       - solid-js
       - vue
 
-  '@tanstack/react-form@1.31.0(@tanstack/react-start@1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@tanstack/react-form@1.31.0(@tanstack/react-start@1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@tanstack/form-core': 1.31.0
       '@tanstack/react-store': 0.9.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
     optionalDependencies:
-      '@tanstack/react-start': 1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@tanstack/react-start': 1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - react-dom
 
@@ -12076,14 +12460,14 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  '@tanstack/react-start-rsc@0.1.39(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@tanstack/react-start-rsc@0.1.39(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@tanstack/react-router': 1.170.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/router-core': 1.171.19
       '@tanstack/router-utils': 1.162.2
       '@tanstack/start-client-core': 1.170.19
       '@tanstack/start-fn-stubs': 1.162.0
-      '@tanstack/start-plugin-core': 1.171.31(@tanstack/react-router@1.170.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.5(srvx@0.11.15))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@tanstack/start-plugin-core': 1.171.31(@tanstack/react-router@1.170.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.5(srvx@0.11.15))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/start-storage-context': 1.167.21
       pathe: 2.0.3
       react: 19.2.6
@@ -12136,21 +12520,21 @@ snapshots:
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/react-start@1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@tanstack/react-start@1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@tanstack/react-router': 1.170.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/react-start-client': 1.168.21(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@tanstack/react-start-rsc': 0.1.39(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@tanstack/react-start-rsc': 0.1.39(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/react-start-server': 1.167.28(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/router-utils': 1.162.2
       '@tanstack/start-client-core': 1.170.19
-      '@tanstack/start-plugin-core': 1.171.31(@tanstack/react-router@1.170.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.5(srvx@0.11.15))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@tanstack/start-plugin-core': 1.171.31(@tanstack/react-router@1.170.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.5(srvx@0.11.15))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/start-server-core': 1.169.23(crossws@0.4.5(srvx@0.11.15))
       pathe: 2.0.3
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
-      vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - crossws
@@ -12232,23 +12616,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.168.27(@tanstack/react-router@1.170.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/template': 7.29.7
-      '@babel/types': 7.29.8
-      '@tanstack/router-core': 1.171.19
-      '@tanstack/router-generator': 1.167.25
-      '@tanstack/router-utils': 1.162.2
-      chokidar: 5.0.0
-      unplugin: 3.0.0
-      zod: 4.4.3
-    optionalDependencies:
-      '@tanstack/react-router': 1.170.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - supports-color
-
   '@tanstack/router-plugin@1.168.27(@tanstack/react-router@1.170.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.0
@@ -12288,14 +12655,14 @@ snapshots:
 
   '@tanstack/start-fn-stubs@1.162.0': {}
 
-  '@tanstack/start-plugin-core@1.171.31(@tanstack/react-router@1.170.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.5(srvx@0.11.15))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@tanstack/start-plugin-core@1.171.31(@tanstack/react-router@1.170.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(crossws@0.4.5(srvx@0.11.15))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.29.0
       '@babel/types': 7.29.8
       '@tanstack/router-core': 1.171.19
       '@tanstack/router-generator': 1.167.25
-      '@tanstack/router-plugin': 1.168.27(@tanstack/react-router@1.170.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@tanstack/router-plugin': 1.168.27(@tanstack/react-router@1.170.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/router-utils': 1.162.2
       '@tanstack/start-server-core': 1.169.23(crossws@0.4.5(srvx@0.11.15))
       exsolve: 1.0.8
@@ -12307,11 +12674,11 @@ snapshots:
       srvx: 0.11.17
       tinyglobby: 0.2.17
       ufo: 1.6.4
-      vitefu: 1.1.3(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitefu: 1.1.3(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       xmlbuilder2: 4.0.3
       zod: 4.4.3
     optionalDependencies:
-      vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@tanstack/react-router'
       - crossws
@@ -12492,6 +12859,27 @@ snapshots:
 
   '@types/aws-lambda@8.10.161': {}
 
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.8
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.8
+
   '@types/bunyan@1.8.11':
     dependencies:
       '@types/node': 25.6.2
@@ -12538,6 +12926,8 @@ snapshots:
       '@types/ms': 2.1.0
 
   '@types/deep-eql@4.0.2': {}
+
+  '@types/doctrine@0.0.9': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -12623,6 +13013,8 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/resolve@1.20.6': {}
+
   '@types/semver@7.7.1': {}
 
   '@types/tedious@4.0.14':
@@ -12664,10 +13056,10 @@ snapshots:
 
   '@vercel/ncc@0.38.4': {}
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitejs/plugin-react@6.0.1(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
@@ -12688,6 +13080,14 @@ snapshots:
       tinyrainbow: 3.1.0
       vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
   '@vitest/expect@4.1.5':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -12697,6 +13097,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
+  '@vitest/mocker@3.2.4(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+
   '@vitest/mocker@4.1.5(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.5
@@ -12704,6 +13112,10 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -12721,6 +13133,10 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
   '@vitest/spy@4.1.5': {}
 
   '@vitest/ui@4.1.5(vitest@4.1.5)':
@@ -12733,6 +13149,12 @@ snapshots:
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@vitest/utils@4.1.5':
     dependencies:
@@ -12855,6 +13277,10 @@ snapshots:
       estree-walker: 3.0.3
       pathe: 2.0.3
 
+  ast-types@0.16.1:
+    dependencies:
+      tslib: 2.8.1
+
   ast-v8-to-istanbul@1.0.0:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -12918,7 +13344,7 @@ snapshots:
 
   before-after-hook@2.2.3: {}
 
-  better-auth@1.6.20(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.11):
+  better-auth@1.6.20(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0))(pg@8.20.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(solid-js@1.9.11)(vitest@4.1.5):
     dependencies:
       '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0))
@@ -12938,13 +13364,14 @@ snapshots:
       nanostores: 1.3.0
       zod: 4.4.3
     optionalDependencies:
-      '@tanstack/react-start': 1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@tanstack/react-start': 1.168.40(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0)
       pg: 8.20.0
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       solid-js: 1.9.11
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -12957,6 +13384,10 @@ snapshots:
       set-cookie-parser: 3.1.0
     optionalDependencies:
       zod: 4.4.3
+
+  better-opn@3.0.2:
+    dependencies:
+      open: 8.4.2
 
   better-path-resolve@1.0.0:
     dependencies:
@@ -13045,6 +13476,14 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chai@6.2.2: {}
 
   chainsaw@0.1.0:
@@ -13067,6 +13506,8 @@ snapshots:
   character-reference-invalid@2.0.1: {}
 
   chardet@2.1.1: {}
+
+  check-error@2.1.3: {}
 
   chokidar@5.0.0:
     dependencies:
@@ -13270,6 +13711,10 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  deep-eql@5.0.2: {}
+
+  define-lazy-prop@2.0.0: {}
+
   defu@6.1.7: {}
 
   depd@2.0.0: {}
@@ -13300,6 +13745,10 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  doctrine@3.0.0:
+    dependencies:
+      esutils: 2.0.3
 
   dom-accessibility-api@0.5.16: {}
 
@@ -13409,6 +13858,13 @@ snapshots:
       acorn: 8.16.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
+
+  esbuild-register@3.6.0(esbuild@0.25.12):
+    dependencies:
+      debug: 4.4.3
+      esbuild: 0.25.12
+    transitivePeerDependencies:
+      - supports-color
 
   esbuild@0.18.20:
     optionalDependencies:
@@ -13600,6 +14056,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  esutils@2.0.3: {}
+
   etag@1.8.1: {}
 
   event-target-shim@5.0.1: {}
@@ -13787,6 +14245,12 @@ snapshots:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
+
+  find-up@7.0.0:
+    dependencies:
+      locate-path: 7.2.0
+      path-exists: 5.0.0
+      unicorn-magic: 0.1.0
 
   flatted@3.4.2: {}
 
@@ -14274,7 +14738,13 @@ snapshots:
 
   is-arrayish@0.2.1: {}
 
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.4
+
   is-decimal@2.0.1: {}
+
+  is-docker@2.2.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -14307,6 +14777,10 @@ snapshots:
   is-unicode-supported@2.1.0: {}
 
   is-windows@1.0.2: {}
+
+  is-wsl@2.2.0:
+    dependencies:
+      is-docker: 2.2.1
 
   isarray@1.0.0: {}
 
@@ -14519,6 +14993,10 @@ snapshots:
     dependencies:
       p-locate: 4.1.0
 
+  locate-path@7.2.0:
+    dependencies:
+      p-locate: 6.0.0
+
   lodash.camelcase@4.3.0: {}
 
   lodash.groupby@4.6.0: {}
@@ -14534,6 +15012,8 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  loupe@3.2.1: {}
 
   lower-case@2.0.2:
     dependencies:
@@ -15156,57 +15636,6 @@ snapshots:
       - sqlite3
       - uploadthing
 
-  nitro@3.0.260429-beta(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0))(jiti@2.7.0)(lru-cache@11.3.5)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
-    dependencies:
-      consola: 3.4.2
-      crossws: 0.4.5(srvx@0.11.15)
-      db0: 0.3.4(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0))
-      env-runner: 0.1.7
-      h3: 2.0.1-rc.21(crossws@0.4.5(srvx@0.11.15))
-      hookable: 6.1.1
-      nf3: 0.3.16
-      ocache: 0.1.4
-      ofetch: 2.0.0-alpha.3
-      ohash: 2.0.11
-      rolldown: 1.0.0-rc.18
-      srvx: 0.11.15
-      unenv: 2.0.0-rc.24
-      unstorage: 2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0)))(lru-cache@11.3.5)(ofetch@2.0.0-alpha.3)
-    optionalDependencies:
-      dotenv: 17.4.2
-      jiti: 2.7.0
-      vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@netlify/runtime'
-      - '@planetscale/database'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - better-sqlite3
-      - chokidar
-      - drizzle-orm
-      - idb-keyval
-      - ioredis
-      - lru-cache
-      - miniflare
-      - mongodb
-      - mysql2
-      - sqlite3
-      - uploadthing
-
   no-case@3.0.4:
     dependencies:
       lower-case: 2.0.2
@@ -15265,6 +15694,12 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
+  open@8.4.2:
+    dependencies:
+      define-lazy-prop: 2.0.0
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
+
   outdent@0.5.0: {}
 
   p-filter@2.1.0:
@@ -15275,9 +15710,17 @@ snapshots:
     dependencies:
       p-try: 2.2.0
 
+  p-limit@4.0.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
   p-locate@4.1.0:
     dependencies:
       p-limit: 2.3.0
+
+  p-locate@6.0.0:
+    dependencies:
+      p-limit: 4.0.0
 
   p-map@2.1.0: {}
 
@@ -15324,11 +15767,15 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-exists@5.0.0: {}
+
   path-expression-matcher@1.5.0: {}
 
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
+
+  path-parse@1.0.7: {}
 
   path-scurry@1.11.1:
     dependencies:
@@ -15340,6 +15787,8 @@ snapshots:
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   pg-cloudflare@1.3.0:
     optional: true
@@ -15508,6 +15957,25 @@ snapshots:
       iconv-lite: 0.7.2
       unpipe: 1.0.0
 
+  react-docgen-typescript@2.4.0(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
+
+  react-docgen@8.0.3:
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
+      '@types/babel__core': 7.20.5
+      '@types/babel__traverse': 7.28.0
+      '@types/doctrine': 0.0.9
+      '@types/resolve': 1.20.6
+      doctrine: 3.0.0
+      resolve: 1.22.12
+      strip-indent: 4.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   react-dom@19.2.6(react@19.2.6):
     dependencies:
       react: 19.2.6
@@ -15648,6 +16116,14 @@ snapshots:
       minimatch: 5.1.9
 
   readdirp@5.0.0: {}
+
+  recast@0.23.21:
+    dependencies:
+      ast-types: 0.16.1
+      esprima: 4.0.1
+      source-map: 0.6.1
+      tiny-invariant: 1.3.3
+      tslib: 2.8.1
 
   recharts-scale@0.4.5:
     dependencies:
@@ -15810,6 +16286,13 @@ snapshots:
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
 
   reusify@1.1.0: {}
 
@@ -16083,6 +16566,30 @@ snapshots:
 
   std-env@4.1.0: {}
 
+  storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.8.3)(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@testing-library/jest-dom': 6.9.1
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/spy': 3.2.4
+      better-opn: 3.0.2
+      esbuild: 0.25.12
+      esbuild-register: 3.6.0(esbuild@0.25.12)
+      recast: 0.23.21
+      semver: 7.8.3
+      ws: 8.19.0
+    optionalDependencies:
+      prettier: 3.8.3
+    transitivePeerDependencies:
+      - '@testing-library/dom'
+      - bufferutil
+      - msw
+      - supports-color
+      - utf-8-validate
+      - vite
+
   streamx@2.25.0:
     dependencies:
       events-universal: 1.0.1
@@ -16133,6 +16640,8 @@ snapshots:
     dependencies:
       min-indent: 1.0.1
 
+  strip-indent@4.1.1: {}
+
   strnum@2.3.0: {}
 
   style-to-js@1.1.21:
@@ -16146,6 +16655,8 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  supports-preserve-symlinks-flag@1.0.0: {}
 
   svg-parser@2.0.4: {}
 
@@ -16214,7 +16725,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyrainbow@2.0.0: {}
+
   tinyrainbow@3.1.0: {}
+
+  tinyspy@4.0.4: {}
 
   tldts-core@7.0.30: {}
 
@@ -16251,6 +16766,14 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
+
+  ts-dedent@2.3.0: {}
+
+  tsconfig-paths@4.2.0:
+    dependencies:
+      json5: 2.2.3
+      minimist: 1.2.8
+      strip-bom: 3.0.0
 
   tsdown@0.22.2(tsx@4.21.0)(typescript@6.0.3):
     dependencies:
@@ -16349,6 +16872,8 @@ snapshots:
     dependencies:
       pathe: 2.0.3
 
+  unicorn-magic@0.1.0: {}
+
   unicorn-magic@0.3.0: {}
 
   unified@11.0.5:
@@ -16399,6 +16924,11 @@ snapshots:
 
   unpipe@1.0.0: {}
 
+  unplugin@1.16.1:
+    dependencies:
+      acorn: 8.16.0
+      webpack-virtual-modules: 0.6.2
+
   unplugin@3.0.0:
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -16408,13 +16938,6 @@ snapshots:
   unstorage@2.0.0-alpha.7(@azure/storage-blob@12.31.0)(chokidar@5.0.0)(db0@0.3.4(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0)))(lru-cache@11.3.5)(ofetch@2.0.0-alpha.3):
     optionalDependencies:
       '@azure/storage-blob': 12.31.0
-      chokidar: 5.0.0
-      db0: 0.3.4(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0))
-      lru-cache: 11.3.5
-      ofetch: 2.0.0-alpha.3
-
-  unstorage@2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0)))(lru-cache@11.3.5)(ofetch@2.0.0-alpha.3):
-    optionalDependencies:
       chokidar: 5.0.0
       db0: 0.3.4(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.20.0))
       lru-cache: 11.3.5
@@ -16497,7 +17020,7 @@ snapshots:
       - supports-color
       - typescript
 
-  vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0):
+  vite@8.0.11(@types/node@25.6.2)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -16506,7 +17029,7 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 25.6.2
-      esbuild: 0.27.4
+      esbuild: 0.25.12
       fsevents: 2.3.3
       jiti: 2.7.0
       tsx: 4.21.0
@@ -16526,10 +17049,6 @@ snapshots:
       jiti: 2.7.0
       tsx: 4.21.0
       yaml: 2.9.0
-
-  vitefu@1.1.3(vite@8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
-    optionalDependencies:
-      vite: 8.0.11(@types/node@25.6.2)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   vitefu@1.1.3(vite@8.0.11(@types/node@25.6.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
     optionalDependencies:
@@ -16660,6 +17179,8 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yocto-queue@1.2.2: {}
 
   yoctocolors@2.2.0: {}
 


### PR DESCRIPTION
## Why

`@everr/ui` had no place to see its components. Reviewing a variant meant finding a page in the app that happened to use it, and any component with no call site was invisible.

## What

A new `packages/storybook` (Storybook 9 + `@storybook/react-vite` + Tailwind v4). It imports `@everr/ui` **from source** through a Vite alias to `packages/ui/src`, so a change in the package shows in the gallery immediately, with no build step in between.

**42 components, 248 stories**, each covering the exported subcomponents, variants, sizes and states.

| Group | Components |
| --- | --- |
| Controls | button, input, textarea, label, switch, toggle, toggle-group, select, kbd, input-group |
| Overlays | dialog, alert-dialog, sheet, popover, tooltip, dropdown-menu, command, sonner, consent-banner, consent-settings-dialog |
| Layout | card, separator, tabs, breadcrumb, sidebar, resizable, collapsible, detail-panel, preview-frame |
| Data | badge, avatar, skeleton, empty, banner, retry-error, data-table, filter-combobox |
| Charts / Time | chart, chart-helpers, sparkline, time-range-picker, refresh-picker |

Tables, comboboxes and charts use a deterministic observability dataset (services, request counts, error counts, p95) so the stories look like the product.

## Run it

```bash
pnpm dev:storybook
```

The package script is `storybook`, not `dev`, so `turbo run dev` does not start it next to the app.

## Notes for the reviewer

- **Tailwind sources.** Tailwind v4 detects its sources from the package that owns the CSS entry, so it only scanned `packages/storybook` and every class baked into the components was missing. `.storybook/theme.css` now registers `packages/ui/src` with an explicit `@source`. The generated stylesheet goes from 19 kB to 103 kB.
- **`toggle.tsx` exports only `toggleVariants`, no `Toggle` component.** The story defines a local one so the variants are visible. If a real `Toggle` belongs in the package, that is a follow-up.
- **Only a dark theme exists** in `global.css` (`:root` only, no light class), so there is no theme switcher.
- The chart stories use the `--chart-1..5` tokens. That palette is a monochrome amber ramp, so two series read as two near-identical yellows. That is the current token set, not a story bug, but it is visible here for the first time.
- `biome.json` gains the package (it was outside the include list) and `.fallowrc.jsonc` learns that Storybook loads its config and stories by glob.

## Verification

- `pnpm typecheck` and `biome check` clean, `storybook build` passes.
- All 248 stories rendered in headless Chrome with an assertion that none hit the Storybook error screen. This caught one real defect: the dropdown-menu stories placed `DropdownMenuLabel` outside a `DropdownMenuGroup`, which Base UI rejects at runtime. Fixed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Storybook workspace for interactively exploring the UI component library.
  * Added stories covering controls, layouts, overlays, data displays, charts, forms, navigation, and states such as loading, empty, disabled, and invalid.
  * Added interactive examples for selections, dialogs, consent settings, refresh intervals, and notifications.
  * Added a welcome page with guidance for browsing components and running Storybook.

* **Chores**
  * Added commands and configuration for developing, building, and type-checking Storybook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->