### PR TITLE
fix(dashboards): stop filtering node panels by namespace in Kubernetes Workloads

### DIFF
--- a/packages/app/src/data/dashboards/built-in/catalog/infrastructure/kubernetes-workloads.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/infrastructure/kubernetes-workloads.yaml
@@ -51,7 +51,7 @@ document:
                   spec:
                     query: |-
                       SELECT nullIf(uniqExact(dimension), 0) AS total
-                      FROM (SELECT ResourceAttributes['k8s.node.name'] AS dimension FROM metrics_gauge WHERE TimeUnix >= {from:String} AND TimeUnix <= {to:String} AND ResourceAttributes['k8s.namespace.name'] IN $namespace AND MetricName = 'k8s.node.cpu.usage' UNION ALL SELECT ResourceAttributes['k8s.node.name'] AS dimension FROM metrics_sum WHERE TimeUnix >= {from:String} AND TimeUnix <= {to:String} AND ResourceAttributes['k8s.namespace.name'] IN $namespace AND MetricName = 'k8s.node.cpu.usage')
+                      FROM (SELECT ResourceAttributes['k8s.node.name'] AS dimension FROM metrics_gauge WHERE TimeUnix >= {from:String} AND TimeUnix <= {to:String} AND MetricName = 'k8s.node.cpu.usage' UNION ALL SELECT ResourceAttributes['k8s.node.name'] AS dimension FROM metrics_sum WHERE TimeUnix >= {from:String} AND TimeUnix <= {to:String} AND MetricName = 'k8s.node.cpu.usage')
       pods:
         kind: Panel
         spec:
@@ -102,7 +102,7 @@ document:
                       SELECT round(
                                avgIf(Value, MetricName = 'k8s.node.memory.working_set')
                                / nullIf(avgIf(Value, MetricName = 'k8s.node.memory.working_set') + avgIf(Value, MetricName = 'k8s.node.memory.available'), 0) * 100, 1) AS pct
-                      FROM (SELECT MetricName, Value FROM metrics_gauge WHERE TimeUnix >= {from:String} AND TimeUnix <= {to:String} AND ResourceAttributes['k8s.namespace.name'] IN $namespace AND MetricName IN ('k8s.node.memory.working_set', 'k8s.node.memory.available') UNION ALL SELECT MetricName, Value FROM metrics_sum WHERE TimeUnix >= {from:String} AND TimeUnix <= {to:String} AND ResourceAttributes['k8s.namespace.name'] IN $namespace AND MetricName IN ('k8s.node.memory.working_set', 'k8s.node.memory.available'))
+                      FROM (SELECT MetricName, Value FROM metrics_gauge WHERE TimeUnix >= {from:String} AND TimeUnix <= {to:String} AND MetricName IN ('k8s.node.memory.working_set', 'k8s.node.memory.available') UNION ALL SELECT MetricName, Value FROM metrics_sum WHERE TimeUnix >= {from:String} AND TimeUnix <= {to:String} AND MetricName IN ('k8s.node.memory.working_set', 'k8s.node.memory.available'))
       node-filesystem-used:
         kind: Panel
         spec:
@@ -133,7 +133,7 @@ document:
                       SELECT round(
                                avgIf(Value, MetricName = 'k8s.node.filesystem.usage')
                                / nullIf(avgIf(Value, MetricName = 'k8s.node.filesystem.capacity'), 0) * 100, 1) AS pct
-                      FROM (SELECT MetricName, Value FROM metrics_gauge WHERE TimeUnix >= {from:String} AND TimeUnix <= {to:String} AND ResourceAttributes['k8s.namespace.name'] IN $namespace AND MetricName IN ('k8s.node.filesystem.usage', 'k8s.node.filesystem.capacity') UNION ALL SELECT MetricName, Value FROM metrics_sum WHERE TimeUnix >= {from:String} AND TimeUnix <= {to:String} AND ResourceAttributes['k8s.namespace.name'] IN $namespace AND MetricName IN ('k8s.node.filesystem.usage', 'k8s.node.filesystem.capacity'))
+                      FROM (SELECT MetricName, Value FROM metrics_gauge WHERE TimeUnix >= {from:String} AND TimeUnix <= {to:String} AND MetricName IN ('k8s.node.filesystem.usage', 'k8s.node.filesystem.capacity') UNION ALL SELECT MetricName, Value FROM metrics_sum WHERE TimeUnix >= {from:String} AND TimeUnix <= {to:String} AND MetricName IN ('k8s.node.filesystem.usage', 'k8s.node.filesystem.capacity'))
       node-cpu:
         kind: Panel
         spec:
@@ -152,7 +152,7 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      WITH points AS (SELECT TimeUnix, Value, ResourceAttributes['k8s.node.name'] AS series FROM metrics_gauge WHERE TimeUnix >= {from:String} AND TimeUnix <= {to:String} AND ResourceAttributes['k8s.namespace.name'] IN $namespace AND MetricName = 'k8s.node.cpu.usage' UNION ALL SELECT TimeUnix, Value, ResourceAttributes['k8s.node.name'] AS series FROM metrics_sum WHERE TimeUnix >= {from:String} AND TimeUnix <= {to:String} AND ResourceAttributes['k8s.namespace.name'] IN $namespace AND MetricName = 'k8s.node.cpu.usage')
+                      WITH points AS (SELECT TimeUnix, Value, ResourceAttributes['k8s.node.name'] AS series FROM metrics_gauge WHERE TimeUnix >= {from:String} AND TimeUnix <= {to:String} AND MetricName = 'k8s.node.cpu.usage' UNION ALL SELECT TimeUnix, Value, ResourceAttributes['k8s.node.name'] AS series FROM metrics_sum WHERE TimeUnix >= {from:String} AND TimeUnix <= {to:String} AND MetricName = 'k8s.node.cpu.usage')
                       SELECT toStartOfInterval(TimeUnix, INTERVAL {step:UInt32} * 6 SECOND) AS ts,
                              series,
                              avg(Value) AS value
@@ -181,7 +181,7 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      WITH points AS (SELECT TimeUnix, Value, ResourceAttributes['k8s.node.name'] AS series FROM metrics_gauge WHERE TimeUnix >= {from:String} AND TimeUnix <= {to:String} AND ResourceAttributes['k8s.namespace.name'] IN $namespace AND MetricName = 'k8s.node.memory.working_set' UNION ALL SELECT TimeUnix, Value, ResourceAttributes['k8s.node.name'] AS series FROM metrics_sum WHERE TimeUnix >= {from:String} AND TimeUnix <= {to:String} AND ResourceAttributes['k8s.namespace.name'] IN $namespace AND MetricName = 'k8s.node.memory.working_set')
+                      WITH points AS (SELECT TimeUnix, Value, ResourceAttributes['k8s.node.name'] AS series FROM metrics_gauge WHERE TimeUnix >= {from:String} AND TimeUnix <= {to:String} AND MetricName = 'k8s.node.memory.working_set' UNION ALL SELECT TimeUnix, Value, ResourceAttributes['k8s.node.name'] AS series FROM metrics_sum WHERE TimeUnix >= {from:String} AND TimeUnix <= {to:String} AND MetricName = 'k8s.node.memory.working_set')
                       SELECT toStartOfInterval(TimeUnix, INTERVAL {step:UInt32} * 6 SECOND) AS ts,
                              series,
                              avg(Value) / 1073741824 AS value
@@ -355,7 +355,7 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      WITH points AS (SELECT TimeUnix, ResourceAttributes, Attributes, Value, Attributes['direction'] AS series FROM metrics_gauge WHERE TimeUnix >= {from:String} AND TimeUnix <= {to:String} AND ResourceAttributes['k8s.namespace.name'] IN $namespace AND MetricName = 'k8s.node.network.io' UNION ALL SELECT TimeUnix, ResourceAttributes, Attributes, Value, Attributes['direction'] AS series FROM metrics_sum WHERE TimeUnix >= {from:String} AND TimeUnix <= {to:String} AND ResourceAttributes['k8s.namespace.name'] IN $namespace AND MetricName = 'k8s.node.network.io')
+                      WITH points AS (SELECT TimeUnix, ResourceAttributes, Attributes, Value, Attributes['direction'] AS series FROM metrics_gauge WHERE TimeUnix >= {from:String} AND TimeUnix <= {to:String} AND MetricName = 'k8s.node.network.io' UNION ALL SELECT TimeUnix, ResourceAttributes, Attributes, Value, Attributes['direction'] AS series FROM metrics_sum WHERE TimeUnix >= {from:String} AND TimeUnix <= {to:String} AND MetricName = 'k8s.node.network.io')
                       SELECT ts, series, sum(delta) / 1048576 AS value
                       FROM (
                         SELECT toStartOfInterval(TimeUnix, INTERVAL {step:UInt32} * 6 SECOND) AS ts, series,


### PR DESCRIPTION
## Problem

Six panels on the built-in Kubernetes Workloads dashboard rendered empty: Nodes, Node memory used, Node filesystem used, Node CPU usage, Node memory working set, and Node network I/O.

## Root cause

Every panel query filtered on `ResourceAttributes['k8s.namespace.name'] IN $namespace`. But the kubeletstats receiver only attaches `k8s.namespace.name` to pod-scoped metrics. Node-scoped metrics (`k8s.node.*`) carry an empty namespace attribute, because a node is not namespaced.

The Namespace variable's option query excludes the empty string (`WHERE namespace != ''`), so with "All" selected, `$namespace` expands to the list of real namespaces. An `IN` over that list can never match the empty namespace on node rows, so all node panels returned zero rows.

Verified against production telemetry for the trailing hour:

- `k8s.pod.*` metrics: populated namespaces (`kube-system`, `app`, ...)
- `k8s.node.*` metrics: namespace attribute is `''`
- Node count with the filter removed: 1; node memory used: 15.6%

Also noted during diagnosis (not addressed here): `k8s.node.network.io` has no data in production at all in the last 24h, so that panel stays empty until the collector emits it.

## Fix

Drop the `$namespace` filter from the six node-scoped panel queries. A node has no namespace, so the filter never applied to anything meaningful. Pod-scoped panels keep their filter.

## Testing

- Verified each rewritten node query returns rows against production ClickHouse.
- Diff is exactly 6 lines changed, pod-panel queries untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Kubernetes node-level dashboard panels to show metrics across all namespaces.
  * Preserved namespace filtering for pod- and namespace-level panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->