### PR TITLE
feat(app): draw the time-series panel with uPlot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,7 +1376,7 @@ dependencies = [
 
 [[package]]
 name = "everr-app"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/timeseries.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/timeseries.md
@@ -9,15 +9,17 @@ A line chart over time (or a stacked area chart with `stacked: true`). It infers
 | `unit` | string | `""` | any string | Suffix on y-axis ticks and tooltip values. Raw concatenation, **no space** — `unit: ms` renders `123ms`. |
 | `showLegend` | boolean | `false` | `true` | Show the series legend. Only the literal `true` enables it. |
 | `lineWidth` | number | `1.5` | any number | Line stroke width. |
-| `curveType` | string | `monotone` | `monotone`, `linear`, `natural`, `stepBefore`, `stepAfter` | Line interpolation. An unknown value falls back to the renderer default. |
+| `curveType` | string | `linear` | `linear`, `stepBefore`, `stepAfter` | Line interpolation. An unknown value falls back to the renderer default. `monotone` and `natural` are **deprecated**: they still parse, so old panels keep applying, but they draw as `linear` and the panel reports the deprecation. Do not write them into new panels. |
 | `connectNulls` | boolean | `false` | `true` | Bridge gaps instead of breaking the line at them. |
 | `stacked` | boolean | `false` | `true` | Render the series as stacked filled areas instead of overlaid lines. A series with no sample at a timestamp contributes 0 there; `connectNulls` has no effect. |
 
 ```yaml
 plugin:
   kind: TimeSeriesChart
-  spec: { unit: ms, showLegend: true, lineWidth: 1.5, curveType: monotone, connectNulls: false, stacked: false }
+  spec: { unit: ms, showLegend: true, lineWidth: 1.5, curveType: linear, connectNulls: false, stacked: false }
 ```
+
+Smoothing was removed on purpose: interpolating between samples draws values nobody measured, and a curve arcing across a gap reads as a slow decline rather than an outage.
 
 These six are the complete set. There is **no** `yAxis` / `min` / `max`, `legend` object, separate area / fill option, `thresholds`, `decimals`, `pointRadius`, or per-series color. Series colors come from a fixed 6-color palette assigned by order (wrapping after 6) and are not configurable.
 

--- a/crates/everr-core/src/apply.rs
+++ b/crates/everr-core/src/apply.rs
@@ -385,6 +385,10 @@ pub struct KindResult {
     /// Live resources taken over from another owning repo (only with `--adopt`).
     #[serde(default)]
     pub adopted: Vec<String>,
+    /// Non-fatal notices about the applied files, e.g. a panel option the app
+    /// has deprecated. The apply succeeded; these say what to migrate.
+    #[serde(default)]
+    pub warnings: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]

--- a/everr/demo/time-series.dashboard.yaml
+++ b/everr/demo/time-series.dashboard.yaml
@@ -8,25 +8,25 @@ spec:
     description: >-
       TimeSeriesChart regression sheet — every option (unit, showLegend,
       lineWidth, curveType, connectNulls, stacked) and behavior (grouped pivot,
-      multi-column, multi-query, null gaps, empty result) exercised with
-      deterministic TestData.
+      multi-column, multi-query, mixed sample rates, gaps, empty result, no
+      numeric column) exercised with deterministic TestData.
   duration: 7d
   refreshInterval: 1m
   panels:
-    # ── Options + core behaviors ─────────────────────────────────────
-    ts-monotone-grouped:
+    # ── Options ──────────────────────────────────────────────────────
+    ts-grouped-legend:
       kind: Panel
       spec:
         display:
-          name: "TS: monotone, grouped, legend"
-          description: "curveType: monotone · showLegend: true · connectNulls: false · grouped pivot (one series per StatusCode)"
+          name: "TS: grouped, legend"
+          description: "curveType: linear (the default) · showLegend: true · connectNulls: false · grouped pivot (one series per StatusCode)"
         plugin:
           kind: TimeSeriesChart
           spec:
             unit: ""
             showLegend: true
             lineWidth: 1.5
-            curveType: monotone
+            curveType: linear
             connectNulls: false
         queries:
           - kind: TestData
@@ -66,54 +66,6 @@ spec:
                   series:
                     - { name: p50_ms, start: 40,  noise: 5,  min: 0 }
                     - { name: p95_ms, start: 120, noise: 12, min: 0 }
-    ts-linear-connect-nulls:
-      kind: Panel
-      spec:
-        display:
-          name: "TS: linear, connectNulls, thick"
-          description: "curveType: linear · connectNulls: true (sparse errors bridge gaps) · lineWidth: 3"
-        plugin:
-          kind: TimeSeriesChart
-          spec:
-            unit: ""
-            showLegend: false
-            lineWidth: 3
-            curveType: linear
-            connectNulls: true
-        queries:
-          - kind: TestData
-            spec:
-              plugin:
-                kind: TestData
-                spec:
-                  scenario: random_walk
-                  seed: 3
-                  series:
-                    - { name: error_spans, start: 4, noise: 3, min: 0, nullChance: 0.45 }
-    ts-natural:
-      kind: Panel
-      spec:
-        display:
-          name: "TS: natural, seconds unit"
-          description: "curveType: natural · unit: s"
-        plugin:
-          kind: TimeSeriesChart
-          spec:
-            unit: s
-            showLegend: false
-            lineWidth: 1.5
-            curveType: natural
-            connectNulls: false
-        queries:
-          - kind: TestData
-            spec:
-              plugin:
-                kind: TestData
-                spec:
-                  scenario: random_walk
-                  seed: 5
-                  series:
-                    - { name: avg_s, start: 0.5, noise: 0.1, min: 0 }
     ts-step-before:
       kind: Panel
       spec:
@@ -138,6 +90,133 @@ spec:
                   seed: 9
                   series:
                     - { name: spans, start: 50, noise: 10, min: 0 }
+    ts-unit-seconds:
+      kind: Panel
+      spec:
+        display:
+          name: "TS: seconds unit"
+          description: "unit: s · single series, default interpolation"
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            unit: s
+            showLegend: false
+            lineWidth: 1.5
+            curveType: linear
+            connectNulls: false
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: random_walk
+                  seed: 5
+                  series:
+                    - { name: avg_s, start: 0.5, noise: 0.1, min: 0 }
+    # ── Gaps ─────────────────────────────────────────────────────────
+    # The same 40 rows feed both panels; only `connectNulls` differs, so the
+    # pair is what makes the option legible. `table` + `values` cycles by row
+    # index, so a run of nulls the length of the row count lands exactly once —
+    # a real outage-shaped hole, not the scatter `nullChance` produces.
+    ts-gap:
+      kind: Panel
+      spec:
+        display:
+          name: "TS: gap, unbridged"
+          description: "connectNulls: false · lineWidth: 3 · a contiguous run of nulls breaks the line where the data stops"
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            unit: ""
+            showLegend: false
+            lineWidth: 3
+            curveType: linear
+            connectNulls: false
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 40
+                  columns:
+                    - { name: ts, time: true }
+                    - name: requests
+                      values: [320, 340, 331, 358, 372, 349, 361, 388, 402, 377,
+                               365, 391, 410, 398, 421,
+                               null, null, null, null, null, null, null, null,
+                               404, 388, 415, 430, 412, 399, 423, 441, 428, 405,
+                               418, 396, 384, 401, 377, 392, 368]
+    ts-gap-connected:
+      kind: Panel
+      spec:
+        display:
+          name: "TS: gap, bridged"
+          description: "connectNulls: true · lineWidth: 3 · same rows as the panel to its left, drawn straight across the hole"
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            unit: ""
+            showLegend: false
+            lineWidth: 3
+            curveType: linear
+            connectNulls: true
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 40
+                  columns:
+                    - { name: ts, time: true }
+                    - name: requests
+                      values: [320, 340, 331, 358, 372, 349, 361, 388, 402, 377,
+                               365, 391, 410, 398, 421,
+                               null, null, null, null, null, null, null, null,
+                               404, 388, 415, 430, 412, 399, 423, 441, 428, 405,
+                               418, 396, 384, 401, 377, 392, 368]
+    ts-mixed-interval:
+      kind: Panel
+      spec:
+        display:
+          name: "TS: mixed sample rates"
+          description: "Two queries, 40 rows vs 9 · every series is null where only the other one sampled, so the coarse series needs connectNulls: true to draw at all"
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            unit: ""
+            showLegend: true
+            lineWidth: 1.5
+            curveType: linear
+            connectNulls: true
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  seed: 31
+                  rows: 40
+                  columns:
+                    - { name: ts, time: true }
+                    - { name: requests, walk: { start: 400, noise: 40, min: 0, round: 0 } }
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  seed: 32
+                  rows: 9
+                  columns:
+                    - { name: ts, time: true }
+                    - { name: batch_jobs, walk: { start: 120, noise: 25, min: 0, round: 0 } }
+    # ── Stacking ─────────────────────────────────────────────────────
     ts-stacked-grouped:
       kind: Panel
       spec:
@@ -150,7 +229,7 @@ spec:
             unit: ""
             showLegend: true
             lineWidth: 1.5
-            curveType: monotone
+            curveType: linear
             connectNulls: false
             stacked: true
         queries:
@@ -171,7 +250,7 @@ spec:
       spec:
         display:
           name: "TS: stacked, sparse series, stepAfter"
-          description: "stacked: true · curveType: stepAfter · sparse series contributes 0 where unsampled (no gaps when stacking)"
+          description: "stacked: true · curveType: stepAfter · a series with no sample contributes 0 there, so stacking never shows a gap and connectNulls has no effect"
         plugin:
           kind: TimeSeriesChart
           spec:
@@ -192,20 +271,20 @@ spec:
                   series:
                     - { name: requests, start: 300, noise: 30, min: 0 }
                     - { name: retries,  start: 25,  noise: 15, min: 0, nullChance: 0.45 }
-    # ── Data-shape behaviors + edge states ───────────────────────────
+    # ── Data-shape behaviors + empty states ──────────────────────────
     ts-multi-query:
       kind: Panel
       spec:
         display:
           name: "TS: multi-query merge"
-          description: "Two queries merged onto one timeline · showLegend: true"
+          description: "Two queries on the same timeline merge into one x-axis · showLegend: true"
         plugin:
           kind: TimeSeriesChart
           spec:
             unit: ""
             showLegend: true
             lineWidth: 1.5
-            curveType: monotone
+            curveType: linear
             connectNulls: false
         queries:
           - kind: TestData
@@ -231,14 +310,14 @@ spec:
       spec:
         display:
           name: "TS: empty result"
-          description: "Query returns no rows → 'No data in this time range' (the chart's single empty state)"
+          description: "Query returns no rows → 'No data in this time range'"
         plugin:
           kind: TimeSeriesChart
           spec:
             unit: ""
             showLegend: false
             lineWidth: 1.5
-            curveType: monotone
+            curveType: linear
             connectNulls: false
         queries:
           - kind: TestData
@@ -249,16 +328,44 @@ spec:
                   scenario: csv
                   columns: [ts, value]
                   rows: []
+    ts-no-numeric:
+      kind: Panel
+      spec:
+        display:
+          name: "TS: no numeric column"
+          description: "Rows arrive but none carry a numeric column → 'No numeric data to plot', the other empty state"
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            unit: ""
+            showLegend: false
+            lineWidth: 1.5
+            curveType: linear
+            connectNulls: false
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: csv
+                  columns: [ts, service]
+                  rows:
+                    - ["2026-01-01 00:00:00", "api"]
+                    - ["2026-01-01 00:01:00", "worker"]
   layouts:
     - kind: Grid
       spec:
         items:
-          - { x: 0,  y: 0,  width: 12, height: 8, content: { $ref: "#/spec/panels/ts-monotone-grouped" } }
+          - { x: 0,  y: 0,  width: 12, height: 8, content: { $ref: "#/spec/panels/ts-grouped-legend" } }
           - { x: 12, y: 0,  width: 12, height: 8, content: { $ref: "#/spec/panels/ts-step-after-multi-column" } }
