### PR TITLE
feat(ui): replace native scrollbars with custom ones

### DIFF
--- a/packages/app/src/components/dashboards/dashboards-list.tsx
+++ b/packages/app/src/components/dashboards/dashboards-list.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@everr/ui/components/button";
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { DEFAULT_TIME_RANGE } from "@everr/ui/lib/time-range";
 import { cn } from "@everr/ui/lib/utils";
 import { useQuery } from "@tanstack/react-query";
@@ -143,7 +144,10 @@ export function DashboardsList({ preview }: { preview?: string }) {
       <RailSearch label="dashboards" value={search} onChange={setSearch} />
 
       {/* Only the rows scroll; the search stays pinned above. */}
-      <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto pr-1 pb-3">
+      <ScrollArea
+        className="min-h-0 flex-1"
+        viewportClassName="flex flex-col gap-4 pr-1 pb-3"
+      >
         <section aria-label="Your dashboards">
           <GroupLabel label="Your dashboards" />
           {listQuery.isLoading && (
@@ -244,7 +248,7 @@ export function DashboardsList({ preview }: { preview?: string }) {
             </>
           )}
         </section>
-      </div>
+      </ScrollArea>
     </div>
   );
 }

--- a/packages/app/src/components/dashboards/dashboards-list.tsx
+++ b/packages/app/src/components/dashboards/dashboards-list.tsx
@@ -146,7 +146,7 @@ export function DashboardsList({ preview }: { preview?: string }) {
       {/* Only the rows scroll; the search stays pinned above. */}
       <ScrollArea
         className="min-h-0 flex-1"
-        viewportClassName="flex flex-col gap-4 pr-1 pb-3"
+        viewportClassName="flex flex-col gap-4 pb-3"
       >
         <section aria-label="Your dashboards">
           <GroupLabel label="Your dashboards" />

--- a/packages/app/src/components/dashboards/dashboards-list.tsx
+++ b/packages/app/src/components/dashboards/dashboards-list.tsx
@@ -1,5 +1,4 @@
 import { Button } from "@everr/ui/components/button";
-import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { DEFAULT_TIME_RANGE } from "@everr/ui/lib/time-range";
 import { cn } from "@everr/ui/lib/utils";
 import { useQuery } from "@tanstack/react-query";
@@ -17,8 +16,8 @@ import {
   TriangleAlert,
 } from "lucide-react";
 import { useState } from "react";
+import { RailList } from "@/components/rail/rail-list";
 import { groupLabelClass, RailRow } from "@/components/rail/rail-row";
-import { RailSearch } from "@/components/rail/rail-search";
 import {
   evaluateBuiltin,
   type TelemetryCapabilities,
@@ -140,116 +139,111 @@ export function DashboardsList({ preview }: { preview?: string }) {
   const visibleNeedsData = showNeedsData ? needsData : pinnedActive(needsData);
 
   return (
-    <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-4">
-      <RailSearch label="dashboards" value={search} onChange={setSearch} />
+    <RailList
+      label="dashboards"
+      search={search}
+      onSearchChange={setSearch}
+      className="gap-4"
+    >
+      <section aria-label="Your dashboards">
+        <GroupLabel label="Your dashboards" />
+        {listQuery.isLoading && (
+          <p className="px-1 py-1 text-muted-foreground text-xs">Loading...</p>
+        )}
+        {listQuery.isError && (
+          <p className="px-1 py-1 text-amber-400 text-xs">
+            Couldn't load your dashboards
+          </p>
+        )}
+        {!listQuery.isLoading &&
+          !listQuery.isError &&
+          dashboards.length === 0 && (
+            <RailRow
+              label="Create your first dashboard"
+              icon={CirclePlus}
+              to="/dashboards/get-started"
+            />
+          )}
+        {dashboards.length > 0 && (
+          <DashboardTree dashboards={dashboards} search={search} />
+        )}
+      </section>
 
-      {/* Only the rows scroll; the search stays pinned above. */}
-      <ScrollArea
-        className="min-h-0 flex-1"
-        viewportClassName="flex flex-col gap-4 pb-3"
-      >
-        <section aria-label="Your dashboards">
-          <GroupLabel label="Your dashboards" />
-          {listQuery.isLoading && (
-            <p className="px-1 py-1 text-muted-foreground text-xs">
-              Loading...
-            </p>
-          )}
-          {listQuery.isError && (
-            <p className="px-1 py-1 text-amber-400 text-xs">
-              Couldn't load your dashboards
-            </p>
-          )}
-          {!listQuery.isLoading &&
-            !listQuery.isError &&
-            dashboards.length === 0 && (
-              <RailRow
-                label="Create your first dashboard"
-                icon={CirclePlus}
-                to="/dashboards/get-started"
-              />
+      <section aria-label="Built-in dashboards">
+        <GroupLabel
+          label="Built-in dashboards"
+          open={!builtinsCollapsed}
+          onToggle={() => {
+            const next = !builtinsCollapsed;
+            setBuiltinsCollapsed(next);
+            writeBuiltinsCollapsed(next);
+          }}
+        />
+
+        {builtinsCollapsed ? (
+          pinnedActive(matching).map((builtin) => (
+            <BuiltinRow key={builtin.id} builtin={builtin} />
+          ))
+        ) : (
+          <>
+            {capabilitiesQuery.isError && (
+              <div className="flex flex-wrap items-center gap-x-2 gap-y-1 px-1 pb-1 text-xs">
+                <span className="inline-flex items-center gap-1.5 text-amber-400">
+                  <TriangleAlert className="size-3.5" />
+                  Couldn't check what you send
+                </span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="xs"
+                  onClick={() => void capabilitiesQuery.refetch()}
+                >
+                  <RotateCw className="size-3" />
+                  Retry
+                </Button>
+              </div>
             )}
-          {dashboards.length > 0 && (
-            <DashboardTree dashboards={dashboards} search={search} />
-          )}
-        </section>
 
-        <section aria-label="Built-in dashboards">
-          <GroupLabel
-            label="Built-in dashboards"
-            open={!builtinsCollapsed}
-            onToggle={() => {
-              const next = !builtinsCollapsed;
-              setBuiltinsCollapsed(next);
-              writeBuiltinsCollapsed(next);
-            }}
-          />
+            {matching.length === 0 && (
+              <p className="px-1 py-1 text-muted-foreground text-xs">
+                No built-in matches that search.
+              </p>
+            )}
 
-          {builtinsCollapsed ? (
-            pinnedActive(matching).map((builtin) => (
+            {ready.map((builtin) => (
               <BuiltinRow key={builtin.id} builtin={builtin} />
-            ))
-          ) : (
-            <>
-              {capabilitiesQuery.isError && (
-                <div className="flex flex-wrap items-center gap-x-2 gap-y-1 px-1 pb-1 text-xs">
-                  <span className="inline-flex items-center gap-1.5 text-amber-400">
-                    <TriangleAlert className="size-3.5" />
-                    Couldn't check what you send
+            ))}
+
+            {needsData.length > 0 && (
+              <>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setNeedsDataDisclosure(showNeedsData ? "closed" : "open")
+                  }
+                  aria-expanded={showNeedsData}
+                  title="Nothing sent in the last 7 days"
+                  className="mt-2.5 mb-0.5 flex w-full items-center gap-1 rounded-md px-1 py-0.5 text-left font-medium text-[0.6875rem] text-muted-foreground/80 hover:text-foreground"
+                >
+                  {showNeedsData ? (
+                    <ChevronDown className="size-3 shrink-0" />
+                  ) : (
+                    <ChevronRight className="size-3 shrink-0" />
+                  )}
+                  Needs data
+                  <span className="ml-1 tabular-nums opacity-80">
+                    {needsData.length}
                   </span>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="xs"
-                    onClick={() => void capabilitiesQuery.refetch()}
-                  >
-                    <RotateCw className="size-3" />
-                    Retry
-                  </Button>
-                </div>
-              )}
-
-              {matching.length === 0 && (
-                <p className="px-1 py-1 text-muted-foreground text-xs">
-                  No built-in matches that search.
-                </p>
-              )}
-
-              {ready.map((builtin) => (
-                <BuiltinRow key={builtin.id} builtin={builtin} />
-              ))}
-
-              {needsData.length > 0 && (
-                <>
-                  <button
-                    type="button"
-                    onClick={() =>
-                      setNeedsDataDisclosure(showNeedsData ? "closed" : "open")
-                    }
-                    aria-expanded={showNeedsData}
-                    title="Nothing sent in the last 7 days"
-                    className="mt-2.5 mb-0.5 flex w-full items-center gap-1 rounded-md px-1 py-0.5 text-left font-medium text-[0.6875rem] text-muted-foreground/80 hover:text-foreground"
-                  >
-                    {showNeedsData ? (
-                      <ChevronDown className="size-3 shrink-0" />
-                    ) : (
-                      <ChevronRight className="size-3 shrink-0" />
-                    )}
-                    Needs data
-                    <span className="ml-1 tabular-nums opacity-80">
-                      {needsData.length}
-                    </span>
-                  </button>
-                  {visibleNeedsData.map((builtin) => (
-                    <BuiltinRow key={builtin.id} builtin={builtin} />
-                  ))}
-                </>
-              )}
-            </>
-          )}
-        </section>
-      </ScrollArea>
-    </div>
+                </button>
+                {visibleNeedsData.map((builtin) => (
+                  <BuiltinRow key={builtin.id} builtin={builtin} />
+                ))}
+              </>
+            )}
+          </>
+        )}
+      </section>
+    </RailList>
   );
 }
 

--- a/packages/app/src/components/dashboards/variable-bar.tsx
+++ b/packages/app/src/components/dashboards/variable-bar.tsx
@@ -248,7 +248,8 @@ function ListVariableField({
         </DropdownMenuTrigger>
         <DropdownMenuContent
           align="start"
-          className="max-h-80 w-auto min-w-(--anchor-width) max-w-80 overflow-y-auto"
+          className="w-auto min-w-(--anchor-width) max-w-80"
+          viewportClassName="max-h-80"
         >
           {allowAll && (
             <>

--- a/packages/app/src/components/dashboards/variable-bar.tsx
+++ b/packages/app/src/components/dashboards/variable-bar.tsx
@@ -249,7 +249,7 @@ function ListVariableField({
         <DropdownMenuContent
           align="start"
           className="w-auto min-w-(--anchor-width) max-w-80"
-          viewportClassName="max-h-80"
+          listClassName="max-h-80"
         >
           {allowAll && (
             <>

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.tsx
@@ -116,70 +116,69 @@ export function GaugeChartVisualization({
   const minText = formatAxisEnd(min, unit);
   const maxText = formatAxisEnd(max, unit);
 
-  const tileNodes = tiles.map((tile) => {
-    const value = tile.value;
-    const name = tile.label || queryLabel(tile.frame);
-    const fraction = value !== undefined ? axisFraction(value, min, max) : 0;
-    const valueText =
-      value === undefined ? noValue : formatStatValue(value, decimals);
-    const label = (multi || showLabel) && (
-      <p
-        className={cn(
-          "truncate text-xs text-muted-foreground",
-          horizontal && "mb-1",
-        )}
-      >
-        {name}
-      </p>
-    );
-    const props: TileProps = {
-      label,
-      value,
-      valueText,
-      unit,
-      fraction,
-      ticks,
-      showAxis,
-      showThresholdLabels,
-      minText,
-      maxText,
-    };
-    const key = `${tile.frame}-${tile.label}`;
-    const ariaLabel = `${name}: ${valueText}${unit ? ` ${unit}` : ""}`;
-
-    return horizontal ? (
-      <GaugeBar
-        key={key}
-        {...props}
-        ariaLabel={ariaLabel}
-        segments={fillSegments(fraction, marks, colors)}
-      />
-    ) : (
-      <GaugeArc
-        key={key}
-        {...props}
-        ariaLabel={ariaLabel}
-        color={
-          (value !== undefined
-            ? resolveThresholdColor(value, thresholds, max)
-            : undefined) ?? fallbackColor
-        }
-      />
-    );
-  });
-
-  // Only the horizontal bars ever overflowed the panel; the arc layout always fit.
-  return horizontal ? (
+  return (
     <ScrollArea
       className="h-full"
-      viewportClassName="flex flex-wrap content-center-safe justify-center gap-x-6 gap-y-4 px-1"
+      viewportClassName={cn(
+        "flex flex-wrap justify-center",
+        horizontal
+          ? "content-center-safe gap-x-6 gap-y-4 px-1"
+          : "items-stretch gap-4",
+      )}
     >
-      {tileNodes}
+      {tiles.map((tile) => {
+        const value = tile.value;
+        const name = tile.label || queryLabel(tile.frame);
+        const fraction =
+          value !== undefined ? axisFraction(value, min, max) : 0;
+        const valueText =
+          value === undefined ? noValue : formatStatValue(value, decimals);
+        const label = (multi || showLabel) && (
+          <p
+            className={cn(
+              "truncate text-xs text-muted-foreground",
+              horizontal && "mb-1",
+            )}
+          >
+            {name}
+          </p>
+        );
+        const props: TileProps = {
+          label,
+          value,
+          valueText,
+          unit,
+          fraction,
+          ticks,
+          showAxis,
+          showThresholdLabels,
+          minText,
+          maxText,
+        };
+        const key = `${tile.frame}-${tile.label}`;
+        const ariaLabel = `${name}: ${valueText}${unit ? ` ${unit}` : ""}`;
+
+        return horizontal ? (
+          <GaugeBar
+            key={key}
+            {...props}
+            ariaLabel={ariaLabel}
+            segments={fillSegments(fraction, marks, colors)}
+          />
+        ) : (
+          <GaugeArc
+            key={key}
+            {...props}
+            ariaLabel={ariaLabel}
+            color={
+              (value !== undefined
+                ? resolveThresholdColor(value, thresholds, max)
+                : undefined) ?? fallbackColor
+            }
+          />
+        );
+      })}
     </ScrollArea>
-  ) : (
-    <div className="flex h-full flex-wrap items-stretch justify-center gap-4">
-      {tileNodes}
-    </div>
   );
 }
 

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.tsx
@@ -116,69 +116,71 @@ export function GaugeChartVisualization({
   const minText = formatAxisEnd(min, unit);
   const maxText = formatAxisEnd(max, unit);
 
-  return (
-    <ScrollArea
-      className="min-h-0 flex-1"
-      viewportClassName={cn(
-        "flex h-full flex-wrap justify-center",
-        horizontal
-          ? "content-center-safe gap-x-6 gap-y-4 px-1"
-          : "items-stretch gap-4",
-      )}
-    >
-      {tiles.map((tile) => {
-        const value = tile.value;
-        const name = tile.label || queryLabel(tile.frame);
-        const fraction =
-          value !== undefined ? axisFraction(value, min, max) : 0;
-        const valueText =
-          value === undefined ? noValue : formatStatValue(value, decimals);
-        const label = (multi || showLabel) && (
-          <p
-            className={cn(
-              "truncate text-xs text-muted-foreground",
-              horizontal && "mb-1",
-            )}
-          >
-            {name}
-          </p>
-        );
-        const props: TileProps = {
-          label,
-          value,
-          valueText,
-          unit,
-          fraction,
-          ticks,
-          showAxis,
-          showThresholdLabels,
-          minText,
-          maxText,
-        };
-        const key = `${tile.frame}-${tile.label}`;
-        const ariaLabel = `${name}: ${valueText}${unit ? ` ${unit}` : ""}`;
+  const tileNodes = tiles.map((tile) => {
+    const value = tile.value;
+    const name = tile.label || queryLabel(tile.frame);
+    const fraction = value !== undefined ? axisFraction(value, min, max) : 0;
+    const valueText =
+      value === undefined ? noValue : formatStatValue(value, decimals);
+    const label = (multi || showLabel) && (
+      <p
+        className={cn(
+          "truncate text-xs text-muted-foreground",
+          horizontal && "mb-1",
+        )}
+      >
+        {name}
+      </p>
+    );
+    const props: TileProps = {
+      label,
+      value,
+      valueText,
+      unit,
+      fraction,
+      ticks,
+      showAxis,
+      showThresholdLabels,
+      minText,
+      maxText,
+    };
+    const key = `${tile.frame}-${tile.label}`;
+    const ariaLabel = `${name}: ${valueText}${unit ? ` ${unit}` : ""}`;
 
-        return horizontal ? (
-          <GaugeBar
-            key={key}
-            {...props}
-            ariaLabel={ariaLabel}
-            segments={fillSegments(fraction, marks, colors)}
-          />
-        ) : (
-          <GaugeArc
-            key={key}
-            {...props}
-            ariaLabel={ariaLabel}
-            color={
-              (value !== undefined
-                ? resolveThresholdColor(value, thresholds, max)
-                : undefined) ?? fallbackColor
-            }
-          />
-        );
-      })}
+    return horizontal ? (
+      <GaugeBar
+        key={key}
+        {...props}
+        ariaLabel={ariaLabel}
+        segments={fillSegments(fraction, marks, colors)}
+      />
+    ) : (
+      <GaugeArc
+        key={key}
+        {...props}
+        ariaLabel={ariaLabel}
+        color={
+          (value !== undefined
+            ? resolveThresholdColor(value, thresholds, max)
+            : undefined) ?? fallbackColor
+        }
+      />
+    );
+  });
+
+  // Only the horizontal bars ever overflowed the panel; the arc layout
+  // always fit, so it keeps its plain div rather than gaining a scrollbar.
+  return horizontal ? (
+    <ScrollArea
+      className="h-full"
+      viewportClassName="flex flex-wrap content-center-safe justify-center gap-x-6 gap-y-4 px-1"
+    >
+      {tileNodes}
     </ScrollArea>
+  ) : (
+    <div className="flex h-full flex-wrap items-stretch justify-center gap-4">
+      {tileNodes}
+    </div>
   );
 }
 

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.tsx
@@ -1,3 +1,4 @@
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { cn } from "@everr/ui/lib/utils";
 import { Gauge } from "lucide-react";
 import { useMemo } from "react";
@@ -116,11 +117,12 @@ export function GaugeChartVisualization({
   const maxText = formatAxisEnd(max, unit);
 
   return (
-    <div
-      className={cn(
+    <ScrollArea
+      className="min-h-0 flex-1"
+      viewportClassName={cn(
         "flex h-full flex-wrap justify-center",
         horizontal
-          ? "content-center-safe gap-x-6 gap-y-4 overflow-y-auto px-1"
+          ? "content-center-safe gap-x-6 gap-y-4 px-1"
           : "items-stretch gap-4",
       )}
     >
@@ -176,7 +178,7 @@ export function GaugeChartVisualization({
           />
         );
       })}
-    </div>
+    </ScrollArea>
   );
 }
 

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.tsx
@@ -168,8 +168,7 @@ export function GaugeChartVisualization({
     );
   });
 
-  // Only the horizontal bars ever overflowed the panel; the arc layout
-  // always fit, so it keeps its plain div rather than gaining a scrollbar.
+  // Only the horizontal bars ever overflowed the panel; the arc layout always fit.
   return horizontal ? (
     <ScrollArea
       className="h-full"

--- a/packages/app/src/components/dashboards/visualizations/heatmap/heatmap-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/heatmap/heatmap-visualization.tsx
@@ -1,3 +1,4 @@
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { Grid3x3 } from "lucide-react";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { CursorTooltip } from "@/components/cursor-tooltip";
@@ -159,7 +160,10 @@ export function HeatmapVisualization({
         {/* No overscroll-none here: rows usually fit, and a non-scrollable
             scroll container with overscroll-behavior:none swallows wheel
             events instead of letting the page scroll. */}
-        <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden">
+        <ScrollArea
+          className="min-h-0 flex-1"
+          viewportClassName="overflow-x-hidden"
+        >
           <div className="flex h-full min-h-fit flex-col">
             {yBuckets.map((bucket, b) => (
               <div key={bucket} className="flex min-h-4 flex-1 items-stretch">
@@ -209,7 +213,7 @@ export function HeatmapVisualization({
               </div>
             ))}
           </div>
-        </div>
+        </ScrollArea>
 
         {/* time axis, aligned with the cell tracks */}
         <div className="flex h-5 shrink-0 items-start overflow-hidden">

--- a/packages/app/src/components/dashboards/visualizations/heatmap/heatmap-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/heatmap/heatmap-visualization.tsx
@@ -160,12 +160,7 @@ export function HeatmapVisualization({
         {/* No overscroll-none here: rows usually fit, and a non-scrollable
             scroll container with overscroll-behavior:none swallows wheel
             events instead of letting the page scroll. */}
-        <ScrollArea
-          className="min-h-0 flex-1"
-          // Base UI writes `overflow: scroll` inline on the viewport, so only
-          // an inline style can turn the horizontal axis off.
-          viewportProps={{ style: { overflowX: "hidden" } }}
-        >
+        <ScrollArea className="min-h-0 flex-1">
           <div className="flex h-full min-h-fit flex-col">
             {yBuckets.map((bucket, b) => (
               <div key={bucket} className="flex min-h-4 flex-1 items-stretch">

--- a/packages/app/src/components/dashboards/visualizations/heatmap/heatmap-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/heatmap/heatmap-visualization.tsx
@@ -162,7 +162,9 @@ export function HeatmapVisualization({
             events instead of letting the page scroll. */}
         <ScrollArea
           className="min-h-0 flex-1"
-          viewportClassName="overflow-x-hidden"
+          // Base UI writes `overflow: scroll` inline on the viewport, so only
+          // an inline style can turn the horizontal axis off.
+          viewportProps={{ style: { overflowX: "hidden" } }}
         >
           <div className="flex h-full min-h-fit flex-col">
             {yBuckets.map((bucket, b) => (

--- a/packages/app/src/components/dashboards/visualizations/lane-timeline-chart.tsx
+++ b/packages/app/src/components/dashboards/visualizations/lane-timeline-chart.tsx
@@ -158,12 +158,7 @@ export function LaneTimelineChart({
         {/* No overscroll-none here: lanes usually fit, and a non-scrollable
             scroll container with overscroll-behavior:none swallows wheel
             events instead of letting the page scroll. */}
-        <ScrollArea
-          className="min-h-0 flex-1"
-          // Base UI writes `overflow: scroll` inline on the viewport, so only
-          // an inline style can turn the horizontal axis off.
-          viewportProps={{ style: { overflowX: "hidden" } }}
-        >
+        <ScrollArea className="min-h-0 flex-1">
           <div className="flex h-full min-h-fit flex-col gap-1 py-1">
             {lanes.map((lane) => (
               <div

--- a/packages/app/src/components/dashboards/visualizations/lane-timeline-chart.tsx
+++ b/packages/app/src/components/dashboards/visualizations/lane-timeline-chart.tsx
@@ -1,3 +1,4 @@
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { cn } from "@everr/ui/lib/utils";
 import { type ReactNode, useCallback, useMemo, useRef, useState } from "react";
 import { CursorTooltip } from "@/components/cursor-tooltip";
@@ -157,7 +158,10 @@ export function LaneTimelineChart({
         {/* No overscroll-none here: lanes usually fit, and a non-scrollable
             scroll container with overscroll-behavior:none swallows wheel
             events instead of letting the page scroll. */}
-        <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden">
+        <ScrollArea
+          className="min-h-0 flex-1"
+          viewportClassName="overflow-x-hidden"
+        >
           <div className="flex h-full min-h-fit flex-col gap-1 py-1">
             {lanes.map((lane) => (
               <div
@@ -209,7 +213,7 @@ export function LaneTimelineChart({
               </div>
             ))}
           </div>
-        </div>
+        </ScrollArea>
 
         {/* time axis, aligned with the item tracks */}
         <div className="flex h-5 shrink-0 items-start overflow-hidden">

--- a/packages/app/src/components/dashboards/visualizations/lane-timeline-chart.tsx
+++ b/packages/app/src/components/dashboards/visualizations/lane-timeline-chart.tsx
@@ -160,7 +160,9 @@ export function LaneTimelineChart({
             events instead of letting the page scroll. */}
         <ScrollArea
           className="min-h-0 flex-1"
-          viewportClassName="overflow-x-hidden"
+          // Base UI writes `overflow: scroll` inline on the viewport, so only
+          // an inline style can turn the horizontal axis off.
+          viewportProps={{ style: { overflowX: "hidden" } }}
         >
           <div className="flex h-full min-h-fit flex-col gap-1 py-1">
             {lanes.map((lane) => (

--- a/packages/app/src/components/dashboards/visualizations/table/table-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/table/table-visualization.tsx
@@ -1,4 +1,5 @@
 import { type Column, DataTable } from "@everr/ui/components/data-table";
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import {
   ToggleGroup,
   ToggleGroupItem,
@@ -74,7 +75,7 @@ export function TableVisualization({
           fit (a non-scrollable scroll container with overscroll-behavior:none
           blocks scroll chaining), leaving the dashboard unscrollable from
           above this panel. */}
-      <div className="min-h-0 flex-1 overflow-auto">
+      <ScrollArea className="min-h-0 flex-1" orientation="both">
         {rows.length === 0 ? (
           <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
             No rows
@@ -88,7 +89,7 @@ export function TableVisualization({
             bordered
           />
         )}
-      </div>
+      </ScrollArea>
     </div>
   );
 }

--- a/packages/app/src/components/dashboards/visualizations/table/table-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/table/table-visualization.tsx
@@ -87,6 +87,8 @@ export function TableVisualization({
             rowKey={(_, i) => String(i)}
             stickyHeader={spec.stickyHeader}
             bordered
+            // The panel above owns the scroll box this table sits in.
+            scrollable={false}
           />
         )}
       </ScrollArea>

--- a/packages/app/src/components/page-container.tsx
+++ b/packages/app/src/components/page-container.tsx
@@ -1,3 +1,4 @@
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { cn } from "@everr/ui/lib/utils";
 import type * as React from "react";
 
@@ -16,5 +17,23 @@ export function PageContainer({
     >
       {children}
     </div>
+  );
+}
+
+// The same inset in a scroll column of its own, for the layouts whose parent
+// column is `overflow-hidden` and so cannot scroll for them. The viewport is a
+// flex column so PageContainer's fill semantics keep working: without it
+// `flex-1` is inert and the inset sizes to its content instead of the column.
+export function ScrollingPageContainer({
+  children,
+  ...props
+}: React.ComponentProps<typeof PageContainer>) {
+  return (
+    <ScrollArea
+      className="min-h-0 flex-1"
+      viewportClassName="flex flex-col overscroll-y-contain"
+    >
+      <PageContainer {...props}>{children}</PageContainer>
+    </ScrollArea>
   );
 }

--- a/packages/app/src/components/rail/rail-frame.tsx
+++ b/packages/app/src/components/rail/rail-frame.tsx
@@ -1,5 +1,6 @@
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { cn } from "@everr/ui/lib/utils";
-import type { ReactNode } from "react";
+import type { ComponentProps, ReactNode } from "react";
 import * as z from "zod";
 
 /**
@@ -28,19 +29,25 @@ export const railFrameRouteOptions = {
  * as the first grid column, and what is open as a pane that scrolls itself, so
  * the page never scrolls.
  *
- * `children` is the pane, an element of the surface's own choosing, because
- * that is the half the two surfaces genuinely differ on.
+ * `children` is what goes in that pane, because that is the half the two
+ * surfaces genuinely differ on.
  */
 export function RailFrame({
   label,
   full,
   rail,
+  paneClassName,
+  paneProps,
   children,
 }: {
   /** Names the rail for assistive technology, e.g. "Dashboards". */
   label: string;
   full: boolean;
   rail: ReactNode;
+  /** Extra layout for the scrolling pane, e.g. its padding or a container name. */
+  paneClassName?: string;
+  /** Attributes for the pane itself, e.g. the router's scroll-to-top marker. */
+  paneProps?: ComponentProps<typeof ScrollArea>["viewportProps"];
   children: ReactNode;
 }) {
   return (
@@ -74,7 +81,14 @@ export function RailFrame({
           {rail}
         </div>
       </aside>
-      {children}
+      <ScrollArea
+        render={<main />}
+        className="min-h-0 min-w-0"
+        viewportClassName={cn("overscroll-y-contain", paneClassName)}
+        viewportProps={paneProps}
+      >
+        {children}
+      </ScrollArea>
     </div>
   );
 }

--- a/packages/app/src/components/rail/rail-list.tsx
+++ b/packages/app/src/components/rail/rail-list.tsx
@@ -1,0 +1,37 @@
+import { ScrollArea } from "@everr/ui/components/scroll-area";
+import { cn } from "@everr/ui/lib/utils";
+import type { ReactNode } from "react";
+import { RailSearch } from "@/components/rail/rail-search";
+
+/**
+ * A rail's search field with its rows scrolling under it. Only the rows
+ * scroll; the search stays pinned above.
+ */
+export function RailList({
+  label,
+  search,
+  onSearchChange,
+  className,
+  children,
+}: {
+  /** Names what the rail lists, e.g. "dashboards". */
+  label: string;
+  search: string;
+  onSearchChange: (value: string) => void;
+  /** Extra layout for the scrolling rows, e.g. the gap between their groups. */
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-4">
+      <RailSearch label={label} value={search} onChange={onSearchChange} />
+      <ScrollArea
+        render={<nav aria-label={label} />}
+        className="min-h-0 flex-1"
+        viewportClassName={cn("flex flex-col pb-3", className)}
+      >
+        {children}
+      </ScrollArea>
+    </div>
+  );
+}

--- a/packages/app/src/components/run-detail/log-viewer.tsx
+++ b/packages/app/src/components/run-detail/log-viewer.tsx
@@ -250,8 +250,11 @@ export function LogViewer({
     ],
   );
 
-  // Memoised because virtuoso remounts the scroller, and so loses the scroll
-  // position, whenever the identity of a component in this map changes.
+  // Memoised so the loaders keep one identity across unrelated re-renders and
+  // remount only when the loading state really flips. The scroller is safe
+  // either way: virtuoso reads each slot of this map separately and ignores a
+  // value it has already seen, and `Scroller` is the same module-level
+  // component every time.
   const components = useMemo(
     () => ({
       ...virtuosoScrollAreaComponents,

--- a/packages/app/src/components/run-detail/log-viewer.tsx
+++ b/packages/app/src/components/run-detail/log-viewer.tsx
@@ -7,6 +7,7 @@ const Ansi =
     : (AnsiImport as unknown as { default: typeof AnsiImport }).default;
 
 import { buttonVariants } from "@everr/ui/components/button";
+import { ScrollAreaScroller } from "@everr/ui/components/scroll-area";
 import { formatTimestampTimeOfDay } from "@everr/ui/lib/timestamp";
 import { cn } from "@everr/ui/lib/utils";
 import {
@@ -249,6 +250,31 @@ export function LogViewer({
     ],
   );
 
+  // Memoised because virtuoso remounts the scroller, and so loses the scroll
+  // position, whenever the identity of a component in this map changes.
+  const components = useMemo(
+    () => ({
+      Scroller: ScrollAreaScroller,
+      Header: isLoadingPrevious
+        ? () => (
+            <div className="text-muted-foreground flex items-center justify-center gap-2 py-2 text-xs">
+              <Loader2 className="size-3 animate-spin" />
+              Loading older logs...
+            </div>
+          )
+        : undefined,
+      Footer: isLoadingNext
+        ? () => (
+            <div className="text-muted-foreground flex items-center justify-center gap-2 py-2 text-xs">
+              <Loader2 className="size-3 animate-spin" />
+              Loading newer logs...
+            </div>
+          )
+        : undefined,
+    }),
+    [isLoadingPrevious, isLoadingNext],
+  );
+
   if (logs.length === 0) {
     return (
       <div className="text-muted-foreground flex h-full items-center justify-center text-sm">
@@ -296,6 +322,10 @@ export function LogViewer({
       {/* Virtualized log content */}
       <div className="bg-muted/50 min-h-0 flex-1 font-mono text-xs">
         <Virtuoso
+          // The scroller renders a ScrollArea root that needs a definite
+          // height of its own; virtuoso's `height: 100%` reaches the viewport
+          // inside it, not this box.
+          className="h-full"
           totalCount={visibleLines.length}
           firstItemIndex={firstItemIndex}
           initialTopMostItemIndex={
@@ -317,24 +347,7 @@ export function LogViewer({
             }
           }}
           itemContent={renderLine}
-          components={{
-            Header: isLoadingPrevious
-              ? () => (
-                  <div className="text-muted-foreground flex items-center justify-center gap-2 py-2 text-xs">
-                    <Loader2 className="size-3 animate-spin" />
-                    Loading older logs...
-                  </div>
-                )
-              : undefined,
-            Footer: isLoadingNext
-              ? () => (
-                  <div className="text-muted-foreground flex items-center justify-center gap-2 py-2 text-xs">
-                    <Loader2 className="size-3 animate-spin" />
-                    Loading newer logs...
-                  </div>
-                )
-              : undefined,
-          }}
+          components={components}
         />
       </div>
     </div>

--- a/packages/app/src/components/run-detail/log-viewer.tsx
+++ b/packages/app/src/components/run-detail/log-viewer.tsx
@@ -7,7 +7,7 @@ const Ansi =
     : (AnsiImport as unknown as { default: typeof AnsiImport }).default;
 
 import { buttonVariants } from "@everr/ui/components/button";
-import { ScrollAreaScroller } from "@everr/ui/components/scroll-area";
+import { virtuosoScrollAreaComponents } from "@everr/ui/components/scroll-area";
 import { formatTimestampTimeOfDay } from "@everr/ui/lib/timestamp";
 import { cn } from "@everr/ui/lib/utils";
 import {
@@ -254,7 +254,7 @@ export function LogViewer({
   // position, whenever the identity of a component in this map changes.
   const components = useMemo(
     () => ({
-      Scroller: ScrollAreaScroller,
+      ...virtuosoScrollAreaComponents,
       Header: isLoadingPrevious
         ? () => (
             <div className="text-muted-foreground flex items-center justify-center gap-2 py-2 text-xs">

--- a/packages/app/src/components/run-detail/trace-waterfall.tsx
+++ b/packages/app/src/components/run-detail/trace-waterfall.tsx
@@ -7,6 +7,7 @@ import {
   ResizablePanel,
   ResizablePanelGroup,
 } from "@everr/ui/components/resizable";
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { formatDuration } from "@everr/ui/lib/formatting";
 import { cn } from "@everr/ui/lib/utils";
 import {
@@ -192,10 +193,16 @@ export function TraceWaterfall({ spans, traceId }: TraceWaterfallProps) {
       <ResizablePanelGroup orientation="horizontal" className="min-h-0 flex-1">
         {/* Left panel — span names */}
         <ResizablePanel>
-          <div
-            ref={leftScrollRef}
-            className="h-full overflow-y-auto overflow-x-hidden"
-            onScroll={() => syncScroll("left")}
+          <ScrollArea
+            className="h-full"
+            viewportRef={leftScrollRef}
+            // Base UI writes `overflow: scroll` inline on the viewport, so a
+            // Tailwind overflow class there is inert. Only an inline style
+            // merges over it and keeps the x axis clipped.
+            viewportProps={{
+              onScroll: () => syncScroll("left"),
+              style: { overflowX: "hidden" },
+            }}
           >
             {/* Spacer matching time-axis height */}
             <div className="sticky top-0 z-10 h-5 bg-card border-b border-border" />
@@ -271,17 +278,20 @@ export function TraceWaterfall({ spans, traceId }: TraceWaterfallProps) {
                 </Fragment>
               );
             })}
-          </div>
+          </ScrollArea>
         </ResizablePanel>
 
         <ResizableHandle withHandle />
 
         {/* Right panel — timeline */}
         <ResizablePanel defaultSize="80%" minSize="20%" maxSize="90%">
-          <div
-            ref={rightScrollRef}
-            className="h-full overflow-y-auto overflow-x-hidden pr-1"
-            onScroll={() => syncScroll("right")}
+          <ScrollArea
+            className="h-full"
+            viewportRef={rightScrollRef}
+            viewportProps={{
+              onScroll: () => syncScroll("right"),
+              style: { overflowX: "hidden" },
+            }}
           >
             {/* Time axis */}
             <div className="sticky top-0 z-10 h-5 bg-card border-b border-border text-xs text-muted-foreground">
@@ -382,7 +392,7 @@ export function TraceWaterfall({ spans, traceId }: TraceWaterfallProps) {
                 );
               })}
             </div>
-          </div>
+          </ScrollArea>
         </ResizablePanel>
       </ResizablePanelGroup>
     </div>

--- a/packages/app/src/components/run-detail/trace-waterfall.tsx
+++ b/packages/app/src/components/run-detail/trace-waterfall.tsx
@@ -196,13 +196,7 @@ export function TraceWaterfall({ spans, traceId }: TraceWaterfallProps) {
           <ScrollArea
             className="h-full"
             viewportRef={leftScrollRef}
-            // Base UI writes `overflow: scroll` inline on the viewport, so a
-            // Tailwind overflow class there is inert. Only an inline style
-            // merges over it and keeps the x axis clipped.
-            viewportProps={{
-              onScroll: () => syncScroll("left"),
-              style: { overflowX: "hidden" },
-            }}
+            viewportProps={{ onScroll: () => syncScroll("left") }}
           >
             {/* Spacer matching time-axis height */}
             <div className="sticky top-0 z-10 h-5 bg-card border-b border-border" />
@@ -288,10 +282,7 @@ export function TraceWaterfall({ spans, traceId }: TraceWaterfallProps) {
           <ScrollArea
             className="h-full"
             viewportRef={rightScrollRef}
-            viewportProps={{
-              onScroll: () => syncScroll("right"),
-              style: { overflowX: "hidden" },
-            }}
+            viewportProps={{ onScroll: () => syncScroll("right") }}
           >
             {/* Time axis */}
             <div className="sticky top-0 z-10 h-5 bg-card border-b border-border text-xs text-muted-foreground">

--- a/packages/app/src/components/runbooks/runbook-pages-nav.tsx
+++ b/packages/app/src/components/runbooks/runbook-pages-nav.tsx
@@ -1,3 +1,4 @@
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { cn } from "@everr/ui/lib/utils";
 import { Link } from "@tanstack/react-router";
 import type { CSSProperties, ReactNode } from "react";
@@ -30,15 +31,14 @@ interface PagesNavProps {
 export function RunbookPagesNav(props: PagesNavProps) {
   return (
     <>
-      <nav
-        aria-label="Runbook pages"
-        className={cn(
-          "-mx-1 mb-5 flex items-center gap-0.5 overflow-x-auto pb-1",
-          noMarginClass,
-        )}
+      <ScrollArea
+        render={<nav aria-label="Runbook pages" />}
+        orientation="horizontal"
+        className={cn("-mx-1 mb-5", noMarginClass)}
+        viewportClassName="flex items-center gap-0.5 pb-1"
       >
         <PageLinks {...props} inline />
-      </nav>
+      </ScrollArea>
       <FloatingMarginNav label="Pages" ariaLabel="Runbook pages">
         <PageLinks {...props} />
       </FloatingMarginNav>

--- a/packages/app/src/components/runbooks/runbooks-list.tsx
+++ b/packages/app/src/components/runbooks/runbooks-list.tsx
@@ -1,3 +1,4 @@
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { useQuery } from "@tanstack/react-query";
 import { CirclePlus } from "lucide-react";
 import { useState } from "react";
@@ -17,7 +18,11 @@ export function RunbooksList({ preview }: { preview?: string }) {
       <RailSearch label="runbooks" value={search} onChange={setSearch} />
 
       {/* Only the rows scroll; the search stays pinned above. */}
-      <nav className="flex min-h-0 flex-1 flex-col overflow-y-auto pr-1 pb-3">
+      <ScrollArea
+        render={<nav />}
+        className="min-h-0 flex-1"
+        viewportClassName="flex flex-col pr-1 pb-3"
+      >
         {listQuery.isLoading && (
           <p className="px-1 py-1 text-muted-foreground text-xs">Loading...</p>
         )}
@@ -42,7 +47,7 @@ export function RunbooksList({ preview }: { preview?: string }) {
             resource="runbook"
           />
         )}
-      </nav>
+      </ScrollArea>
     </div>
   );
 }

--- a/packages/app/src/components/runbooks/runbooks-list.tsx
+++ b/packages/app/src/components/runbooks/runbooks-list.tsx
@@ -21,7 +21,7 @@ export function RunbooksList({ preview }: { preview?: string }) {
       <ScrollArea
         render={<nav />}
         className="min-h-0 flex-1"
-        viewportClassName="flex flex-col pr-1 pb-3"
+        viewportClassName="flex flex-col pb-3"
       >
         {listQuery.isLoading && (
           <p className="px-1 py-1 text-muted-foreground text-xs">Loading...</p>

--- a/packages/app/src/components/runbooks/runbooks-list.tsx
+++ b/packages/app/src/components/runbooks/runbooks-list.tsx
@@ -1,10 +1,9 @@
-import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { useQuery } from "@tanstack/react-query";
 import { CirclePlus } from "lucide-react";
 import { useState } from "react";
 import { DashboardTree } from "@/components/dashboards/dashboard-tree";
+import { RailList } from "@/components/rail/rail-list";
 import { RailRow } from "@/components/rail/rail-row";
-import { RailSearch } from "@/components/rail/rail-search";
 import { runbookListOptions } from "@/data/runbooks/options";
 
 /** The first navigation level: every runbook in the organization. */
@@ -14,40 +13,29 @@ export function RunbooksList({ preview }: { preview?: string }) {
   const runbooks = listQuery.data ?? [];
 
   return (
-    <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-4">
-      <RailSearch label="runbooks" value={search} onChange={setSearch} />
-
-      {/* Only the rows scroll; the search stays pinned above. */}
-      <ScrollArea
-        render={<nav />}
-        className="min-h-0 flex-1"
-        viewportClassName="flex flex-col pb-3"
-      >
-        {listQuery.isLoading && (
-          <p className="px-1 py-1 text-muted-foreground text-xs">Loading...</p>
-        )}
-        {listQuery.isError && (
-          <p className="px-1 py-1 text-amber-400 text-xs">
-            Couldn't load your runbooks
-          </p>
-        )}
-        {!listQuery.isLoading &&
-          !listQuery.isError &&
-          runbooks.length === 0 && (
-            <RailRow
-              label="Create your first runbook"
-              icon={CirclePlus}
-              to="/runbooks/get-started"
-            />
-          )}
-        {runbooks.length > 0 && (
-          <DashboardTree
-            dashboards={runbooks}
-            search={search}
-            resource="runbook"
-          />
-        )}
-      </ScrollArea>
-    </div>
+    <RailList label="runbooks" search={search} onSearchChange={setSearch}>
+      {listQuery.isLoading && (
+        <p className="px-1 py-1 text-muted-foreground text-xs">Loading...</p>
+      )}
+      {listQuery.isError && (
+        <p className="px-1 py-1 text-amber-400 text-xs">
+          Couldn't load your runbooks
+        </p>
+      )}
+      {!listQuery.isLoading && !listQuery.isError && runbooks.length === 0 && (
+        <RailRow
+          label="Create your first runbook"
+          icon={CirclePlus}
+          to="/runbooks/get-started"
+        />
+      )}
+      {runbooks.length > 0 && (
+        <DashboardTree
+          dashboards={runbooks}
+          search={search}
+          resource="runbook"
+        />
+      )}
+    </RailList>
   );
 }

--- a/packages/app/src/components/workflows/run-gantt.tsx
+++ b/packages/app/src/components/workflows/run-gantt.tsx
@@ -8,6 +8,7 @@ import {
   CardTitle,
 } from "@everr/ui/components/card";
 import { Empty, EmptyDescription } from "@everr/ui/components/empty";
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { Skeleton } from "@everr/ui/components/skeleton";
 import { formatDuration } from "@everr/ui/lib/formatting";
 import { formatRelativeTime } from "@everr/ui/lib/timestamp";
@@ -157,7 +158,7 @@ function RunLanes({ run }: { run: WorkflowRunGantt }) {
         </span>
       </div>
 
-      <div className="max-h-[320px] space-y-1 overflow-y-auto pr-1">
+      <ScrollArea className="max-h-[320px]" viewportClassName="space-y-1 pr-1">
         {run.jobs.map((job) => {
           const left = toPct(job.startMs);
           const width = Math.max(toPct(job.endMs) - left, 1.5);
@@ -188,7 +189,7 @@ function RunLanes({ run }: { run: WorkflowRunGantt }) {
             </div>
           );
         })}
-      </div>
+      </ScrollArea>
     </div>
   );
 }

--- a/packages/app/src/components/workflows/run-gantt.tsx
+++ b/packages/app/src/components/workflows/run-gantt.tsx
@@ -158,7 +158,7 @@ function RunLanes({ run }: { run: WorkflowRunGantt }) {
         </span>
       </div>
 
-      <ScrollArea className="max-h-[320px]" viewportClassName="space-y-1 pr-1">
+      <ScrollArea className="max-h-[320px]" viewportClassName="space-y-1">
         {run.jobs.map((job) => {
           const left = toPct(job.startMs);
           const width = Math.max(toPct(job.endMs) - left, 1.5);

--- a/packages/app/src/routes/_authenticated/_dashboard/_padded.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_padded.tsx
@@ -1,3 +1,4 @@
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 import { PageContainer } from "@/components/page-container";
 
@@ -10,10 +11,13 @@ export const Route = createFileRoute("/_authenticated/_dashboard/_padded")({
 // keeps `PageContainer`'s fill working for both tall and full-height content.
 function PaddedLayout() {
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-auto overscroll-y-contain">
+    <ScrollArea
+      className="min-h-0 flex-1"
+      viewportClassName="flex flex-col overscroll-y-contain"
+    >
       <PageContainer>
         <Outlet />
       </PageContainer>
-    </div>
+    </ScrollArea>
   );
 }

--- a/packages/app/src/routes/_authenticated/_dashboard/_padded.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_padded.tsx
@@ -1,23 +1,16 @@
-import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { createFileRoute, Outlet } from "@tanstack/react-router";
-import { PageContainer } from "@/components/page-container";
+import { ScrollingPageContainer } from "@/components/page-container";
 
 export const Route = createFileRoute("/_authenticated/_dashboard/_padded")({
   component: PaddedLayout,
 });
 
-// Standard-inset pages (settings, home, cost analysis, …). Owns its own scroll
-// because the shared `_dashboard` column is `overflow-hidden`; the flex idiom
-// keeps `PageContainer`'s fill working for both tall and full-height content.
+// Standard-inset pages (settings, home, cost analysis, ...). Owns its own
+// scroll because the shared `_dashboard` column is `overflow-hidden`.
 function PaddedLayout() {
   return (
-    <ScrollArea
-      className="min-h-0 flex-1"
-      viewportClassName="flex flex-col overscroll-y-contain"
-    >
-      <PageContainer>
-        <Outlet />
-      </PageContainer>
-    </ScrollArea>
+    <ScrollingPageContainer>
+      <Outlet />
+    </ScrollingPageContainer>
   );
 }

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@everr/ui/components/button";
 import { PreviewFrame } from "@everr/ui/components/preview-frame";
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { createFileRoute, Outlet, useMatches } from "@tanstack/react-router";
 import { GitBranch, LogOut } from "lucide-react";
 import { PageContainer } from "@/components/page-container";
@@ -43,11 +44,14 @@ function PreviewableLayout() {
       <Outlet />
     </div>
   ) : (
-    <div className="min-h-0 flex-1 overflow-auto overscroll-y-contain">
+    <ScrollArea
+      className="min-h-0 flex-1"
+      viewportClassName="overscroll-y-contain"
+    >
       <PageContainer>
         <Outlet />
       </PageContainer>
-    </div>
+    </ScrollArea>
   );
 
   if (!name) return content;

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable.tsx
@@ -1,9 +1,8 @@
 import { Button } from "@everr/ui/components/button";
 import { PreviewFrame } from "@everr/ui/components/preview-frame";
-import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { createFileRoute, Outlet, useMatches } from "@tanstack/react-router";
 import { GitBranch, LogOut } from "lucide-react";
-import { PageContainer } from "@/components/page-container";
+import { ScrollingPageContainer } from "@/components/page-container";
 import { previewMessage } from "@/components/preview-message";
 import type { PreviewStatus } from "@/data/previews/overlay";
 import { usePreview } from "@/hooks/use-preview";
@@ -44,14 +43,9 @@ function PreviewableLayout() {
       <Outlet />
     </div>
   ) : (
-    <ScrollArea
-      className="min-h-0 flex-1"
-      viewportClassName="overscroll-y-contain"
-    >
-      <PageContainer>
-        <Outlet />
-      </PageContainer>
-    </ScrollArea>
+    <ScrollingPageContainer>
+      <Outlet />
+    </ScrollingPageContainer>
   );
 
   if (!name) return content;

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts.tsx
@@ -502,7 +502,10 @@ function NotificationSettingsDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-md">
-        <ScrollArea className="min-h-0 flex-1">
+        <ScrollArea
+          className="min-h-0 flex-1"
+          viewportClassName="flex flex-col gap-4"
+        >
           <DialogHeader>
             <DialogTitle>Notification settings</DialogTitle>
             <DialogDescription>

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts.tsx
@@ -12,6 +12,7 @@ import {
 } from "@everr/ui/components/dialog";
 import { Input } from "@everr/ui/components/input";
 import { Label } from "@everr/ui/components/label";
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { Skeleton } from "@everr/ui/components/skeleton";
 import { Switch } from "@everr/ui/components/switch";
 import { cn } from "@everr/ui/lib/utils";
@@ -500,37 +501,39 @@ function NotificationSettingsDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>Notification settings</DialogTitle>
-          <DialogDescription>
-            Choose where firing alerts are delivered for everyone in this
-            organization.{" "}
-            <a
-              className="underline underline-offset-4"
-              href="https://everr.dev/docs/guides/set-up-notifications"
-              target="_blank"
-              rel="noreferrer"
-            >
-              Learn more
-            </a>
-            .
-          </DialogDescription>
-        </DialogHeader>
-        {settings.isError ? (
-          <p className="text-destructive text-sm" role="alert">
-            Unable to load notification settings.
-          </p>
-        ) : settings.data ? (
-          // Mounted fresh on every dialog open (the popup unmounts on close),
-          // so the form reads its defaults once — no effect syncing state.
-          <NotificationSettingsForm
-            initial={settings.data.delivery}
-            onClose={() => onOpenChange(false)}
-          />
-        ) : (
-          <Skeleton className="h-48 w-full" />
-        )}
+      <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-md">
+        <ScrollArea className="min-h-0 flex-1">
+          <DialogHeader>
+            <DialogTitle>Notification settings</DialogTitle>
+            <DialogDescription>
+              Choose where firing alerts are delivered for everyone in this
+              organization.{" "}
+              <a
+                className="underline underline-offset-4"
+                href="https://everr.dev/docs/guides/set-up-notifications"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Learn more
+              </a>
+              .
+            </DialogDescription>
+          </DialogHeader>
+          {settings.isError ? (
+            <p className="text-destructive text-sm" role="alert">
+              Unable to load notification settings.
+            </p>
+          ) : settings.data ? (
+            // Mounted fresh on every dialog open (the popup unmounts on close),
+            // so the form reads its defaults once — no effect syncing state.
+            <NotificationSettingsForm
+              initial={settings.data.delivery}
+              onClose={() => onOpenChange(false)}
+            />
+          ) : (
+            <Skeleton className="h-48 w-full" />
+          )}
+        </ScrollArea>
       </DialogContent>
     </Dialog>
   );

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts_.$alertId.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts_.$alertId.tsx
@@ -17,6 +17,7 @@ import {
 } from "@everr/ui/components/dialog";
 import { Input } from "@everr/ui/components/input";
 import { Label } from "@everr/ui/components/label";
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import {
   Select,
   SelectContent,
@@ -365,18 +366,28 @@ function AlertDetailPage() {
             <div className="flex flex-col gap-4">
               <DefinitionTable rows={definitionRows} />
               {detail.lastEvaluationError && (
-                <pre className="max-h-32 overflow-auto rounded bg-muted/30 p-2 text-xs text-destructive">
-                  {detail.lastEvaluationError}
-                </pre>
+                <ScrollArea
+                  orientation="both"
+                  className="max-h-32 rounded bg-muted/30"
+                >
+                  <pre className="whitespace-pre p-2 text-xs text-destructive">
+                    {detail.lastEvaluationError}
+                  </pre>
+                </ScrollArea>
               )}
 
               <div className="flex flex-col gap-1.5">
                 <span className="font-medium text-muted-foreground text-xs">
                   Query
                 </span>
-                <pre className="max-h-72 overflow-auto rounded-md border border-border/60 bg-muted/20 p-3 text-xs leading-relaxed">
-                  {detail.parsedQuery}
-                </pre>
+                <ScrollArea
+                  orientation="both"
+                  className="max-h-72 rounded-md border border-border/60 bg-muted/20"
+                >
+                  <pre className="whitespace-pre p-3 text-xs leading-relaxed">
+                    {detail.parsedQuery}
+                  </pre>
+                </ScrollArea>
               </div>
             </div>
           </CardContent>

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts_.$alertId.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts_.$alertId.tsx
@@ -6,6 +6,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@everr/ui/components/card";
+import { CodeBlock } from "@everr/ui/components/code-block";
 import { type Column, DataTable } from "@everr/ui/components/data-table";
 import {
   Dialog,
@@ -17,7 +18,6 @@ import {
 } from "@everr/ui/components/dialog";
 import { Input } from "@everr/ui/components/input";
 import { Label } from "@everr/ui/components/label";
-import { ScrollArea } from "@everr/ui/components/scroll-area";
 import {
   Select,
   SelectContent,
@@ -366,28 +366,21 @@ function AlertDetailPage() {
             <div className="flex flex-col gap-4">
               <DefinitionTable rows={definitionRows} />
               {detail.lastEvaluationError && (
-                <ScrollArea
-                  orientation="both"
+                <CodeBlock
                   className="max-h-32 rounded bg-muted/30"
+                  codeClassName="p-2 text-destructive"
                 >
-                  <pre className="whitespace-pre p-2 text-xs text-destructive">
-                    {detail.lastEvaluationError}
-                  </pre>
-                </ScrollArea>
+                  {detail.lastEvaluationError}
+                </CodeBlock>
               )}
 
               <div className="flex flex-col gap-1.5">
                 <span className="font-medium text-muted-foreground text-xs">
                   Query
                 </span>
-                <ScrollArea
-                  orientation="both"
-                  className="max-h-72 rounded-md border border-border/60 bg-muted/20"
-                >
-                  <pre className="whitespace-pre p-3 text-xs leading-relaxed">
-                    {detail.parsedQuery}
-                  </pre>
-                </ScrollArea>
+                <CodeBlock className="max-h-72 rounded-md border border-border/60 bg-muted/20">
+                  {detail.parsedQuery}
+                </CodeBlock>
               </div>
             </div>
           </CardContent>

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/dashboards/route.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/dashboards/route.tsx
@@ -1,4 +1,3 @@
-import { ScrollArea } from "@everr/ui/components/scroll-area";
 import {
   createFileRoute,
   Outlet,
@@ -31,16 +30,9 @@ function DashboardsLayout() {
       label="Dashboards"
       full={full ?? false}
       rail={<DashboardsList preview={preview} />}
+      paneClassName="p-3"
     >
-      <ScrollArea
-        render={<main />}
-        className="min-h-0 min-w-0"
-        viewportClassName="overscroll-y-contain"
-      >
-        <div className="p-3">
-          <Outlet />
-        </div>
-      </ScrollArea>
+      <Outlet />
     </RailFrame>
   );
 }

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/dashboards/route.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/dashboards/route.tsx
@@ -1,3 +1,4 @@
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import {
   createFileRoute,
   Outlet,
@@ -31,11 +32,15 @@ function DashboardsLayout() {
       full={full ?? false}
       rail={<DashboardsList preview={preview} />}
     >
-      <main className="min-h-0 min-w-0 overflow-auto overscroll-y-contain">
+      <ScrollArea
+        render={<main />}
+        className="min-h-0 min-w-0"
+        viewportClassName="overscroll-y-contain"
+      >
         <div className="p-3">
           <Outlet />
         </div>
-      </main>
+      </ScrollArea>
     </RailFrame>
   );
 }

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/runbooks/route.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/runbooks/route.tsx
@@ -43,13 +43,10 @@ function RunbooksLayout() {
         render={<main />}
         className="min-h-0 min-w-0"
         viewportClassName="@container/pane overscroll-y-contain"
-        // The router resets scroll by selector (`data-scroll-to-top`, see
-        // `scrollToTopSelectors` in router.tsx); that selector must find the
-        // element that actually scrolls, which is the ScrollArea viewport,
-        // not this root.
-        viewportRef={(node) => {
-          node?.setAttribute("data-scroll-to-top", "");
-        }}
+        // scrollToTopSelectors (router.tsx) queries `[data-scroll-to-top]` and
+        // calls scrollTo on whatever it finds, so the attribute must sit on
+        // the element that actually scrolls: the viewport, not this root.
+        viewportProps={{ "data-scroll-to-top": "" }}
       >
         {/* The toggle belongs to the rail, not to the runbook, so it sits at
             the pane's edge against it rather than over the centered text. */}

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/runbooks/route.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/runbooks/route.tsx
@@ -1,4 +1,3 @@
-import { ScrollArea } from "@everr/ui/components/scroll-area";
 import {
   createFileRoute,
   Outlet,
@@ -32,38 +31,28 @@ function RunbooksLayout() {
       label="Runbooks"
       full={full ?? false}
       rail={<RunbooksList preview={preview} />}
+      // Named container: the pages nav floats or lies down by how much room
+      // this pane has, which the viewport alone cannot tell it.
+      paneClassName="@container/pane"
+      // The router resets this pane to the top on navigation, keyed off
+      // `data-scroll-to-top` (see `scrollToTopSelectors` in router.tsx).
+      paneProps={{ "data-scroll-to-top": "" }}
     >
-      {/*
-        Named container: the pages nav floats or lies down by how much room
-        this pane has, which the viewport alone cannot tell it. The router
-        resets this pane to the top on navigation, keyed off
-        `data-scroll-to-top` (see `scrollToTopSelectors` in router.tsx).
-      */}
-      <ScrollArea
-        render={<main />}
-        className="min-h-0 min-w-0"
-        viewportClassName="@container/pane overscroll-y-contain"
-        // scrollToTopSelectors (router.tsx) queries `[data-scroll-to-top]` and
-        // calls scrollTo on whatever it finds, so the attribute must sit on
-        // the element that actually scrolls: the viewport, not this root.
-        viewportProps={{ "data-scroll-to-top": "" }}
-      >
-        {/* The toggle belongs to the rail, not to the runbook, so it sits at
+      {/* The toggle belongs to the rail, not to the runbook, so it sits at
             the pane's edge against it rather than over the centered text. */}
-        <div className="p-3 pb-2">
-          <FrameToggle listLabel="runbook list" />
-        </div>
-        {/* Every step up widens the reading column and the navs floating
+      <div className="p-3 pb-2">
+        <FrameToggle listLabel="runbook list" />
+      </div>
+      {/* Every step up widens the reading column and the navs floating
             beside it together, so the margins never shrink below what they
             need. `relative` is what those navs pin themselves to.
 
             No top padding: a floating nav pins to this box, so padding here
             would start the text below the nav and the two would not line up.
             The space above the text belongs to the toggle row instead. */}
-        <div className="relative mx-auto w-full max-w-2xl px-3 pb-3 @[76rem]/pane:max-w-3xl @[88rem]/pane:max-w-4xl">
-          <Outlet />
-        </div>
-      </ScrollArea>
+      <div className="relative mx-auto w-full max-w-2xl px-3 pb-3 @[76rem]/pane:max-w-3xl @[88rem]/pane:max-w-4xl">
+        <Outlet />
+      </div>
     </RailFrame>
   );
 }

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/runbooks/route.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/runbooks/route.tsx
@@ -1,3 +1,4 @@
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import {
   createFileRoute,
   Outlet,
@@ -38,9 +39,17 @@ function RunbooksLayout() {
         resets this pane to the top on navigation, keyed off
         `data-scroll-to-top` (see `scrollToTopSelectors` in router.tsx).
       */}
-      <main
-        data-scroll-to-top
-        className="@container/pane min-h-0 min-w-0 overflow-auto overscroll-y-contain"
+      <ScrollArea
+        render={<main />}
+        className="min-h-0 min-w-0"
+        viewportClassName="@container/pane overscroll-y-contain"
+        // The router resets scroll by selector (`data-scroll-to-top`, see
+        // `scrollToTopSelectors` in router.tsx); that selector must find the
+        // element that actually scrolls, which is the ScrollArea viewport,
+        // not this root.
+        viewportRef={(node) => {
+          node?.setAttribute("data-scroll-to-top", "");
+        }}
       >
         {/* The toggle belongs to the rail, not to the runbook, so it sits at
             the pane's edge against it rather than over the centered text. */}
@@ -57,7 +66,7 @@ function RunbooksLayout() {
         <div className="relative mx-auto w-full max-w-2xl px-3 pb-3 @[76rem]/pane:max-w-3xl @[88rem]/pane:max-w-4xl">
           <Outlet />
         </div>
-      </main>
+      </ScrollArea>
     </RailFrame>
   );
 }

--- a/packages/app/src/routes/_authenticated/_dashboard/runs/$traceId/route.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/runs/$traceId/route.tsx
@@ -6,6 +6,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@everr/ui/components/card";
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { Skeleton } from "@everr/ui/components/skeleton";
 import {
   Tabs,
@@ -164,13 +165,15 @@ function RunDetailLayout() {
                   {(jobs ?? []).length} jobs in this run
                 </CardDescription>
               </CardHeader>
-              <CardContent className="min-h-0 flex-1 overflow-auto">
-                <JobTreeNav
-                  jobs={jobs ?? []}
-                  stepsByJobId={stepsByJobId ?? {}}
-                  traceId={traceId}
-                  selectedJobId={(params as { jobId?: string }).jobId}
-                />
+              <CardContent className="min-h-0 flex-1">
+                <ScrollArea orientation="both" className="size-full">
+                  <JobTreeNav
+                    jobs={jobs ?? []}
+                    stepsByJobId={stepsByJobId ?? {}}
+                    traceId={traceId}
+                    selectedJobId={(params as { jobId?: string }).jobId}
+                  />
+                </ScrollArea>
               </CardContent>
             </Card>
 
@@ -201,10 +204,16 @@ function RunDetailSkeleton() {
             <Skeleton className="h-4 w-16" />
             <Skeleton className="h-3 w-32" />
           </CardHeader>
-          <CardContent className="min-h-0 flex-1 space-y-2 overflow-auto">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <Skeleton key={i} className="h-8 w-full" />
-            ))}
+          <CardContent className="min-h-0 flex-1">
+            <ScrollArea
+              orientation="both"
+              className="size-full"
+              viewportClassName="space-y-2"
+            >
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Skeleton key={i} className="h-8 w-full" />
+              ))}
+            </ScrollArea>
           </CardContent>
         </Card>
         <Card size="sm" className="h-full">

--- a/packages/app/src/routes/onboarding.tsx
+++ b/packages/app/src/routes/onboarding.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@everr/ui/components/button";
 import { Input } from "@everr/ui/components/input";
 import { Label } from "@everr/ui/components/label";
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { cn } from "@everr/ui/lib/utils";
 
 import { useForm } from "@tanstack/react-form";
@@ -763,7 +764,11 @@ function WorkflowsStep({
                     No repositories found for this installation.
                   </p>
                 ) : (
-                  <ul className="max-h-64 space-y-1 overflow-y-auto">
+                  <ScrollArea
+                    render={<ul />}
+                    className="max-h-64"
+                    viewportClassName="space-y-1"
+                  >
                     {reposQuery.data.map((repo) => {
                       const selected = selectedRepos.has(repo.fullName);
                       const disabled =
@@ -798,7 +803,7 @@ function WorkflowsStep({
                         </li>
                       );
                     })}
-                  </ul>
+                  </ScrollArea>
                 )}
               </div>
             )}

--- a/packages/app/src/routes/onboarding.tsx
+++ b/packages/app/src/routes/onboarding.tsx
@@ -765,9 +765,9 @@ function WorkflowsStep({
                   </p>
                 ) : (
                   <ScrollArea
-                    render={<ul />}
                     className="max-h-64"
                     viewportClassName="space-y-1"
+                    viewportProps={{ render: <ul /> }}
                   >
                     {reposQuery.data.map((repo) => {
                       const selected = selectedRepos.has(repo.fullName);

--- a/packages/app/src/test-setup.ts
+++ b/packages/app/src/test-setup.ts
@@ -1,4 +1,5 @@
 import "@testing-library/jest-dom/vitest";
+import "@everr/ui/testing/jsdom-shims";
 import { cleanup } from "@testing-library/react";
 import { afterEach, vi } from "vitest";
 import {
@@ -198,16 +199,6 @@ if (typeof Element !== "undefined" && !Element.prototype.scrollIntoView) {
   Object.defineProperty(Element.prototype, "scrollIntoView", {
     writable: true,
     value() {},
-  });
-}
-
-// jsdom does not implement getAnimations; Base UI's scroll area calls it.
-if (typeof Element !== "undefined" && !Element.prototype.getAnimations) {
-  Object.defineProperty(Element.prototype, "getAnimations", {
-    writable: true,
-    value() {
-      return [];
-    },
   });
 }
 

--- a/packages/app/src/test-setup.ts
+++ b/packages/app/src/test-setup.ts
@@ -201,6 +201,16 @@ if (typeof Element !== "undefined" && !Element.prototype.scrollIntoView) {
   });
 }
 
+// jsdom does not implement getAnimations; Base UI's scroll area calls it.
+if (typeof Element !== "undefined" && !Element.prototype.getAnimations) {
+  Object.defineProperty(Element.prototype, "getAnimations", {
+    writable: true,
+    value() {
+      return [];
+    },
+  });
+}
+
 // ---------------------------------------------------------------------------
 afterEach(() => {
   cleanup();

--- a/packages/desktop-app/src/features/desktop-shell/app-shell.tsx
+++ b/packages/desktop-app/src/features/desktop-shell/app-shell.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@everr/ui/components/dropdown-menu";
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { Link, Outlet, useNavigate } from "@tanstack/react-router";
 import {
   Bug,
@@ -93,8 +94,12 @@ export function AppShell() {
                 <AuthStatusIndicator />
               </div>
             </nav>
-            <CardContent className="min-w-0 flex-1 overflow-y-auto overscroll-none p-0">
-              <Outlet />
+            <CardContent className="min-w-0 flex-1 p-0">
+              {/* overscroll-none dropped: some panes (Settings, Developer) fit
+                  without scrolling, and it would swallow wheel events there. */}
+              <ScrollArea className="size-full">
+                <Outlet />
+              </ScrollArea>
             </CardContent>
           </div>
         </TitleBarSlotsContext.Provider>

--- a/packages/desktop-app/src/features/desktop-shell/app-shell.tsx
+++ b/packages/desktop-app/src/features/desktop-shell/app-shell.tsx
@@ -95,8 +95,9 @@ export function AppShell() {
               </div>
             </nav>
             <CardContent className="min-w-0 flex-1 p-0">
-              {/* overscroll-none dropped: some panes (Settings, Developer) fit
-                  without scrolling, and it would swallow wheel events there. */}
+              {/* No overscroll-none: the ancestor main and Card are both
+                  h-screen/overflow-hidden, so there is no window scroll to
+                  chain to and nothing for it to guard. */}
               <ScrollArea className="size-full">
                 <Outlet />
               </ScrollArea>

--- a/packages/desktop-app/src/features/desktop-shell/settings-page.tsx
+++ b/packages/desktop-app/src/features/desktop-shell/settings-page.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@everr/ui/components/button";
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { RotateCw } from "lucide-react";
 import { AuthSettingsSection } from "../auth/auth";
 import {
@@ -79,14 +80,14 @@ export function SettingsPage() {
   return (
     <div className="flex h-full flex-col overflow-hidden">
       <PageTitleBar title="Settings" />
-      <div className="min-h-0 flex-1 overflow-y-auto">
+      <ScrollArea className="min-h-0 flex-1">
         <div className="grid divide-y divide-white/[0.08]">
           <AuthSettingsSection />
           <NotificationEmailsSection />
           <SkillsSection />
           <LocalTelemetrySection />
         </div>
-      </div>
+      </ScrollArea>
     </div>
   );
 }

--- a/packages/desktop-app/src/features/desktop-shell/settings-page.tsx
+++ b/packages/desktop-app/src/features/desktop-shell/settings-page.tsx
@@ -1,5 +1,4 @@
 import { Button } from "@everr/ui/components/button";
-import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { RotateCw } from "lucide-react";
 import { AuthSettingsSection } from "../auth/auth";
 import {
@@ -8,7 +7,7 @@ import {
 } from "../local-telemetry/collector-status";
 import { NotificationEmailsSection } from "../notifications/notification-emails-section";
 import { SkillsSection } from "../skills/skills-section";
-import { PageTitleBar } from "./title-bar";
+import { SectionsPage } from "./title-bar";
 import { SettingsSection } from "./ui";
 
 function LocalTelemetrySection() {
@@ -78,16 +77,11 @@ function LocalTelemetrySection() {
 
 export function SettingsPage() {
   return (
-    <div className="flex h-full flex-col overflow-hidden">
-      <PageTitleBar title="Settings" />
-      <ScrollArea className="min-h-0 flex-1">
-        <div className="grid divide-y divide-white/[0.08]">
-          <AuthSettingsSection />
-          <NotificationEmailsSection />
-          <SkillsSection />
-          <LocalTelemetrySection />
-        </div>
-      </ScrollArea>
-    </div>
+    <SectionsPage title="Settings">
+      <AuthSettingsSection />
+      <NotificationEmailsSection />
+      <SkillsSection />
+      <LocalTelemetrySection />
+    </SectionsPage>
   );
 }

--- a/packages/desktop-app/src/features/desktop-shell/title-bar.tsx
+++ b/packages/desktop-app/src/features/desktop-shell/title-bar.tsx
@@ -1,3 +1,4 @@
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { createContext, type ReactNode, useContext } from "react";
 import { createPortal } from "react-dom";
 
@@ -37,5 +38,31 @@ export function PageTitleBar({
         : null}
       {right && actions ? createPortal(actions, right) : null}
     </>
+  );
+}
+
+/**
+ * A page of stacked sections under the title bar, scrolling as one. The window
+ * itself never scrolls, so the sections do.
+ */
+export function SectionsPage({
+  title,
+  actions,
+  children,
+}: {
+  title?: ReactNode;
+  actions?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <PageTitleBar title={title} actions={actions} />
+      <ScrollArea
+        className="min-h-0 flex-1"
+        viewportClassName="grid divide-y divide-white/[0.08]"
+      >
+        {children}
+      </ScrollArea>
+    </div>
   );
 }

--- a/packages/desktop-app/src/features/developer/developer-page.tsx
+++ b/packages/desktop-app/src/features/developer/developer-page.tsx
@@ -1,20 +1,14 @@
-import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { DeveloperUpdateSection } from "../desktop-shell/app-update";
-import { PageTitleBar } from "../desktop-shell/title-bar";
+import { SectionsPage } from "../desktop-shell/title-bar";
 import { DeveloperNotificationSection } from "../notifications/notification-window";
 import { ErrorTrackingSection } from "./error-tracking-section";
 
 export function DeveloperPage() {
   return (
-    <div className="flex h-full flex-col overflow-hidden">
-      <PageTitleBar title="Developer" />
-      <ScrollArea className="min-h-0 flex-1">
-        <div className="grid divide-y divide-white/[0.06]">
-          <DeveloperNotificationSection />
-          <DeveloperUpdateSection />
-          <ErrorTrackingSection />
-        </div>
-      </ScrollArea>
-    </div>
+    <SectionsPage title="Developer">
+      <DeveloperNotificationSection />
+      <DeveloperUpdateSection />
+      <ErrorTrackingSection />
+    </SectionsPage>
   );
 }

--- a/packages/desktop-app/src/features/developer/developer-page.tsx
+++ b/packages/desktop-app/src/features/developer/developer-page.tsx
@@ -1,3 +1,4 @@
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { DeveloperUpdateSection } from "../desktop-shell/app-update";
 import { PageTitleBar } from "../desktop-shell/title-bar";
 import { DeveloperNotificationSection } from "../notifications/notification-window";
@@ -7,13 +8,13 @@ export function DeveloperPage() {
   return (
     <div className="flex h-full flex-col overflow-hidden">
       <PageTitleBar title="Developer" />
-      <div className="min-h-0 flex-1 overflow-y-auto">
+      <ScrollArea className="min-h-0 flex-1">
         <div className="grid divide-y divide-white/[0.06]">
           <DeveloperNotificationSection />
           <DeveloperUpdateSection />
           <ErrorTrackingSection />
         </div>
-      </div>
+      </ScrollArea>
     </div>
   );
 }

--- a/packages/desktop-app/src/test-setup.ts
+++ b/packages/desktop-app/src/test-setup.ts
@@ -30,3 +30,9 @@ afterEach(() => {
   clearMocks();
   vi.useRealTimers();
 });
+
+// jsdom has no Web Animations API. Base UI's ScrollArea calls getAnimations()
+// on the viewport from a timer, which throws after a test has finished.
+if (!Element.prototype.getAnimations) {
+  Element.prototype.getAnimations = () => [];
+}

--- a/packages/desktop-app/src/test-setup.ts
+++ b/packages/desktop-app/src/test-setup.ts
@@ -1,4 +1,5 @@
 import "@testing-library/jest-dom/vitest";
+import "@everr/ui/testing/jsdom-shims";
 import { clearMocks } from "@tauri-apps/api/mocks";
 import { cleanup } from "@testing-library/react";
 import { afterEach, vi } from "vitest";
@@ -30,9 +31,3 @@ afterEach(() => {
   clearMocks();
   vi.useRealTimers();
 });
-
-// jsdom has no Web Animations API. Base UI's ScrollArea calls getAnimations()
-// on the viewport from a timer, which throws after a test has finished.
-if (!Element.prototype.getAnimations) {
-  Element.prototype.getAnimations = () => [];
-}

--- a/packages/storybook/src/stories/data-table.stories.tsx
+++ b/packages/storybook/src/stories/data-table.stories.tsx
@@ -134,7 +134,7 @@ export const StickyHeader: Story = {
     ],
     rowKey: (row: ServiceRow) => `${row.service}-${row.environment}`,
     stickyHeader: true,
-    containerClassName: "h-56 overflow-auto rounded-lg border border-border",
+    containerClassName: "h-56 rounded-lg border border-border",
   },
 };
 

--- a/packages/storybook/src/stories/scroll-area.stories.tsx
+++ b/packages/storybook/src/stories/scroll-area.stories.tsx
@@ -61,3 +61,60 @@ export const ContentThatFits: Story = {
     </ScrollArea>
   ),
 };
+
+export const MaxHeightRoot: Story = {
+  render: () => (
+    <ScrollArea className="border-border max-h-[320px] w-72 rounded-md border">
+      <ul className="grid gap-1 p-3 font-mono text-sm">
+        {services.map((service) => (
+          <li key={service}>{service}</li>
+        ))}
+      </ul>
+    </ScrollArea>
+  ),
+};
+
+export const AutoHeightRootInDefiniteAncestor: Story = {
+  render: () => (
+    <div className="border-border flex h-96 w-96 flex-col gap-2 rounded-md border p-2">
+      <ScrollArea
+        orientation="horizontal"
+        className="border-border w-full rounded-md border"
+      >
+        <p className="whitespace-nowrap p-3 font-mono text-sm">{wideRow}</p>
+      </ScrollArea>
+      <p className="text-muted-foreground text-sm">
+        The strip above stays one line tall.
+      </p>
+    </div>
+  ),
+};
+
+export const FlexOneRoot: Story = {
+  render: () => (
+    <div className="border-border flex h-64 w-72 flex-col rounded-md border">
+      <p className="border-border border-b p-2 font-mono text-sm">header</p>
+      <ScrollArea className="min-h-0 flex-1">
+        <ul className="grid gap-1 p-3 font-mono text-sm">
+          {services.map((service) => (
+            <li key={service}>{service}</li>
+          ))}
+        </ul>
+      </ScrollArea>
+    </div>
+  ),
+};
+
+export const FullHeightRoot: Story = {
+  render: () => (
+    <div className="border-border h-64 w-72 rounded-md border">
+      <ScrollArea className="h-full">
+        <ul className="grid gap-1 p-3 font-mono text-sm">
+          {services.map((service) => (
+            <li key={service}>{service}</li>
+          ))}
+        </ul>
+      </ScrollArea>
+    </div>
+  ),
+};

--- a/packages/storybook/src/stories/scroll-area.stories.tsx
+++ b/packages/storybook/src/stories/scroll-area.stories.tsx
@@ -1,0 +1,63 @@
+import { ScrollArea } from "@everr/ui/components/scroll-area";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Layout/ScrollArea",
+  component: ScrollArea,
+} satisfies Meta<typeof ScrollArea>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const services = Array.from({ length: 40 }, (_, i) => `checkout-api-${i + 1}`);
+
+const wideRow =
+  "service.name = checkout-api  deployment.environment = production  http.route = /cart/checkout  http.status_code = 200";
+
+export const Default: Story = {
+  render: (args) => (
+    <ScrollArea {...args} className="border-border h-64 w-72 rounded-md border">
+      <ul className="grid gap-1 p-3 font-mono text-sm">
+        {services.map((service) => (
+          <li key={service}>{service}</li>
+        ))}
+      </ul>
+    </ScrollArea>
+  ),
+};
+
+export const Horizontal: Story = {
+  render: () => (
+    <ScrollArea
+      orientation="horizontal"
+      className="border-border w-72 rounded-md border"
+    >
+      <p className="whitespace-nowrap p-3 font-mono text-sm">{wideRow}</p>
+    </ScrollArea>
+  ),
+};
+
+export const BothAxes: Story = {
+  render: () => (
+    <ScrollArea
+      orientation="both"
+      className="border-border h-64 w-72 rounded-md border"
+    >
+      <ul className="grid w-max gap-1 p-3 font-mono text-sm">
+        {services.map((service) => (
+          <li key={service} className="whitespace-nowrap">
+            {service} {wideRow}
+          </li>
+        ))}
+      </ul>
+    </ScrollArea>
+  ),
+};
+
+export const ContentThatFits: Story = {
+  render: () => (
+    <ScrollArea className="border-border h-64 w-72 rounded-md border">
+      <p className="p-3 font-mono text-sm">checkout-api</p>
+    </ScrollArea>
+  ),
+};

--- a/packages/telemetry-explorer/src/errors/ui/error-detail.tsx
+++ b/packages/telemetry-explorer/src/errors/ui/error-detail.tsx
@@ -122,6 +122,9 @@ export function ErrorDetail({
         actions={<ErrorHandoffButton issue={detail.summary} />}
       />
       <ScrollArea render={<main />} className="min-h-0 flex-1">
+        {/* The column is centred inside a full-width scroller, so its width
+            bound belongs to a child: on the viewport it would narrow the
+            scrolling box itself and pull the scrollbar in with it. */}
         <div className="mx-auto grid max-w-7xl gap-3 p-3">
           <ErrorStacktrace
             stacktrace={selected.exceptionStacktrace}

--- a/packages/telemetry-explorer/src/errors/ui/error-detail.tsx
+++ b/packages/telemetry-explorer/src/errors/ui/error-detail.tsx
@@ -6,6 +6,7 @@ import {
   EmptyHeader,
   EmptyTitle,
 } from "@everr/ui/components/empty";
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { Skeleton } from "@everr/ui/components/skeleton";
 import type { TimeRange } from "@everr/ui/lib/time-range";
 import { useQuery } from "@tanstack/react-query";
@@ -120,7 +121,7 @@ export function ErrorDetail({
         onClose={onClose}
         actions={<ErrorHandoffButton issue={detail.summary} />}
       />
-      <main className="min-h-0 flex-1 overflow-auto">
+      <ScrollArea render={<main />} className="min-h-0 flex-1">
         <div className="mx-auto grid max-w-7xl gap-3 p-3">
           <ErrorStacktrace
             stacktrace={selected.exceptionStacktrace}
@@ -136,7 +137,7 @@ export function ErrorDetail({
             />
           </div>
         </div>
-      </main>
+      </ScrollArea>
     </div>
   );
 }

--- a/packages/telemetry-explorer/src/errors/ui/error-issue-list.tsx
+++ b/packages/telemetry-explorer/src/errors/ui/error-issue-list.tsx
@@ -6,7 +6,7 @@ import {
   EmptyHeader,
   EmptyTitle,
 } from "@everr/ui/components/empty";
-import { ScrollAreaScroller } from "@everr/ui/components/scroll-area";
+import { virtuosoScrollAreaComponents } from "@everr/ui/components/scroll-area";
 import { Skeleton } from "@everr/ui/components/skeleton";
 import { RefreshCw } from "lucide-react";
 import { useCallback, useMemo } from "react";
@@ -39,7 +39,7 @@ export function ErrorIssueList({
 
   const components = useMemo(
     () => ({
-      Scroller: ScrollAreaScroller,
+      ...virtuosoScrollAreaComponents,
       Footer: () => (
         <div className="text-muted-foreground flex h-12 items-center justify-center px-3 text-xs">
           {isFetchingNextPage ? (

--- a/packages/telemetry-explorer/src/errors/ui/error-issue-list.tsx
+++ b/packages/telemetry-explorer/src/errors/ui/error-issue-list.tsx
@@ -6,6 +6,7 @@ import {
   EmptyHeader,
   EmptyTitle,
 } from "@everr/ui/components/empty";
+import { ScrollAreaScroller } from "@everr/ui/components/scroll-area";
 import { Skeleton } from "@everr/ui/components/skeleton";
 import { RefreshCw } from "lucide-react";
 import { useCallback, useMemo } from "react";
@@ -38,6 +39,7 @@ export function ErrorIssueList({
 
   const components = useMemo(
     () => ({
+      Scroller: ScrollAreaScroller,
       Footer: () => (
         <div className="text-muted-foreground flex h-12 items-center justify-center px-3 text-xs">
           {isFetchingNextPage ? (

--- a/packages/telemetry-explorer/src/errors/ui/error-stacktrace.tsx
+++ b/packages/telemetry-explorer/src/errors/ui/error-stacktrace.tsx
@@ -1,5 +1,5 @@
+import { CodeBlock } from "@everr/ui/components/code-block";
 import { CopyValueButton } from "@everr/ui/components/detail-panel";
-import { ScrollArea } from "@everr/ui/components/scroll-area";
 
 export function ErrorStacktrace({
   stacktrace,
@@ -20,14 +20,9 @@ export function ErrorStacktrace({
           className="opacity-100 focus-visible:opacity-100"
         />
       </div>
-      <ScrollArea
-        orientation="both"
-        className="max-h-[28rem] rounded-md bg-muted/40"
-      >
-        <pre className="p-3 text-xs leading-relaxed whitespace-pre">
-          <code className="font-mono">{stacktrace}</code>
-        </pre>
-      </ScrollArea>
+      <CodeBlock className="max-h-[28rem] rounded-md bg-muted/40">
+        <code className="font-mono">{stacktrace}</code>
+      </CodeBlock>
     </section>
   );
 }

--- a/packages/telemetry-explorer/src/errors/ui/error-stacktrace.tsx
+++ b/packages/telemetry-explorer/src/errors/ui/error-stacktrace.tsx
@@ -1,4 +1,5 @@
 import { CopyValueButton } from "@everr/ui/components/detail-panel";
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 
 export function ErrorStacktrace({
   stacktrace,
@@ -19,9 +20,14 @@ export function ErrorStacktrace({
           className="opacity-100 focus-visible:opacity-100"
         />
       </div>
-      <pre className="max-h-[28rem] overflow-auto rounded-md bg-muted/40 p-3 text-xs leading-relaxed">
-        <code className="font-mono">{stacktrace}</code>
-      </pre>
+      <ScrollArea
+        orientation="both"
+        className="max-h-[28rem] rounded-md bg-muted/40"
+      >
+        <pre className="p-3 text-xs leading-relaxed whitespace-pre">
+          <code className="font-mono">{stacktrace}</code>
+        </pre>
+      </ScrollArea>
     </section>
   );
 }

--- a/packages/telemetry-explorer/src/filters/ui/filter-sidebar.test.tsx
+++ b/packages/telemetry-explorer/src/filters/ui/filter-sidebar.test.tsx
@@ -2,6 +2,12 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { FilterSidebar } from "./filter-sidebar";
 
+// The ScrollArea viewport that wraps the rail also carries role="presentation",
+// so the decorative divider is matched by its own slot instead of by role.
+function divider(container: HTMLElement) {
+  return container.querySelector('[data-slot="filter-sidebar-divider"]');
+}
+
 describe("FilterSidebar", () => {
   it("renders the Filters header and children", () => {
     render(
@@ -48,7 +54,7 @@ describe("FilterSidebar", () => {
   });
 
   it("puts the persistent zone above the page zone, separated by a divider", () => {
-    render(
+    const { container } = render(
       <FilterSidebar
         label="Trace filters"
         hasActiveFilters={false}
@@ -63,11 +69,11 @@ describe("FilterSidebar", () => {
     expect(persistent.compareDocumentPosition(page)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
-    expect(screen.getByRole("presentation")).toBeInTheDocument();
+    expect(divider(container)).toBeInTheDocument();
   });
 
   it("omits the divider when there is no persistent zone", () => {
-    render(
+    const { container } = render(
       <FilterSidebar
         label="Trace filters"
         hasActiveFilters={false}
@@ -76,6 +82,6 @@ describe("FilterSidebar", () => {
         <div>page zone</div>
       </FilterSidebar>,
     );
-    expect(screen.queryByRole("presentation")).not.toBeInTheDocument();
+    expect(divider(container)).toBeNull();
   });
 });

--- a/packages/telemetry-explorer/src/filters/ui/filter-sidebar.tsx
+++ b/packages/telemetry-explorer/src/filters/ui/filter-sidebar.tsx
@@ -31,7 +31,16 @@ export function FilterSidebar({
 }) {
   return (
     <ScrollArea
-      render={<aside aria-label={label} />}
+      render={
+        <aside
+          aria-label={label}
+          // The Base UI ScrollArea root writes role="presentation" onto this
+          // element, which strips the implied landmark off the aside, so the
+          // explicit role is not redundant here: it wins the landmark back.
+          // biome-ignore lint/a11y/noRedundantRoles: overridden by Base UI
+          role="complementary"
+        />
+      }
       className="bg-muted/15 h-full min-h-0 border-b lg:border-r lg:border-b-0"
       viewportClassName="flex flex-col gap-3 p-3"
     >
@@ -44,6 +53,7 @@ export function FilterSidebar({
         <>
           <div className="flex flex-col gap-3">{persistentFilters}</div>
           <div
+            data-slot="filter-sidebar-divider"
             role="presentation"
             className="bg-border/80 my-1 h-0.5 shrink-0 rounded-full"
           />

--- a/packages/telemetry-explorer/src/filters/ui/filter-sidebar.tsx
+++ b/packages/telemetry-explorer/src/filters/ui/filter-sidebar.tsx
@@ -31,16 +31,7 @@ export function FilterSidebar({
 }) {
   return (
     <ScrollArea
-      render={
-        <aside
-          aria-label={label}
-          // The Base UI ScrollArea root writes role="presentation" onto this
-          // element, which strips the implied landmark off the aside, so the
-          // explicit role is not redundant here: it wins the landmark back.
-          // biome-ignore lint/a11y/noRedundantRoles: overridden by Base UI
-          role="complementary"
-        />
-      }
+      render={<aside aria-label={label} />}
       className="bg-muted/15 h-full min-h-0 border-b lg:border-r lg:border-b-0"
       viewportClassName="flex flex-col gap-3 p-3"
     >

--- a/packages/telemetry-explorer/src/filters/ui/filter-sidebar.tsx
+++ b/packages/telemetry-explorer/src/filters/ui/filter-sidebar.tsx
@@ -1,3 +1,4 @@
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { ListFilter } from "lucide-react";
 import type { ReactNode } from "react";
 
@@ -29,9 +30,10 @@ export function FilterSidebar({
   children: ReactNode;
 }) {
   return (
-    <aside
-      aria-label={label}
-      className="bg-muted/15 flex h-full min-h-0 flex-col gap-3 overflow-auto border-b p-3 lg:border-r lg:border-b-0"
+    <ScrollArea
+      render={<aside aria-label={label} />}
+      className="bg-muted/15 h-full min-h-0 border-b lg:border-r lg:border-b-0"
+      viewportClassName="flex flex-col gap-3 p-3"
     >
       <div className="text-muted-foreground flex items-center gap-2 text-[0.6875rem] font-medium tracking-wider uppercase">
         <ListFilter className="size-3.5" />
@@ -59,6 +61,6 @@ export function FilterSidebar({
           Clear page filters
         </button>
       )}
-    </aside>
+    </ScrollArea>
   );
 }

--- a/packages/telemetry-explorer/src/logs/ui/log-inspector.tsx
+++ b/packages/telemetry-explorer/src/logs/ui/log-inspector.tsx
@@ -6,6 +6,7 @@ import {
   DetailItem,
   DetailSection,
 } from "@everr/ui/components/detail-panel";
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { Skeleton } from "@everr/ui/components/skeleton";
 import { formatRelativeTime } from "@everr/ui/lib/timestamp";
 import { cn } from "@everr/ui/lib/utils";
@@ -258,7 +259,7 @@ export function LogInspectorPanel({
         </div>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-auto p-3">
+      <ScrollArea className="min-h-0 flex-1" viewportClassName="p-3">
         <div className="group relative mb-4 rounded-md border bg-background p-3">
           <div className="text-muted-foreground mb-2 text-xs font-medium">
             Message
@@ -292,7 +293,7 @@ export function LogInspectorPanel({
         ) : showSkeleton ? (
           <LogInspectorSkeleton />
         ) : null}
-      </div>
+      </ScrollArea>
     </div>
   );
 }

--- a/packages/telemetry-explorer/src/logs/ui/log-inspector.tsx
+++ b/packages/telemetry-explorer/src/logs/ui/log-inspector.tsx
@@ -259,7 +259,13 @@ export function LogInspectorPanel({
         </div>
       </div>
 
-      <ScrollArea className="min-h-0 flex-1" viewportClassName="p-3">
+      {/* Both axes: a log body is arbitrary text with no wrapping rule on it,
+          so a long unbroken line has to stay reachable sideways. */}
+      <ScrollArea
+        orientation="both"
+        className="min-h-0 flex-1"
+        viewportClassName="p-3"
+      >
         <div className="group relative mb-4 rounded-md border bg-background p-3">
           <div className="text-muted-foreground mb-2 text-xs font-medium">
             Message

--- a/packages/telemetry-explorer/src/logs/ui/log-inspector.tsx
+++ b/packages/telemetry-explorer/src/logs/ui/log-inspector.tsx
@@ -264,9 +264,10 @@ export function LogInspectorPanel({
           <div className="text-muted-foreground mb-2 text-xs font-medium">
             Message
           </div>
-          {/* The body wraps on its own at spaces and hyphens. `break-words`
-              covers what has neither: a long path, an id, a base64 blob. */}
-          <div className="font-mono text-xs leading-5 break-words">
+          {/* Same treatment as a row in the list: keep the log's own line
+              breaks, wrap the long lines, and break a run that has nowhere to
+              wrap (a long path, an id, a base64 blob). */}
+          <div className="font-mono text-xs leading-5 whitespace-pre-wrap break-words">
             <Ansi useClasses>{log.body}</Ansi>
           </div>
           <CopyValueButton

--- a/packages/telemetry-explorer/src/logs/ui/log-inspector.tsx
+++ b/packages/telemetry-explorer/src/logs/ui/log-inspector.tsx
@@ -259,18 +259,14 @@ export function LogInspectorPanel({
         </div>
       </div>
 
-      {/* Both axes: a log body is arbitrary text with no wrapping rule on it,
-          so a long unbroken line has to stay reachable sideways. */}
-      <ScrollArea
-        orientation="both"
-        className="min-h-0 flex-1"
-        viewportClassName="p-3"
-      >
+      <ScrollArea className="min-h-0 flex-1" viewportClassName="p-3">
         <div className="group relative mb-4 rounded-md border bg-background p-3">
           <div className="text-muted-foreground mb-2 text-xs font-medium">
             Message
           </div>
-          <div className="font-mono text-xs leading-5">
+          {/* The body wraps on its own at spaces and hyphens. `break-words`
+              covers what has neither: a long path, an id, a base64 blob. */}
+          <div className="font-mono text-xs leading-5 break-words">
             <Ansi useClasses>{log.body}</Ansi>
           </div>
           <CopyValueButton

--- a/packages/telemetry-explorer/src/logs/ui/logs-explorer.tsx
+++ b/packages/telemetry-explorer/src/logs/ui/logs-explorer.tsx
@@ -4,7 +4,7 @@ import {
   DialogTitle,
 } from "@everr/ui/components/dialog";
 import { RetryError } from "@everr/ui/components/retry-error";
-import { ScrollAreaScroller } from "@everr/ui/components/scroll-area";
+import { virtuosoScrollAreaComponents } from "@everr/ui/components/scroll-area";
 import { Skeleton } from "@everr/ui/components/skeleton";
 import type { TimeRange } from "@everr/ui/lib/time-range";
 import { cn } from "@everr/ui/lib/utils";
@@ -119,7 +119,7 @@ function LogStream({
 
   const components = useMemo(
     () => ({
-      Scroller: ScrollAreaScroller,
+      ...virtuosoScrollAreaComponents,
       Footer: () => (
         <div className="text-muted-foreground flex h-12 items-center justify-center px-3 text-xs">
           {isFetchingNextPage ? (

--- a/packages/telemetry-explorer/src/logs/ui/logs-explorer.tsx
+++ b/packages/telemetry-explorer/src/logs/ui/logs-explorer.tsx
@@ -4,6 +4,7 @@ import {
   DialogTitle,
 } from "@everr/ui/components/dialog";
 import { RetryError } from "@everr/ui/components/retry-error";
+import { ScrollAreaScroller } from "@everr/ui/components/scroll-area";
 import { Skeleton } from "@everr/ui/components/skeleton";
 import type { TimeRange } from "@everr/ui/lib/time-range";
 import { cn } from "@everr/ui/lib/utils";
@@ -118,6 +119,7 @@ function LogStream({
 
   const components = useMemo(
     () => ({
+      Scroller: ScrollAreaScroller,
       Footer: () => (
         <div className="text-muted-foreground flex h-12 items-center justify-center px-3 text-xs">
           {isFetchingNextPage ? (

--- a/packages/telemetry-explorer/src/runs/ui/runs-results-list.tsx
+++ b/packages/telemetry-explorer/src/runs/ui/runs-results-list.tsx
@@ -7,7 +7,7 @@ import {
   EmptyTitle,
 } from "@everr/ui/components/empty";
 import { RetryError } from "@everr/ui/components/retry-error";
-import { ScrollAreaScroller } from "@everr/ui/components/scroll-area";
+import { virtuosoScrollAreaComponents } from "@everr/ui/components/scroll-area";
 import { Skeleton } from "@everr/ui/components/skeleton";
 import {
   Tooltip,
@@ -98,7 +98,7 @@ export function RunsResultsList({
 
   const components = useMemo(
     () => ({
-      Scroller: ScrollAreaScroller,
+      ...virtuosoScrollAreaComponents,
       Footer: () => (
         <ResultsFooter
           count={runs.length}

--- a/packages/telemetry-explorer/src/runs/ui/runs-results-list.tsx
+++ b/packages/telemetry-explorer/src/runs/ui/runs-results-list.tsx
@@ -7,6 +7,7 @@ import {
   EmptyTitle,
 } from "@everr/ui/components/empty";
 import { RetryError } from "@everr/ui/components/retry-error";
+import { ScrollAreaScroller } from "@everr/ui/components/scroll-area";
 import { Skeleton } from "@everr/ui/components/skeleton";
 import {
   Tooltip,
@@ -97,6 +98,7 @@ export function RunsResultsList({
 
   const components = useMemo(
     () => ({
+      Scroller: ScrollAreaScroller,
       Footer: () => (
         <ResultsFooter
           count={runs.length}

--- a/packages/telemetry-explorer/src/test-setup.ts
+++ b/packages/telemetry-explorer/src/test-setup.ts
@@ -1,4 +1,5 @@
 import "@testing-library/jest-dom/vitest";
+import "@everr/ui/testing/jsdom-shims";
 
 // jsdom lacks a few browser APIs that base-ui (popover positioning) and cmdk
 // (command list highlighting) call during render. Provide noop polyfills so
@@ -13,10 +14,4 @@ if (!globalThis.ResizeObserver) {
 
 if (!Element.prototype.scrollIntoView) {
   Element.prototype.scrollIntoView = () => {};
-}
-
-// jsdom has no Web Animations API. Base UI's ScrollArea calls getAnimations()
-// on the viewport from a timer, which throws after a test has finished.
-if (!Element.prototype.getAnimations) {
-  Element.prototype.getAnimations = () => [];
 }

--- a/packages/telemetry-explorer/src/test-setup.ts
+++ b/packages/telemetry-explorer/src/test-setup.ts
@@ -14,3 +14,9 @@ if (!globalThis.ResizeObserver) {
 if (!Element.prototype.scrollIntoView) {
   Element.prototype.scrollIntoView = () => {};
 }
+
+// jsdom has no Web Animations API. Base UI's ScrollArea calls getAnimations()
+// on the viewport from a timer, which throws after a test has finished.
+if (!Element.prototype.getAnimations) {
+  Element.prototype.getAnimations = () => [];
+}

--- a/packages/telemetry-explorer/src/traces/ui/timeline/span-detail-panel.tsx
+++ b/packages/telemetry-explorer/src/traces/ui/timeline/span-detail-panel.tsx
@@ -4,6 +4,7 @@ import {
   DetailItem,
   DetailSection,
 } from "@everr/ui/components/detail-panel";
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { formatDuration } from "@everr/ui/lib/formatting";
 import { Clock3, Fingerprint, Server, X } from "lucide-react";
 import type { Span } from "../../data/types";
@@ -36,7 +37,7 @@ export function SpanDetailPanel({ span, traceStartNs, onClose }: Props) {
         </Button>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-auto p-3">
+      <ScrollArea className="min-h-0 flex-1" viewportClassName="p-3">
         <DetailSection title="Overview">
           <DetailItem
             icon={<Server />}
@@ -122,7 +123,7 @@ export function SpanDetailPanel({ span, traceStartNs, onClose }: Props) {
             ))}
           </DetailSection>
         ) : null}
-      </div>
+      </ScrollArea>
     </aside>
   );
 }

--- a/packages/telemetry-explorer/src/traces/ui/timeline/timeline-view.tsx
+++ b/packages/telemetry-explorer/src/traces/ui/timeline/timeline-view.tsx
@@ -1,9 +1,14 @@
+import { ScrollAreaScroller } from "@everr/ui/components/scroll-area";
 import { useMemo } from "react";
 import { Virtuoso } from "react-virtuoso";
 import type { Span } from "../../data/types";
 import { SpanDetailPanel } from "./span-detail-panel";
 import { SpanRow } from "./span-row";
 import { useTimelineLayout } from "./use-timeline-layout";
+
+// Kept at module level: virtuoso remounts the scroller, and so loses the
+// scroll position, whenever the component identity changes.
+const components = { Scroller: ScrollAreaScroller };
 
 type Props = {
   spans: Span[];
@@ -26,6 +31,7 @@ export function TimelineView({ spans, focusedSpan, onSelectSpan }: Props) {
       <Virtuoso
         className="flex-1"
         data={rows}
+        components={components}
         computeItemKey={(_, row) => row.span.spanId}
         itemContent={(_, row) => (
           <SpanRow

--- a/packages/telemetry-explorer/src/traces/ui/timeline/timeline-view.tsx
+++ b/packages/telemetry-explorer/src/traces/ui/timeline/timeline-view.tsx
@@ -1,14 +1,10 @@
-import { ScrollAreaScroller } from "@everr/ui/components/scroll-area";
+import { virtuosoScrollAreaComponents } from "@everr/ui/components/scroll-area";
 import { useMemo } from "react";
 import { Virtuoso } from "react-virtuoso";
 import type { Span } from "../../data/types";
 import { SpanDetailPanel } from "./span-detail-panel";
 import { SpanRow } from "./span-row";
 import { useTimelineLayout } from "./use-timeline-layout";
-
-// Kept at module level: virtuoso remounts the scroller, and so loses the
-// scroll position, whenever the component identity changes.
-const components = { Scroller: ScrollAreaScroller };
 
 type Props = {
   spans: Span[];
@@ -31,7 +27,7 @@ export function TimelineView({ spans, focusedSpan, onSelectSpan }: Props) {
       <Virtuoso
         className="flex-1"
         data={rows}
-        components={components}
+        components={virtuosoScrollAreaComponents}
         computeItemKey={(_, row) => row.span.spanId}
         itemContent={(_, row) => (
           <SpanRow

--- a/packages/telemetry-explorer/src/traces/ui/trace-results-list.tsx
+++ b/packages/telemetry-explorer/src/traces/ui/trace-results-list.tsx
@@ -7,6 +7,7 @@ import {
   EmptyTitle,
 } from "@everr/ui/components/empty";
 import { RetryError } from "@everr/ui/components/retry-error";
+import { ScrollAreaScroller } from "@everr/ui/components/scroll-area";
 import { Skeleton } from "@everr/ui/components/skeleton";
 import {
   Tooltip,
@@ -92,6 +93,7 @@ export function TraceResultsList({
 
   const components = useMemo(
     () => ({
+      Scroller: ScrollAreaScroller,
       Footer: () => (
         <ResultsFooter
           count={rows.length}

--- a/packages/telemetry-explorer/src/traces/ui/trace-results-list.tsx
+++ b/packages/telemetry-explorer/src/traces/ui/trace-results-list.tsx
@@ -7,7 +7,7 @@ import {
   EmptyTitle,
 } from "@everr/ui/components/empty";
 import { RetryError } from "@everr/ui/components/retry-error";
-import { ScrollAreaScroller } from "@everr/ui/components/scroll-area";
+import { virtuosoScrollAreaComponents } from "@everr/ui/components/scroll-area";
 import { Skeleton } from "@everr/ui/components/skeleton";
 import {
   Tooltip,
@@ -93,7 +93,7 @@ export function TraceResultsList({
 
   const components = useMemo(
     () => ({
-      Scroller: ScrollAreaScroller,
+      ...virtuosoScrollAreaComponents,
       Footer: () => (
         <ResultsFooter
           count={rows.length}

--- a/packages/ui/src/components/code-block.tsx
+++ b/packages/ui/src/components/code-block.tsx
@@ -1,0 +1,28 @@
+import { ScrollArea } from "@everr/ui/components/scroll-area";
+import { cn } from "@everr/ui/lib/utils";
+import type { ReactNode } from "react";
+
+/**
+ * Preformatted text in a box that scrolls both ways. The `<pre>` no longer owns
+ * the scroll, so the box is what bounds the height, and long lines keep running
+ * off the side instead of wrapping.
+ */
+export function CodeBlock({
+  className,
+  codeClassName,
+  children,
+}: {
+  /** The box: its height bound, background and border. */
+  className?: string;
+  /** The text: its padding, size and colour. */
+  codeClassName?: string;
+  children: ReactNode;
+}) {
+  return (
+    <ScrollArea orientation="both" className={className}>
+      <pre className={cn("p-3 text-xs leading-relaxed", codeClassName)}>
+        {children}
+      </pre>
+    </ScrollArea>
+  );
+}

--- a/packages/ui/src/components/command.tsx
+++ b/packages/ui/src/components/command.tsx
@@ -104,11 +104,9 @@ function CommandList({
     <ScrollArea
       className={cn("max-h-72", className)}
       // scroll-py-1 is scroll-padding, so it only counts on the element that
-      // scrolls. Base UI writes `overflow: scroll` inline on the viewport, so
-      // the horizontal axis has to be hidden inline as well.
+      // scrolls.
       viewportClassName="scroll-py-1 outline-none"
       viewportProps={{
-        style: { overflowX: "hidden" },
         render: <CommandPrimitive.List data-slot="command-list" {...props} />,
       }}
     >

--- a/packages/ui/src/components/command.tsx
+++ b/packages/ui/src/components/command.tsx
@@ -6,6 +6,7 @@ import {
   DialogTitle,
 } from "@everr/ui/components/dialog";
 import { InputGroup, InputGroupAddon } from "@everr/ui/components/input-group";
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { cn } from "@everr/ui/lib/utils";
 import { Command as CommandPrimitive } from "cmdk";
 import { CheckIcon, SearchIcon } from "lucide-react";
@@ -96,17 +97,23 @@ function CommandInput({
 
 function CommandList({
   className,
+  children,
   ...props
 }: React.ComponentProps<typeof CommandPrimitive.List>) {
   return (
-    <CommandPrimitive.List
-      data-slot="command-list"
-      className={cn(
-        "max-h-72 scroll-py-1 outline-none overflow-x-hidden overflow-y-auto",
-        className,
-      )}
-      {...props}
-    />
+    <ScrollArea
+      className={cn("max-h-72", className)}
+      // scroll-py-1 is scroll-padding, so it only counts on the element that
+      // scrolls. Base UI writes `overflow: scroll` inline on the viewport, so
+      // the horizontal axis has to be hidden inline as well.
+      viewportClassName="scroll-py-1 outline-none"
+      viewportProps={{
+        style: { overflowX: "hidden" },
+        render: <CommandPrimitive.List data-slot="command-list" {...props} />,
+      }}
+    >
+      {children}
+    </ScrollArea>
   );
 }
 

--- a/packages/ui/src/components/command.tsx
+++ b/packages/ui/src/components/command.tsx
@@ -102,7 +102,7 @@ function CommandList({
     <CommandPrimitive.List
       data-slot="command-list"
       className={cn(
-        "no-scrollbar max-h-72 scroll-py-1 outline-none overflow-x-hidden overflow-y-auto",
+        "max-h-72 scroll-py-1 outline-none overflow-x-hidden overflow-y-auto",
         className,
       )}
       {...props}

--- a/packages/ui/src/components/data-table.tsx
+++ b/packages/ui/src/components/data-table.tsx
@@ -1,3 +1,4 @@
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { cn } from "@everr/ui/lib/utils";
 import type { MouseEvent, ReactNode } from "react";
 
@@ -43,72 +44,83 @@ export function DataTable<T>({
   const isFirst = (i: number) => i === 0;
   const isLast = (i: number) => i === columns.length - 1;
 
-  return (
-    <div className={cn(!bordered && "overflow-x-auto", containerClassName)}>
-      <table
-        className={cn(
-          "w-full text-sm",
-          bordered && "border-separate border-spacing-0",
-        )}
-      >
-        <thead className={cn(stickyHeader && "sticky top-0 z-10 bg-card")}>
-          <tr className="text-left text-muted-foreground">
-            {columns.map((col, i) => (
-              <th
-                key={i}
-                className={cn(
-                  "whitespace-nowrap",
-                  col.className ??
-                    (bordered
-                      ? "border-b border-r border-border px-3 py-2 font-medium last:border-r-0"
-                      : cn(
-                          "pb-2",
-                          !isLast(i) && "pr-4",
-                          isFirst(i) && "pl-3",
-                          isLast(i) && "pr-3",
-                        )),
-                )}
-              >
-                {col.header}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody className={bordered ? "[&>tr:last-child>td]:border-b-0" : ""}>
-          {data.map((row, rowIndex) => (
-            <tr
-              key={rowKey(row, rowIndex)}
-              onClick={
-                onRowClick ? (event) => onRowClick(row, event) : undefined
-              }
+  const table = (
+    <table
+      className={cn(
+        "w-full text-sm",
+        bordered && "border-separate border-spacing-0",
+      )}
+    >
+      <thead className={cn(stickyHeader && "sticky top-0 z-10 bg-card")}>
+        <tr className="text-left text-muted-foreground">
+          {columns.map((col, i) => (
+            <th
+              key={i}
               className={cn(
-                "hover:bg-muted/50",
-                !bordered && "border-b last:border-0",
-                rowClassName?.(row, rowIndex),
+                "whitespace-nowrap",
+                col.className ??
+                  (bordered
+                    ? "border-b border-r border-border px-3 py-2 font-medium last:border-r-0"
+                    : cn(
+                        "pb-2",
+                        !isLast(i) && "pr-4",
+                        isFirst(i) && "pl-3",
+                        isLast(i) && "pr-3",
+                      )),
               )}
             >
-              {columns.map((col, i) => (
-                <td
-                  key={i}
-                  className={
-                    col.cellClassName ??
-                    (bordered
-                      ? "border-b border-r border-border px-3 py-2 last:border-r-0"
-                      : cn(
-                          "py-2",
-                          !isLast(i) && "pr-4",
-                          isFirst(i) && "pl-3",
-                          isLast(i) && "pr-3",
-                        ))
-                  }
-                >
-                  {col.cell(row)}
-                </td>
-              ))}
-            </tr>
+              {col.header}
+            </th>
           ))}
-        </tbody>
-      </table>
-    </div>
+        </tr>
+      </thead>
+      <tbody className={bordered ? "[&>tr:last-child>td]:border-b-0" : ""}>
+        {data.map((row, rowIndex) => (
+          <tr
+            key={rowKey(row, rowIndex)}
+            onClick={onRowClick ? (event) => onRowClick(row, event) : undefined}
+            className={cn(
+              "hover:bg-muted/50",
+              !bordered && "border-b last:border-0",
+              rowClassName?.(row, rowIndex),
+            )}
+          >
+            {columns.map((col, i) => (
+              <td
+                key={i}
+                className={
+                  col.cellClassName ??
+                  (bordered
+                    ? "border-b border-r border-border px-3 py-2 last:border-r-0"
+                    : cn(
+                        "py-2",
+                        !isLast(i) && "pr-4",
+                        isFirst(i) && "pl-3",
+                        isLast(i) && "pr-3",
+                      ))
+                }
+              >
+                {col.cell(row)}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+
+  // A bordered table is always placed inside a scroll box owned by the caller,
+  // so it must not add a second one: nesting two viewports would leave the
+  // inner one unable to overflow and would double the tab stops.
+  if (bordered) {
+    return <div className={containerClassName}>{table}</div>;
+  }
+
+  // Both axes: a table overflows sideways on narrow panes, and the viewport
+  // scrolls on both axes regardless, so a missing scrollbar would be silent.
+  return (
+    <ScrollArea className={containerClassName} orientation="both">
+      {table}
+    </ScrollArea>
   );
 }

--- a/packages/ui/src/components/data-table.tsx
+++ b/packages/ui/src/components/data-table.tsx
@@ -17,6 +17,12 @@ interface DataTableProps<T> {
   emptyState?: ReactNode;
   stickyHeader?: boolean;
   bordered?: boolean;
+  /**
+   * Whether the table brings its own scroll box. Turn it off when the caller
+   * already owns one: nesting two viewports leaves the inner one unable to
+   * overflow and doubles the tab stops.
+   */
+  scrollable?: boolean;
   containerClassName?: string;
   /**
    * Makes rows clickable (mouse convenience). Keep a real link inside a cell as
@@ -34,6 +40,7 @@ export function DataTable<T>({
   emptyState,
   stickyHeader,
   bordered,
+  scrollable = true,
   containerClassName,
   onRowClick,
 }: DataTableProps<T>) {
@@ -109,15 +116,12 @@ export function DataTable<T>({
     </table>
   );
 
-  // A bordered table is always placed inside a scroll box owned by the caller,
-  // so it must not add a second one: nesting two viewports would leave the
-  // inner one unable to overflow and would double the tab stops.
-  if (bordered) {
+  if (!scrollable) {
     return <div className={containerClassName}>{table}</div>;
   }
 
-  // Both axes: a table overflows sideways on narrow panes, and the viewport
-  // scrolls on both axes regardless, so a missing scrollbar would be silent.
+  // Both axes: a table overflows sideways on narrow panes as readily as it
+  // does downwards, and a missing scrollbar on either would be silent.
   return (
     <ScrollArea className={containerClassName} orientation="both">
       {table}

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -21,14 +21,17 @@ function DropdownMenuContent({
   side = "bottom",
   sideOffset = 4,
   className,
-  viewportClassName,
+  listClassName,
   children,
   ...props
 }: MenuPrimitive.Popup.Props &
   Pick<
     MenuPrimitive.Positioner.Props,
     "align" | "alignOffset" | "side" | "sideOffset"
-  > & { viewportClassName?: string }) {
+  > & {
+    /** Extra layout for the scrolling item list, e.g. a height bound on it. */
+    listClassName?: string;
+  }) {
   return (
     <MenuPrimitive.Portal>
       <MenuPrimitive.Positioner
@@ -51,8 +54,7 @@ function DropdownMenuContent({
               has to sit on the viewport to scroll with the items. */}
           <ScrollArea
             className="max-h-(--available-height)"
-            viewportClassName={cn("p-1", viewportClassName)}
-            viewportProps={{ style: { overflowX: "hidden" } }}
+            viewportClassName={cn("p-1", listClassName)}
           >
             {children}
           </ScrollArea>

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -1,4 +1,5 @@
 import { Menu as MenuPrimitive } from "@base-ui/react/menu";
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { cn } from "@everr/ui/lib/utils";
 import { CheckIcon, ChevronRightIcon } from "lucide-react";
 
@@ -20,12 +21,14 @@ function DropdownMenuContent({
   side = "bottom",
   sideOffset = 4,
   className,
+  viewportClassName,
+  children,
   ...props
 }: MenuPrimitive.Popup.Props &
   Pick<
     MenuPrimitive.Positioner.Props,
     "align" | "alignOffset" | "side" | "sideOffset"
-  >) {
+  > & { viewportClassName?: string }) {
   return (
     <MenuPrimitive.Portal>
       <MenuPrimitive.Positioner
@@ -38,11 +41,22 @@ function DropdownMenuContent({
         <MenuPrimitive.Popup
           data-slot="dropdown-menu-content"
           className={cn(
-            "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-32 rounded-lg p-1 shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 z-50 max-h-(--available-height) w-(--anchor-width) origin-(--transform-origin) overflow-x-hidden overflow-y-auto outline-none data-closed:overflow-hidden",
+            "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-32 rounded-lg shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 z-50 w-(--anchor-width) origin-(--transform-origin) outline-none",
             className,
           )}
           {...props}
-        />
+        >
+          {/* The popup keeps the positioning and the animation; the scroll area
+              inside it owns the height bound and the scrolling, so the padding
+              has to sit on the viewport to scroll with the items. */}
+          <ScrollArea
+            className="max-h-(--available-height)"
+            viewportClassName={cn("p-1", viewportClassName)}
+            viewportProps={{ style: { overflowX: "hidden" } }}
+          >
+            {children}
+          </ScrollArea>
+        </MenuPrimitive.Popup>
       </MenuPrimitive.Positioner>
     </MenuPrimitive.Portal>
   );
@@ -157,7 +171,7 @@ function DropdownMenuSubContent({
     <DropdownMenuContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-32 rounded-lg p-1 shadow-md ring-1 duration-100 w-auto",
+        "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-32 rounded-lg shadow-md ring-1 duration-100 w-auto",
         className,
       )}
       align={align}

--- a/packages/ui/src/components/scroll-area.test.tsx
+++ b/packages/ui/src/components/scroll-area.test.tsx
@@ -1,6 +1,33 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
 import { ScrollArea, ScrollAreaScroller } from "./scroll-area";
+
+// jsdom lays nothing out, so every element measures 0x0 and Base UI reads the
+// scroll area as having nothing to scroll. Scrollbars only mount for an axis
+// that overflows, so the size has to be faked for them to appear at all.
+const sizeKeys = [
+  "clientHeight",
+  "clientWidth",
+  "scrollHeight",
+  "scrollWidth",
+] as const;
+
+function overflowBothAxes() {
+  for (const key of sizeKeys) {
+    Object.defineProperty(HTMLElement.prototype, key, {
+      configurable: true,
+      get() {
+        return key.startsWith("scroll") ? 500 : 100;
+      },
+    });
+  }
+}
+
+afterEach(() => {
+  for (const key of sizeKeys) {
+    delete (HTMLElement.prototype as Partial<HTMLElement>)[key];
+  }
+});
 
 describe("ScrollArea", () => {
   it("renders its children inside the viewport", () => {
@@ -40,28 +67,83 @@ describe("ScrollArea", () => {
     expect(viewport).toHaveAttribute("data-scroll-to-top", "");
   });
 
-  it("renders only the vertical scrollbar by default", () => {
+  it("renders only the vertical scrollbar by default", async () => {
+    overflowBothAxes();
     const { container } = render(
       <ScrollArea>
         <p>content</p>
       </ScrollArea>,
     );
-    const bars = container.querySelectorAll(
-      "[data-slot='scroll-area-scrollbar']",
-    );
-    expect(bars).toHaveLength(1);
-    expect(bars[0]).toHaveAttribute("data-orientation", "vertical");
+    await waitFor(() => {
+      const bars = container.querySelectorAll(
+        "[data-slot='scroll-area-scrollbar']",
+      );
+      expect(bars).toHaveLength(1);
+      expect(bars[0]).toHaveAttribute("data-orientation", "vertical");
+    });
   });
 
-  it("renders both scrollbars when orientation is both", () => {
+  it("clips the axis it does not scroll", () => {
+    const { container } = render(
+      <>
+        <ScrollArea>
+          <p>vertical</p>
+        </ScrollArea>
+        <ScrollArea orientation="horizontal">
+          <p>horizontal</p>
+        </ScrollArea>
+        <ScrollArea orientation="both">
+          <p>both</p>
+        </ScrollArea>
+      </>,
+    );
+    const [v, h, b] = Array.from(
+      container.querySelectorAll<HTMLElement>(
+        "[data-slot='scroll-area-viewport']",
+      ),
+    );
+    expect(v?.style.overflowX).toBe("hidden");
+    expect(v?.style.overflowY).toBe("");
+    expect(h?.style.overflowY).toBe("hidden");
+    expect(h?.style.overflowX).toBe("");
+    expect(b?.style.overflowX).toBe("");
+    expect(b?.style.overflowY).toBe("");
+  });
+
+  it("keeps the landmark of a semantic render element", () => {
+    render(
+      <ScrollArea render={<main />}>
+        <p>content</p>
+      </ScrollArea>,
+    );
+    expect(screen.getByRole("main")).toBeInTheDocument();
+  });
+
+  it("renders both scrollbars when orientation is both", async () => {
+    overflowBothAxes();
     const { container } = render(
       <ScrollArea orientation="both">
         <p>content</p>
       </ScrollArea>,
     );
-    expect(
-      container.querySelectorAll("[data-slot='scroll-area-scrollbar']"),
-    ).toHaveLength(2);
+    await waitFor(() =>
+      expect(
+        container.querySelectorAll("[data-slot='scroll-area-scrollbar']"),
+      ).toHaveLength(2),
+    );
+  });
+
+  it("renders no scrollbar for an axis with nothing to scroll", async () => {
+    const { container } = render(
+      <ScrollArea orientation="both">
+        <p>content</p>
+      </ScrollArea>,
+    );
+    await waitFor(() =>
+      expect(
+        container.querySelectorAll("[data-slot='scroll-area-scrollbar']"),
+      ).toHaveLength(0),
+    );
   });
 });
 

--- a/packages/ui/src/components/scroll-area.test.tsx
+++ b/packages/ui/src/components/scroll-area.test.tsx
@@ -28,6 +28,18 @@ describe("ScrollArea", () => {
     expect(viewport).toHaveAttribute("data-slot", "scroll-area-viewport");
   });
 
+  it("forwards viewportProps to the viewport element", () => {
+    render(
+      <ScrollArea viewportProps={{ "data-scroll-to-top": "" }}>
+        <p>content</p>
+      </ScrollArea>,
+    );
+    const viewport = screen
+      .getByText("content")
+      .closest("[data-slot='scroll-area-viewport']");
+    expect(viewport).toHaveAttribute("data-scroll-to-top", "");
+  });
+
   it("renders only the vertical scrollbar by default", () => {
     const { container } = render(
       <ScrollArea>

--- a/packages/ui/src/components/scroll-area.test.tsx
+++ b/packages/ui/src/components/scroll-area.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { ScrollArea } from "./scroll-area";
+import { ScrollArea, ScrollAreaScroller } from "./scroll-area";
 
 describe("ScrollArea", () => {
   it("renders its children inside the viewport", () => {
@@ -62,5 +62,53 @@ describe("ScrollArea", () => {
     expect(
       container.querySelectorAll("[data-slot='scroll-area-scrollbar']"),
     ).toHaveLength(2);
+  });
+});
+
+describe("ScrollAreaScroller", () => {
+  it("puts the ref and the virtuoso attributes on the scrolling viewport", () => {
+    let scroller: HTMLDivElement | null = null;
+    render(
+      <ScrollAreaScroller
+        ref={(node) => {
+          scroller = node;
+        }}
+        data-virtuoso-scroller
+        tabIndex={0}
+        style={{ position: "relative", overflowY: "auto" }}
+      >
+        <p>rows</p>
+      </ScrollAreaScroller>,
+    );
+    expect(scroller).toHaveAttribute("data-slot", "scroll-area-viewport");
+    expect(scroller).toHaveAttribute("data-virtuoso-scroller");
+    expect(scroller).toHaveAttribute("tabindex", "0");
+    expect(scroller).toHaveStyle({ position: "relative" });
+  });
+
+  it("leaves the overflow of the viewport to the scroll area", () => {
+    const { container } = render(
+      <ScrollAreaScroller style={{ overflowY: "auto" }}>
+        <p>rows</p>
+      </ScrollAreaScroller>,
+    );
+    const viewport = container.querySelector<HTMLDivElement>(
+      "[data-slot='scroll-area-viewport']",
+    );
+    expect(viewport?.style.overflowY).toBe("");
+  });
+
+  it("sizes the root, not the viewport, from className", () => {
+    const { container } = render(
+      <ScrollAreaScroller className="h-full">
+        <p>rows</p>
+      </ScrollAreaScroller>,
+    );
+    expect(container.querySelector("[data-slot='scroll-area']")).toHaveClass(
+      "h-full",
+    );
+    expect(
+      container.querySelector("[data-slot='scroll-area-viewport']"),
+    ).not.toHaveClass("h-full");
   });
 });

--- a/packages/ui/src/components/scroll-area.test.tsx
+++ b/packages/ui/src/components/scroll-area.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ScrollArea } from "./scroll-area";
+
+describe("ScrollArea", () => {
+  it("renders its children inside the viewport", () => {
+    render(
+      <ScrollArea className="h-20">
+        <p>span attributes</p>
+      </ScrollArea>,
+    );
+    const child = screen.getByText("span attributes");
+    expect(child.closest("[data-slot='scroll-area-viewport']")).not.toBeNull();
+  });
+
+  it("forwards the viewport ref to the scrolling element", () => {
+    let viewport: HTMLDivElement | null = null;
+    render(
+      <ScrollArea
+        viewportRef={(node) => {
+          viewport = node;
+        }}
+      >
+        <p>content</p>
+      </ScrollArea>,
+    );
+    expect(viewport).not.toBeNull();
+    expect(viewport).toHaveAttribute("data-slot", "scroll-area-viewport");
+  });
+
+  it("renders only the vertical scrollbar by default", () => {
+    const { container } = render(
+      <ScrollArea>
+        <p>content</p>
+      </ScrollArea>,
+    );
+    const bars = container.querySelectorAll(
+      "[data-slot='scroll-area-scrollbar']",
+    );
+    expect(bars).toHaveLength(1);
+    expect(bars[0]).toHaveAttribute("data-orientation", "vertical");
+  });
+
+  it("renders both scrollbars when orientation is both", () => {
+    const { container } = render(
+      <ScrollArea orientation="both">
+        <p>content</p>
+      </ScrollArea>,
+    );
+    expect(
+      container.querySelectorAll("[data-slot='scroll-area-scrollbar']"),
+    ).toHaveLength(2);
+  });
+});

--- a/packages/ui/src/components/scroll-area.tsx
+++ b/packages/ui/src/components/scroll-area.tsx
@@ -97,6 +97,8 @@ function ScrollAreaCorner({
 interface ScrollAreaProps extends ScrollAreaPrimitive.Root.Props {
   viewportClassName?: string;
   viewportRef?: React.Ref<HTMLDivElement>;
+  viewportProps?: ScrollAreaPrimitive.Viewport.Props &
+    Record<`data-${string}`, string>;
   orientation?: "vertical" | "horizontal" | "both";
 }
 
@@ -105,6 +107,13 @@ function ScrollArea({
   children,
   viewportClassName,
   viewportRef,
+  // ref and className are pulled through their own dedicated props above, so
+  // a caller passing viewportProps can never clobber either.
+  viewportProps: {
+    ref: _ignoredRef,
+    className: _ignoredClassName,
+    ...viewportProps
+  } = {},
   orientation = "vertical",
   ...props
 }: ScrollAreaProps) {
@@ -112,7 +121,11 @@ function ScrollArea({
   const horizontal = orientation === "horizontal" || orientation === "both";
   return (
     <ScrollAreaRoot data-slot="scroll-area" className={className} {...props}>
-      <ScrollAreaViewport ref={viewportRef} className={viewportClassName}>
+      <ScrollAreaViewport
+        ref={viewportRef}
+        className={viewportClassName}
+        {...viewportProps}
+      >
         {children}
       </ScrollAreaViewport>
       {vertical && (

--- a/packages/ui/src/components/scroll-area.tsx
+++ b/packages/ui/src/components/scroll-area.tsx
@@ -9,7 +9,11 @@ function ScrollAreaRoot({
   return (
     <ScrollAreaPrimitive.Root
       data-slot="scroll-area-root"
-      className={cn("relative overflow-hidden", className)}
+      // A flex column is what lets the viewport track the root's height in
+      // every sizing shape. Base UI forces `overflow: scroll` inline on the
+      // viewport, so a percentage height there resolves against whichever
+      // ancestor is definite and the root silently clips instead of scrolling.
+      className={cn("relative flex flex-col overflow-hidden", className)}
       {...props}
     />
   );
@@ -23,7 +27,7 @@ function ScrollAreaViewport({
     <ScrollAreaPrimitive.Viewport
       data-slot="scroll-area-viewport"
       className={cn(
-        "size-full rounded-[inherit] focus-visible:outline-none",
+        "w-full min-h-0 flex-1 rounded-[inherit] focus-visible:outline-none",
         className,
       )}
       {...props}

--- a/packages/ui/src/components/scroll-area.tsx
+++ b/packages/ui/src/components/scroll-area.tsx
@@ -2,23 +2,6 @@ import { ScrollArea as ScrollAreaPrimitive } from "@base-ui/react/scroll-area";
 import { cn } from "@everr/ui/lib/utils";
 import type * as React from "react";
 
-function ScrollAreaRoot({
-  className,
-  ...props
-}: ScrollAreaPrimitive.Root.Props) {
-  return (
-    <ScrollAreaPrimitive.Root
-      data-slot="scroll-area-root"
-      // A flex column is what lets the viewport track the root's height in
-      // every sizing shape. Base UI forces `overflow: scroll` inline on the
-      // viewport, so a percentage height there resolves against whichever
-      // ancestor is definite and the root silently clips instead of scrolling.
-      className={cn("relative flex flex-col overflow-hidden", className)}
-      {...props}
-    />
-  );
-}
-
 function ScrollAreaViewport({
   className,
   ...props
@@ -27,76 +10,45 @@ function ScrollAreaViewport({
     <ScrollAreaPrimitive.Viewport
       data-slot="scroll-area-viewport"
       className={cn(
-        "w-full min-h-0 flex-1 rounded-[inherit] focus-visible:outline-none",
+        "min-h-0 flex-1 rounded-[inherit] focus-visible:outline-none",
         className,
       )}
-      {...props}
-    />
-  );
-}
-
-function ScrollAreaContent({
-  className,
-  ...props
-}: ScrollAreaPrimitive.Content.Props) {
-  return (
-    <ScrollAreaPrimitive.Content
-      data-slot="scroll-area-content"
-      className={className}
       {...props}
     />
   );
 }
 
 function ScrollAreaScrollbar({
-  className,
-  orientation = "vertical",
-  ...props
-}: ScrollAreaPrimitive.Scrollbar.Props) {
+  orientation,
+}: {
+  orientation: "vertical" | "horizontal";
+}) {
   return (
+    // Not keepMounted: Base UI unmounts the bar when the axis does not
+    // overflow, and every mounted bar costs a getComputedStyle on every scroll
+    // event, whether or not it has anything to show.
     <ScrollAreaPrimitive.Scrollbar
       data-slot="scroll-area-scrollbar"
       orientation={orientation}
       className={cn(
         "z-20 flex touch-none select-none p-0.5 opacity-0 transition-opacity duration-150",
         "data-scrolling:opacity-100",
-        orientation === "vertical" && "h-full w-2.5",
-        orientation === "horizontal" && "w-full flex-col h-2.5",
-        className,
+        orientation === "vertical" ? "h-full w-2.5" : "h-2.5 w-full flex-col",
       )}
-      {...props}
-    />
+    >
+      <ScrollAreaPrimitive.Thumb
+        data-slot="scroll-area-thumb"
+        className="bg-scrollbar-thumb flex-1 rounded-full"
+      />
+    </ScrollAreaPrimitive.Scrollbar>
   );
 }
 
-function ScrollAreaThumb({
-  className,
-  ...props
-}: ScrollAreaPrimitive.Thumb.Props) {
-  return (
-    <ScrollAreaPrimitive.Thumb
-      data-slot="scroll-area-thumb"
-      className={cn(
-        "bg-(--scrollbar-thumb) hover:bg-(--scrollbar-thumb-hover) flex-1 rounded-full transition-colors",
-        className,
-      )}
-      {...props}
-    />
-  );
-}
-
-function ScrollAreaCorner({
-  className,
-  ...props
-}: ScrollAreaPrimitive.Corner.Props) {
-  return (
-    <ScrollAreaPrimitive.Corner
-      data-slot="scroll-area-corner"
-      className={cn("bg-transparent", className)}
-      {...props}
-    />
-  );
-}
+// Base UI's Root writes role="presentation". That is a no-op on the default
+// div, but on a semantic `render` element it strips the landmark, so <main>,
+// <nav> and <aside> roots stop being addressable. Clearing it restores them; a
+// caller's own role still wins, because its props are spread afterwards.
+const clearPresentationRole = { role: undefined };
 
 interface ScrollAreaProps extends ScrollAreaPrimitive.Root.Props {
   viewportClassName?: string;
@@ -116,6 +68,7 @@ function ScrollArea({
   viewportProps: {
     ref: _ignoredRef,
     className: _ignoredClassName,
+    style: viewportStyle,
     ...viewportProps
   } = {},
   orientation = "vertical",
@@ -124,26 +77,39 @@ function ScrollArea({
   const vertical = orientation === "vertical" || orientation === "both";
   const horizontal = orientation === "horizontal" || orientation === "both";
   return (
-    <ScrollAreaRoot data-slot="scroll-area" className={className} {...props}>
+    <ScrollAreaPrimitive.Root
+      data-slot="scroll-area"
+      // A flex column is what lets the viewport track the root's height in
+      // every sizing shape. Base UI forces `overflow: scroll` inline on the
+      // viewport, so a percentage height there resolves against whichever
+      // ancestor is definite and the root silently clips instead of scrolling.
+      className={cn("flex flex-col overflow-hidden", className)}
+      {...clearPresentationRole}
+      {...props}
+    >
       <ScrollAreaViewport
         ref={viewportRef}
         className={viewportClassName}
+        // Base UI writes `overflow: scroll` on both axes, so the axis this
+        // scroll area does not own has to be clipped back inline. Without it
+        // an `orientation="vertical"` area still scrolls sideways, with no
+        // scrollbar to show for it.
+        style={{
+          ...(horizontal ? undefined : { overflowX: "hidden" as const }),
+          ...(vertical ? undefined : { overflowY: "hidden" as const }),
+          ...viewportStyle,
+        }}
         {...viewportProps}
       >
         {children}
       </ScrollAreaViewport>
-      {vertical && (
-        <ScrollAreaScrollbar orientation="vertical" keepMounted>
-          <ScrollAreaThumb />
-        </ScrollAreaScrollbar>
-      )}
-      {horizontal && (
-        <ScrollAreaScrollbar orientation="horizontal" keepMounted>
-          <ScrollAreaThumb />
-        </ScrollAreaScrollbar>
-      )}
-      {orientation === "both" && <ScrollAreaCorner />}
-    </ScrollAreaRoot>
+      {vertical && <ScrollAreaScrollbar orientation="vertical" />}
+      {horizontal && <ScrollAreaScrollbar orientation="horizontal" />}
+      {/* No Corner: it only reserves the square where the two bars meet, which
+          overlay bars do not need, and mounting one makes Base UI write a fresh
+          corner size into state on every scroll event, re-rendering the whole
+          scroll area with it. */}
+    </ScrollAreaPrimitive.Root>
   );
 }
 
@@ -167,10 +133,10 @@ function ScrollAreaScroller({
   context: _context,
   ...props
 }: ScrollAreaScrollerProps) {
-  // Virtuoso's own overflow keys are dropped: Base UI already writes
-  // `overflow: scroll` inline on the viewport, and a second axis-specific value
-  // merged on top would fight it. `position: relative` is kept because the
-  // virtuoso item list is absolutely positioned against the scroller.
+  // Virtuoso's own overflow keys are dropped: the scroll area already sets
+  // overflow on both axes, and a value merged on top would fight it.
+  // `position: relative` is kept because the virtuoso item list is absolutely
+  // positioned against the scroller.
   const {
     overflowY: _y,
     overflowX: _x,
@@ -188,13 +154,9 @@ function ScrollAreaScroller({
   );
 }
 
-export {
-  ScrollArea,
-  ScrollAreaContent,
-  ScrollAreaCorner,
-  ScrollAreaRoot,
-  ScrollAreaScrollbar,
-  ScrollAreaScroller,
-  ScrollAreaThumb,
-  ScrollAreaViewport,
-};
+// Virtuoso remounts its scroller, losing the scroll position, whenever the
+// `components` map hands it a new component identity. Sharing this one object
+// keeps every list on the same stable identity, with no memoisation per list.
+const virtuosoScrollAreaComponents = { Scroller: ScrollAreaScroller };
+
+export { ScrollArea, ScrollAreaScroller, virtuosoScrollAreaComponents };

--- a/packages/ui/src/components/scroll-area.tsx
+++ b/packages/ui/src/components/scroll-area.tsx
@@ -1,0 +1,141 @@
+import { ScrollArea as ScrollAreaPrimitive } from "@base-ui/react/scroll-area";
+import { cn } from "@everr/ui/lib/utils";
+import type * as React from "react";
+
+function ScrollAreaRoot({
+  className,
+  ...props
+}: ScrollAreaPrimitive.Root.Props) {
+  return (
+    <ScrollAreaPrimitive.Root
+      data-slot="scroll-area-root"
+      className={cn("relative overflow-hidden", className)}
+      {...props}
+    />
+  );
+}
+
+function ScrollAreaViewport({
+  className,
+  ...props
+}: ScrollAreaPrimitive.Viewport.Props) {
+  return (
+    <ScrollAreaPrimitive.Viewport
+      data-slot="scroll-area-viewport"
+      className={cn(
+        "size-full rounded-[inherit] focus-visible:outline-none",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ScrollAreaContent({
+  className,
+  ...props
+}: ScrollAreaPrimitive.Content.Props) {
+  return (
+    <ScrollAreaPrimitive.Content
+      data-slot="scroll-area-content"
+      className={className}
+      {...props}
+    />
+  );
+}
+
+function ScrollAreaScrollbar({
+  className,
+  orientation = "vertical",
+  ...props
+}: ScrollAreaPrimitive.Scrollbar.Props) {
+  return (
+    <ScrollAreaPrimitive.Scrollbar
+      data-slot="scroll-area-scrollbar"
+      orientation={orientation}
+      className={cn(
+        "z-20 flex touch-none select-none p-0.5 opacity-0 transition-opacity duration-150",
+        "data-hovering:opacity-100 data-scrolling:opacity-100",
+        orientation === "vertical" && "h-full w-2.5",
+        orientation === "horizontal" && "w-full flex-col h-2.5",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ScrollAreaThumb({
+  className,
+  ...props
+}: ScrollAreaPrimitive.Thumb.Props) {
+  return (
+    <ScrollAreaPrimitive.Thumb
+      data-slot="scroll-area-thumb"
+      className={cn(
+        "bg-(--scrollbar-thumb) hover:bg-(--scrollbar-thumb-hover) flex-1 rounded-full transition-colors",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ScrollAreaCorner({
+  className,
+  ...props
+}: ScrollAreaPrimitive.Corner.Props) {
+  return (
+    <ScrollAreaPrimitive.Corner
+      data-slot="scroll-area-corner"
+      className={cn("bg-transparent", className)}
+      {...props}
+    />
+  );
+}
+
+interface ScrollAreaProps extends ScrollAreaPrimitive.Root.Props {
+  viewportClassName?: string;
+  viewportRef?: React.Ref<HTMLDivElement>;
+  orientation?: "vertical" | "horizontal" | "both";
+}
+
+function ScrollArea({
+  className,
+  children,
+  viewportClassName,
+  viewportRef,
+  orientation = "vertical",
+  ...props
+}: ScrollAreaProps) {
+  const vertical = orientation === "vertical" || orientation === "both";
+  const horizontal = orientation === "horizontal" || orientation === "both";
+  return (
+    <ScrollAreaRoot data-slot="scroll-area" className={className} {...props}>
+      <ScrollAreaViewport ref={viewportRef} className={viewportClassName}>
+        {children}
+      </ScrollAreaViewport>
+      {vertical && (
+        <ScrollAreaScrollbar orientation="vertical" keepMounted>
+          <ScrollAreaThumb />
+        </ScrollAreaScrollbar>
+      )}
+      {horizontal && (
+        <ScrollAreaScrollbar orientation="horizontal" keepMounted>
+          <ScrollAreaThumb />
+        </ScrollAreaScrollbar>
+      )}
+      {orientation === "both" && <ScrollAreaCorner />}
+    </ScrollAreaRoot>
+  );
+}
+
+export {
+  ScrollArea,
+  ScrollAreaContent,
+  ScrollAreaCorner,
+  ScrollAreaRoot,
+  ScrollAreaScrollbar,
+  ScrollAreaThumb,
+  ScrollAreaViewport,
+};

--- a/packages/ui/src/components/scroll-area.tsx
+++ b/packages/ui/src/components/scroll-area.tsx
@@ -147,12 +147,54 @@ function ScrollArea({
   );
 }
 
+interface ScrollAreaScrollerProps extends React.HTMLAttributes<HTMLDivElement> {
+  ref?: React.Ref<HTMLDivElement>;
+  // Virtuoso passes its `context` value to every custom component. It is not a
+  // DOM attribute, so it is dropped here instead of reaching the viewport.
+  context?: unknown;
+}
+
+// react-virtuoso attaches its scroll listener, and reads scrollTop,
+// scrollHeight and offsetHeight, on whatever element it gets this ref for, so
+// the ref has to land on the real scrolling element (the viewport) and never on
+// the root. Everything else virtuoso passes (tabIndex, data-virtuoso-scroller,
+// data-testid, the inline style) goes to the same element.
+function ScrollAreaScroller({
+  ref,
+  children,
+  className,
+  style,
+  context: _context,
+  ...props
+}: ScrollAreaScrollerProps) {
+  // Virtuoso's own overflow keys are dropped: Base UI already writes
+  // `overflow: scroll` inline on the viewport, and a second axis-specific value
+  // merged on top would fight it. `position: relative` is kept because the
+  // virtuoso item list is absolutely positioned against the scroller.
+  const {
+    overflowY: _y,
+    overflowX: _x,
+    overflow: _o,
+    ...scrollerStyle
+  } = style ?? {};
+  return (
+    <ScrollArea
+      className={className}
+      viewportRef={ref}
+      viewportProps={{ ...props, style: scrollerStyle }}
+    >
+      {children}
+    </ScrollArea>
+  );
+}
+
 export {
   ScrollArea,
   ScrollAreaContent,
   ScrollAreaCorner,
   ScrollAreaRoot,
   ScrollAreaScrollbar,
+  ScrollAreaScroller,
   ScrollAreaThumb,
   ScrollAreaViewport,
 };

--- a/packages/ui/src/components/scroll-area.tsx
+++ b/packages/ui/src/components/scroll-area.tsx
@@ -55,7 +55,7 @@ function ScrollAreaScrollbar({
       orientation={orientation}
       className={cn(
         "z-20 flex touch-none select-none p-0.5 opacity-0 transition-opacity duration-150",
-        "data-hovering:opacity-100 data-scrolling:opacity-100",
+        "data-scrolling:opacity-100",
         orientation === "vertical" && "h-full w-2.5",
         orientation === "horizontal" && "w-full flex-col h-2.5",
         className,

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -92,9 +92,8 @@ function SelectContent({
               not a child of one. `h-full` carries the popup's height down when
               `alignItemWithTrigger` sets `height: 100%` on the popup, and
               `max-h-(--available-height)` bounds the root when it does not.
-              `overflowX` must be an inline style: Base UI writes
-              `overflow: scroll` on the viewport, and the List adds its own
-              `overflow-x: hidden` before it, so only an important class wins. */}
+              Base UI applies `overflowX: hidden` before the viewport's
+              `overflow: scroll`, so an important class is required. */}
           <ScrollArea
             className="h-full max-h-(--available-height) rounded-[inherit]"
             viewportClassName="overflow-x-hidden!"

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -91,12 +91,9 @@ function SelectContent({
               (`listElement ?? popupRef`), so it has to be the viewport itself,
               not a child of one. `h-full` carries the popup's height down when
               `alignItemWithTrigger` sets `height: 100%` on the popup, and
-              `max-h-(--available-height)` bounds the root when it does not.
-              Base UI applies `overflowX: hidden` before the viewport's
-              `overflow: scroll`, so an important class is required. */}
+              `max-h-(--available-height)` bounds the root when it does not. */}
           <ScrollArea
             className="h-full max-h-(--available-height) rounded-[inherit]"
-            viewportClassName="overflow-x-hidden!"
             viewportProps={{
               // The viewport's own `role="presentation"` would otherwise win
               // the merge and strip the listbox role off the List.

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -1,4 +1,5 @@
 import { Select as SelectPrimitive } from "@base-ui/react/select";
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { cn } from "@everr/ui/lib/utils";
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
 
@@ -80,13 +81,31 @@ function SelectContent({
           data-slot="select-content"
           data-align-trigger={alignItemWithTrigger}
           className={cn(
-            "bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 min-w-32 rounded-lg shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 relative isolate z-50 max-h-(--available-height) w-(--anchor-width) origin-(--transform-origin) overflow-x-hidden overflow-y-auto data-[align-trigger=true]:animate-none",
+            "bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 min-w-32 rounded-lg shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 relative isolate z-50 max-h-(--available-height) w-(--anchor-width) origin-(--transform-origin) overflow-hidden data-[align-trigger=true]:animate-none",
             className,
           )}
           {...props}
         >
           <SelectScrollUpButton />
-          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+          {/* The List is the element Base UI treats as the scroller
+              (`listElement ?? popupRef`), so it has to be the viewport itself,
+              not a child of one. `h-full` carries the popup's height down when
+              `alignItemWithTrigger` sets `height: 100%` on the popup, and
+              `max-h-(--available-height)` bounds the root when it does not.
+              `overflowX` must be an inline style: Base UI writes
+              `overflow: scroll` on the viewport, and the List adds its own
+              `overflow-x: hidden` before it, so only an important class wins. */}
+          <ScrollArea
+            className="h-full max-h-(--available-height) rounded-[inherit]"
+            viewportClassName="overflow-x-hidden!"
+            viewportProps={{
+              // The viewport's own `role="presentation"` would otherwise win
+              // the merge and strip the listbox role off the List.
+              render: <SelectPrimitive.List role="listbox" />,
+            }}
+          >
+            {children}
+          </ScrollArea>
           <SelectScrollDownButton />
         </SelectPrimitive.Popup>
       </SelectPrimitive.Positioner>

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -2,6 +2,7 @@ import { mergeProps } from "@base-ui/react/merge-props";
 import { useRender } from "@base-ui/react/use-render";
 import { Button } from "@everr/ui/components/button";
 import { Input } from "@everr/ui/components/input";
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { Separator } from "@everr/ui/components/separator";
 import {
   Sheet,
@@ -518,17 +519,24 @@ function SidebarSeparator({
   );
 }
 
-function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
+function SidebarContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"div">) {
   return (
-    <div
+    <ScrollArea
       data-slot="sidebar-content"
       data-sidebar="content"
       className={cn(
-        "gap-0 flex min-h-0 flex-1 flex-col overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        "min-h-0 flex-1 group-data-[collapsible=icon]:overflow-hidden",
         className,
       )}
+      viewportClassName="flex flex-col gap-0"
       {...props}
-    />
+    >
+      {children}
+    </ScrollArea>
   );
 }
 

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -524,7 +524,7 @@ function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="sidebar-content"
       data-sidebar="content"
       className={cn(
-        "no-scrollbar gap-0 flex min-h-0 flex-1 flex-col overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        "gap-0 flex min-h-0 flex-1 flex-col overflow-auto group-data-[collapsible=icon]:overflow-hidden",
         className,
       )}
       {...props}

--- a/packages/ui/src/components/time-range-picker.tsx
+++ b/packages/ui/src/components/time-range-picker.tsx
@@ -1,4 +1,5 @@
 import { isValid, resolve } from "@everr/datemath";
+import { ScrollArea } from "@everr/ui/components/scroll-area";
 import { ChevronDownIcon, Clock } from "lucide-react";
 import { useMemo, useState } from "react";
 import { DEFAULT_TIME_RANGE, type TimeRange } from "../lib/time-range";
@@ -191,7 +192,7 @@ export function TimeRangePicker({
                 className="rounded-none bg-transparent border-none h-10 px-3 focus:ring-0 focus-visible:ring-0"
               />
             </div>
-            <div className="max-h-[320px] overflow-y-auto p-1">
+            <ScrollArea className="max-h-[320px]" viewportClassName="p-1">
               {filteredGroups.length === 0 ? (
                 <div className="px-2 py-3 text-xs text-muted-foreground text-center">
                   No matches
@@ -228,7 +229,7 @@ export function TimeRangePicker({
                   </div>
                 ))
               )}
-            </div>
+            </ScrollArea>
           </div>
 
           {/* Right panel: custom range */}

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -89,6 +89,7 @@
 @layer base {
   * {
     @apply border-border outline-ring/50;
+
     scrollbar-width: thin;
   }
 

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -68,6 +68,8 @@
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.556 0 0);
+  --scrollbar-thumb: oklch(1 0 0 / 18%);
+  --scrollbar-thumb-hover: oklch(1 0 0 / 32%);
   --chart-1: oklch(0.905 0.182 98.111);
   --chart-2: oklch(0.795 0.184 86.047);
   --chart-3: oklch(0.681 0.162 75.834);
@@ -87,6 +89,31 @@
   * {
     @apply border-border outline-ring/50;
   }
+
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: var(--scrollbar-thumb) transparent;
+  }
+
+  /* WebKit ignores scrollbar-color, so the thumb is restyled separately.
+     Setting ::-webkit-scrollbar opts the whole scrollbar out of the native
+     look, so every part below has to be given back explicitly. */
+  ::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+  ::-webkit-scrollbar-track,
+  ::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+  ::-webkit-scrollbar-thumb {
+    background-color: var(--scrollbar-thumb);
+    border-radius: 9999px;
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    background-color: var(--scrollbar-thumb-hover);
+  }
+
   body {
     @apply font-sans bg-background text-foreground;
   }

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -33,6 +33,7 @@
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
+  --color-scrollbar-thumb: var(--scrollbar-thumb);
   --color-chart-1: var(--chart-1);
   --color-chart-2: var(--chart-2);
   --color-chart-3: var(--chart-3);
@@ -88,10 +89,11 @@
 @layer base {
   * {
     @apply border-border outline-ring/50;
+    scrollbar-width: thin;
   }
 
-  * {
-    scrollbar-width: thin;
+  /* scrollbar-color inherits, so the root is the only element that needs it. */
+  :root {
     scrollbar-color: var(--scrollbar-thumb) transparent;
   }
 

--- a/packages/ui/src/test-setup.ts
+++ b/packages/ui/src/test-setup.ts
@@ -1,1 +1,7 @@
 import "@testing-library/jest-dom/vitest";
+
+// jsdom has no Web Animations API. Base UI's ScrollArea calls getAnimations()
+// on the viewport from a timer, which throws after a test has finished.
+if (!Element.prototype.getAnimations) {
+  Element.prototype.getAnimations = () => [];
+}

--- a/packages/ui/src/test-setup.ts
+++ b/packages/ui/src/test-setup.ts
@@ -1,7 +1,2 @@
 import "@testing-library/jest-dom/vitest";
-
-// jsdom has no Web Animations API. Base UI's ScrollArea calls getAnimations()
-// on the viewport from a timer, which throws after a test has finished.
-if (!Element.prototype.getAnimations) {
-  Element.prototype.getAnimations = () => [];
-}
+import "@everr/ui/testing/jsdom-shims";

--- a/packages/ui/src/testing/jsdom-shims.ts
+++ b/packages/ui/src/testing/jsdom-shims.ts
@@ -1,0 +1,9 @@
+// Browser APIs that jsdom does not implement but @everr/ui components call.
+// Imported for its side effects from every package's vitest setup file, so the
+// package that owns the components also owns the shims they need.
+
+// Base UI's ScrollArea calls getAnimations() on the viewport from a timer,
+// which throws after a test has finished.
+if (typeof Element !== "undefined" && !Element.prototype.getAnimations) {
+  Element.prototype.getAnimations = () => [];
+}


### PR DESCRIPTION
Native scrollbars looked wrong and looked different on every operating system. On Windows and Linux they also reserved layout width, which changed how panels were sized.

This replaces them in two layers.

**A global CSS floor** in `packages/ui/src/styles/global.css` themes every native scrollbar in the product, including the surfaces that cannot use a component. Two tokens, `--scrollbar-thumb` and `--scrollbar-thumb-hover`, plus `scrollbar-color` and `::-webkit-scrollbar` rules.

**A `ScrollArea` component** in `packages/ui/src/components/scroll-area.tsx`, wrapping `@base-ui/react/scroll-area`, which was already installed. No new dependency. It gives overlay scrollbars that reserve no layout width and reveal only while scrolling, matching native macOS behaviour, then fade.

## Coverage

Every scroll container in `app`, `telemetry-explorer`, `ui`, and `desktop-app` now uses the component: 36 in total, including the six `react-virtuoso` lists (logs, traces, errors, runs, the trace timeline, and the run detail log viewer), which get a shared `ScrollAreaScroller`.

Two surfaces stay native, themed by the CSS floor, because neither can take a component:

- the document scroll on the auth, onboarding, and device routes
- `<textarea>`, 4 occurrences

## Verification

Every conversion was measured in a real browser against the dev server, not only in jsdom. Per surface: that no native scrollbar remains, that virtualization still recycles, that infinite scroll still loads, that scroll position stays stable, and that keyboard navigation still brings the highlighted item into view.

The virtualized lists were checked with a temporary diagnostic that painted native scrollbars red, and the detector was self-tested on each page (inject a native scroller, confirm it registers) before a null result was trusted. That diagnostic is not part of this branch.

Suites: `ui` 40, `telemetry-explorer` 242, `app` 1308, all exit 0. `desktop-app` typechecks.

## Notes for review

- `data-table` sticky headers keep working: `position: sticky` resolves against the nearest scrolling ancestor, which the viewport becomes. Measured at delta 0, with column widths unchanged to the hundredth of a pixel across 14 consumers.
- `select.tsx` needs two deviations from the usual idiom, both commented in place: `role="listbox"` is restated because Base UI drops the popup to `role="presentation"` when a list element exists, and `overflow-x` needs an important class rather than an inline style because `LIST_FUNCTIONAL_STYLES` writes the shorthand last.
- Scrollbar gutters (`pr-1`) are gone where they existed only to clear the native bar, including the trace waterfall's right pane.
- `DataTable`'s `bordered` prop now also decides scroll ownership. Correct for its single current consumer, but a future bordered-and-scrolling caller would silently not scroll.
- Pre-existing and untouched: the two sticky tables in `alerts_.$alertId.tsx` have no bounded height, so their headers never stuck.
- Accessibility beyond two fixed regressions (the filter rail's `complementary` landmark and select's listbox role) has not been audited. Base UI's `role="presentation"` can strip a role from an element that still looks semantic in the DOM, so other converted elements may have lost one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent scrolling across dashboards, runbooks, timelines, tables, settings, onboarding, and telemetry views.
  * Introduced reusable scrollable code blocks and integrated scrolling for commands, selects, dropdowns, and sidebars.
  * Added streamlined dashboard and runbook navigation with integrated search.
* **Improvements**
  * Standardized scrollbar appearance across light and dark themes.
  * Improved desktop settings and developer page layouts.
  * Preserved synchronized trace scrolling and optimized large result lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->