### PR TITLE
feat(collector): compile memory_limiter and file_storage into the collector

### DIFF
--- a/collector/config/manifest.yaml
+++ b/collector/config/manifest.yaml
@@ -14,11 +14,13 @@ connectors: []
 
 processors:
   - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.152.0
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.152.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.152.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.152.0
 
 extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.152.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage v0.152.0
   - gomod: github.com/everr-labs/everr/collector/extension/everrapikeyauth v0.152.0
 
 receivers:


### PR DESCRIPTION
## What

Add two components to the compiled collector (`collector/config/manifest.yaml`):

- processor `memory_limiter` (`go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.152.0`)
- extension `file_storage` (`github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage v0.152.0`)

The dev stack config (`collector/config.yml`) is not changed. The components are available in the binary but no pipeline uses them yet.

## Verification

- `make build` (OCB v0.152.0) compiles.
- `./build/everr-collector components` lists `memory_limiter` under processors and `file_storage` under extensions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for memory usage limiting in the collector.
  * Added file-based storage capabilities to the collector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->