-          - { x: 0,  y: 8,  width: 8,  height: 7, content: { $ref: "#/spec/panels/ts-linear-connect-nulls" } }
-          - { x: 8,  y: 8,  width: 8,  height: 7, content: { $ref: "#/spec/panels/ts-natural" } }
-          - { x: 16, y: 8,  width: 8,  height: 7, content: { $ref: "#/spec/panels/ts-step-before" } }
-          - { x: 0,  y: 15, width: 12, height: 8, content: { $ref: "#/spec/panels/ts-stacked-grouped" } }
-          - { x: 12, y: 15, width: 12, height: 8, content: { $ref: "#/spec/panels/ts-stacked-sparse-step" } }
-          - { x: 0,  y: 23, width: 16, height: 8, content: { $ref: "#/spec/panels/ts-multi-query" } }
-          - { x: 16, y: 23, width: 8,  height: 8, content: { $ref: "#/spec/panels/ts-empty" } }
+          - { x: 0,  y: 8,  width: 12, height: 8, content: { $ref: "#/spec/panels/ts-gap" } }
+          - { x: 12, y: 8,  width: 12, height: 8, content: { $ref: "#/spec/panels/ts-gap-connected" } }
+          - { x: 0,  y: 16, width: 8,  height: 7, content: { $ref: "#/spec/panels/ts-step-before" } }
+          - { x: 8,  y: 16, width: 8,  height: 7, content: { $ref: "#/spec/panels/ts-unit-seconds" } }
+          - { x: 16, y: 16, width: 8,  height: 7, content: { $ref: "#/spec/panels/ts-mixed-interval" } }
+          - { x: 0,  y: 23, width: 12, height: 8, content: { $ref: "#/spec/panels/ts-stacked-grouped" } }
+          - { x: 12, y: 23, width: 12, height: 8, content: { $ref: "#/spec/panels/ts-stacked-sparse-step" } }
+          - { x: 0,  y: 31, width: 12, height: 8, content: { $ref: "#/spec/panels/ts-multi-query" } }
+          - { x: 12, y: 31, width: 6,  height: 8, content: { $ref: "#/spec/panels/ts-empty" } }
+          - { x: 18, y: 31, width: 6,  height: 8, content: { $ref: "#/spec/panels/ts-no-numeric" } }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -69,6 +69,7 @@
     "simple-icons": "^16.18.1",
     "sonner": "^2.0.7",
     "topojson-client": "^3.1.0",
+    "uplot": "catalog:",
     "world-atlas": "^2.0.2",
     "yaml": "^2.9.0",
     "zod": "catalog:"

--- a/packages/app/src/components/dashboards/dashboard-panel.tsx
+++ b/packages/app/src/components/dashboards/dashboard-panel.tsx
@@ -1,10 +1,18 @@
+import { Button } from "@everr/ui/components/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@everr/ui/components/popover";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@everr/ui/components/tooltip";
+import { useCopyToClipboard } from "@everr/ui/hooks/use-copy-to-clipboard";
+import { cn } from "@everr/ui/lib/utils";
 import { useNavigate } from "@tanstack/react-router";
-import { TriangleAlert } from "lucide-react";
+import { Check, Copy, TriangleAlert } from "lucide-react";
 import type { ReactNode } from "react";
 import { useCallback, useMemo, useRef } from "react";
 import type { Panel } from "@/data/dashboards/schema";
@@ -13,9 +21,14 @@ import { useDashboardPanelData } from "./use-dashboard-panel-data";
 import { useInView } from "./use-in-view";
 import {
   getVisualizationInset,
+  getVisualizationSpecDeprecations,
   getVisualizationSpecWarnings,
   PanelVisualization,
 } from "./visualizations";
+import {
+  deprecatedOptionsPrompt,
+  type SpecDeprecation,
+} from "./visualizations/deprecations";
 
 interface DashboardPanelProps {
   panel: Panel;
@@ -52,6 +65,92 @@ function SpecWarningsIndicator({ warnings }: { warnings: string[] }) {
   );
 }
 
