### PR TITLE
docs: document the source of the public ingest key

### DIFF
--- a/packages/docs/src/lib/telemetry.ts
+++ b/packages/docs/src/lib/telemetry.ts
@@ -26,6 +26,12 @@ new WebSDK({
   // Without the commit, the SDK falls back to its own package version.
   serviceVersion: env.VITE_COMMIT_SHA,
   deploymentEnvironment: import.meta.env.MODE,
+  // The public key is origin-bound and ingest-only, and Vite bakes it into the
+  // client bundle at build time. It comes from the DOCS_EVERR_PUBLIC_INGEST_KEY
+  // repository variable, which the image build passes as a build argument. When
+  // that variable holds nothing, the bundle carries no key and the telemetry
+  // stays off without a sign. The origin of the site must appear on the allowed
+  // origins of the key, or the collector refuses the authenticated request.
   ingestKey: env.VITE_EVERR_PUBLIC_INGEST_KEY,
   endpoint: env.VITE_EVERR_INGEST_ENDPOINT,
   dev: import.meta.env.DEV,


### PR DESCRIPTION
Browser telemetry on the docs site has been silently off. `DOCS_EVERR_PUBLIC_INGEST_KEY` was never set as a repository variable, so `build-and-push-images.yml` passed an empty build argument, Vite baked no key into the bundle, and `@everr/otel-web` returned a null transport — no request, no warning, no `everr-docs` service in ClickHouse.

The variable is now set. This commit exists mainly to produce a new commit sha so the docs image rebuilds and picks it up: `build-and-push-images.yml` only triggers on pushes to `main` under `packages/docs/**`, and the image is tagged `github.sha`. Re-running an older build would overwrite an existing tag that `images.auto.tfvars` already points at, so terraform would see no diff and never roll the service.

The comment itself is worth keeping — it records where the key comes from and that the site origin has to be on the key's allowed-origins list, which is the part that is invisible from this file.

Comment-only change; no behaviour change in this repo.

## Depends on

everr-labs/everr-deploy#287 — the public OTLP receiver has no `cors` block, so browser preflights from `everr.dev` get a bare 401 with no `Access-Control-Allow-Origin`. Until that merges, a correctly-keyed docs bundle still cannot post.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on the origin-bound, ingest-only telemetry key.
  * Documented where the key is provided during the build process.
  * Clarified application behavior when the key is not configured.
  * Explained the origin requirements for telemetry requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->