### PR TITLE
fix(app): keep the issued API key on screen after the first key is created

### DIFF
--- a/packages/app/src/components/api-keys/api-keys-table.tsx
+++ b/packages/app/src/components/api-keys/api-keys-table.tsx
@@ -14,11 +14,18 @@ import { Button } from "@everr/ui/components/button";
 import { Card, CardContent } from "@everr/ui/components/card";
 import { type Column, DataTable } from "@everr/ui/components/data-table";
 import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@everr/ui/components/empty";
+import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@everr/ui/components/tooltip";
-import { Globe } from "lucide-react";
+import { Globe, KeyRound, type LucideIcon } from "lucide-react";
 import { toast } from "sonner";
 import { CreateApiKeyDialog } from "@/components/api-keys/create-api-key-dialog";
 import { formatDate } from "@/components/users-management/format-date";
@@ -293,11 +300,28 @@ function publicColumns(onRevoke: RevokeFn): Column<ApiKey>[] {
   ];
 }
 
-function SectionEmpty({ children }: { children: React.ReactNode }) {
+// A section with no keys still has to say what belongs there and why. The
+// button that creates one sits in the section header just above, so the state
+// stays a briefing, not a second copy of the same control.
+function SectionEmpty({
+  icon: Icon,
+  title,
+  children,
+}: {
+  icon: LucideIcon;
+  title: string;
+  children: React.ReactNode;
+}) {
   return (
-    <p className="text-muted-foreground px-3 py-8 text-center text-sm text-balance">
-      {children}
-    </p>
+    <Empty className="border-0 py-10">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <Icon />
+        </EmptyMedia>
+        <EmptyTitle>{title}</EmptyTitle>
+        <EmptyDescription>{children}</EmptyDescription>
+      </EmptyHeader>
+    </Empty>
   );
 }
 
@@ -334,9 +358,10 @@ export function ApiKeysSections({ keys }: ApiKeysSectionsProps) {
               rowKey={(row) => row.id}
             />
           ) : (
-            <SectionEmpty>
-              No organization keys yet. Create one for servers, CLIs, and
-              collectors.
+            <SectionEmpty icon={KeyRound} title="No organization keys yet">
+              Create one to send OpenTelemetry data from servers, CLIs, and
+              collectors, or to manage dashboards, runbooks, and alerts with{" "}
+              <code className="font-mono text-[0.7rem]">everr apply</code>.
             </SectionEmpty>
           )}
         </CardContent>
@@ -371,9 +396,9 @@ export function ApiKeysSections({ keys }: ApiKeysSectionsProps) {
                 rowKey={(row) => row.id}
               />
             ) : (
-              <SectionEmpty>
-                No public keys yet. Create one to send telemetry straight from a
-                web page.
+              <SectionEmpty icon={Globe} title="No public keys yet">
+                Create one to send telemetry straight from a web page: page
+                views, web vitals, and front-end errors.
               </SectionEmpty>
             )}
           </CardContent>

--- a/packages/app/src/routes/_authenticated/_dashboard/_padded/-api-keys.test.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_padded/-api-keys.test.tsx
@@ -1,0 +1,63 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { ApiKey } from "@/data/api-keys";
+
+const mocks = vi.hoisted(() => ({
+  createApiKey: vi.fn(),
+  listApiKeys: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-router", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@tanstack/react-router")>()),
+  createFileRoute: () => (options: Record<string, unknown>) => ({ options }),
+}));
+vi.mock("@tanstack/react-start/server", () => ({
+  getRequestHeaders: () => ({}),
+}));
+vi.mock("@/data/api-keys", () => mocks);
+// The page's admin guard runs in `beforeLoad`, never in the component, so the
+// handler only has to exist.
+vi.mock("@/lib/serverFn", () => ({
+  createAuthenticatedServerFn: { handler: (fn: unknown) => fn },
+}));
+
+import { Route } from "./api-keys";
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={new QueryClient()}>
+    {children}
+  </QueryClientProvider>
+);
+
+describe("/api-keys route", () => {
+  it("keeps the issued key on screen after the first key lands in the list", async () => {
+    const keys: ApiKey[] = [];
+    mocks.listApiKeys.mockImplementation(async () => [...keys]);
+    mocks.createApiKey.mockImplementation(async () => {
+      keys.push({ id: "k1", name: "ci-deploy" } as ApiKey);
+      return { key: "ek_the_only_copy" };
+    });
+
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />, { wrapper });
+
+    // Each interaction re-queries: the node a `findBy*` resolves with can be
+    // replaced by the next render, and an event on a stale node reaches nothing.
+    await screen.findByRole("button", { name: "New key" });
+    fireEvent.click(screen.getByRole("button", { name: "New key" }));
+    await screen.findByLabelText("Name");
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "ci-deploy" },
+    });
+    fireEvent.click(screen.getByRole("switch", { name: /Send telemetry/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Create key" }));
+
+    expect(await screen.findByText("ek_the_only_copy")).toBeInTheDocument();
+    // The refetch flips the list out of its empty state. The issued key has to
+    // survive that render: it is the only time it is ever shown.
+    expect(await screen.findByText("ci-deploy")).toBeInTheDocument();
+    expect(screen.getByText("ek_the_only_copy")).toBeInTheDocument();
+  });
+});