+/**
+ * A deprecated option isn't a mistake to point at — it's an edit waiting to be
+ * made in a file this UI can't write (ADR 0004). So this opens rather than
+ * hovers: the reader needs to get the prompt out, not just read the warning.
+ */
+function SpecDeprecationsIndicator({
+  panelName,
+  deprecations,
+}: {
+  panelName: string;
+  deprecations: SpecDeprecation[];
+}) {
+  const prompt = deprecatedOptionsPrompt({ panelName, deprecations });
+  const promptRef = useRef<HTMLElement>(null);
+  const { state: copyState, copy } = useCopyToClipboard(prompt, {
+    selectOnFailure: promptRef,
+  });
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        render={
+          <button
+            type="button"
+            className="text-amber-500 hover:text-amber-400"
+            aria-label="Deprecated panel options"
+          />
+        }
+      >
+        <TriangleAlert className="size-4" />
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-96">
+        <p className="font-medium text-sm">Deprecated panel options</p>
+        <ul className="mt-2 list-disc space-y-1 pl-4 text-muted-foreground text-xs/relaxed">
+          {deprecations.map((d) => (
+            <li key={d.option}>
+              <code className="font-mono text-foreground/90">{d.option}</code>:{" "}
+              {d.message}
+            </li>
+          ))}
+        </ul>
+        <p className="mt-3 text-muted-foreground text-xs/relaxed">
+          Paste this into your coding assistant. It finds the as-code file,
+          makes the edit, and ships it the way this repository delivers
+          resources.
+        </p>
+        <div className="mt-3 flex items-start gap-3 rounded-lg border bg-muted/30 p-3">
+          <code
+            ref={promptRef}
+            className="min-w-0 flex-1 whitespace-pre-wrap break-words font-mono text-[0.6875rem]/relaxed text-foreground/90"
+          >
+            {prompt}
+          </code>
+        </div>
+        <Button
+          type="button"
+          size="sm"
+          className="mt-3 w-full"
+          onClick={copy}
+          aria-label="Copy assistant prompt"
+        >
+          {copyState === "copied" ? (
+            <Check className="size-3.5" />
+          ) : (
+            <Copy className="size-3.5" />
+          )}
+          {copyState === "copied" ? "Copied" : "Copy prompt"}
+        </Button>
+        {/* One status line serves sighted and screen-reader users alike:
+            visible on failure, announced-only for the transient "copied". */}
+        <p
+          role="status"
+          className={cn(
+            "mt-2 text-amber-400 text-xs",
+            copyState !== "failed" && "sr-only",
+          )}
+        >
+          {copyState === "copied" && "Prompt copied to clipboard."}
+          {copyState === "failed" &&
+            "Couldn't access the clipboard. The prompt is selected, copy it manually."}
+        </p>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
 export function DashboardPanel({
   panel,
   panelKey,
@@ -70,6 +169,11 @@ export function DashboardPanel({
 
   const specWarnings = useMemo(
     () => getVisualizationSpecWarnings(plugin),
+    [plugin],
+  );
+
+  const specDeprecations = useMemo(
+    () => getVisualizationSpecDeprecations(plugin),
     [plugin],
   );
 
@@ -98,10 +202,16 @@ export function DashboardPanel({
         className="h-full"
         inset={getVisualizationInset(plugin.kind)}
         action={
-          action || specWarnings.length > 0 ? (
+          action || specWarnings.length > 0 || specDeprecations.length > 0 ? (
             <div className="flex items-center gap-1.5">
               {specWarnings.length > 0 && (
                 <SpecWarningsIndicator warnings={specWarnings} />
+              )}
+              {specDeprecations.length > 0 && (
+                <SpecDeprecationsIndicator
+                  panelName={display?.name ?? panelKey}
+                  deprecations={specDeprecations}
+                />
               )}
               {action}
             </div>

--- a/packages/app/src/components/dashboards/visualizations/deprecations.ts
+++ b/packages/app/src/components/dashboards/visualizations/deprecations.ts
@@ -1,0 +1,38 @@
+/**
+ * A panel option that still parses but no longer does what it says.
+ *
+ * Removing such an option outright would break every stored panel that sets
+ * it — the dashboard would fail to apply and the panel would lose its other
+ * options to the schema fallback. So the value stays accepted, the renderer
+ * ignores it, and both surfaces that can reach the author (the panel header
+ * and `everr apply`) say so until the file is migrated.
+ */
+export interface SpecDeprecation {
+  /** Option path within the plugin spec, e.g. `curveType`. */
+  option: string;
+  /** What the panel does now, for someone looking at it. */
+  message: string;
+  /** The edit that resolves it, phrased as an instruction to an agent. */
+  fix: string;
+}
+
+/**
+ * The handoff prompt for migrating a panel off deprecated options. Dashboards
+ * are as-code documents reconciled by apply, so the fix belongs in the YAML
+ * file, not in a UI the app doesn't offer (ADR 0004) — this hands the Agent
+ * the panel, the options, and the edit, and lets it find the file.
+ *
+ * It deliberately does NOT say to run `everr apply`: plenty of repositories
+ * apply from CI on merge, where an apply from someone's machine is at best
+ * redundant and at worst a write from an unreviewed working tree. The edit is
+ * the ask; how it ships is the repository's own convention to follow.
+ */
+export function deprecatedOptionsPrompt(input: {
+  panelName: string;
+  deprecations: SpecDeprecation[];
+}): string {
+  const list = input.deprecations
+    .map((d) => `- \`${d.option}\`: ${d.fix}`)
+    .join("\n");
+  return `/everr-setup-resources The panel "${input.panelName}" in this repository's as-code dashboards uses options Everr has deprecated:\n${list}\n\nFind the file that defines this panel and make those edits. Check the repository's other dashboards and runbooks for the same options while you are there, then ship the change the way this repository already delivers as-code resources — if a pipeline runs \`everr apply\`, commit and let it; only apply by hand if that is how this repository does it.`;
+}

--- a/packages/app/src/components/dashboards/visualizations/index.tsx
+++ b/packages/app/src/components/dashboards/visualizations/index.tsx
@@ -1,8 +1,10 @@
 import { type ComponentType, lazy, Suspense, useMemo } from "react";
 import type * as z from "zod";
+import { panelPluginDeprecations } from "@/data/dashboards/plugin-specs";
 import type { PanelPlugin } from "@/data/dashboards/schema";
 import { BarChartVisualization } from "./bar-chart/bar-chart-visualization";
 import { barChartSpec } from "./bar-chart/spec";
+import type { SpecDeprecation } from "./deprecations";
 import { GaugeChartVisualization } from "./gauge-chart/gauge-chart-visualization";
 import { gaugeChartSpec } from "./gauge-chart/spec";
 import type { GeoMapSpec } from "./geo-map/spec";
@@ -132,6 +134,17 @@ export function getVisualizationSpecWarnings(plugin: PanelPlugin): string[] {
   const entry = registry[plugin.kind];
   if (!entry) return [];
   return parseSpecLenient(entry.schema, plugin.spec).warnings;
+}
+
+/**
+ * Options this panel sets that still parse but no longer do what they say.
+ * Unlike a spec warning, nothing was ignored for being invalid — the panel
+ * renders, just not the way the file asks.
+ */
+export function getVisualizationSpecDeprecations(
+  plugin: PanelPlugin,
+): SpecDeprecation[] {
+  return panelPluginDeprecations[plugin.kind]?.(plugin.spec) ?? [];
 }
 
 export interface PanelVisualizationProps {

--- a/packages/app/src/components/dashboards/visualizations/parse-spec.test.ts
+++ b/packages/app/src/components/dashboards/visualizations/parse-spec.test.ts
@@ -13,7 +13,7 @@ describe("parseSpecLenient", () => {
     expect(warnings).toEqual([]);
     expect(spec.unit).toBe("ms");
     expect(spec.lineWidth).toBe(2);
-    expect(spec.curveType).toBe("monotone");
+    expect(spec.curveType).toBe("linear");
   });
 
   it("drops an invalid option to its default and warns with the path", () => {
@@ -34,7 +34,7 @@ describe("parseSpecLenient", () => {
       showLegend: true,
     });
     expect(spec.lineWidth).toBe(1.5);
-    expect(spec.curveType).toBe("monotone");
+    expect(spec.curveType).toBe("linear");
     expect(spec.showLegend).toBe(true);
     expect(warnings).toHaveLength(2);
   });

--- a/packages/app/src/components/dashboards/visualizations/time-series-chart/spec.ts
+++ b/packages/app/src/components/dashboards/visualizations/time-series-chart/spec.ts
@@ -1,4 +1,22 @@
 import * as z from "zod";
+import type { SpecDeprecation } from "../deprecations";
+
+/**
+ * Line interpolations. `monotone` and `natural` are the smoothed ones: they
+ * are still accepted so stored panels keep loading, but they draw as `linear`
+ * and report a deprecation. Smoothing invents values between samples, which
+ * on a time series reads as data that was never measured — a curve arcing
+ * across a gap looks like a slow decline rather than an outage.
+ */
+const CURVE_TYPES = [
+  "linear",
+  "stepBefore",
+  "stepAfter",
+  "monotone",
+  "natural",
+] as const;
+
+const DEPRECATED_CURVE_TYPES = new Set<string>(["monotone", "natural"]);
 
 /**
  * TimeSeriesChart plugin options. Loose so unknown keys flow through verbatim
@@ -9,11 +27,24 @@ export const timeSeriesChartSpec = z.looseObject({
   unit: z.string().default(""),
   showLegend: z.boolean().default(false),
   lineWidth: z.number().positive().default(1.5),
-  curveType: z
-    .enum(["monotone", "linear", "natural", "stepBefore", "stepAfter"])
-    .default("monotone"),
+  curveType: z.enum(CURVE_TYPES).default("linear"),
   connectNulls: z.boolean().default(false),
   stacked: z.boolean().default(false),
 });
 
 export type TimeSeriesChartSpec = z.infer<typeof timeSeriesChartSpec>;
+
+export function timeSeriesChartDeprecations(raw: unknown): SpecDeprecation[] {
+  const curveType = (raw as { curveType?: unknown } | null | undefined)
+    ?.curveType;
+  if (typeof curveType !== "string" || !DEPRECATED_CURVE_TYPES.has(curveType)) {
+    return [];
+  }
+  return [
+    {
+      option: "curveType",
+      message: `"${curveType}" smoothing is no longer drawn; this panel renders as "linear"`,
+      fix: `replace \`curveType: ${curveType}\` with \`curveType: linear\`, or drop the line (linear is the default)`,
+    },
+  ];
+}

--- a/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-chart-visualization.tsx
@@ -1,21 +1,7 @@
-import {
-  ChartContainer,
-  ChartLegend,
-  ChartLegendContent,
-} from "@everr/ui/components/chart";
 import { LineChart as LineChartIcon } from "lucide-react";
-import { useCallback, useMemo, useRef, useState } from "react";
-import {
-  Area,
-  CartesianGrid,
-  ComposedChart,
-  Line,
-  ReferenceArea,
-  ReferenceDot,
-  ReferenceLine,
-  XAxis,
-  YAxis,
-} from "recharts";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type uPlot from "uplot";
+import UPlot from "uplot";
 import { CursorTooltip } from "@/components/cursor-tooltip";
 import {
   createTimeTickFormatter,
@@ -25,26 +11,84 @@ import {
 import type { VisualizationProps } from "../index";
 import { SeriesTooltipContent } from "../series-tooltip";
 import type { TimeSeriesChartSpec } from "./spec";
-import { buildChartModel, buildStackedData, TS_KEY } from "./time-series-data";
+import { buildChartModel, buildStackedValues } from "./time-series-data";
+import { TimeSeriesLegend } from "./time-series-legend";
+import { UplotChart, type UplotOptions } from "./uplot-chart";
 
 const BRUSH_COLOR = SERIES_COLORS[0]!;
 const MAX_X_TICKS = 6;
+/** Ignore a brush that selects less than a second — it's a click, not a zoom. */
+const MIN_ZOOM_MS = 1000;
+const AXIS_FONT = "12px system-ui, sans-serif";
 
-function getPlotArea(container: HTMLElement): DOMRect | null {
-  const grid = container.querySelector(".recharts-cartesian-grid");
-  return grid?.getBoundingClientRect() ?? null;
+/**
+ * `SERIES_COLORS` are literal `hsl(h, s%, l%)` strings; areas and the brush
+ * want the same hue at partial opacity. Anything else passes through opaque.
+ */
+function withAlpha(color: string, alpha: number): string {
+  return color.startsWith("hsl(")
+    ? `hsla(${color.slice(4, -1)}, ${alpha})`
+    : color;
 }
 
-function pxToTimestamp(
-  clientX: number,
-  plotRect: DOMRect,
-  domain: [number, number],
-): number {
-  const ratio = Math.max(
-    0,
-    Math.min(1, (clientX - plotRect.left) / plotRect.width),
+const cssColorCache = new Map<string, string>();
+
+/**
+ * A theme token as a literal color. The chart draws to a canvas, which can't
+ * resolve `var(--border)`, so the value is measured off a throwaway element.
+ */
+function cssColor(token: string, fallback: string): string {
+  const cached = cssColorCache.get(token);
+  if (cached !== undefined) return cached;
+  if (typeof document === "undefined") return fallback;
+
+  const probe = document.createElement("span");
+  probe.style.color = `var(${token})`;
+  probe.style.display = "none";
+  document.body.appendChild(probe);
+  const resolved = getComputedStyle(probe).color || fallback;
+  probe.remove();
+
+  cssColorCache.set(token, resolved);
+  return resolved;
+}
+
+function pathBuilder(curveType: TimeSeriesChartSpec["curveType"]) {
+  const paths = UPlot.paths!;
+  switch (curveType) {
+    // The step happens before the point (align -1) or after it (align 1).
+    case "stepBefore":
+      return paths.stepped!({ align: -1 });
+    case "stepAfter":
+      return paths.stepped!({ align: 1 });
+    // `monotone` and `natural` reach here from panels written before smoothing
+    // was deprecated; they draw straight, and the panel says so.
+    default:
+      return paths.linear!();
+  }
+}
+
+/**
+ * uPlot gives an axis a fixed width unless told otherwise, which clips wide
+ * labels ("4,288MB" renders as "88MB"). Measure the widest one instead.
+ */
+function measureAxisSize(u: uPlot, values: string[] | null, gap: number) {
+  const longest = (values ?? []).reduce(
+    (acc, value) => (value.length > acc.length ? value : acc),
+    "",
   );
-  return domain[0] + ratio * (domain[1] - domain[0]);
+  if (longest === "") return gap;
+  u.ctx.save();
+  u.ctx.font = AXIS_FONT;
+  const width = u.ctx.measureText(longest).width;
+  u.ctx.restore();
+  return Math.ceil(width) + gap;
+}
+
+interface CursorState {
+  idx: number;
+  clientX: number;
+  clientY: number;
 }
 
 export function TimeSeriesChartVisualization({
@@ -56,106 +100,215 @@ export function TimeSeriesChartVisualization({
   const { showLegend, connectNulls, lineWidth, unit, curveType, stacked } =
     spec;
 
-  const containerRef = useRef<HTMLDivElement>(null);
-  const plotRectRef = useRef<DOMRect | null>(null);
-  const [brushStart, setBrushStart] = useState<number | null>(null);
-  const [brushEnd, setBrushEnd] = useState<number | null>(null);
-  const [tooltipState, setTooltipState] = useState<{
-    clientX: number;
-    clientY: number;
-    index: number;
-  } | null>(null);
+  const [cursor, setCursor] = useState<CursorState | null>(null);
+  const draggingRef = useRef(false);
+
+  const onTimeRangeChangeRef = useRef(onTimeRangeChange);
+  useEffect(() => {
+    onTimeRangeChangeRef.current = onTimeRangeChange;
+  }, [onTimeRangeChange]);
 
   const domain = useMemo<[number, number]>(
     () => [timeRange.from.getTime(), timeRange.to.getTime()],
     [timeRange],
   );
 
-  const { chartData, valueKeys, chartConfig, seriesData } = useMemo(
+  const frame = useMemo(
     () => buildChartModel(data ?? [], domain),
     [data, domain],
   );
 
-  const stackedData = useMemo(
-    () => (stacked ? buildStackedData(chartData, valueKeys) : null),
-    [stacked, chartData, valueKeys],
+  const alignedData = useMemo<uPlot.AlignedData>(() => {
+    const values = stacked
+      ? buildStackedValues(frame.series)
+      : frame.series.map((s) => s.values);
+    return [frame.x, ...values] as uPlot.AlignedData;
+  }, [frame, stacked]);
+
+  const formatValue = useMemo(
+    () => (value: number) => (unit ? `${value}${unit}` : String(value)),
+    [unit],
   );
 
-  const ticks = useMemo(() => generateTimeTicks(domain, MAX_X_TICKS), [domain]);
+  const options = useMemo<UplotOptions>(() => {
+    const axisColor = cssColor("--muted-foreground", "#8a8a8a");
+    const gridColor = cssColor("--border", "#d4d4d8");
+    const pointStroke = cssColor("--card", "#ffffff");
+    const ticks = generateTimeTicks(domain, MAX_X_TICKS);
+    const formatTick = createTimeTickFormatter(domain);
+    let stopDragTracking: (() => void) | undefined;
 
-  const handleChartMouseMove = useCallback(
-    (e: React.MouseEvent) => {
-      if (!containerRef.current || chartData.length === 0) return;
-      const plotRect = getPlotArea(containerRef.current);
-      if (!plotRect) return;
-      const ts = pxToTimestamp(e.clientX, plotRect, domain);
-      let nearest = 0;
-      let minDist = Math.abs((chartData[0]![TS_KEY] as number) - ts);
-      for (let i = 1; i < chartData.length; i++) {
-        const dist = Math.abs((chartData[i]![TS_KEY] as number) - ts);
-        if (dist < minDist) {
-          minDist = dist;
-          nearest = i;
-        }
-      }
-      setTooltipState({
-        clientX: e.clientX,
-        clientY: e.clientY,
-        index: nearest,
-      });
-    },
-    [domain, chartData],
-  );
+    return {
+      // The x axis is pinned to the panel's time range rather than to the
+      // data: the leading bucket kept by the frame sits before `from`, and
+      // letting it stretch the axis would misplace every other point.
+      scales: {
+        x: { time: false, range: () => domain },
+        // Lines auto-range to the data (a flat series near 11ms is worth
+        // seeing at 11ms, not squashed against a zero baseline), but a stacked
+        // band is a quantity piled on zero — cutting the baseline off would
+        // make the areas mean nothing.
+        y: stacked
+          ? {
+              range: (_u, min, max) =>
+                UPlot.rangeNum(Math.min(0, min), max, 0.1, true),
+            }
+          : {},
+      },
+      padding: [8, 12, 0, 0],
+      legend: { show: false },
+      cursor: {
+        y: false,
+        drag: { x: true, y: false, setScale: false, dist: 4 },
+        points: { size: 8, width: 2, stroke: () => pointStroke },
+        // Snap the crosshair onto the sample the tooltip is reporting — left
+        // free, the two disagree by however far the nearest sample is, which
+        // on a sparse panel is hours. A drag is exempt: uPlot draws the
+        // selection from this same position, and a zoom has to be able to
+        // start and end between samples.
+        move: (u, left, top) => {
+          if (draggingRef.current || left < 0) return [left, top];
+          const ts = u.data[0][u.posToIdx(left)];
+          return ts == null ? [left, top] : [u.valToPos(ts, "x"), top];
+        },
+      },
+      axes: [
+        {
+          stroke: axisColor,
+          font: AXIS_FONT,
+          gap: 8,
+          ticks: { show: false },
+          border: { show: false },
+          grid: { show: false },
+          splits: () => ticks,
+          values: (_u, splits) => splits.map(formatTick),
+        },
+        {
+          stroke: axisColor,
+          font: AXIS_FONT,
+          gap: 8,
+          ticks: { show: false },
+          border: { show: false },
+          grid: { stroke: gridColor, width: 1 },
+          values: (_u, splits) => splits.map(formatValue),
+          size: (u, values) => measureAxisSize(u, values, 12),
+        },
+      ],
+      series: [
+        {},
+        ...frame.series.map((s) => ({
+          label: s.label,
+          stroke: s.color,
+          width: lineWidth,
+          spanGaps: connectNulls,
+          paths: pathBuilder(curveType),
+          points: { show: false },
+          ...(stacked ? { fill: withAlpha(s.color, 0.4) } : {}),
+        })),
+      ],
+      // Stacked series carry running totals, so each band is the strip between
+      // its own line and the one below it. The bottom series has nothing below
+      // it and fills to zero on its own.
+      bands: stacked
+        ? frame.series
+            .slice(1)
+            .map((_, i) => ({ series: [i + 2, i + 1] as [number, number] }))
+        : undefined,
+      hooks: {
+        ready: [
+          (u: uPlot) => {
+            const down = () => {
+              draggingRef.current = true;
+            };
+            const up = () => {
+              draggingRef.current = false;
+            };
+            // Capture phase: uPlot computes the drag's start position from
+            // `cursor.move` inside its own mousedown handler, so the flag has
+            // to be set before that handler runs or the start snaps.
+            u.over.addEventListener("mousedown", down, true);
+            // On the document, not the plot: a drag often ends outside it.
+            document.addEventListener("mouseup", up);
+            stopDragTracking = () => {
+              u.over.removeEventListener("mousedown", down, true);
+              document.removeEventListener("mouseup", up);
+            };
+          },
+        ],
+        destroy: [
+          () => {
+            stopDragTracking?.();
+            draggingRef.current = false;
+          },
+        ],
+        setCursor: [
+          (u: uPlot) => {
+            const { idx, left, top } = u.cursor;
+            if (idx == null || left == null || left < 0) {
+              setCursor(null);
+              return;
+            }
+            const rect = u.over.getBoundingClientRect();
+            setCursor({
+              idx,
+              clientX: rect.left + left,
+              clientY: rect.top + (top ?? 0),
+            });
+          },
+        ],
+        setSelect: [
+          (u: uPlot) => {
+            const { left, width } = u.select;
+            if (width <= 0) return;
+            const from = u.posToVal(left, "x");
+            const to = u.posToVal(left + width, "x");
+            // Clear before dispatching: the new time range rebuilds the chart,
+            // and a leftover selection would be drawn over it.
+            u.setSelect({ left: 0, top: 0, width: 0, height: 0 }, false);
+            if (to - from > MIN_ZOOM_MS) {
+              onTimeRangeChangeRef.current({
+                from: new Date(from),
+                to: new Date(to),
+              });
+            }
+          },
+        ],
+      },
+    };
+  }, [
+    frame.series,
+    domain,
+    lineWidth,
+    connectNulls,
+    curveType,
+    stacked,
+    formatValue,
+  ]);
 
-  const handleChartMouseLeave = useCallback(() => {
-    setTooltipState(null);
-  }, []);
+  // Everything the options close over that is worth a rebuilt canvas. A new
+  // frame with the same series line-up is a `setData` update, not a rebuild.
+  const optionsKey = [
+    frame.series.map((s) => `${s.key}:${s.label}`).join("|"),
+    domain[0],
+    domain[1],
+    lineWidth,
+    connectNulls,
+    curveType,
+    stacked,
+    unit,
+  ].join("/");
 
-  const handlePointerDown = useCallback(
-    (e: React.PointerEvent) => {
-      if (!containerRef.current) return;
-      const plotRect = getPlotArea(containerRef.current);
-      if (!plotRect) return;
-      plotRectRef.current = plotRect;
-      const ts = pxToTimestamp(e.clientX, plotRect, domain);
-      setBrushStart(ts);
-      setBrushEnd(null);
-      (e.target as HTMLElement).setPointerCapture(e.pointerId);
-    },
-    [domain],
-  );
-
-  const handlePointerMove = useCallback(
-    (e: React.PointerEvent) => {
-      if (brushStart == null || !plotRectRef.current) return;
-      const ts = pxToTimestamp(e.clientX, plotRectRef.current, domain);
-      setBrushEnd(ts);
-    },
-    [brushStart, domain],
-  );
-
-  const handlePointerUp = useCallback(() => {
-    if (brushStart != null && brushEnd != null) {
-      const from = Math.min(brushStart, brushEnd);
-      const to = Math.max(brushStart, brushEnd);
-      if (to - from > 1000) {
-        onTimeRangeChange({ from: new Date(from), to: new Date(to) });
-      }
-    }
-    setBrushStart(null);
-    setBrushEnd(null);
-    plotRectRef.current = null;
-  }, [brushStart, brushEnd, onTimeRangeChange]);
-
-  // `valueKeys.length === 0` means rows came back but none had a numeric column
-  // to plot — buildChartModel still emits timestamp-only entries, so guard on it
-  // explicitly instead of letting an axis-only, line-less chart render.
-  if (!data || chartData.length === 0 || valueKeys.length === 0) {
+  // A frame with no series or no timestamps would render as an axis-only,
+  // line-less chart — guard on both explicitly.
+  if (!data || frame.series.length === 0 || frame.x.length === 0) {
+    // Rows but no series means the query returned no numeric column to plot,
+    // which is a different problem from a query that returned nothing.
+    const hasRows = data?.some((rows) => rows?.length > 0) ?? false;
     const message = !data
       ? "Configure a query to see results"
-      : chartData.length === 0
-        ? "No data in this time range"
-        : "No numeric data to plot";
+      : hasRows && frame.series.length === 0
+        ? "No numeric data to plot"
+        : "No data in this time range";
     return (
       <div className="flex h-full flex-col items-center justify-center gap-2 text-muted-foreground">
         <LineChartIcon className="size-8" />
@@ -164,139 +317,46 @@ export function TimeSeriesChartVisualization({
     );
   }
 
-  const tooltipRow = tooltipState ? chartData[tooltipState.index] : undefined;
-  const tooltipTs = tooltipRow ? (tooltipRow[TS_KEY] as number) : undefined;
+  const tooltipRows = cursor
+    ? frame.series
+        .map((s) => ({ series: s, value: s.values[cursor.idx] }))
+        .filter((row) => row.value != null)
+        .map(({ series, value }) => ({
+          key: series.key,
+          color: series.color,
+          label: series.label,
+          value: formatValue(value!),
+        }))
+    : [];
+
+  const legendItems = frame.series.map((s) => ({
+    key: s.key,
+    label: s.label,
+    color: s.color,
+  }));
 
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: chart interaction area
     <div
-      ref={containerRef}
-      className="relative h-full w-full select-none"
-      onMouseMove={handleChartMouseMove}
-      onMouseLeave={handleChartMouseLeave}
-      onPointerDown={handlePointerDown}
-      onPointerMove={handlePointerMove}
-      onPointerUp={handlePointerUp}
+      className="flex h-full w-full select-none flex-col"
+      style={
+        {
+          "--brush-fill": withAlpha(BRUSH_COLOR, 0.15),
+          "--brush-stroke": withAlpha(BRUSH_COLOR, 0.3),
+        } as React.CSSProperties
+      }
     >
-      <ChartContainer config={chartConfig} className="h-full w-full">
-        <ComposedChart
-          data={stackedData ?? chartData}
-          margin={{ left: 12, right: 12, top: 8 }}
-        >
-          <CartesianGrid vertical={false} />
-          <XAxis
-            dataKey={TS_KEY}
-            type="number"
-            domain={domain}
-            ticks={ticks}
-            tickLine={false}
-            axisLine={false}
-            tickMargin={8}
-            tickFormatter={createTimeTickFormatter(domain)}
-            // Hard domain: the leading bucket kept by buildSeriesData sits
-            // before `from` — clip its line at the plot edge instead of letting
-            // recharts stretch the axis to fit it (which would also skew the
-            // linear px↔ts mapping the brush and crosshair rely on).
-            allowDataOverflow
-          />
-          <YAxis
-            tickLine={false}
-            axisLine={false}
-            tickMargin={8}
-            tickFormatter={(v) => (unit ? `${v}${unit}` : String(v))}
-          />
-          {showLegend && <ChartLegend content={<ChartLegendContent />} />}
-          {valueKeys.map((key) =>
-            stacked ? (
-              // Stacked areas must all read from the chart-level data (the
-              // zero-filled merged timeline) — recharts accumulates stackId
-              // offsets across that shared array, not across per-series ones.
-              <Area
-                key={key}
-                stackId="stack"
-                dataKey={key}
-                type={curveType}
-                stroke={`var(--color-${key})`}
-                fill={`var(--color-${key})`}
-                fillOpacity={0.4}
-                strokeWidth={lineWidth}
-                dot={false}
-                isAnimationActive={false}
-              />
-            ) : (
-              <Line
-                key={key}
-                // Each line renders from its own data so it connects its own
-                // points regardless of where other series have samples.
-                data={seriesData[key]}
-                dataKey={key}
-                type={curveType}
-                stroke={`var(--color-${key})`}
-                strokeWidth={lineWidth}
-                dot={false}
-                connectNulls={connectNulls}
-                isAnimationActive={false}
-              />
-            ),
-          )}
-          {tooltipTs !== undefined && (
-            <ReferenceLine
-              x={tooltipTs}
-              stroke="var(--border)"
-              strokeDasharray="3 3"
-            />
-          )}
-          {tooltipTs !== undefined &&
-            (() => {
-              // In stacked mode each dot sits at the series' cumulative top
-              // (the running sum in render order), matching where the band
-              // edge is drawn — not at the raw value.
-              let stackTop = 0;
-              return valueKeys.map((key) => {
-                const val = tooltipRow?.[key];
-                const raw = typeof val === "number" ? val : 0;
-                stackTop += raw;
-                if (typeof val !== "number") return null;
-                return (
-                  <ReferenceDot
-                    key={key}
-                    x={tooltipTs}
-                    y={stacked ? stackTop : val}
-                    r={4}
-                    fill={chartConfig[key]?.color}
-                    stroke="var(--card)"
-                    strokeWidth={2}
-                  />
-                );
-              });
-            })()}
-          {brushStart != null && brushEnd != null && (
-            <ReferenceArea
-              x1={brushStart}
-              x2={brushEnd}
-              fill={BRUSH_COLOR}
-              fillOpacity={0.15}
-              stroke={BRUSH_COLOR}
-              strokeOpacity={0.3}
-            />
-          )}
-        </ComposedChart>
-      </ChartContainer>
-      {tooltipRow && (
-        <CursorTooltip x={tooltipState!.clientX} y={tooltipState!.clientY}>
+      <UplotChart
+        options={options}
+        optionsKey={optionsKey}
+        data={alignedData}
+        className="min-h-0 flex-1 [&_.u-cursor-x]:border-border [&_.u-cursor-x]:border-dashed [&_.u-select]:border [&_.u-select]:border-[var(--brush-stroke)] [&_.u-select]:bg-[var(--brush-fill)]"
+      />
+      {showLegend && <TimeSeriesLegend items={legendItems} />}
+      {cursor && tooltipRows.length > 0 && (
+        <CursorTooltip x={cursor.clientX} y={cursor.clientY}>
           <SeriesTooltipContent
-            title={new Date(tooltipTs!).toLocaleString()}
-            rows={valueKeys
-              .filter((key) => tooltipRow[key] != null)
-              .map((key) => {
-                const val = tooltipRow[key];
-                return {
-                  key,
-                  color: chartConfig[key]?.color,
-                  label: chartConfig[key]?.label ?? key,
-                  value: unit ? `${val}${unit}` : String(val),
-                };
-              })}
+            title={new Date(frame.x[cursor.idx]!).toLocaleString()}
+            rows={tooltipRows}
           />
         </CursorTooltip>
       )}

--- a/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-data.test.ts
+++ b/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-data.test.ts
@@ -1,26 +1,32 @@
 import { describe, expect, it } from "vitest";
-import { buildChartModel, buildStackedData } from "./time-series-data";
-
-const TS_KEY = "__ts";
+import {
+  buildChartModel,
+  buildStackedValues,
+  type TimeSeriesFrame,
+} from "./time-series-data";
 
 // A domain wide enough that no test data is clamped away.
 const WIDE: [number, number] = [0, Date.parse("2100-01-01T00:00:00Z")];
 
+const keys = (frame: TimeSeriesFrame) => frame.series.map((s) => s.key);
+const values = (frame: TimeSeriesFrame, key: string) =>
+  frame.series.find((s) => s.key === key)?.values;
+const labels = (frame: TimeSeriesFrame) => frame.series.map((s) => s.label);
+
 describe("buildChartModel", () => {
   it("assigns an opaque render key and keeps the column name as the label", () => {
-    const model = buildChartModel(
+    const frame = buildChartModel(
       [[{ time: "2026-06-07T00:00:00", value: 5 }]],
       WIDE,
     );
-    expect(model.valueKeys).toEqual(["s0"]);
-    expect(model.chartConfig.s0?.label).toBe("value");
-    expect(model.chartData[0]?.[TS_KEY]).toBeTypeOf("number");
-    expect(model.chartData[0]?.s0).toBe(5);
-    expect(model.seriesData.s0?.[0]?.s0).toBe(5);
+    expect(keys(frame)).toEqual(["s0"]);
+    expect(labels(frame)).toEqual(["value"]);
+    expect(frame.x[0]).toBeTypeOf("number");
+    expect(values(frame, "s0")).toEqual([5]);
   });
 
   it("skips rows whose timestamp cannot be parsed", () => {
-    const model = buildChartModel(
+    const frame = buildChartModel(
       [
         [
           { time: "garbage", value: 99 },
@@ -30,27 +36,26 @@ describe("buildChartModel", () => {
       WIDE,
     );
     // The bad row must not become a point at epoch 0.
-    expect(model.chartData).toHaveLength(1);
-    expect(model.chartData[0]?.s0).toBe(5);
-    expect(model.seriesData.s0).toHaveLength(1);
+    expect(frame.x).toHaveLength(1);
+    expect(values(frame, "s0")).toEqual([5]);
   });
 
   it("gives each series a distinct key across two queries and merges by time", () => {
-    const model = buildChartModel(
+    const frame = buildChartModel(
       [
         [{ time: "2026-06-07T00:00:00", value: 1 }],
         [{ time: "2026-06-07T00:00:00", value: 2 }],
       ],
       WIDE,
     );
-    expect(model.valueKeys).toEqual(["s0", "s1"]);
-    expect(model.chartData).toHaveLength(1);
-    expect(model.chartData[0]?.s0).toBe(1);
-    expect(model.chartData[0]?.s1).toBe(2);
+    expect(keys(frame)).toEqual(["s0", "s1"]);
+    expect(frame.x).toHaveLength(1);
+    expect(values(frame, "s0")).toEqual([1]);
+    expect(values(frame, "s1")).toEqual([2]);
   });
 
-  it("renders each series from its own data so non-overlapping query timestamps don't break lines", () => {
-    const model = buildChartModel(
+  it("aligns every series to one timeline, leaving a null where a series has no sample", () => {
+    const frame = buildChartModel(
       [
         [
           { time: "2026-06-07T00:00:00", value: 1 },
@@ -63,39 +68,31 @@ describe("buildChartModel", () => {
       ],
       WIDE,
     );
-    expect(model.valueKeys).toEqual(["s0", "s1"]);
-    // Each series' own array holds only its own points — the other query's
-    // timestamps are absent, not undefined holes that would break the line.
-    expect(model.seriesData.s0?.map((r) => r.s0)).toEqual([1, 2]);
-    expect(model.seriesData.s0).toHaveLength(2);
-    expect(model.seriesData.s1?.map((r) => r.s1)).toEqual([3, 4]);
-    expect(model.seriesData.s1).toHaveLength(2);
-    // The merged timeline still carries every timestamp for the crosshair.
-    expect(model.chartData).toHaveLength(4);
+    expect(keys(frame)).toEqual(["s0", "s1"]);
+    expect(frame.x).toHaveLength(4);
+    // Each query samples half the timeline; the other half is a gap, not a
+    // value the query never returned.
+    expect(values(frame, "s0")).toEqual([1, 2, null, null]);
+    expect(values(frame, "s1")).toEqual([null, null, 3, 4]);
   });
 
   it("assigns distinct colors to series across queries", () => {
-    const model = buildChartModel(
+    const frame = buildChartModel(
       [
         [{ time: "2026-06-07T00:00:00", value: 1 }],
         [{ time: "2026-06-07T00:00:00", value: 2 }],
       ],
       WIDE,
     );
-    expect(model.chartConfig.s0?.color).not.toBe(model.chartConfig.s1?.color);
+    expect(frame.series[0]?.color).not.toBe(frame.series[1]?.color);
   });
 
-  it("returns an empty model for empty input", () => {
-    expect(buildChartModel([], WIDE)).toEqual({
-      chartData: [],
-      valueKeys: [],
-      chartConfig: {},
-      seriesData: {},
-    });
+  it("returns an empty frame for empty input", () => {
+    expect(buildChartModel([], WIDE)).toEqual({ x: [], series: [] });
   });
 
   it("pivots a grouped series into one key per group value", () => {
-    const model = buildChartModel(
+    const frame = buildChartModel(
       [
         [
           { time: "2026-06-07T00:00:00", host: "a", value: 1 },
@@ -106,22 +103,17 @@ describe("buildChartModel", () => {
       WIDE,
     );
     // One opaque key per group value, in the order the rows arrived (a, b).
-    expect(model.valueKeys).toEqual(["s0", "s1"]);
-    expect(model.chartConfig.s0?.label).toBe("a");
-    expect(model.chartConfig.s1?.label).toBe("b");
+    expect(keys(frame)).toEqual(["s0", "s1"]);
+    expect(labels(frame)).toEqual(["a", "b"]);
     // Rows are merged by timestamp: host a+b at t0, host a at t1.
-    expect(model.chartData).toHaveLength(2);
-    expect(model.chartData[0]?.s0).toBe(1);
-    expect(model.chartData[0]?.s1).toBe(2);
-    expect(model.chartData[1]?.s0).toBe(3);
-    // host "b" only has a point at t0 — its line data is that one point, not a
-    // hole at t1.
-    expect(model.seriesData.s1?.map((r) => r.s1)).toEqual([2]);
-    expect(model.seriesData.s0?.map((r) => r.s0)).toEqual([1, 3]);
+    expect(frame.x).toHaveLength(2);
+    expect(values(frame, "s0")).toEqual([1, 3]);
+    // host "b" is absent at t1 — a gap there, not a zero.
+    expect(values(frame, "s1")).toEqual([2, null]);
   });
 
   it("keeps distinct group values that would mangle to the same key separate", () => {
-    const model = buildChartModel(
+    const frame = buildChartModel(
       [
         [
           { time: "2026-06-07T00:00:00", host: "a-b", value: 1 },
@@ -132,27 +124,26 @@ describe("buildChartModel", () => {
     );
     // "a-b" and "a b" both sanitize to "a_b"; opaque keys keep them apart so
     // neither series overwrites the other.
-    expect(model.valueKeys).toEqual(["s0", "s1"]);
-    const labels = model.valueKeys.map((k) => model.chartConfig[k]?.label);
-    expect(labels).toEqual(["a-b", "a b"]); // first-seen group order
-    expect(model.chartData[0]?.s0).toBe(1); // "a-b"
-    expect(model.chartData[0]?.s1).toBe(2); // "a b"
+    expect(keys(frame)).toEqual(["s0", "s1"]);
+    expect(labels(frame)).toEqual(["a-b", "a b"]); // first-seen group order
+    expect(values(frame, "s0")).toEqual([1]);
+    expect(values(frame, "s1")).toEqual([2]);
   });
 
   it("keeps non-identifier column names as the label without mangling the key", () => {
-    const model = buildChartModel(
+    const frame = buildChartModel(
       [[{ time: "2026-06-07T00:00:00", "count()": "42" }]],
       WIDE,
     );
-    // `count()` as a render key would produce `var(--color-count())` (invalid);
-    // the opaque key sidesteps that and the original name stays as the label.
-    expect(model.valueKeys).toEqual(["s0"]);
-    expect(model.chartConfig.s0?.label).toBe("count()");
-    expect(model.chartData[0]?.s0).toBe(42);
+    // The key identifies the series everywhere it is looked up; the original
+    // name, punctuation and all, stays as the label.
+    expect(keys(frame)).toEqual(["s0"]);
+    expect(labels(frame)).toEqual(["count()"]);
+    expect(values(frame, "s0")).toEqual([42]);
   });
 
   it("detects a series whose first bucket is NULL but later buckets are numeric", () => {
-    const model = buildChartModel(
+    const frame = buildChartModel(
       [
         [
           { time: "2026-06-07T00:00:00", p99: null },
@@ -161,25 +152,25 @@ describe("buildChartModel", () => {
       ],
       WIDE,
     );
-    expect(model.valueKeys).toEqual(["s0"]);
-    expect(model.chartConfig.s0?.label).toBe("p99");
-    expect(model.chartData[1]?.s0).toBe(12.5);
+    expect(keys(frame)).toEqual(["s0"]);
+    expect(labels(frame)).toEqual(["p99"]);
+    expect(values(frame, "s0")).toEqual([null, 12.5]);
   });
 
   it("treats quoted numeric strings (ClickHouse aggregates) as values", () => {
-    const model = buildChartModel(
+    const frame = buildChartModel(
       [[{ time: "2026-06-07T00:00:00", count: "42" }]],
       WIDE,
     );
-    expect(model.valueKeys).toEqual(["s0"]);
-    expect(model.chartData[0]?.s0).toBe(42);
+    expect(keys(frame)).toEqual(["s0"]);
+    expect(values(frame, "s0")).toEqual([42]);
   });
 
   it("keeps in-domain rows at their real timestamps, even when offset from any grid", () => {
     const minute = 60_000;
     // 13s past the minute boundary: an epoch-aligned grid would drop these.
     const t0 = Date.parse("2026-06-07T00:00:13Z");
-    const model = buildChartModel(
+    const frame = buildChartModel(
       [
         [
           { time: "2026-06-07T00:00:13", value: 1 },
@@ -189,15 +180,14 @@ describe("buildChartModel", () => {
       ],
       [t0 - minute, t0 + 5 * minute],
     );
-    expect(model.seriesData.s0).toHaveLength(3);
-    expect(model.seriesData.s0?.map((r) => r.s0)).toEqual([1, 2, 3]);
-    expect(model.seriesData.s0?.[0]?.[TS_KEY]).toBe(t0);
+    expect(frame.x).toEqual([t0, t0 + minute, t0 + 2 * minute]);
+    expect(values(frame, "s0")).toEqual([1, 2, 3]);
   });
 
   it("drops rows outside the domain", () => {
     const minute = 60_000;
     const t1 = Date.parse("2026-06-07T00:01:00Z");
-    const model = buildChartModel(
+    const frame = buildChartModel(
       [
         [
           // Before the domain, and its bucket [00:00, 00:01) ends exactly at
@@ -209,14 +199,14 @@ describe("buildChartModel", () => {
       ],
       [t1, t1 + 5 * minute],
     );
-    expect(model.seriesData.s0?.map((r) => r.s0)).toEqual([2, 3]);
-    expect(model.chartData.map((r) => r.s0)).toEqual([2, 3]);
+    expect(frame.x).toEqual([t1, t1 + minute]);
+    expect(values(frame, "s0")).toEqual([2, 3]);
   });
 
   it("keeps the leading bucket when its interval overlaps an unaligned domain start", () => {
     const minute = 60_000;
     const t0 = Date.parse("2026-06-07T00:00:00Z");
-    const model = buildChartModel(
+    const frame = buildChartModel(
       [
         [
           // 30m buckets; the domain starts mid-bucket at 00:05, so the 00:00
@@ -228,28 +218,26 @@ describe("buildChartModel", () => {
       ],
       [t0 + 5 * minute, t0 + 95 * minute],
     );
-    expect(model.seriesData.s0?.map((r) => r.s0)).toEqual([1, 2, 3]);
-    expect(model.seriesData.s0?.[0]?.[TS_KEY]).toBe(t0);
-    // The merged crosshair/tooltip timeline stays strictly in-domain: the
-    // off-axis point renders (clipped) but is not hoverable.
-    expect(model.chartData.map((r) => r.s0)).toEqual([2, 3]);
+    // The leading point keeps its real timestamp, left of the axis; the chart
+    // pins the axis to the domain and clips the line at the plot edge.
+    expect(frame.x[0]).toBe(t0);
+    expect(values(frame, "s0")).toEqual([1, 2, 3]);
   });
 
   it("still drops a lone pre-domain point when no bucket width can be inferred", () => {
     const minute = 60_000;
     const t0 = Date.parse("2026-06-07T00:00:00Z");
-    const model = buildChartModel(
+    const frame = buildChartModel(
       [[{ time: "2026-06-07T00:00:00", value: 1 }]],
       [t0 + 5 * minute, t0 + 65 * minute],
     );
-    expect(model.seriesData.s0 ?? []).toHaveLength(0);
-    expect(model.chartData).toHaveLength(0);
+    expect(frame.x).toHaveLength(0);
   });
 
-  it("inserts a single null marker into a series to break the line across a real gap", () => {
+  it("breaks a series' line at both edges of a real gap", () => {
     const minute = 60_000;
     const t0 = Date.parse("2026-06-07T00:00:00Z");
-    const model = buildChartModel(
+    const frame = buildChartModel(
       [
         [
           { time: "2026-06-07T00:00:00", value: 1 },
@@ -261,30 +249,39 @@ describe("buildChartModel", () => {
       ],
       [t0, t0 + 15 * minute],
     );
-    // The gap marker lives in the per-series data (5 real points + 1 null),
-    // not in the merged crosshair timeline (5 points).
-    expect(model.seriesData.s0).toHaveLength(6);
-    expect(model.seriesData.s0?.filter((r) => r.s0 === null)).toHaveLength(1);
-    expect(model.chartData).toHaveLength(5);
+    // A marker one bucket after the gap opens and one before it closes, so the
+    // line leaves and re-enters the gap at its edges instead of arcing across.
+    expect(frame.x).toEqual([
+      t0,
+      t0 + minute,
+      t0 + 2 * minute,
+      t0 + 3 * minute,
+      t0 + 4 * minute,
+      t0 + 9 * minute,
+      t0 + 10 * minute,
+    ]);
+    expect(values(frame, "s0")).toEqual([1, 2, 3, 4, null, null, 5]);
   });
 });
 
-describe("buildStackedData", () => {
-  it("fills missing and null samples with 0 so every row carries every series", () => {
-    const model = buildChartModel(
+describe("buildStackedValues", () => {
+  it("accumulates in series order, counting a missing sample as no contribution", () => {
+    const frame = buildChartModel(
       [
         [
           { time: "2026-06-07T00:00:00", a: 1, b: 10 },
-          { time: "2026-06-07T00:01:00", a: 2, b: "oops" }, // non-numeric → null sample
+          { time: "2026-06-07T00:01:00", a: 2, b: "oops" }, // non-numeric → null
         ],
         [{ time: "2026-06-07T00:00:00", c: 100 }], // absent at 00:01
       ],
       WIDE,
     );
-    const stacked = buildStackedData(model.chartData, model.valueKeys);
-    expect(stacked).toHaveLength(2);
-    expect(stacked[0]).toMatchObject({ s0: 1, s1: 10, s2: 100 });
-    expect(stacked[1]).toMatchObject({ s0: 2, s1: 0, s2: 0 });
-    expect(stacked[0]?.[TS_KEY]).toBe(model.chartData[0]?.[TS_KEY]);
+    // Running totals: a, then a+b, then a+b+c. At 00:01 only `a` reports, so
+    // both bands above it sit flat on it rather than breaking the stack.
+    expect(buildStackedValues(frame.series)).toEqual([
+      [1, 2],
+      [11, 2],
+      [111, 2],
+    ]);
   });
 });

--- a/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-data.ts
+++ b/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-data.ts
@@ -1,4 +1,3 @@
-import type { ChartConfig } from "@everr/ui/components/chart";
 import {
   detectTimeKey,
   getGroupKeys,
@@ -10,7 +9,23 @@ import {
 } from "../data-utils";
 import type { QueryResultRow } from "../index";
 
-export const TS_KEY = "__ts";
+export interface TimeSeries {
+  /** Opaque, sequential id (`s0`, `s1`, …) — never derived from the name, so
+   * two names that would mangle to the same string can't collide. */
+  key: string;
+  label: string;
+  color: string;
+  /** One entry per timestamp in `TimeSeriesFrame.x`. `null` means this series
+   * has no sample there — a gap, unless the panel connects nulls. */
+  values: Array<number | null>;
+}
+
+export interface TimeSeriesFrame {
+  /** The shared, ascending time axis in ms. uPlot aligns every series to one
+   * x array, so a timestamp any series samples appears here once. */
+  x: number[];
+  series: TimeSeries[];
+}
 
 function detectInterval(timestamps: number[]): number | null {
   if (timestamps.length < 2) return null;
@@ -22,119 +37,86 @@ function detectInterval(timestamps: number[]): number | null {
   return diffs[Math.floor(diffs.length / 2)]!;
 }
 
-/** Sort the merged timeline and clamp it to the domain (no gap markers — this
- * array drives the x-axis and the crosshair/tooltip lookup, not the lines). */
-function clampMerged(
-  byTs: Map<number, Record<string, unknown>>,
-  domain: [number, number],
-): Array<Record<string, unknown>> {
-  return [...byTs.values()]
-    .filter((r) => {
-      const ts = r[TS_KEY] as number;
-      return ts >= domain[0] && ts <= domain[1];
-    })
-    .sort((a, b) => (a[TS_KEY] as number) - (b[TS_KEY] as number));
-}
-
 /**
- * Build one line's data from its OWN samples (ts → value), independent of any
- * other series' timestamps. Each line is rendered with its own array so a
- * timestamp where only another series has a point is simply absent here — it
- * never becomes a hole that breaks the line. We do NOT snap onto an
- * epoch-aligned grid: every in-range point keeps its real timestamp. A single
- * null marker is inserted when two consecutive points of THIS series are more
- * than ~1.5× its own typical interval apart, so a non-connecting line shows the
- * genuine gap.
+ * One series' in-domain samples, plus the timestamps where its line must break.
  *
  * Domain clamping treats each point as a BUCKET, not an instant: a bucketed
- * timestamp (e.g. ClickHouse `toStartOfInterval`) labels the bucket's start,
- * so the bucket just before `from` still covers in-range rows whenever `from`
- * isn't bucket-aligned. That point is kept when its bucket overlaps the
- * domain; it sits left of the axis and the line clips at the plot edge
- * (Grafana-style) instead of silently losing up to a bucket of data.
+ * timestamp (e.g. ClickHouse `toStartOfInterval`) labels the bucket's start, so
+ * the bucket just before `from` still covers in-range rows whenever `from`
+ * isn't bucket-aligned. That point is kept when its bucket overlaps the domain;
+ * it sits left of the axis and the line clips at the plot edge (Grafana-style)
+ * instead of silently losing up to a bucket of data.
+ *
+ * Break markers are emitted when two consecutive samples of THIS series are
+ * more than ~1.5× its own typical interval apart. Without them a long outage
+ * between two samples would draw as one smooth curve across the whole gap,
+ * since nothing else puts an x position in there. One marker sits a bucket
+ * after the gap opens and another a bucket before it closes, so the curve
+ * leaves and re-enters the gap at its edges rather than arcing across it —
+ * a stacked panel, which reads a missing sample as a zero contribution, would
+ * otherwise ramp smoothly through hours of no data.
  */
-function buildSeriesData(
+function clampSamples(
   samples: Map<number, number | null>,
-  renderKey: string,
   domain: [number, number],
-): Array<Record<string, unknown>> {
+): { points: Map<number, number | null>; breaks: number[] } {
   const sorted = [...samples.entries()].sort((a, b) => a[0] - b[0]);
   // Inferred from ALL samples, pre-clamp, so the leading bucket's width is
   // known even when only one point lands inside the domain.
   const interval = detectInterval(sorted.map(([ts]) => ts));
-  const points = sorted.filter(([ts]) => {
+  const kept = sorted.filter(([ts]) => {
     if (ts > domain[1]) return false;
     if (ts >= domain[0]) return true;
     return interval !== null && ts + interval > domain[0];
   });
 
-  const gapThreshold = interval ? interval * 1.5 : null;
-
-  const result: Array<Record<string, unknown>> = [];
-  for (let i = 0; i < points.length; i++) {
-    const [ts, value] = points[i]!;
-    if (i > 0 && interval && gapThreshold) {
-      const prevTs = points[i - 1]![0];
-      if (ts - prevTs > gapThreshold) {
-        result.push({ [TS_KEY]: prevTs + interval, [renderKey]: null });
+  const breaks: number[] = [];
+  if (interval !== null) {
+    for (let i = 1; i < kept.length; i++) {
+      const prevTs = kept[i - 1]![0];
+      const ts = kept[i]![0];
+      if (ts - prevTs > interval * 1.5) {
+        breaks.push(prevTs + interval, ts - interval);
       }
     }
-    result.push({ [TS_KEY]: ts, [renderKey]: value });
   }
-  return result;
+
+  return { points: new Map(kept), breaks };
 }
 
 /**
- * Stacking renders every series from ONE shared array (recharts accumulates
- * `stackId` series row-by-row across the chart-level data), so each merged
- * timestamp must carry a number for every series. A missing or null sample
- * means "this series contributes nothing to the bucket" — fill it with 0;
- * leaving it undefined would corrupt the running stack offset for the series
+ * Running totals for a stacked chart, in series order.
+ *
+ * A null sample means "this series contributes nothing to the bucket" — it
+ * counts as 0; leaving it null would break the running total for every band
  * above it.
  */
-export function buildStackedData(
-  chartData: Array<Record<string, unknown>>,
-  valueKeys: string[],
-): Array<Record<string, unknown>> {
-  return chartData.map((row) => {
-    const filled: Record<string, unknown> = { [TS_KEY]: row[TS_KEY] };
-    for (const key of valueKeys) {
-      const value = row[key];
-      filled[key] = typeof value === "number" ? value : 0;
-    }
-    return filled;
-  });
-}
-
-export interface ChartModel {
-  /** Merged timeline (all series by timestamp). Drives the x-axis domain and
-   * the crosshair/tooltip lookup — NOT the lines. */
-  chartData: Array<Record<string, unknown>>;
-  valueKeys: string[];
-  chartConfig: ChartConfig;
-  /** Per-series data arrays, keyed by render key. Each `<Line>` renders from its
-   * own array so it connects its own points regardless of other series. */
-  seriesData: Record<string, Array<Record<string, unknown>>>;
+export function buildStackedValues(series: TimeSeries[]): number[][] {
+  const running: number[] = [];
+  return series.map((s) =>
+    s.values.map((value, i) => {
+      running[i] = (running[i] ?? 0) + (value ?? 0);
+      return running[i]!;
+    }),
+  );
 }
 
 /**
- * Builds a chart model by merging rows from every query result set onto a
+ * Builds the uPlot frame by merging rows from every query result set onto a
  * single shared timeline keyed by timestamp. Rows that share a timestamp —
  * whether across different queries OR within a single query — are merged into
- * one entry, so a single set containing duplicate timestamps is collapsed
+ * one x position, so a single set containing duplicate timestamps is collapsed
  * last-write-wins. This merge is intentional: it's how multiple queries' series
  * land on one x-axis.
  */
 export function buildChartModel(
   dataSets: QueryResultRow[][],
   domain: [number, number],
-): ChartModel {
-  const chartConfig: ChartConfig = {};
-  const valueKeys: string[] = [];
+): TimeSeriesFrame {
   // Per render key: its own samples (ts → value), collapsed last-write-wins on
-  // duplicate timestamps. The single source of truth — both the per-series
-  // line data and the merged timeline derive from it.
+  // duplicate timestamps. The single source of truth the frame derives from.
   const samplesByKey = new Map<string, Map<number, number | null>>();
+  const metaByKey = new Map<string, { label: string; color: string }>();
   let seriesIndex = 0;
 
   dataSets.forEach((data) => {
@@ -146,9 +128,9 @@ export function buildChartModel(
     const rawValueKeys = getValueKeys(data, tk);
 
     let rows: QueryResultRow[];
-    // The series' source names: pivoted group values, or raw value-column names.
-    // Each is unique within its result set and is used as the human-readable
-    // legend/tooltip label.
+    // The series' source names: pivoted group values, or raw value-column
+    // names. Each is unique within its result set and is used as the
+    // human-readable legend/tooltip label.
     let seriesNames: string[];
 
     if (groupKeys.length >= 1 && rawValueKeys.length === 1) {
@@ -165,20 +147,14 @@ export function buildChartModel(
       seriesNames = rawValueKeys;
     }
 
-    // Render keys are opaque, sequential ids (`s0`, `s1`, …) — never derived
-    // from the name. This guarantees a unique, valid CSS-var/dataKey identifier
-    // per series, so distinct names that would mangle to the same string (e.g.
-    // `a-b` and `a b`) can't collide and overwrite each other. The original name
-    // stays as the label.
     const renderKeyByName = new Map<string, string>();
     for (const name of seriesNames) {
       const renderKey = `s${seriesIndex}`;
       renderKeyByName.set(name, renderKey);
-      valueKeys.push(renderKey);
-      chartConfig[renderKey] = {
+      metaByKey.set(renderKey, {
         label: name,
-        color: SERIES_COLORS[seriesIndex % SERIES_COLORS.length],
-      };
+        color: SERIES_COLORS[seriesIndex % SERIES_COLORS.length]!,
+      });
       samplesByKey.set(renderKey, new Map());
       seriesIndex++;
     }
@@ -187,13 +163,12 @@ export function buildChartModel(
       const ts = toTimestamp(row[tk]);
       if (ts === null) continue;
       for (const name of seriesNames) {
-        // Only record a sample where this series actually has one. A pivoted row
-        // carries only the groups present at its timestamp, so a missing key is
-        // "not sampled here" — NOT a gap — and must not appear in this series'
-        // data (where it would break the line).
+        // Only record a sample where this series actually has one. A pivoted
+        // row carries only the groups present at its timestamp, so a missing
+        // key is "not sampled here".
         if (!(name in row)) continue;
-        // Coerce numeric strings (quoted ClickHouse aggregates) to numbers so
-        // recharts plots them; non-numeric values become null (a gap).
+        // Coerce numeric strings (quoted ClickHouse aggregates) to numbers;
+        // non-numeric values become null (a gap).
         samplesByKey
           .get(renderKeyByName.get(name)!)!
           .set(ts, toNumber(row[name]));
@@ -201,24 +176,28 @@ export function buildChartModel(
     }
   });
 
-  const byTs = new Map<number, Record<string, unknown>>();
-  const seriesData: Record<string, Array<Record<string, unknown>>> = {};
+  const clamped = new Map<string, Map<number, number | null>>();
+  const timestamps = new Set<number>();
   for (const [key, samples] of samplesByKey) {
-    for (const [ts, value] of samples) {
-      let entry = byTs.get(ts);
-      if (!entry) {
-        entry = { [TS_KEY]: ts };
-        byTs.set(ts, entry);
-      }
-      entry[key] = value;
-    }
-    seriesData[key] = buildSeriesData(samples, key, domain);
+    const { points, breaks } = clampSamples(samples, domain);
+    clamped.set(key, points);
+    for (const ts of points.keys()) timestamps.add(ts);
+    // A break marker is an x position no series samples, so every series is
+    // null there and the line breaks — which is what a gap should look like.
+    for (const ts of breaks) timestamps.add(ts);
   }
 
-  return {
-    chartData: clampMerged(byTs, domain),
-    valueKeys,
-    chartConfig,
-    seriesData,
-  };
+  const x = [...timestamps].sort((a, b) => a - b);
+  const series: TimeSeries[] = [];
+  for (const [key, points] of clamped) {
+    const meta = metaByKey.get(key)!;
+    series.push({
+      key,
+      label: meta.label,
+      color: meta.color,
+      values: x.map((ts) => (points.has(ts) ? points.get(ts)! : null)),
+    });
+  }
+
+  return { x, series };
 }

--- a/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-legend.tsx
+++ b/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-legend.tsx
@@ -1,0 +1,26 @@
+export interface TimeSeriesLegendItem {
+  key: string;
+  label: string;
+  color: string;
+}
+
+/**
+ * Legend for the time-series panel: swatch · label, one entry per series.
+ * uPlot ships its own legend, but it is a table with its own markup and
+ * typography; this one matches the legends the other visualizations render.
+ */
+export function TimeSeriesLegend({ items }: { items: TimeSeriesLegendItem[] }) {
+  return (
+    <div className="flex max-h-24 shrink-0 flex-wrap justify-center gap-x-4 gap-y-1 overflow-y-auto px-2 pt-2 text-xs">
+      {items.map((item) => (
+        <div key={item.key} className="flex items-center gap-1.5">
+          <span
+            className="inline-block size-2.5 shrink-0 rounded-full"
+            style={{ backgroundColor: item.color }}
+          />
+          <span className="truncate text-muted-foreground">{item.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/app/src/components/dashboards/visualizations/time-series-chart/uplot-chart.tsx
+++ b/packages/app/src/components/dashboards/visualizations/time-series-chart/uplot-chart.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useRef } from "react";
+import uPlot from "uplot";
+import "uplot/dist/uPlot.min.css";
+
+export type UplotOptions = Omit<uPlot.Options, "width" | "height">;
+
+export interface UplotChartProps {
+  options: UplotOptions;
+  /**
+   * Recreating a uPlot instance throws away its canvas, so option identity
+   * alone must NOT trigger it: the options object is rebuilt on every render
+   * (it closes over the current series), while only a change to this key —
+   * the series line-up, the spec, the time range — is worth a rebuild. Every
+   * other update goes through `setData`, which is the whole point of uPlot.
+   */
+  optionsKey: string;
+  data: uPlot.AlignedData;
+  className?: string;
+}
+
+export function UplotChart({
+  options,
+  optionsKey,
+  data,
+  className,
+}: UplotChartProps) {
+  const hostRef = useRef<HTMLDivElement>(null);
+  const plotRef = useRef<uPlot | null>(null);
+  const optionsRef = useRef(options);
+  const dataRef = useRef(data);
+  // The instance is built inside an effect, so it must read whatever the last
+  // render produced rather than what the effect's own closure captured.
+  optionsRef.current = options;
+  dataRef.current = data;
+  const appliedRef = useRef<uPlot.AlignedData | null>(null);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+
+    const plot = new uPlot(
+      {
+        ...optionsRef.current,
+        width: Math.max(1, host.clientWidth),
+        height: Math.max(1, host.clientHeight),
+      },
+      dataRef.current,
+      host,
+    );
+    plotRef.current = plot;
+    appliedRef.current = dataRef.current;
+
+    const observer = new ResizeObserver(() => {
+      plot.setSize({
+        width: Math.max(1, host.clientWidth),
+        height: Math.max(1, host.clientHeight),
+      });
+    });
+    observer.observe(host);
+
+    return () => {
+      observer.disconnect();
+      plot.destroy();
+      plotRef.current = null;
+      appliedRef.current = null;
+    };
+  }, [optionsKey]);
+
+  useEffect(() => {
+    // The creation effect already drew this frame; setting it again would
+    // rescale and repaint for nothing.
+    if (appliedRef.current === data) return;
+    appliedRef.current = data;
+    plotRef.current?.setData(data);
+  }, [data]);
+
+  return <div ref={hostRef} className={className} />;
+}

--- a/packages/app/src/data/alerts/apply.server.test.ts
+++ b/packages/app/src/data/alerts/apply.server.test.ts
@@ -156,6 +156,7 @@ describe("applyAlertSpecs", () => {
       deleted: [],
       adopted: [],
       conflicts: [],
+      warnings: [],
     });
     expect(mockedQuerySqlApiWithMeta).toHaveBeenCalledWith(
       expect.stringContaining("INTERVAL 15 MINUTE"),
@@ -297,6 +298,7 @@ describe("applyAlertSpecs", () => {
       deleted: ["stale"],
       adopted: [],
       conflicts: [],
+      warnings: [],
     });
     expect(updateSets).toEqual([expect.objectContaining({ active: true })]);
     expect(deleteCalled).toBe(true);

--- a/packages/app/src/data/alerts/apply.server.ts
+++ b/packages/app/src/data/alerts/apply.server.ts
@@ -54,6 +54,8 @@ interface ApplyAlertsResult {
   deleted: string[];
   adopted: string[];
   conflicts: OwnershipConflict[];
+  /** Alert rules carry no panels, so nothing here is ever deprecated yet. */
+  warnings: string[];
 }
 
 function pathForLink(path: string): string {
@@ -448,6 +450,7 @@ export const applyAlertSpecs: Reconciler = async ({
     deleted: deletes.map((row) => row.slug),
     adopted,
     conflicts,
+    warnings: [],
   };
 
   if (dryRun) return summary;

--- a/packages/app/src/data/as-code/registry.ts
+++ b/packages/app/src/data/as-code/registry.ts
@@ -18,6 +18,9 @@ export interface KindResult {
   deleted: string[];
   /** Live resources taken over from another owning repo (only with `adopt`). */
   adopted: string[];
+  /** Non-fatal notices about the applied files, e.g. deprecated panel options.
+   * The apply succeeds; these tell the author what to migrate. */
+  warnings: string[];
 }
 
 export interface ApplyResourcesResult {
@@ -46,6 +49,8 @@ export type Reconciler = (opts: {
   adopted: string[];
   /** Creates colliding with another repo's live resource; empty when adopting. */
   conflicts: OwnershipConflict[];
+  /** Non-fatal notices about the applied files; never blocks the apply. */
+  warnings: string[];
 }>;
 
 /**
@@ -117,6 +122,7 @@ export async function applyResources(opts: {
       updated: string[];
       deleted: string[];
       adopted: string[];
+      warnings: string[];
     },
   ): KindResult => ({
     kind,
@@ -124,6 +130,7 @@ export async function applyResources(opts: {
     updated: r.updated,
     deleted: r.deleted,
     adopted: r.adopted,
+    warnings: r.warnings,
   });
 
   // Live, or the preview resolved to its registry id via the given resolver.

--- a/packages/app/src/data/dashboards/apply.server.test.ts
+++ b/packages/app/src/data/dashboards/apply.server.test.ts
@@ -128,6 +128,7 @@ describe("applyDashboardSpecs", () => {
       deleted: ["old"],
       adopted: [],
       conflicts: [],
+      warnings: [],
     });
   });
 

--- a/packages/app/src/data/dashboards/apply.server.ts
+++ b/packages/app/src/data/dashboards/apply.server.ts
@@ -11,6 +11,7 @@ import {
   previewScope,
 } from "@/data/previews/scope";
 import { dashboards } from "@/db/schema";
+import { collectPanelsMapWarnings } from "./deprecations";
 import { buildDesiredSet } from "./desired";
 import type { Dashboard } from "./schema";
 
@@ -20,6 +21,7 @@ export interface ApplyDashboardsResult {
   deleted: string[];
   adopted: string[];
   conflicts: OwnershipConflict[];
+  warnings: string[];
 }
 
 /**
@@ -42,6 +44,12 @@ export const applyDashboardSpecs: Reconciler = async ({
 }): Promise<ApplyDashboardsResult> => {
   const desired = buildDesiredSet(
     resources.map((r) => ({ path: r.path, document: r.resource })),
+  );
+
+  // Scanned from the submitted files, not the reconciled diff: a panel whose
+  // options are stale is worth reporting whether or not this apply changes it.
+  const warnings = resources.flatMap((r) =>
+    collectPanelsMapWarnings(r.path, r.resource),
   );
 
   const scope = previewScope(dashboards, namespace);
@@ -81,6 +89,7 @@ export const applyDashboardSpecs: Reconciler = async ({
     deleted: diff.deletes.map((d) => d.slug),
     adopted,
     conflicts,
+    warnings,
   };
 
   if (dryRun) return summary;

--- a/packages/app/src/data/dashboards/deprecations.test.ts
+++ b/packages/app/src/data/dashboards/deprecations.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { collectPanelsMapWarnings } from "./deprecations";
+import { buildDesiredSet } from "./desired";
+
+const doc = {
+  kind: "Dashboard",
+  metadata: { name: "legacy" },
+  spec: {
+    panels: {
+      old: {
+        kind: "Panel",
+        spec: {
+          display: { name: "Old panel" },
+          plugin: {
+            kind: "TimeSeriesChart",
+            spec: { curveType: "monotone", unit: "ms" },
+          },
+          queries: [],
+        },
+      },
+      fine: {
+        kind: "Panel",
+        spec: {
+          display: { name: "Fine panel" },
+          plugin: { kind: "TimeSeriesChart", spec: { curveType: "stepAfter" } },
+          queries: [],
+        },
+      },
+    },
+    layouts: [],
+  },
+};
+
+describe("deprecated options on the apply path", () => {
+  // The whole point of deprecating rather than removing: a stored file that
+  // predates the change keeps applying.
+  it("does not fail validation", () => {
+    expect(() =>
+      buildDesiredSet([{ path: "everr/legacy.dashboard.yaml", document: doc }]),
+    ).not.toThrow();
+  });
+
+  it("reports one warning naming the file and panel", () => {
+    const warnings = collectPanelsMapWarnings(
+      "everr/legacy.dashboard.yaml",
+      doc,
+    );
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("everr/legacy.dashboard.yaml");
+    expect(warnings[0]).toContain('panel "old"');
+    expect(warnings[0]).toContain("monotone");
+  });
+});

--- a/packages/app/src/data/dashboards/deprecations.ts
+++ b/packages/app/src/data/dashboards/deprecations.ts
@@ -1,0 +1,52 @@
+import type { SpecDeprecation } from "@/components/dashboards/visualizations/deprecations";
+import { panelPluginDeprecations } from "./plugin-specs";
+
+/**
+ * Deprecated options set by one panel's plugin block.
+ *
+ * Reads defensively: the apply path scans documents that have already passed
+ * strict validation, but a deprecated option is by definition one the schema
+ * still accepts, so nothing here may assume a shape.
+ */
+export function collectPanelDeprecations(plugin: unknown): SpecDeprecation[] {
+  const kind = (plugin as { kind?: unknown } | null | undefined)?.kind;
+  if (typeof kind !== "string") return [];
+  const collect = panelPluginDeprecations[kind];
+  if (!collect) return [];
+  return collect((plugin as { spec?: unknown }).spec);
+}
+
+/** One line per deprecated option, naming the file the author has to edit. */
+export function formatDeprecation(
+  path: string,
+  panelKey: string,
+  deprecation: SpecDeprecation,
+): string {
+  return `${path}: panel "${panelKey}" — ${deprecation.message} (${deprecation.fix})`;
+}
+
+/**
+ * Deprecation warnings for a document's `spec.panels` map. Shared by dashboards
+ * and runbooks, which carry the same panels map; runbooks add their inline
+ * markdown embeds on top.
+ */
+export function collectPanelsMapWarnings(
+  path: string,
+  document: unknown,
+): string[] {
+  const panels = (
+    document as { spec?: { panels?: unknown } } | null | undefined
+  )?.spec?.panels;
+  if (!panels || typeof panels !== "object") return [];
+
+  const warnings: string[] = [];
+  for (const [key, panel] of Object.entries(
+    panels as Record<string, unknown>,
+  )) {
+    const plugin = (panel as { spec?: { plugin?: unknown } })?.spec?.plugin;
+    for (const deprecation of collectPanelDeprecations(plugin)) {
+      warnings.push(formatDeprecation(path, key, deprecation));
+    }
+  }
+  return warnings;
+}

--- a/packages/app/src/data/dashboards/plugin-specs.ts
+++ b/packages/app/src/data/dashboards/plugin-specs.ts
@@ -1,5 +1,6 @@
 import type * as z from "zod";
 import { barChartSpec } from "@/components/dashboards/visualizations/bar-chart/spec";
+import type { SpecDeprecation } from "@/components/dashboards/visualizations/deprecations";
 import { gaugeChartSpec } from "@/components/dashboards/visualizations/gauge-chart/spec";
 import { geoMapSpec } from "@/components/dashboards/visualizations/geo-map/spec";
 import { heatmapSpec } from "@/components/dashboards/visualizations/heatmap/spec";
@@ -8,7 +9,10 @@ import { statChartSpec } from "@/components/dashboards/visualizations/stat-chart
 import { stateTimelineSpec } from "@/components/dashboards/visualizations/state-timeline/spec";
 import { statusHistorySpec } from "@/components/dashboards/visualizations/status-history/spec";
 import { tableSpec } from "@/components/dashboards/visualizations/table/spec";
-import { timeSeriesChartSpec } from "@/components/dashboards/visualizations/time-series-chart/spec";
+import {
+  timeSeriesChartDeprecations,
+  timeSeriesChartSpec,
+} from "@/components/dashboards/visualizations/time-series-chart/spec";
 import { treemapSpec } from "@/components/dashboards/visualizations/treemap/spec";
 import { testDataSpec } from "./testdata/spec";
 
@@ -31,6 +35,22 @@ export const panelPluginSpecs: Record<string, z.ZodType> = {
   Table: tableSpec,
   TimeSeriesChart: timeSeriesChartSpec,
   Treemap: treemapSpec,
+};
+
+/**
+ * Options per panel plugin kind that still parse but no longer do what they
+ * say. Read from the raw spec, not the parsed one, so the original value is
+ * available to name in the message.
+ *
+ * A kind with nothing deprecated is simply absent. Keeping this beside the
+ * schemas is deliberate: both the render path and the apply path need it, and
+ * both already load this module.
+ */
+export const panelPluginDeprecations: Record<
+  string,
+  (raw: unknown) => SpecDeprecation[]
+> = {
+  TimeSeriesChart: timeSeriesChartDeprecations,
 };
 
 /**

--- a/packages/app/src/data/runbooks/apply.server.test.ts
+++ b/packages/app/src/data/runbooks/apply.server.test.ts
@@ -148,6 +148,7 @@ describe("applyRunbookSpecs", () => {
       deleted: ["old"],
       adopted: [],
       conflicts: [],
+      warnings: [],
     });
   });
 

--- a/packages/app/src/data/runbooks/apply.server.ts
+++ b/packages/app/src/data/runbooks/apply.server.ts
@@ -11,6 +11,7 @@ import {
   previewScope,
 } from "@/data/previews/scope";
 import { runbooks } from "@/db/schema";
+import { collectRunbookWarnings } from "./deprecations";
 import { buildDesiredRunbookSet } from "./desired";
 import type { Runbook } from "./schema";
 
@@ -20,6 +21,7 @@ export interface ApplyRunbooksResult {
   deleted: string[];
   adopted: string[];
   conflicts: OwnershipConflict[];
+  warnings: string[];
 }
 
 /**
@@ -43,6 +45,12 @@ export const applyRunbookSpecs: Reconciler = async ({
 }): Promise<ApplyRunbooksResult> => {
   const desired = buildDesiredRunbookSet(
     resources.map((r) => ({ path: r.path, document: r.resource })),
+  );
+
+  // Scanned from the submitted files, not the reconciled diff: a panel whose
+  // options are stale is worth reporting whether or not this apply changes it.
+  const warnings = resources.flatMap((r) =>
+    collectRunbookWarnings(r.path, r.resource),
   );
 
   const scope = previewScope(runbooks, namespace);
@@ -82,6 +90,7 @@ export const applyRunbookSpecs: Reconciler = async ({
     deleted: diff.deletes.map((d) => d.slug),
     adopted,
     conflicts,
+    warnings,
   };
 
   if (dryRun) return summary;

--- a/packages/app/src/data/runbooks/deprecations.ts
+++ b/packages/app/src/data/runbooks/deprecations.ts
@@ -1,0 +1,59 @@
+import {
+  collectPanelDeprecations,
+  collectPanelsMapWarnings,
+  formatDeprecation,
+} from "@/data/dashboards/deprecations";
+import { extractPanelFences, parsePanelEmbed } from "./embed";
+import type { RunbookPage } from "./schema";
+import { runbookSpecSchema } from "./schema";
+
+/**
+ * Deprecation warnings for a runbook: its `spec.panels` map plus every inline
+ * panel embedded in markdown. A fence that doesn't parse is skipped rather
+ * than reported — `validateFences` has already failed the apply for it, and a
+ * deprecation notice on top would only bury that error.
+ */
+export function collectRunbookWarnings(
+  path: string,
+  document: unknown,
+): string[] {
+  const warnings = collectPanelsMapWarnings(path, document);
+
+  // Non-strict on purpose: a spec that fails strict validation never reaches a
+  // successful apply, and one that fails even this parse has no markdown worth
+  // walking.
+  const parsed = runbookSpecSchema.safeParse(
+    (document as { spec?: unknown } | null | undefined)?.spec,
+  );
+  if (!parsed.success) return warnings;
+  const spec = parsed.data;
+
+  const scan = (markdown: string | undefined, where: string) => {
+    for (const fence of extractPanelFences(markdown ?? "")) {
+      let embed: ReturnType<typeof parsePanelEmbed>;
+      try {
+        embed = parsePanelEmbed(fence.yaml);
+      } catch {
+        continue;
+      }
+      if (embed.kind !== "inline") continue;
+      for (const deprecation of collectPanelDeprecations(
+        embed.panel.spec.plugin,
+      )) {
+        warnings.push(formatDeprecation(path, where, deprecation));
+      }
+    }
+  };
+
+  scan(spec.markdown.inline, "index markdown");
+  const walk = (pages: RunbookPage[] | undefined, prefix: string) => {
+    for (const page of pages ?? []) {
+      const pagePath = prefix ? `${prefix}/${page.name}` : page.name;
+      scan(page.markdown.inline, `page "${pagePath}"`);
+      walk(page.pages, pagePath);
+    }
+  };
+  walk(spec.pages, "");
+
+  return warnings;
+}

--- a/packages/desktop-app/src-cli/src/core.rs
+++ b/packages/desktop-app/src-cli/src/core.rs
@@ -977,6 +977,9 @@ fn print_apply_summary(summary: &everr_core::apply::ApplySummary, plan: bool) {
         for s in &r.adopted {
             println!("  ⇄ {s}");
         }
+        for s in &r.warnings {
+            println!("  {} {s}", console::style("!").yellow());
+        }
     }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ catalogs:
     typescript:
       specifier: ^6.0.3
       version: 6.0.3
+    uplot:
+      specifier: ^1.6.32
+      version: 1.6.32
     vite:
       specifier: ^8.0.11
       version: 8.0.11
@@ -270,6 +273,9 @@ importers:
       topojson-client:
         specifier: ^3.1.0
         version: 3.1.0
+      uplot:
+        specifier: 'catalog:'
+        version: 1.6.32
       world-atlas:
         specifier: ^2.0.2
         version: 2.0.2
@@ -8563,6 +8569,9 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  uplot@1.6.32:
+    resolution: {integrity: sha512-KIMVnG68zvu5XXUbC4LQEPnhwOxBuLyW1AHtpm6IKTXImkbLgkMy+jabjLgSLMasNuGGzQm/ep3tOkyTxpiQIw==}
 
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -16993,6 +17002,8 @@ snapshots:
       browserslist: 4.24.4
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  uplot@1.6.32: {}
 
   use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.6):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,7 @@ catalog:
   recharts: "^2.15.4"
   tailwindcss: ^4.3.0
   typescript: ^6.0.3
+  uplot: ^1.6.32
   vite: ^8.0.11
   zod: ^4.4.3
 


### PR DESCRIPTION
Swaps the dashboard time-series panel from recharts to uPlot, then deprecates the smoothed `curveType` values the new renderer no longer draws.

## Why uPlot

Recharts renders the panel as SVG — a node per point — and gets slow well before the point counts a real dashboard reaches. uPlot draws to a canvas and brings its own cursor and drag-select, so the panel also sheds ~80 lines of hand-rolled px↔timestamp math.

Recharts stays for the bar, treemap and stat panels; this is not a dependency removal.

## The data model had to change

uPlot aligns every series to **one** x array. The old model gave each line its own timestamps, so a line connected straight across timestamps only its neighbours had sampled. The frame now carries a shared x plus a `null` per series wherever that series has no sample, and those nulls read as gaps.

**Expect sparse panels to look more broken than before.** They were always that sparse; the old model hid it.

Two related fixes fell out:

- **Gaps get a break marker at both edges**, not one. Without the second marker a curve arcs across the hole — an eight-hour stretch with no traffic drew as a smooth decline.
- **The y axis measures its widest label** instead of taking uPlot's fixed 50px, which rendered `4,288MB` as `88MB`.

The crosshair snaps to the sample the tooltip reports, matching the previous `ReferenceLine`. A drag is exempt: uPlot draws the selection from that same position, and a zoom has to be able to start and end between samples.

## Deprecating smoothing rather than removing it

Smoothing invents values between samples. On a time series that reads as data nobody measured, and across a gap it reads as a slow decline rather than an outage. `curveType` now defaults to `linear`; `stepBefore`/`stepAfter` stay, since a step is a different rendering intent, not a smoothed one.

`monotone` and `natural` stay in the enum. The same schema validates at apply time, so removing them would **fail `everr apply` on every stored file that sets one**, and the lenient render path would discard the panel's other options along with them. Instead they parse, draw straight, and report themselves in both places that can reach the author:

- **Panel header** — a popover naming the option and what the chart actually draws, with a copy-able prompt that locates the as-code file and makes the edit. The prompt does not tell anyone to run `everr apply`; plenty of repositories apply from CI on merge.
- **`everr apply`** — reconcilers gained a `warnings` channel, carried through `KindResult` to the CLI, printed under the apply summary. The apply still succeeds.

Runbooks are scanned too — their panels map and the inline panels embedded in markdown.

## Gallery

The demo sheet claimed to exercise null gaps but never showed one: `nullChance` scatters single nulls, and the only panel producing them set `connectNulls: true`, which bridges them. Two panels now share the same 40 rows and differ only in `connectNulls`. Adds the two behaviors the sheet never reached — series sampled at different rates, and rows carrying no numeric column (the second empty state; the sheet described the chart as having one).

## Verification

- 757 tests pass; `tsc --noEmit` clean; `cargo check` clean on `everr-core` and `everr-cli`.
- Data-layer tests ported to the frame shape — same scenarios (clamping, leading bucket, gap markers, dedup, pivot), restated.
- Checked in the browser against `cloud-query`, `http-requests` and `nodejs-runtime`: rendering, tooltip, legend, drag-to-zoom, the deprecation popover, and both empty states.
- Gallery validated offline against the strict apply schema and the real TestData generator.

## Not verified, and why

`everr apply` **could not be run**: `/api/apply` returns 500 for every input in the local dev environment, including an empty resource directory. It fails right after auth with no Postgres spans, and the server log shows a `DrizzleQueryError` selecting `document`, `parsed_query`, `summary_template` and friends from `alert_definitions` — columns the dev database does not have (it still has the older `spec`/`version` shape). Pre-existing and unrelated to this branch: the first failure is timestamped eight minutes before this work started. The dev database needs bringing up to the current drizzle schema; that is a separate change.

## Incidental

`Cargo.lock` picks up a one-line `everr-app` version sync that was already stale on `main`; any `cargo` invocation produces it.

## Follow-ups deliberately left out

- **Legend values.** Held back as its own change: one field on `TimeSeriesLegendItem`, a `lastValue` helper, and reading `cursor.idx`.
- **Migrating the remaining `curveType: monotone` panels** in `everr/` (10 occurrences, 5 files). They now show the deprecation badge, which is the feature working — happy to sweep them.
