### PR TITLE
perf(app): halve the Home overview's ClickHouse work

### DIFF
--- a/packages/app/src/data/home/server.ts
+++ b/packages/app/src/data/home/server.ts
@@ -119,14 +119,13 @@ function topServices(
 /**
  * The three statements the overview runs, built for one bucket granularity.
  *
- * Kept apart from the handler so the SQL can be read and exercised on its own,
- * rather than only through an authenticated request: these are the queries that
- * decide how fast Home loads, so they need to be runnable against a real
- * ClickHouse in isolation.
+ * Kept apart from the handler so the SQL can be read on its own, rather than
+ * only in the middle of the request that runs it: these are the queries that
+ * decide how fast Home loads.
  *
  * Both time filters are bound through `{fromTime:String}` / `{toTime:String}`.
  */
-export function buildHomeQueries(granularity: BucketGranularity): {
+function buildHomeQueries(granularity: BucketGranularity): {
   logsSql: string;
   tracesSql: string;
   ciSql: string;

--- a/packages/app/src/data/home/server.ts
+++ b/packages/app/src/data/home/server.ts
@@ -6,7 +6,7 @@ import {
   resourceAttribute,
 } from "@/data/run-query-helpers";
 import { createAuthenticatedServerFn } from "@/lib/serverFn";
-import { getBucketGranularity } from "@/lib/time-range";
+import { type BucketGranularity, getBucketGranularity } from "@/lib/time-range";
 import { bucketExpr, bucketGrid } from "./buckets";
 
 export interface HomeService {
@@ -36,17 +36,47 @@ function fillSeries<Key extends string>(
 }
 
 /**
- * `GROUP BY ... WITH ROLLUP` appends one extra row per query holding the
- * range-wide total, with every grouping key defaulted. For a `String` bucket
- * key that default is the empty string, which no real bucket key can collide
- * with, so it doubles as the marker for "this is the total row".
+ * Each query below aggregates one table at three grains at once: per bucket,
+ * per second key (service, or PR), and range-wide. `GROUP BY GROUPING SETS`
+ * computes exactly those three and nothing else, so the table is read once
+ * instead of once per grain, and the cross product `CUBE` would add is never
+ * built.
+ *
+ * A row's grain cannot be read off its key columns: the keys not in a set come
+ * back defaulted to the empty string, which collides with the real rows whose
+ * `ServiceName` or PR url is genuinely empty. `grouping()` reports whether a
+ * key was aggregated away rather than grouped on, which separates the two, so
+ * every query labels its own rows with it and callers match on the label.
  */
-const ROLLUP_TOTAL_BUCKET = "";
+type RowKind = "bucket" | "service" | "pr" | "total";
 
-function rollupTotal<Row extends { bucket: string }>(
+/** Labels each row of a `(bucket) / (key) / ()` grouping set with its grain. */
+function groupingKindExpr(key: "service" | "pr"): string {
+  return `multiIf(grouping(bucket) = 0, 'bucket', grouping(${key}) = 0, '${key}', 'total')`;
+}
+
+function ofKind<Row extends { kind: RowKind }>(
   rows: Row[],
-): Row | undefined {
-  return rows.find((r) => r.bucket === ROLLUP_TOTAL_BUCKET);
+  kind: RowKind,
+): Row[] {
+  return rows.filter((r) => r.kind === kind);
+}
+
+function totalRow<Row extends { kind: RowKind }>(rows: Row[]): Row | undefined {
+  return rows.find((r) => r.kind === "total");
+}
+
+/**
+ * The median, interpolated between the two middle values on an even count, to
+ * match the `quantile(0.5)` this used to be computed with in ClickHouse.
+ */
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = (sorted.length - 1) / 2;
+  const lower = sorted[Math.floor(mid)];
+  const upper = sorted[Math.ceil(mid)];
+  return lower + (upper - lower) * (mid - Math.floor(mid));
 }
 
 function* interleave<T>(a: readonly T[], b: readonly T[]): Generator<T> {
@@ -86,6 +116,98 @@ function topServices(
   return picked;
 }
 
+/**
+ * The three statements the overview runs, built for one bucket granularity.
+ *
+ * Kept apart from the handler so the SQL can be read and exercised on its own,
+ * rather than only through an authenticated request: these are the queries that
+ * decide how fast Home loads, so they need to be runnable against a real
+ * ClickHouse in isolation.
+ *
+ * Both time filters are bound through `{fromTime:String}` / `{toTime:String}`.
+ */
+export function buildHomeQueries(granularity: BucketGranularity): {
+  logsSql: string;
+  tracesSql: string;
+  ciSql: string;
+} {
+  const timeFilter = `Timestamp >= parseDateTimeBestEffort({fromTime:String}) AND Timestamp <= parseDateTimeBestEffort({toTime:String})`;
+  const logsTimeFilter = `TimestampTime >= parseDateTimeBestEffort({fromTime:String}) AND TimestampTime <= parseDateTimeBestEffort({toTime:String})`;
+
+  const logsSql = `
+      SELECT
+        ${bucketExpr("TimestampTime", granularity)} AS bucket,
+        ServiceName AS service,
+        ${groupingKindExpr("service")} AS kind,
+        count() AS logCount,
+        ${errorIssueCountExpr()} AS issueCount
+      FROM logs
+      WHERE ${logsTimeFilter}
+      GROUP BY GROUPING SETS ((bucket), (service), ())
+    `;
+
+  const tracesSql = `
+      SELECT
+        ${bucketExpr("Timestamp", granularity)} AS bucket,
+        ServiceName AS service,
+        ${groupingKindExpr("service")} AS kind,
+        uniqIf(TraceId, TraceId != '') AS traceCount
+      FROM traces
+      WHERE ${timeFilter}
+      GROUP BY GROUPING SETS ((bucket), (service), ())
+    `;
+
+  /**
+   * The run id, the PR url and the task result each live on their own spans
+   * of a run, so none of them can be filtered before the rows are grouped
+   * into runs. Filtering the result first would leave `lastTimestamp` as the
+   * last result bearing span rather than the last span of the run, and a run
+   * whose closing span crosses a bucket boundary would then be counted one
+   * bucket early, or fall off the end of the grid entirely. All three are
+   * pulled up with `max` and filtered afterwards, which keeps the same set of
+   * runs.
+   *
+   * The time filter is the one predicate that stays ahead of the group, and
+   * it defines what a run means here: the spans it has inside the selected
+   * range. A run still going at the range end is therefore counted at its
+   * last span inside the range, not at the span that closes it. Moving the
+   * time filter after the group would read the whole table on every load,
+   * since nothing would be left to prune partitions or the primary index on.
+   *
+   * Run counts and PR durations sit at different grains, so the grouping
+   * sets here are per bucket and per PR rather than per bucket and per
+   * service. Requiring a result keeps the PR median over the same population
+   * the run count reports, rather than dragging it down with the partial
+   * duration of an in-flight run. The median itself is taken from the per-PR
+   * rows in the handler, since an aggregate over one grouping set's rows is
+   * not something the same query can also return.
+   */
+  const ciSql = `
+      SELECT
+        ${bucketExpr("lastTimestamp", granularity)} AS bucket,
+        pr,
+        ${groupingKindExpr("pr")} AS kind,
+        count() AS runCount,
+        sum(runDurationMs) AS prTotalMs
+      FROM (
+        SELECT
+          ${resourceAttribute("cicd.pipeline.run.id")} AS run_id,
+          max(${resourceAttribute("everr.git.pull_requests.url")}) AS pr,
+          max(${resourceAttribute("cicd.pipeline.task.run.result")}) AS result,
+          max(Timestamp) AS lastTimestamp,
+          max(Duration) / 1000000 AS runDurationMs
+        FROM traces
+        WHERE ${timeFilter}
+          AND ${nonEmptyResourceAttribute("cicd.pipeline.run.id")}
+        GROUP BY run_id
+      )
+      WHERE result != ''
+      GROUP BY GROUPING SETS ((bucket), (pr), ())
+    `;
+
+  return { logsSql, tracesSql, ciSql };
+}
+
 export const getHomeOverview = createAuthenticatedServerFn({ method: "GET" })
   .inputValidator(TimeRangeInputSchema)
   .handler(async ({ data: { timeRange }, context: { clickhouse } }) => {
@@ -93,139 +215,29 @@ export const getHomeOverview = createAuthenticatedServerFn({ method: "GET" })
     const granularity = getBucketGranularity(fromDate, toDate);
     const grid = bucketGrid(fromDate, toDate, granularity);
     const params = { fromTime: fromISO, toTime: toISO };
-    const timeFilter = `Timestamp >= parseDateTimeBestEffort({fromTime:String}) AND Timestamp <= parseDateTimeBestEffort({toTime:String})`;
-    const logsTimeFilter = `TimestampTime >= parseDateTimeBestEffort({fromTime:String}) AND TimestampTime <= parseDateTimeBestEffort({toTime:String})`;
+    const { logsSql, tracesSql, ciSql } = buildHomeQueries(granularity);
 
-    const logsSql = `
-      SELECT
-        ${bucketExpr("TimestampTime", granularity)} AS bucket,
-        count() AS logCount,
-        ${errorIssueCountExpr()} AS issueCount
-      FROM logs
-      WHERE ${logsTimeFilter}
-      GROUP BY bucket WITH ROLLUP
-    `;
-
-    const tracesSql = `
-      SELECT
-        ${bucketExpr("Timestamp", granularity)} AS bucket,
-        uniqIf(TraceId, TraceId != '') AS traceCount
-      FROM traces
-      WHERE ${timeFilter}
-      GROUP BY bucket WITH ROLLUP
-    `;
-
-    const traceServicesSql = `
-      SELECT
-        ServiceName AS service,
-        uniqIf(TraceId, TraceId != '') AS traceCount
-      FROM traces
-      WHERE ${timeFilter} AND ServiceName != ''
-      GROUP BY service
-    `;
-
-    const logServicesSql = `
-      SELECT
-        ServiceName AS service,
-        count() AS logCount,
-        ${errorIssueCountExpr()} AS errorCount
-      FROM logs
-      WHERE ${logsTimeFilter} AND ServiceName != ''
-      GROUP BY service
-    `;
-
-    /**
-     * The task result lives on its own spans of a run, so it cannot be
-     * filtered before the rows are grouped into runs. Filtering first would
-     * leave `lastTimestamp` as the last result bearing span rather than the
-     * last span of the run, and a run whose closing span crosses a bucket
-     * boundary would then be counted one bucket early, or fall off the end of
-     * the grid entirely. The result is pulled up with `max` and filtered
-     * afterwards, which keeps the same set of runs.
-     *
-     * The time filter is the one predicate that stays ahead of the group, and
-     * it defines what a run means here: the spans it has inside the selected
-     * range. A run still going at the range end is therefore counted at its
-     * last span inside the range, not at the span that closes it. Moving the
-     * time filter after the group would read the whole table on every load,
-     * since nothing would be left to prune partitions or the primary index on.
-     */
-    const ciSql = `
-      SELECT
-        ${bucketExpr("lastTimestamp", granularity)} AS bucket,
-        count() AS runCount
-      FROM (
-        SELECT run_id, lastTimestamp
-        FROM (
-          SELECT
-            ${resourceAttribute("cicd.pipeline.run.id")} AS run_id,
-            max(${resourceAttribute("cicd.pipeline.task.run.result")}) AS result,
-            max(Timestamp) AS lastTimestamp
-          FROM traces
-          WHERE ${timeFilter}
-            AND ${nonEmptyResourceAttribute("cicd.pipeline.run.id")}
-          GROUP BY run_id
-        )
-        WHERE result != ''
-      )
-      GROUP BY bucket WITH ROLLUP
-    `;
-
-    /**
-     * The PR url and the task result live on different spans of a run, so
-     * neither can be filtered before the rows are grouped into runs. Both are
-     * pulled up with `max` and filtered afterwards. Requiring a result keeps
-     * this median over the same population the run count above reports, rather
-     * than dragging it down with the partial duration of an in-flight run.
-     */
-    const prTimeSql = `
-      SELECT quantile(0.5)(prTotalMs) AS prMedianTotalTimeMs
-      FROM (
-        SELECT pr, sum(runDurationMs) AS prTotalMs
-        FROM (
-          SELECT
-            ${resourceAttribute("cicd.pipeline.run.id")} AS run_id,
-            max(${resourceAttribute("everr.git.pull_requests.url")}) AS pr,
-            max(${resourceAttribute("cicd.pipeline.task.run.result")}) AS result,
-            max(Duration) / 1000000 AS runDurationMs
-          FROM traces
-          WHERE ${timeFilter}
-            AND ${nonEmptyResourceAttribute("cicd.pipeline.run.id")}
-          GROUP BY run_id
-        )
-        WHERE pr != '' AND result != ''
-        GROUP BY pr
-      )
-    `;
-
-    const [
-      logsRows,
-      tracesRows,
-      traceServiceRows,
-      logServiceRows,
-      ciRows,
-      prTimeRows,
-    ] = await Promise.all([
+    const [logsRows, tracesRows, ciRows] = await Promise.all([
       clickhouse.query<{
+        kind: RowKind;
         bucket: string;
+        service: string;
         logCount: string;
         issueCount: string;
       }>(logsSql, params),
-      clickhouse.query<{ bucket: string; traceCount: string }>(
-        tracesSql,
-        params,
-      ),
-      clickhouse.query<{ service: string; traceCount: string }>(
-        traceServicesSql,
-        params,
-      ),
       clickhouse.query<{
+        kind: RowKind;
+        bucket: string;
         service: string;
-        logCount: string;
-        errorCount: string;
-      }>(logServicesSql, params),
-      clickhouse.query<{ bucket: string; runCount: string }>(ciSql, params),
-      clickhouse.query<{ prMedianTotalTimeMs: string }>(prTimeSql, params),
+        traceCount: string;
+      }>(tracesSql, params),
+      clickhouse.query<{
+        kind: RowKind;
+        bucket: string;
+        pr: string;
+        runCount: string;
+        prTotalMs: string;
+      }>(ciSql, params),
     ]);
 
     const services = new Map<string, HomeService>();
@@ -237,38 +249,46 @@ export const getHomeOverview = createAuthenticatedServerFn({ method: "GET" })
       }
       return entry;
     };
-    for (const row of traceServiceRows) {
+    // The unnamed service was filtered out in SQL when the per-service totals
+    // were their own query. It is dropped here instead, so the bucket series
+    // and range totals sharing the scan keep counting every row.
+    const named = <Row extends { service: string }>(rows: Row[]) =>
+      rows.filter((r) => r.service !== "");
+
+    for (const row of named(ofKind(tracesRows, "service"))) {
       service(row.service).traceCount = Number(row.traceCount);
     }
-    for (const row of logServiceRows) {
+    for (const row of named(ofKind(logsRows, "service"))) {
       const entry = service(row.service);
       entry.logCount = Number(row.logCount);
-      entry.errorCount = Number(row.errorCount);
+      entry.errorCount = Number(row.issueCount);
     }
 
     const serviceList = topServices(services.values(), MAX_SERVICES);
 
-    const logsTotal = rollupTotal(logsRows);
-    const totalRuns = Number(rollupTotal(ciRows)?.runCount ?? 0);
+    const logsTotal = totalRow(logsRows);
+    const prTotals = ofKind(ciRows, "pr")
+      .filter((r) => r.pr !== "")
+      .map((r) => Number(r.prTotalMs));
 
     return {
       logs: {
         total: Number(logsTotal?.logCount ?? 0),
-        series: fillSeries(grid, logsRows, "logCount"),
+        series: fillSeries(grid, ofKind(logsRows, "bucket"), "logCount"),
       },
       traces: {
-        total: Number(rollupTotal(tracesRows)?.traceCount ?? 0),
-        series: fillSeries(grid, tracesRows, "traceCount"),
+        total: Number(totalRow(tracesRows)?.traceCount ?? 0),
+        series: fillSeries(grid, ofKind(tracesRows, "bucket"), "traceCount"),
       },
       services: serviceList,
       errors: {
         issues: Number(logsTotal?.issueCount ?? 0),
-        series: fillSeries(grid, logsRows, "issueCount"),
+        series: fillSeries(grid, ofKind(logsRows, "bucket"), "issueCount"),
       },
       ci: {
-        totalRuns,
-        prMedianTotalTimeMs: Number(prTimeRows[0]?.prMedianTotalTimeMs ?? 0),
-        series: fillSeries(grid, ciRows, "runCount"),
+        totalRuns: Number(totalRow(ciRows)?.runCount ?? 0),
+        prMedianTotalTimeMs: median(prTotals),
+        series: fillSeries(grid, ofKind(ciRows, "bucket"), "runCount"),
       },
     } satisfies HomeOverview;
   });

--- a/packages/app/src/data/home/server.ts
+++ b/packages/app/src/data/home/server.ts
@@ -1,10 +1,6 @@
 import { errorIssueCountExpr } from "@everr/telemetry-explorer/errors";
 import { resolveTimeRange } from "@everr/ui/lib/time-range";
 import { TimeRangeInputSchema } from "@/data/analytics/schemas";
-import {
-  nonEmptyResourceAttribute,
-  resourceAttribute,
-} from "@/data/run-query-helpers";
 import { createAuthenticatedServerFn } from "@/lib/serverFn";
 import { type BucketGranularity, getBucketGranularity } from "@/lib/time-range";
 import { bucketExpr, bucketGrid } from "./buckets";
@@ -46,14 +42,10 @@ function fillSeries<Key extends string>(
  * back defaulted to the empty string, which collides with the real rows whose
  * `ServiceName` or PR url is genuinely empty. `grouping()` reports whether a
  * key was aggregated away rather than grouped on, which separates the two, so
- * every query labels its own rows with it and callers match on the label.
+ * every query labels its own rows with a `multiIf` over `grouping()` as `kind`
+ * and callers match on the label.
  */
 type RowKind = "bucket" | "service" | "pr" | "total";
-
-/** Labels each row of a `(bucket) / (key) / ()` grouping set with its grain. */
-function groupingKindExpr(key: "service" | "pr"): string {
-  return `multiIf(grouping(bucket) = 0, 'bucket', grouping(${key}) = 0, '${key}', 'total')`;
-}
 
 function ofKind<Row extends { kind: RowKind }>(
   rows: Row[],
@@ -123,25 +115,30 @@ function topServices(
  * only in the middle of the request that runs it: these are the queries that
  * decide how fast Home loads.
  *
+ * The SQL is written out in full, so what runs can be read straight off the
+ * page and pasted into a ClickHouse client. Only two things are interpolated,
+ * and neither can be a literal here: the bucket expression, which is the one
+ * part granularity changes, and the error fingerprint, which has to stay the
+ * same expression the errors surface counts issues with.
+ *
  * Both time filters are bound through `{fromTime:String}` / `{toTime:String}`.
+ * `logs` timestamps its rows with `TimestampTime`, `traces` with `Timestamp`.
  */
 function buildHomeQueries(granularity: BucketGranularity): {
   logsSql: string;
   tracesSql: string;
   ciSql: string;
 } {
-  const timeFilter = `Timestamp >= parseDateTimeBestEffort({fromTime:String}) AND Timestamp <= parseDateTimeBestEffort({toTime:String})`;
-  const logsTimeFilter = `TimestampTime >= parseDateTimeBestEffort({fromTime:String}) AND TimestampTime <= parseDateTimeBestEffort({toTime:String})`;
-
   const logsSql = `
       SELECT
         ${bucketExpr("TimestampTime", granularity)} AS bucket,
         ServiceName AS service,
-        ${groupingKindExpr("service")} AS kind,
+        multiIf(grouping(bucket) = 0, 'bucket', grouping(service) = 0, 'service', 'total') AS kind,
         count() AS logCount,
         ${errorIssueCountExpr()} AS issueCount
       FROM logs
-      WHERE ${logsTimeFilter}
+      WHERE TimestampTime >= parseDateTimeBestEffort({fromTime:String})
+        AND TimestampTime <= parseDateTimeBestEffort({toTime:String})
       GROUP BY GROUPING SETS ((bucket), (service), ())
     `;
 
@@ -149,10 +146,11 @@ function buildHomeQueries(granularity: BucketGranularity): {
       SELECT
         ${bucketExpr("Timestamp", granularity)} AS bucket,
         ServiceName AS service,
-        ${groupingKindExpr("service")} AS kind,
+        multiIf(grouping(bucket) = 0, 'bucket', grouping(service) = 0, 'service', 'total') AS kind,
         uniqIf(TraceId, TraceId != '') AS traceCount
       FROM traces
-      WHERE ${timeFilter}
+      WHERE Timestamp >= parseDateTimeBestEffort({fromTime:String})
+        AND Timestamp <= parseDateTimeBestEffort({toTime:String})
       GROUP BY GROUPING SETS ((bucket), (service), ())
     `;
 
@@ -173,6 +171,10 @@ function buildHomeQueries(granularity: BucketGranularity): {
    * time filter after the group would read the whole table on every load,
    * since nothing would be left to prune partitions or the primary index on.
    *
+   * The `mapContains` beside it is not redundant with the `!= ''` that
+   * follows: it lets the `idx_res_attr_key` bloom skip index drop granules
+   * that carry no run id at all, before any value is read.
+   *
    * Run counts and PR durations sit at different grains, so the grouping
    * sets here are per bucket and per PR rather than per bucket and per
    * service. Requiring a result keeps the PR median over the same population
@@ -185,19 +187,21 @@ function buildHomeQueries(granularity: BucketGranularity): {
       SELECT
         ${bucketExpr("lastTimestamp", granularity)} AS bucket,
         pr,
-        ${groupingKindExpr("pr")} AS kind,
+        multiIf(grouping(bucket) = 0, 'bucket', grouping(pr) = 0, 'pr', 'total') AS kind,
         count() AS runCount,
         sum(runDurationMs) AS prTotalMs
       FROM (
         SELECT
-          ${resourceAttribute("cicd.pipeline.run.id")} AS run_id,
-          max(${resourceAttribute("everr.git.pull_requests.url")}) AS pr,
-          max(${resourceAttribute("cicd.pipeline.task.run.result")}) AS result,
+          ResourceAttributes['cicd.pipeline.run.id'] AS run_id,
+          max(ResourceAttributes['everr.git.pull_requests.url']) AS pr,
+          max(ResourceAttributes['cicd.pipeline.task.run.result']) AS result,
           max(Timestamp) AS lastTimestamp,
           max(Duration) / 1000000 AS runDurationMs
         FROM traces
-        WHERE ${timeFilter}
-          AND ${nonEmptyResourceAttribute("cicd.pipeline.run.id")}
+        WHERE Timestamp >= parseDateTimeBestEffort({fromTime:String})
+          AND Timestamp <= parseDateTimeBestEffort({toTime:String})
+          AND mapContains(ResourceAttributes, 'cicd.pipeline.run.id')
+          AND ResourceAttributes['cicd.pipeline.run.id'] != ''
         GROUP BY run_id
       )
       WHERE result != ''


### PR DESCRIPTION
## The problem

Home was the slowest server function in production: `GET /_serverFn/getHomeOverview` at **p50 4.1s, p95 6.2s**.

The trace showed six ClickHouse queries starting within 1ms of each other and finishing in a staircase:

```
serverFn getHomeOverview            6745ms
├─ ClickHouse QUERY  1995ms
├─ ClickHouse QUERY  2499ms
├─ ClickHouse QUERY  4396ms
├─ ClickHouse QUERY  5567ms
├─ ClickHouse QUERY  6714ms
└─ ClickHouse QUERY  6725ms
```

Timed individually against production they sum to 6.80s, which is what the "parallel" batch actually took. The queries contend for the same cores, so fanning them out buys nothing and the only lever is doing less work.

## The change

The six were three scans done twice:

- `logs` scanned once by bucket and again by service
- `traces` scanned once by bucket and again by service
- the CI run count and the PR median sharing a **byte-identical** per-run subquery

Each pair is now one statement using `GROUP BY GROUPING SETS ((bucket), (key), ())`, which computes the per-bucket, per-key and range-wide grains from a single read. `GROUPING SETS` rather than `CUBE` so the bucket x service cross product is never built.

Row grain can't be read off the key columns any more: keys outside a grouping set come back as the empty string and collide with rows whose `ServiceName` or PR url is genuinely empty. Each query labels its own rows with `grouping()` and the handler matches on the label, replacing the empty-string marker `WITH ROLLUP` used to leave behind.

The PR median moved into the handler (interpolated, to match `quantile(0.5)`), since an aggregate over one grouping set's rows isn't something the same query can also return. Grouping by PR instead of by run keeps that bounded: 88 rows over a week containing 931 runs.

The SQL also moved out of the handler into `buildHomeQueries`, so it can be run against a real ClickHouse without going through an authenticated request.

## Numbers

Solo, 7d range, production:

| | before | after |
|---|---|---|
| logs (2 queries -> 1) | 1.53 + 1.62s | **2.15s** |
| traces (2 -> 1) | 1.07 + 0.76s | **0.81s** |
| CI (2 -> 1) | 0.81 + 0.85s | **0.91s** |
| total ClickHouse work | 6.64s | **3.87s** |

Fired concurrently as the handler does, averaged over 3 runs: **3.91s -> 2.46s (-37%)**.

## Indexes

`EXPLAIN indexes = 1` on all three, to check nothing is missing:

- **CI query**: 336 -> 60 parts, 13950 -> 217 granules on the primary key, then 217 -> **61** on the `idx_res_attr_key` bloom. The `cicd.pipeline.run.id` map-key lookup is already fully served.
- **logs**: 32290 -> **364 granules**. **traces**: 129887 -> **218 granules**.

The latter two read the whole selected range by design, so the granules read *are* the rows needed and there's no further pruning available. No new index is warranted.

The remaining hot spot isn't an index problem: dropping `errorFingerprint` takes the logs query from 1.60s to 0.68s, so the UDF is ~57% of it. A materialized fingerprint column would be the next lever, but that's a schema migration and out of scope here.

## Verification

- The **app's real generated SQL** (dumped from `buildHomeQueries`, params bound) run against production: all **11/11** derived outputs identical to the previous queries, on a pinned window. A moving `now()` window drifts by whatever is ingested between runs, which is why the window is pinned.
- Both bucket granularities exercised (hour over 7d, day over 30d).
- Empty range returns the single zeroed `total` row each caller expects, so `fillSeries` zero-fills and `median([])` is 0.
- `tsc --noEmit` clean, biome clean, 420 tests pass.
- Manual: logged into the app on this branch, Home renders correctly, including the rewritten CI tiles.

## Not included

The route loader at `_padded/index.tsx:31` still awaits `homeOverview` and `costOverview` together. `getCostOverview` is a single query but shows p50 1.9s / p95 4.0s, largely from queuing behind Home's six; this change helps it for free. Letting the shell paint before the tiles is a separate product call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - No user-facing changes were introduced to the home overview.
  - Existing totals, time-series breakdowns, service reporting, pull request metrics, and filtering behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->