--- a/packages/app/src/routes/_authenticated/_dashboard/_padded/api-keys.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_padded/api-keys.tsx
@@ -1,18 +1,9 @@
 import { Card, CardContent } from "@everr/ui/components/card";
-import {
-  Empty,
-  EmptyContent,
-  EmptyDescription,
-  EmptyHeader,
-  EmptyMedia,
-  EmptyTitle,
-} from "@everr/ui/components/empty";
 import { RetryError } from "@everr/ui/components/retry-error";
 import { Skeleton } from "@everr/ui/components/skeleton";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { getRequestHeaders } from "@tanstack/react-start/server";
-import { KeyRound } from "lucide-react";
 import { ApiKeysSections } from "@/components/api-keys/api-keys-table";
 import { CreateApiKeyDialog } from "@/components/api-keys/create-api-key-dialog";
 import { apiKeysQueryOptions } from "@/components/api-keys/queries";
@@ -60,30 +51,8 @@ function KeysSkeleton() {
   );
 }
 
-function ApiKeysEmpty() {
-  return (
-    <Empty className="border-0">
-      <EmptyHeader>
-        <EmptyMedia variant="icon">
-          <KeyRound />
-        </EmptyMedia>
-        <EmptyTitle>No API keys yet</EmptyTitle>
-        <EmptyDescription>
-          Create a key to send OpenTelemetry data to Everr or to manage
-          dashboards, runbooks, and alerts with <code>everr apply</code>.
-        </EmptyDescription>
-      </EmptyHeader>
-      <EmptyContent>
-        <CreateApiKeyDialog />
-      </EmptyContent>
-    </Empty>
-  );
-}
-
 function ApiKeysPage() {
   const keys = useQuery(apiKeysQueryOptions());
-  const isEmpty =
-    !keys.isPending && !keys.isError && (keys.data?.length ?? 0) === 0;
 
   return (
     <div className="mx-auto w-full max-w-4xl space-y-8">
@@ -104,7 +73,10 @@ function ApiKeysPage() {
             </a>
           </p>
         </div>
-        {!isEmpty && <CreateApiKeyDialog />}
+        {/* Sits outside every data-dependent branch below. The dialog shows a
+            new key exactly once, so a branch swapping under it would drop the
+            key before it can be copied. */}
+        <CreateApiKeyDialog />
       </div>
 
       {keys.isPending ? (
@@ -125,12 +97,6 @@ function ApiKeysPage() {
               }
               onRetry={() => keys.refetch()}
             />
-          </CardContent>
-        </Card>
-      ) : isEmpty ? (
-        <Card inset="flush-content">
-          <CardContent>
-            <ApiKeysEmpty />
           </CardContent>
         </Card>
       ) : (


### PR DESCRIPTION
Creating the **first** API key in an organization closed the "Copy your key now" dialog before it could be copied. The key is unrecoverable after that.

The dialog was rendered inside the page's empty-state branch. On success the keys query is invalidated, the refetch returns one key, `isEmpty` flips, and React unmounts that branch with the dialog and its `issuedKey` state inside it. Only the first key hit this; later creates run from a dialog whose parent survives the data change.

**The fix is a deletion.** `ApiKeysSections` already renders a per-section empty state, so the page-level `ApiKeysEmpty` was a second empty state on top of the first, and it was the part that unmounted the dialog. The sections now always render, the dialog moves to the page header outside every data-dependent branch, and the two section empty states pick up the icon, title, and description the deleted one had. `CreateApiKeyDialog` is untouched.

## Empty state

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/everr-labs/everr/4406ef3ed1641456fff38dc31221db7d375cf968/pr-assets/api-key-fix/before-1-empty.png" width="470"> | <img src="https://raw.githubusercontent.com/everr-labs/everr/4406ef3ed1641456fff38dc31221db7d375cf968/pr-assets/api-key-fix/after-1-empty.png" width="470"> |

## The bug

Same flow both times: create the first key, grant "Send telemetry", press **Create key**.

| Before: dialog gone, key with it | After: dialog stays, list refreshed behind it |
| --- | --- |
| <img src="https://raw.githubusercontent.com/everr-labs/everr/4406ef3ed1641456fff38dc31221db7d375cf968/pr-assets/api-key-fix/before-3-issued.png" width="470"> | <img src="https://raw.githubusercontent.com/everr-labs/everr/4406ef3ed1641456fff38dc31221db7d375cf968/pr-assets/api-key-fix/after-3-issued.png" width="470"> |

The key above is blurred and was revoked right after the screenshot.

## Testing

`-api-keys.test.tsx` creates the first key on an empty list and asserts the issued key is still on screen after the refetch lands the row. It goes red when the dialog is moved back inside a data-dependent branch. Full `packages/app` suite green, `tsc` and Biome clean, plus a manual pass on a real empty organization: open dialogs after create went from 0 to 1.

Screenshots live on the `screenshots-api-key-fix` branch, referenced by commit SHA; delete it once this merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved empty states for organization and public API keys with clearer titles, helpful descriptions, and visual icons.
  - Empty API-key pages now continue to provide access to key creation, making it easier to get started.
  - Added guidance on supported workflows and telemetry examples when no keys are available.

- **Bug Fixes**
  - Improved API-key loading, error, creation, and refresh behavior so newly created keys and list entries remain visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->