### PR TITLE
feat(app): add service accounts

### DIFF
--- a/crates/everr-core/src/auth.rs
+++ b/crates/everr-core/src/auth.rs
@@ -1,6 +1,7 @@
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
+use reqwest::StatusCode;
 use reqwest::header::CONTENT_TYPE;
 use serde::Deserialize;
 use tokio::time::sleep;
@@ -172,6 +173,81 @@ pub fn session_from_device_token(
     build_session(config.api_base_url.clone(), token)
 }
 
+#[derive(Debug, Deserialize)]
+struct ServiceAccountTokenResponse {
+    token: String,
+    // Not read yet. No caller tracks expiry, and none re-exchanges on a 401 either:
+    // the CLI exchanges once per process and caches the session, so a process that
+    // runs longer than the token's hour fails instead of refreshing. Refresh on 401
+    // is a known gap, not a behavior that exists.
+    #[allow(dead_code)]
+    expires_at: String,
+}
+
+/// How long to wait before the single retry of a rate limited exchange.
+const RATE_LIMIT_RETRY_DELAY: Duration = Duration::from_secs(2);
+
+pub async fn exchange_service_account_secret(config: &AuthConfig, secret: &str) -> Result<Session> {
+    exchange_service_account_secret_after(config, secret, RATE_LIMIT_RETRY_DELAY).await
+}
+
+async fn exchange_service_account_secret_after(
+    config: &AuthConfig,
+    secret: &str,
+    retry_delay: Duration,
+) -> Result<Session> {
+    let client = build_http_client()?;
+    let mut response = post_service_account_secret(&client, config, secret).await?;
+
+    // Nobody attends an unattended run, so one retry here is the difference
+    // between a command that recovers from a burst of agents sharing an
+    // egress address and one that fails the whole job.
+    if response.status() == StatusCode::TOO_MANY_REQUESTS {
+        sleep(retry_delay).await;
+        response = post_service_account_secret(&client, config, secret).await?;
+    }
+
+    if !response.status().is_success() {
+        if response.status() == StatusCode::TOO_MANY_REQUESTS {
+            bail!(
+                "the service account token endpoint rate limited this request and the retry that followed it; retry later"
+            );
+        }
+        bail!("the service account secret was rejected");
+    }
+
+    let body: ServiceAccountTokenResponse = response
+        .json()
+        .await
+        .context("failed to read the service account token response")?;
+
+    if body.token.trim().is_empty() {
+        bail!("received an empty service account token");
+    }
+
+    Ok(Session {
+        api_base_url: config.api_base_url.clone(),
+        token: body.token,
+    })
+}
+
+async fn post_service_account_secret(
+    client: &reqwest::Client,
+    config: &AuthConfig,
+    secret: &str,
+) -> Result<reqwest::Response> {
+    client
+        .post(format!(
+            "{}/api/service-accounts/token",
+            config.api_base_url
+        ))
+        .header(CONTENT_TYPE, "application/json")
+        .json(&serde_json::json!({ "secret": secret }))
+        .send()
+        .await
+        .context("failed to reach the service account token endpoint")
+}
+
 fn build_http_client() -> Result<reqwest::Client> {
     reqwest::Client::builder()
         .build()
@@ -269,7 +345,16 @@ async fn complete_device_authorization_with_url(
 
 #[cfg(test)]
 mod tests {
-    use super::{AuthConfig, DeviceTokenResponse, session_from_device_token};
+    use std::time::Duration;
+
+    use super::{
+        AuthConfig, DeviceTokenResponse, exchange_service_account_secret,
+        exchange_service_account_secret_after, session_from_device_token,
+    };
+
+    // The tests below drive the retry with no delay so they never wait for
+    // the real one.
+    const NO_DELAY: Duration = Duration::ZERO;
 
     #[test]
     fn session_from_device_token_rejects_blank_tokens() {
@@ -284,5 +369,98 @@ mod tests {
         .expect_err("blank token should fail");
 
         assert_eq!(error.to_string(), "received an empty access token");
+    }
+
+    #[tokio::test]
+    async fn exchange_service_account_secret_rejects_an_empty_token() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("POST", "/api/service-accounts/token")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"token":"","expires_at":"2026-01-01T00:00:00Z"}"#)
+            .create_async()
+            .await;
+        let config = AuthConfig {
+            api_base_url: server.url(),
+        };
+
+        let error = exchange_service_account_secret(&config, "sa-secret")
+            .await
+            .expect_err("an empty token should fail");
+
+        assert_eq!(error.to_string(), "received an empty service account token");
+    }
+
+    #[tokio::test]
+    async fn exchange_service_account_secret_retries_once_when_rate_limited() {
+        // Agents behind one egress address share the endpoint's bucket, so a
+        // burst can rate limit a run that nobody is there to start again.
+        let mut server = mockito::Server::new_async().await;
+        let limited = server
+            .mock("POST", "/api/service-accounts/token")
+            .with_status(429)
+            .expect(1)
+            .create_async()
+            .await;
+        let issued = server
+            .mock("POST", "/api/service-accounts/token")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"token":"st_abc","expires_at":"2026-01-01T00:00:00Z"}"#)
+            .expect(1)
+            .create_async()
+            .await;
+        let config = AuthConfig {
+            api_base_url: server.url(),
+        };
+
+        let session = exchange_service_account_secret_after(&config, "sa-secret", NO_DELAY)
+            .await
+            .expect("the retry should succeed");
+
+        assert_eq!(session.token, "st_abc");
+        limited.assert_async().await;
+        issued.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn exchange_service_account_secret_reports_rate_limiting_distinctly() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("POST", "/api/service-accounts/token")
+            .with_status(429)
+            .create_async()
+            .await;
+        let config = AuthConfig {
+            api_base_url: server.url(),
+        };
+
+        let error = exchange_service_account_secret_after(&config, "sa-secret", NO_DELAY)
+            .await
+            .expect_err("a 429 that repeats should fail");
+
+        let message = error.to_string();
+        assert!(message.contains("retry"), "message was: {message}");
+        assert!(!message.contains("rejected"), "message was: {message}");
+    }
+
+    #[tokio::test]
+    async fn exchange_service_account_secret_reports_other_failures_as_rejected() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("POST", "/api/service-accounts/token")
+            .with_status(401)
+            .create_async()
+            .await;
+        let config = AuthConfig {
+            api_base_url: server.url(),
+        };
+
+        let error = exchange_service_account_secret(&config, "sa-secret")
+            .await
+            .expect_err("a 401 should fail");
+
+        assert_eq!(error.to_string(), "the service account secret was rejected");
     }
 }

--- a/crates/everr-core/src/state.rs
+++ b/crates/everr-core/src/state.rs
@@ -207,6 +207,21 @@ impl AppStateStore {
         bail!(NO_ACTIVE_SESSION);
     }
 
+    /// Picks the session to use for a request. An already exchanged session (for
+    /// example a service account token) always wins over the stored session, so a
+    /// machine principal never depends on a human having logged in on this device.
+    pub fn resolve_session(
+        &self,
+        expected_api_base_url: &str,
+        exchanged: Option<&Session>,
+    ) -> Result<Session> {
+        if let Some(session) = exchanged {
+            return Ok(session.clone());
+        }
+
+        self.load_session_for_api_base_url(expected_api_base_url)
+    }
+
     /// Deletes the state file entirely, removing all session and settings data.
     pub fn wipe(&self) -> Result<()> {
         let path = self.session_file_path()?;
@@ -436,6 +451,48 @@ mod tests {
                 Some("https://app.everr.dev")
             );
             assert!(state.settings.wizard_state.wizard_completed);
+        });
+    }
+
+    #[test]
+    fn service_account_secret_takes_precedence_over_a_stored_session() {
+        with_temp_config_home(|store| {
+            store
+                .save_session(&Session {
+                    api_base_url: "http://localhost:5173".to_string(),
+                    token: "stored-human-token".to_string(),
+                })
+                .expect("save session");
+
+            let resolved = store
+                .resolve_session(
+                    "http://localhost:5173",
+                    Some(&Session {
+                        api_base_url: "http://localhost:5173".to_string(),
+                        token: "st_exchanged".to_string(),
+                    }),
+                )
+                .expect("resolve session");
+
+            assert_eq!(resolved.token, "st_exchanged");
+        });
+    }
+
+    #[test]
+    fn a_stored_session_is_used_when_no_secret_is_set() {
+        with_temp_config_home(|store| {
+            store
+                .save_session(&Session {
+                    api_base_url: "http://localhost:5173".to_string(),
+                    token: "stored-human-token".to_string(),
+                })
+                .expect("save session");
+
+            let resolved = store
+                .resolve_session("http://localhost:5173", None)
+                .expect("resolve session");
+
+            assert_eq!(resolved.token, "stored-human-token");
         });
     }
 

--- a/packages/app/drizzle/0012_service_accounts.sql
+++ b/packages/app/drizzle/0012_service_accounts.sql
@@ -1,0 +1,38 @@
+CREATE TABLE "service_account" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"created_by_user_id" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"last_used_at" timestamp
+);
+--> statement-breakpoint
+CREATE TABLE "service_account_secret" (
+	"id" text PRIMARY KEY NOT NULL,
+	"service_account_id" text NOT NULL,
+	"hash" text NOT NULL,
+	"start" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"last_used_at" timestamp,
+	"revoked_at" timestamp,
+	"request_count" integer DEFAULT 0 NOT NULL,
+	"last_request" timestamp
+);
+--> statement-breakpoint
+CREATE TABLE "service_account_token" (
+	"id" text PRIMARY KEY NOT NULL,
+	"service_account_secret_id" text NOT NULL,
+	"hash" text NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "is_service_account" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "service_account" ADD CONSTRAINT "service_account_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "service_account" ADD CONSTRAINT "service_account_created_by_user_id_user_id_fk" FOREIGN KEY ("created_by_user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "service_account_secret" ADD CONSTRAINT "service_account_secret_service_account_id_service_account_id_fk" FOREIGN KEY ("service_account_id") REFERENCES "public"."service_account"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "service_account_token" ADD CONSTRAINT "service_account_token_service_account_secret_id_service_account_secret_id_fk" FOREIGN KEY ("service_account_secret_id") REFERENCES "public"."service_account_secret"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "service_account_userId_uidx" ON "service_account" USING btree ("user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "service_account_secret_hash_uidx" ON "service_account_secret" USING btree ("hash");--> statement-breakpoint
+CREATE INDEX "service_account_secret_accountId_idx" ON "service_account_secret" USING btree ("service_account_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "service_account_token_hash_uidx" ON "service_account_token" USING btree ("hash");--> statement-breakpoint
+CREATE INDEX "service_account_token_secretId_idx" ON "service_account_token" USING btree ("service_account_secret_id");

--- a/packages/app/drizzle/meta/0012_snapshot.json
+++ b/packages/app/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,3952 @@
+{
+  "id": "7707f1ae-6c3f-4ba1-9b1a-fe2b06da0d7a",
+  "prevId": "c390e17c-6394-47a5-a135-45f6d46b6121",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.alert_definitions": {
+      "name": "alert_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repoid": {
+          "name": "repoid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_id": {
+          "name": "preview_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "evaluation_interval_seconds": {
+          "name": "evaluation_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parsed_query": {
+          "name": "parsed_query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary_template": {
+          "name": "summary_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_template": {
+          "name": "description_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "next_evaluation_at": {
+          "name": "next_evaluation_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_jitter_seconds": {
+          "name": "schedule_jitter_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_enqueued_at": {
+          "name": "last_enqueued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_file_path": {
+          "name": "config_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "source_link": {
+          "name": "source_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "runbook_project": {
+          "name": "runbook_project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "runbook_slug": {
+          "name": "runbook_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_evaluation_status": {
+          "name": "last_evaluation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "last_evaluation_error": {
+          "name": "last_evaluation_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "current_state": {
+          "name": "current_state",
+          "type": "alert_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "last_evaluated_at": {
+          "name": "last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_resolved_at": {
+          "name": "last_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_row_count": {
+          "name": "last_row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_evidence_snapshot": {
+          "name": "last_evidence_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "firing_instance_count": {
+          "name": "firing_instance_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "instance_label_columns": {
+          "name": "instance_label_columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {
+        "alert_definitions_live_project_slug_uq": {
+          "name": "alert_definitions_live_project_slug_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"alert_definitions\".\"preview_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_definitions_preview_project_slug_uq": {
+          "name": "alert_definitions_preview_project_slug_uq",
+          "columns": [
+            {
+              "expression": "preview_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"alert_definitions\".\"preview_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "alert_definitions_due_idx": {
+          "name": "alert_definitions_due_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_evaluation_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_definitions_preview_id_previews_id_fk": {
+          "name": "alert_definitions_preview_id_previews_id_fk",
+          "tableFrom": "alert_definitions",
+          "tableTo": "previews",
+          "columnsFrom": [
+            "preview_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "alert_definitions_live_xor_preview": {
+          "name": "alert_definitions_live_xor_preview",
+          "value": "(\"alert_definitions\".\"preview_id\" IS NULL) <> (\"alert_definitions\".\"repoid\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.alert_settings": {
+      "name": "alert_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery": {
+          "name": "delivery",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "alert_settings_organization_id_unique": {
+          "name": "alert_settings_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_silences": {
+      "name": "alert_silences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alert_definition_id": {
+          "name": "alert_definition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "matchers": {
+          "name": "matchers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_by_user_id": {
+          "name": "cancelled_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "alert_silences_active_lookup_idx": {
+          "name": "alert_silences_active_lookup_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alert_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "cancelled_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alert_silences_alert_definition_id_alert_definitions_id_fk": {
+          "name": "alert_silences_alert_definition_id_alert_definitions_id_fk",
+          "tableFrom": "alert_silences",
+          "tableTo": "alert_definitions",
+          "columnsFrom": [
+            "alert_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboards": {
+      "name": "dashboards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repoid": {
+          "name": "repoid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_id": {
+          "name": "preview_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "folder_path": {
+          "name": "folder_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dashboards_live_project_slug_uq": {
+          "name": "dashboards_live_project_slug_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"dashboards\".\"preview_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboards_preview_project_slug_uq": {
+          "name": "dashboards_preview_project_slug_uq",
+          "columns": [
+            {
+              "expression": "preview_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"dashboards\".\"preview_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dashboards_tenant_updated_idx": {
+          "name": "dashboards_tenant_updated_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dashboards_preview_id_previews_id_fk": {
+          "name": "dashboards_preview_id_previews_id_fk",
+          "tableFrom": "dashboards",
+          "tableTo": "previews",
+          "columnsFrom": [
+            "preview_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "dashboards_live_xor_preview": {
+          "name": "dashboards_live_xor_preview",
+          "value": "(\"dashboards\".\"preview_id\" IS NULL) <> (\"dashboards\".\"repoid\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.github_installation_organizations": {
+      "name": "github_installation_organizations",
+      "schema": "",
+      "columns": {
+        "github_installation_id": {
+          "name": "github_installation_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "installation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installation_orgs_org_id_idx": {
+          "name": "github_installation_orgs_org_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.previews": {
+      "name": "previews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repoid": {
+          "name": "repoid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_applied_at": {
+          "name": "last_applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "previews_tenant_repo_name_uq": {
+          "name": "previews_tenant_repo_name_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repoid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runbooks": {
+      "name": "runbooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repoid": {
+          "name": "repoid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_id": {
+          "name": "preview_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "folder_path": {
+          "name": "folder_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runbooks_live_project_slug_uq": {
+          "name": "runbooks_live_project_slug_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"runbooks\".\"preview_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runbooks_preview_project_slug_uq": {
+          "name": "runbooks_preview_project_slug_uq",
+          "columns": [
+            {
+              "expression": "preview_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"runbooks\".\"preview_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runbooks_tenant_updated_idx": {
+          "name": "runbooks_tenant_updated_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runbooks_preview_id_previews_id_fk": {
+          "name": "runbooks_preview_id_previews_id_fk",
+          "tableFrom": "runbooks",
+          "tableTo": "previews",
+          "columnsFrom": [
+            "preview_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runbooks_live_xor_preview": {
+          "name": "runbooks_live_xor_preview",
+          "value": "(\"runbooks\".\"preview_id\" IS NULL) <> (\"runbooks\".\"repoid\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_jobs": {
+      "name": "workflow_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "workflow_jobs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha": {
+          "name": "sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conclusion": {
+          "name": "conclusion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_jobs_tenant_job_uq": {
+          "name": "workflow_jobs_tenant_job_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_jobs_tenant_trace_id_idx": {
+          "name": "workflow_jobs_tenant_trace_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_runs": {
+      "name": "workflow_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "workflow_runs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha": {
+          "name": "sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conclusion": {
+          "name": "conclusion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_email": {
+          "name": "author_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_started_at": {
+          "name": "run_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_completed_at": {
+          "name": "run_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_runs_tenant_run_attempts_uq": {
+          "name": "workflow_runs_tenant_run_attempts_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_tenant_trace_id_uq": {
+          "name": "workflow_runs_tenant_trace_id_uq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_tenant_repo_sha_ref_idx": {
+          "name": "workflow_runs_tenant_repo_sha_ref_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_tenant_last_event_idx": {
+          "name": "workflow_runs_tenant_last_event_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_event_at DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_issuer_accountId_uidx": {
+          "name": "account_issuer_accountId_uidx",
+          "columns": [
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 86400000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "apikey_configId_idx": {
+          "name": "apikey_configId_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_referenceId_idx": {
+          "name": "apikey_referenceId_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_code": {
+      "name": "device_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "device_code_deviceCode_uidx": {
+          "name": "device_code_deviceCode_uidx",
+          "columns": [
+            {
+              "expression": "device_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_code_userCode_uidx": {
+          "name": "device_code_userCode_uidx",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_slug_uidx": {
+          "name": "organization_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_service_account": {
+          "name": "is_service_account",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_subscription": {
+      "name": "org_subscription",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "polar_subscription_id": {
+          "name": "polar_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "polar_product_id": {
+          "name": "polar_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "polar_modified_at": {
+          "name": "polar_modified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "org_subscription_org_id_organization_id_fk": {
+          "name": "org_subscription_org_id_organization_id_fk",
+          "tableFrom": "org_subscription",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alg": {
+          "name": "alg",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crv": {
+          "name": "crv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorization_code_id": {
+          "name": "authorization_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resources": {
+          "name": "resources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_user_info_claims": {
+          "name": "requested_user_info_claims",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation": {
+          "name": "confirmation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthAccessToken_clientId_idx": {
+          "name": "oauthAccessToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_sessionId_idx": {
+          "name": "oauthAccessToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_userId_idx": {
+          "name": "oauthAccessToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_refreshId_idx": {
+          "name": "oauthAccessToken_refreshId_idx",
+          "columns": [
+            {
+              "expression": "refresh_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_discovery_id": {
+          "name": "client_discovery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_credentials_scopes": {
+          "name": "client_credentials_scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backchannel_logout_uri": {
+          "name": "backchannel_logout_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backchannel_logout_session_required": {
+          "name": "backchannel_logout_session_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_type": {
+          "name": "application_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jwks": {
+          "name": "jwks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jwks_uri": {
+          "name": "jwks_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dpop_bound_access_tokens": {
+          "name": "dpop_bound_access_tokens",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthClient_userId_idx": {
+          "name": "oauthClient_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client_assertion": {
+      "name": "oauth_client_assertion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client_resource": {
+      "name": "oauth_client_resource",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthClientResource_clientId_resourceId_uidx": {
+          "name": "oauthClientResource_clientId_resourceId_uidx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_resource_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_client_resource_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_client_resource",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_client_resource_resource_id_oauth_resource_identifier_fk": {
+          "name": "oauth_client_resource_resource_id_oauth_resource_identifier_fk",
+          "tableFrom": "oauth_client_resource",
+          "tableTo": "oauth_resource",
+          "columnsFrom": [
+            "resource_id"
+          ],
+          "columnsTo": [
+            "identifier"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resources": {
+          "name": "resources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_user_info_claims": {
+          "name": "requested_user_info_claims",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthConsent_clientId_idx": {
+          "name": "oauthConsent_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthConsent_userId_idx": {
+          "name": "oauthConsent_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorization_code_id": {
+          "name": "authorization_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resources": {
+          "name": "resources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_user_info_claims": {
+          "name": "requested_user_info_claims",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_replay_response": {
+          "name": "rotation_replay_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_replay_expires_at": {
+          "name": "rotation_replay_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation": {
+          "name": "confirmation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthRefreshToken_clientId_idx": {
+          "name": "oauthRefreshToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_sessionId_idx": {
+          "name": "oauthRefreshToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_userId_idx": {
+          "name": "oauthRefreshToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_token_token_unique": {
+          "name": "oauth_refresh_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_resource": {
+      "name": "oauth_resource",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_ttl": {
+          "name": "access_token_ttl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_ttl": {
+          "name": "refresh_token_ttl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signing_algorithm": {
+          "name": "signing_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signing_key_id": {
+          "name": "signing_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_scopes": {
+          "name": "allowed_scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_claims": {
+          "name": "custom_claims",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dpop_bound_access_tokens_required": {
+          "name": "dpop_bound_access_tokens_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_resource_identifier_unique": {
+          "name": "oauth_resource_identifier_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "identifier"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_account": {
+      "name": "service_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "service_account_userId_uidx": {
+          "name": "service_account_userId_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "service_account_user_id_user_id_fk": {
+          "name": "service_account_user_id_user_id_fk",
+          "tableFrom": "service_account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "service_account_created_by_user_id_user_id_fk": {
+          "name": "service_account_created_by_user_id_user_id_fk",
+          "tableFrom": "service_account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_account_secret": {
+      "name": "service_account_secret",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "service_account_id": {
+          "name": "service_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "service_account_secret_hash_uidx": {
+          "name": "service_account_secret_hash_uidx",
+          "columns": [
+            {
+              "expression": "hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_account_secret_accountId_idx": {
+          "name": "service_account_secret_accountId_idx",
+          "columns": [
+            {
+              "expression": "service_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "service_account_secret_service_account_id_service_account_id_fk": {
+          "name": "service_account_secret_service_account_id_service_account_id_fk",
+          "tableFrom": "service_account_secret",
+          "tableTo": "service_account",
+          "columnsFrom": [
+            "service_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_account_token": {
+      "name": "service_account_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "service_account_secret_id": {
+          "name": "service_account_secret_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "service_account_token_hash_uidx": {
+          "name": "service_account_token_hash_uidx",
+          "columns": [
+            {
+              "expression": "hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_account_token_secretId_idx": {
+          "name": "service_account_token_secretId_idx",
+          "columns": [
+            {
+              "expression": "service_account_secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "service_account_token_service_account_secret_id_service_account_secret_id_fk": {
+          "name": "service_account_token_service_account_secret_id_service_account_secret_id_fk",
+          "tableFrom": "service_account_token",
+          "tableTo": "service_account_secret",
+          "columnsFrom": [
+            "service_account_secret_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.alert_state": {
+      "name": "alert_state",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "resolved",
+        "firing"
+      ]
+    },
+    "public.installation_status": {
+      "name": "installation_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "suspended",
+        "uninstalled"
+      ]
+    },
+    "public.workflow_status": {
+      "name": "workflow_status",
+      "schema": "public",
+      "values": [
+        "requested",
+        "waiting",
+        "queued",
+        "in_progress",
+        "completed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/app/drizzle/meta/_journal.json
+++ b/packages/app/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1787701242767,
       "tag": "0011_better_auth_1_7",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1787780821769,
+      "tag": "0012_service_accounts",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/app/src/components/service-accounts/create-service-account-dialog.tsx
+++ b/packages/app/src/components/service-accounts/create-service-account-dialog.tsx
@@ -1,0 +1,159 @@
+import { Button } from "@everr/ui/components/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@everr/ui/components/dialog";
+import { Input } from "@everr/ui/components/input";
+import { Label } from "@everr/ui/components/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@everr/ui/components/select";
+import { Bot, Loader2, Plus } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { useCreateServiceAccount } from "@/components/service-accounts/queries";
+import { SecretReveal } from "@/components/service-accounts/secret-reveal";
+import {
+  SERVICE_ACCOUNT_ROLES,
+  type ServiceAccountRole,
+} from "@/data/service-accounts";
+
+const ROLE_LABELS: Record<ServiceAccountRole, string> = {
+  admin: "Admin",
+  member: "Member",
+};
+
+export function CreateServiceAccountDialog() {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [role, setRole] = useState<ServiceAccountRole>("member");
+  const [issuedSecret, setIssuedSecret] = useState<string | null>(null);
+  const create = useCreateServiceAccount();
+
+  const reset = () => {
+    setName("");
+    setRole("member");
+    setIssuedSecret(null);
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next && create.isPending) return;
+    // Reset on open, not close: clearing `issuedSecret` on close would swap
+    // the success screen back to the form mid close-out animation. Closing
+    // keeps whatever was shown; the next open starts fresh.
+    if (next) reset();
+    setOpen(next);
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    create.mutate(
+      { name: trimmed, role },
+      {
+        onSuccess: (data) => {
+          setIssuedSecret(data.secret);
+          toast.success("Service account created");
+        },
+        onError: (err) => toast.error(err.message),
+      },
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger render={<Button size="sm" variant="outline" />}>
+        <Plus className="size-4" />
+        New service account
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        {issuedSecret ? (
+          <SecretReveal
+            secret={issuedSecret}
+            title="Copy the secret now"
+            description="This is the only time the full secret is shown. Store it in your secret manager. You won't be able to retrieve it later."
+            onDone={() => handleOpenChange(false)}
+          />
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-5">
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <span className="bg-primary/10 text-primary flex size-7 items-center justify-center rounded-md">
+                  <Bot className="size-4" />
+                </span>
+                New service account
+              </DialogTitle>
+              <DialogDescription>
+                A machine member of this organization. It exchanges its secret
+                for a short-lived bearer token, the same way a person signs in.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="service-account-name">Name</Label>
+                <Input
+                  id="service-account-name"
+                  name="service-account-name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="ci-deploy-bot"
+                  required
+                  autoFocus
+                  autoComplete="off"
+                  data-1p-ignore
+                  data-lpignore="true"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="service-account-role">Role</Label>
+                <Select
+                  value={role}
+                  onValueChange={(v) => setRole(v as ServiceAccountRole)}
+                >
+                  <SelectTrigger id="service-account-role" className="w-full">
+                    <SelectValue>{ROLE_LABELS[role]}</SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    {SERVICE_ACCOUNT_ROLES.map((r) => (
+                      <SelectItem key={r} value={r}>
+                        {ROLE_LABELS[r]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleOpenChange(false)}
+                disabled={create.isPending}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={create.isPending}>
+                {create.isPending && (
+                  <Loader2 className="size-4 animate-spin" />
+                )}
+                Create service account
+              </Button>
+            </DialogFooter>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/app/src/components/service-accounts/queries.ts
+++ b/packages/app/src/components/service-accounts/queries.ts
@@ -1,0 +1,66 @@
+import {
+  queryOptions,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
+import {
+  createServiceAccount,
+  deleteServiceAccount,
+  listServiceAccounts,
+  revokeServiceAccountSecret,
+  rotateServiceAccountSecret,
+  type ServiceAccountRole,
+} from "@/data/service-accounts";
+
+const serviceAccountsQueryKey = ["service-accounts"] as const;
+
+export function serviceAccountsQueryOptions() {
+  return queryOptions({
+    queryKey: serviceAccountsQueryKey,
+    queryFn: () => listServiceAccounts(),
+  });
+}
+
+export function useCreateServiceAccount() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: { name: string; role: ServiceAccountRole }) =>
+      createServiceAccount({ data: vars }),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: serviceAccountsQueryKey });
+    },
+  });
+}
+
+export function useRotateServiceAccountSecret() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: { serviceAccountId: string }) =>
+      rotateServiceAccountSecret({ data: vars }),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: serviceAccountsQueryKey });
+    },
+  });
+}
+
+export function useRevokeServiceAccountSecret() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: { secretId: string }) =>
+      revokeServiceAccountSecret({ data: vars }),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: serviceAccountsQueryKey });
+    },
+  });
+}
+
+export function useDeleteServiceAccount() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: { serviceAccountId: string }) =>
+      deleteServiceAccount({ data: vars }),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: serviceAccountsQueryKey });
+    },
+  });
+}

--- a/packages/app/src/components/service-accounts/secret-reveal.tsx
+++ b/packages/app/src/components/service-accounts/secret-reveal.tsx
@@ -1,0 +1,70 @@
+import { Button } from "@everr/ui/components/button";
+import {
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@everr/ui/components/dialog";
+import { Bot, Check, Copy } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+
+interface SecretRevealProps {
+  secret: string;
+  title: string;
+  description: string;
+  onDone: () => void;
+}
+
+// A secret is readable once, at creation and again at rotation. Both places
+// need the same copy button, the same "Copied" countdown, and the same
+// reminder that there is no second chance to read it.
+export function SecretReveal({
+  secret,
+  title,
+  description,
+  onDone,
+}: SecretRevealProps) {
+  const [copied, setCopied] = useState(false);
+  const copyResetTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  // Clear the "Copied" reset timer if the dialog unmounts mid-countdown.
+  useEffect(() => () => clearTimeout(copyResetTimer.current), []);
+
+  const copySecret = async () => {
+    try {
+      await navigator.clipboard.writeText(secret);
+      setCopied(true);
+      clearTimeout(copyResetTimer.current);
+      copyResetTimer.current = setTimeout(() => setCopied(false), 1500);
+    } catch {
+      toast.error("Could not copy to clipboard");
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <DialogHeader>
+        <DialogTitle className="flex items-center gap-2">
+          <span className="bg-primary/10 text-primary flex size-7 items-center justify-center rounded-md">
+            <Bot className="size-4" />
+          </span>
+          {title}
+        </DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <div className="bg-muted/40 rounded-md border p-3 font-mono text-xs break-all">
+        {secret}
+      </div>
+      <DialogFooter>
+        <Button variant="outline" onClick={onDone}>
+          Done
+        </Button>
+        <Button onClick={copySecret}>
+          {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
+          {copied ? "Copied" : "Copy secret"}
+        </Button>
+      </DialogFooter>
+    </div>
+  );
+}

--- a/packages/app/src/components/service-accounts/service-accounts-table.tsx
+++ b/packages/app/src/components/service-accounts/service-accounts-table.tsx
@@ -1,0 +1,337 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@everr/ui/components/alert-dialog";
+import { Badge } from "@everr/ui/components/badge";
+import { Button } from "@everr/ui/components/button";
+import { type Column, DataTable } from "@everr/ui/components/data-table";
+import { Dialog, DialogContent } from "@everr/ui/components/dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@everr/ui/components/tooltip";
+import { Bot, Loader2 } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+  useDeleteServiceAccount,
+  useRevokeServiceAccountSecret,
+  useRotateServiceAccountSecret,
+} from "@/components/service-accounts/queries";
+import { SecretReveal } from "@/components/service-accounts/secret-reveal";
+import { formatDate } from "@/components/users-management/format-date";
+import type {
+  ServiceAccountSecretSummary,
+  ServiceAccountSummary,
+} from "@/data/service-accounts";
+
+const RELATIVE = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+const RELATIVE_UNITS: [Intl.RelativeTimeFormatUnit, number][] = [
+  ["year", 31_536_000],
+  ["month", 2_592_000],
+  ["week", 604_800],
+  ["day", 86_400],
+  ["hour", 3_600],
+  ["minute", 60],
+];
+
+function relativeFromNow(value?: string | Date | null): string | null {
+  if (!value) return null;
+  const then = new Date(value).getTime();
+  if (Number.isNaN(then)) return null;
+  const seconds = Math.round((then - Date.now()) / 1000);
+  const abs = Math.abs(seconds);
+  for (const [unit, secs] of RELATIVE_UNITS) {
+    if (abs >= secs) return RELATIVE.format(Math.round(seconds / secs), unit);
+  }
+  return "just now";
+}
+
+function exactDate(value: string | Date) {
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return String(value);
+  return d.toLocaleString();
+}
+
+function LastUsed({ value }: { value?: string | Date | null }) {
+  const relative = relativeFromNow(value);
+  if (!relative || !value) {
+    return <span className="text-muted-foreground">Never used</span>;
+  }
+  return (
+    <Tooltip>
+      <TooltipTrigger render={<span className="cursor-default" />}>
+        {relative}
+      </TooltipTrigger>
+      <TooltipContent>{exactDate(value)}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+function RevokeSecretAction({
+  secret,
+  accountName,
+}: {
+  secret: ServiceAccountSecretSummary;
+  accountName: string;
+}) {
+  const revoke = useRevokeServiceAccountSecret();
+
+  const handleRevoke = () => {
+    revoke.mutate(
+      { secretId: secret.id },
+      {
+        onSuccess: () =>
+          toast.success(`Secret ${secret.start}… revoked for ${accountName}`),
+        onError: (err) => toast.error(err.message),
+      },
+    );
+  };
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-muted-foreground hover:text-destructive h-6 px-1.5 text-xs"
+          />
+        }
+      >
+        Revoke
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Revoke this secret?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Any caller using secret {secret.start}… loses access immediately.
+            This cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleRevoke}
+            className="bg-destructive hover:bg-destructive/90 text-white"
+          >
+            Revoke secret
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+function ActiveSecrets({ row }: { row: ServiceAccountSummary }) {
+  const active = row.secrets.filter((s) => !s.revokedAt);
+  if (active.length === 0) {
+    return <span className="text-muted-foreground">None</span>;
+  }
+  return (
+    <div className="flex flex-col gap-1.5">
+      {active.map((secret) => (
+        <div key={secret.id} className="flex items-center gap-2">
+          <code className="bg-muted/40 text-muted-foreground rounded border px-1.5 py-0.5 font-mono text-[0.7rem]">
+            {secret.start}…
+          </code>
+          <span className="text-muted-foreground text-xs">
+            <LastUsed value={secret.lastUsedAt} />
+          </span>
+          <RevokeSecretAction secret={secret} accountName={row.name} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// Rotating adds a new secret without disturbing the ones already active, so
+// it needs no confirm step. The new secret is shown once, the same reveal
+// pattern as account creation, because it can never be shown again.
+function RotateSecretButton({ account }: { account: ServiceAccountSummary }) {
+  const rotate = useRotateServiceAccountSecret();
+  const [open, setOpen] = useState(false);
+  const [issuedSecret, setIssuedSecret] = useState<string | null>(null);
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next && rotate.isPending) return;
+    setOpen(next);
+    if (!next) setIssuedSecret(null);
+  };
+
+  const handleClick = () => {
+    setOpen(true);
+    rotate.mutate(
+      { serviceAccountId: account.id },
+      {
+        onSuccess: (data) => setIssuedSecret(data.secret),
+        onError: (err) => {
+          toast.error(err.message);
+          setOpen(false);
+        },
+      },
+    );
+  };
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={handleClick}
+        disabled={rotate.isPending}
+      >
+        Rotate
+      </Button>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="sm:max-w-md">
+          {issuedSecret ? (
+            <SecretReveal
+              secret={issuedSecret}
+              title="Copy the new secret now"
+              description="This is the only time the full secret is shown. Store it in your secret manager. The account's earlier secrets stay active until you revoke them."
+              onDone={() => handleOpenChange(false)}
+            />
+          ) : (
+            <div className="flex items-center justify-center py-10">
+              <Loader2 className="text-muted-foreground size-5 animate-spin" />
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function DeleteAccountButton({ account }: { account: ServiceAccountSummary }) {
+  const del = useDeleteServiceAccount();
+
+  const handleDelete = () => {
+    del.mutate(
+      { serviceAccountId: account.id },
+      {
+        onSuccess: () => toast.success(`${account.name} deleted`),
+        onError: (err) => toast.error(err.message),
+      },
+    );
+  };
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-muted-foreground hover:text-destructive"
+          />
+        }
+      >
+        Delete
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete “{account.name}”?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This removes the service account, its membership, and every one of
+            its secrets. Any caller still using them loses access immediately.
+            This cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleDelete}
+            className="bg-destructive hover:bg-destructive/90 text-white"
+          >
+            Delete service account
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+interface ServiceAccountsTableProps {
+  accounts: ServiceAccountSummary[];
+}
+
+export function ServiceAccountsTable({ accounts }: ServiceAccountsTableProps) {
+  const columns: Column<ServiceAccountSummary>[] = [
+    {
+      header: "Name",
+      cell: (row) => (
+        <div className="flex items-center gap-2.5">
+          <span className="bg-muted text-muted-foreground flex size-6 shrink-0 items-center justify-center rounded-md border">
+            <Bot className="size-3.5" />
+          </span>
+          <span className="truncate font-medium">{row.name}</span>
+        </div>
+      ),
+    },
+    {
+      header: "Role",
+      cell: (row) => (
+        <Badge variant="outline" className="capitalize">
+          {row.role}
+        </Badge>
+      ),
+    },
+    {
+      header: "Created by",
+      cell: (row) => (
+        <span className="text-muted-foreground">
+          {row.createdByName ?? "Unknown"}
+        </span>
+      ),
+    },
+    {
+      header: "Created",
+      cell: (row) => (
+        <span className="text-muted-foreground">
+          {formatDate(row.createdAt)}
+        </span>
+      ),
+    },
+    {
+      header: "Last used",
+      cell: (row) => <LastUsed value={row.lastUsedAt} />,
+    },
+    {
+      header: "Active secrets",
+      cell: (row) => <ActiveSecrets row={row} />,
+    },
+    {
+      header: <span className="sr-only">Actions</span>,
+      cell: (row) => (
+        <div className="flex items-center justify-end gap-1">
+          <RotateSecretButton account={row} />
+          <DeleteAccountButton account={row} />
+        </div>
+      ),
+      cellClassName: "py-2 pr-3 text-right",
+      className: "pb-2 pr-3",
+    },
+  ];
+
+  return (
+    <DataTable
+      data={accounts}
+      columns={columns}
+      rowKey={(row) => row.id}
+      emptyState={
+        <p className="py-8 text-center text-sm text-muted-foreground">
+          No service accounts yet.
+        </p>
+      }
+    />
+  );
+}

--- a/packages/app/src/components/users-management/members-table.tsx
+++ b/packages/app/src/components/users-management/members-table.tsx
@@ -19,8 +19,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@everr/ui/components/select";
+import { Bot } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
+import type { ServiceAccountSummary } from "@/data/service-accounts";
 import { formatDate } from "./format-date";
 import {
   type Member,
@@ -32,6 +34,11 @@ import {
 interface MembersTableProps {
   members: Member[];
   currentUserId: string | undefined;
+  // The organization's service accounts, from the list the page already
+  // holds. Undefined while that list loads: a row nobody knows to be a
+  // machine reads as a person, so the badge and the guards appear once the
+  // list arrives.
+  serviceAccounts: ServiceAccountSummary[] | undefined;
 }
 
 interface RoleChangePending {
@@ -41,12 +48,22 @@ interface RoleChangePending {
   nextRole: OrgRole;
 }
 
-export function MembersTable({ members, currentUserId }: MembersTableProps) {
+export function MembersTable({
+  members,
+  currentUserId,
+  serviceAccounts,
+}: MembersTableProps) {
   const updateRole = useUpdateMemberRole();
   const remove = useRemoveMember();
   const [rolePending, setRolePending] = useState<RoleChangePending | null>(
     null,
   );
+
+  const serviceAccountUserIds = new Set(
+    (serviceAccounts ?? []).map((account) => account.userId),
+  );
+  const isServiceAccount = (row: Member) =>
+    serviceAccountUserIds.has(row.userId);
 
   const ownerCount = members.filter((m) => m.role === "owner").length;
 
@@ -81,10 +98,16 @@ export function MembersTable({ members, currentUserId }: MembersTableProps) {
     {
       header: "Name",
       cell: (row) => (
-        <span>
+        <span className="inline-flex items-center gap-1.5">
           {row.user?.name ?? "—"}
           {row.userId === currentUserId && (
-            <span className="ml-1.5 text-xs text-muted-foreground">(you)</span>
+            <span className="text-xs text-muted-foreground">(you)</span>
+          )}
+          {isServiceAccount(row) && (
+            <Badge variant="outline" className="gap-1">
+              <Bot />
+              Service account
+            </Badge>
           )}
         </span>
       ),
@@ -127,7 +150,9 @@ export function MembersTable({ members, currentUserId }: MembersTableProps) {
             <SelectContent>
               <SelectItem value="member">Member</SelectItem>
               <SelectItem value="admin">Admin</SelectItem>
-              <SelectItem value="owner">Owner</SelectItem>
+              {!isServiceAccount(row) && (
+                <SelectItem value="owner">Owner</SelectItem>
+              )}
             </SelectContent>
           </Select>
         );
@@ -142,7 +167,11 @@ export function MembersTable({ members, currentUserId }: MembersTableProps) {
       cell: (row) => {
         const isSelf = row.userId === currentUserId;
         const isLastOwner = row.role === "owner" && ownerCount <= 1;
-        if (isSelf || isLastOwner) return null;
+        // A service account is deleted from the Service accounts table
+        // below, which also removes its membership. Removing it here
+        // instead would leave the account, its secrets, and its user row
+        // behind with no membership to act through.
+        if (isSelf || isLastOwner || isServiceAccount(row)) return null;
         const memberName = row.user?.name ?? row.user?.email ?? "this member";
 
         return (

--- a/packages/app/src/components/users-management/queries.ts
+++ b/packages/app/src/components/users-management/queries.ts
@@ -3,6 +3,7 @@ import {
   useMutation,
   useQueryClient,
 } from "@tanstack/react-query";
+import { inviteMember } from "@/data/invite";
 import { authClient } from "@/lib/auth-client";
 
 type ListMembersResult = Awaited<
@@ -77,15 +78,11 @@ export function invitationsQueryOptions() {
 export function useInviteMember() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: async (vars: { email: string; role: OrgRole }) => {
-      const res = await authClient.organization.inviteMember({
-        email: vars.email,
-        role: vars.role,
-      });
-      if (res.error)
-        throw new Error(res.error.message ?? "Failed to send invitation");
-      return res.data;
-    },
+    // Routed through the server function so the service-account domain
+    // guard (`@/data/invite`) sits on every invite, not only the ones the
+    // UI happens to filter.
+    mutationFn: (vars: { email: string; role: OrgRole }) =>
+      inviteMember({ data: { email: vars.email, role: vars.role } }),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: invitationsQueryKey });
     },

--- a/packages/app/src/data/invite.test.ts
+++ b/packages/app/src/data/invite.test.ts
@@ -1,4 +1,40 @@
-import { describe, expect, it, vi } from "vitest";
+import { APIError } from "better-auth/api";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The `user` row the invitation guard reads for the address it was given.
+// An empty array is an address nobody holds.
+let recipientRows: Array<{ isServiceAccount: boolean }> = [];
+
+vi.mock("@/db/client", () => ({
+  db: {
+    select: () => {
+      // biome-ignore lint/suspicious/noExplicitAny: a query-builder passthrough mock has no fixed shape.
+      const chain: any = {
+        from: () => chain,
+        where: () => chain,
+        limit: async () => recipientRows,
+      };
+      return chain;
+    },
+  },
+}));
+
+const createInvitation = vi.fn();
+
+vi.mock("@/lib/auth.server", () => ({
+  auth: {
+    api: {
+      getSession: vi.fn(),
+      createInvitation: (...args: unknown[]) => createInvitation(...args),
+    },
+  },
+}));
+
+vi.mock("@tanstack/react-start/server", () => ({
+  getRequestHeaders: () => new Headers({ cookie: "better-auth.session=x" }),
+}));
+
+import { inviteMember } from "@/data/invite";
 import {
   deriveInvitationLookup,
   type InvitationRow,
@@ -247,5 +283,52 @@ describe("resolveInvitationLoader", () => {
       organizationName: "Acme",
       invitedEmail: "a@x.com",
     });
+  });
+});
+
+describe("inviteMember", () => {
+  beforeEach(() => {
+    createInvitation.mockReset();
+    recipientRows = [];
+  });
+
+  it("refuses to invite a service account", async () => {
+    recipientRows = [{ isServiceAccount: true }];
+
+    await expect(
+      inviteMember({
+        data: { email: "deploy-bot@svc.everr.invalid", role: "member" },
+      } as never),
+    ).rejects.toThrow(/service account/i);
+    expect(createInvitation).not.toHaveBeenCalled();
+  });
+
+  it("invites a real address with the chosen role", async () => {
+    createInvitation.mockResolvedValue({ id: "inv_1", status: "pending" });
+
+    const result = await inviteMember({
+      data: { email: "new.hire@example.com", role: "admin" },
+    } as never);
+
+    expect(createInvitation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: { email: "new.hire@example.com", role: "admin" },
+      }),
+    );
+    expect(result).toEqual({ id: "inv_1", status: "pending" });
+  });
+
+  it("passes a refusal from better-auth back with its message intact", async () => {
+    createInvitation.mockRejectedValue(
+      new APIError("BAD_REQUEST", {
+        message: "User is already a member of this organization",
+      }),
+    );
+
+    await expect(
+      inviteMember({
+        data: { email: "already.here@example.com", role: "member" },
+      } as never),
+    ).rejects.toThrow("User is already a member of this organization");
   });
 });

--- a/packages/app/src/data/invite.ts
+++ b/packages/app/src/data/invite.ts
@@ -1,9 +1,15 @@
 import { createServerFn } from "@tanstack/react-start";
+import { getRequestHeaders } from "@tanstack/react-start/server";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/db/client";
 import { invitation, member, organization, user } from "@/db/schema";
-import { createPartiallyAuthenticatedServerFn } from "@/lib/serverFn";
+import { auth } from "@/lib/auth.server";
+import {
+  createAuthenticatedServerFn,
+  createPartiallyAuthenticatedServerFn,
+} from "@/lib/serverFn";
+import { assertInvitationRecipientAllowed } from "@/lib/service-account-member-guards.server";
 import {
   deriveInvitationLookup,
   type InvitationLookup,
@@ -50,4 +56,27 @@ export const isMemberOfOrg = createPartiallyAuthenticatedServerFn({
       )
       .limit(1);
     return { isMember: Boolean(row) };
+  });
+
+const InviteMemberInput = z
+  .object({
+    email: z.string().trim().min(1, "Email is required"),
+    role: z.enum(["member", "admin", "owner"]),
+  })
+  .strict();
+
+// A service account's membership comes from the account itself, so an
+// invitation to one is a dead end. The same guard runs on the organization
+// plugin's `beforeCreateInvitation` hook, which is the security boundary
+// (`/organization/invite-member` is client-callable and bypasses this server
+// function); calling it here gives the UI the refusal before the round trip.
+export const inviteMember = createAuthenticatedServerFn({ method: "POST" })
+  .inputValidator(InviteMemberInput)
+  .handler(async ({ data }) => {
+    await assertInvitationRecipientAllowed(data.email);
+
+    return auth.api.createInvitation({
+      body: { email: data.email, role: data.role },
+      headers: getRequestHeaders(),
+    });
   });

--- a/packages/app/src/data/service-accounts.test.ts
+++ b/packages/app/src/data/service-accounts.test.ts
@@ -1,0 +1,348 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { member, serviceAccount } from "@/db/schema";
+import { SERVICE_ACCOUNT_ROLES, serviceAccountEmail } from "./service-accounts";
+
+const mocks = vi.hoisted(() => ({
+  createUser: vi.fn(async (data: Record<string, unknown>) => ({
+    id: "user-1",
+    ...data,
+  })),
+  deleteUser: vi.fn(async () => {}),
+  getActiveMemberRole: vi.fn(async () => ({ role: "admin" })),
+}));
+
+vi.mock("@/lib/auth.server", () => ({
+  auth: {
+    $context: Promise.resolve({
+      internalAdapter: {
+        createUser: mocks.createUser,
+        deleteUser: mocks.deleteUser,
+      },
+    }),
+    api: {
+      getActiveMemberRole: mocks.getActiveMemberRole,
+    },
+  },
+}));
+
+vi.mock("@tanstack/react-start/server", () => ({
+  getRequestHeaders: () => new Headers(),
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: (...args: unknown[]) => ({ type: "and", args }),
+  eq: (left: unknown, right: unknown) => ({ type: "eq", left, right }),
+}));
+
+vi.mock("drizzle-orm/pg-core", () => ({
+  alias: (table: unknown, name: string) => ({ ...(table as object), name }),
+}));
+
+// Each column is its own object so a condition built from it says which
+// column it was built from. `name` stays a string on every table because
+// the executor below keys its recording off it.
+vi.mock("@/db/schema", () => ({
+  member: {
+    name: "member",
+    userId: { column: "member.user_id" },
+    organizationId: { column: "member.organization_id" },
+    role: { column: "member.role" },
+  },
+  serviceAccount: {
+    name: "service_account",
+    id: { column: "service_account.id" },
+    userId: { column: "service_account.user_id" },
+    createdAt: { column: "service_account.created_at" },
+    lastUsedAt: { column: "service_account.last_used_at" },
+    createdByUserId: { column: "service_account.created_by_user_id" },
+  },
+  serviceAccountSecret: {
+    name: "service_account_secret",
+    id: { column: "service_account_secret.id" },
+    serviceAccountId: { column: "service_account_secret.service_account_id" },
+    start: { column: "service_account_secret.start" },
+    createdAt: { column: "service_account_secret.created_at" },
+    lastUsedAt: { column: "service_account_secret.last_used_at" },
+    revokedAt: { column: "service_account_secret.revoked_at" },
+  },
+  serviceAccountToken: {
+    name: "service_account_token",
+    serviceAccountSecretId: {
+      column: "service_account_token.service_account_secret_id",
+    },
+  },
+  user: {
+    name: "user",
+    id: { column: "user.id" },
+  },
+}));
+
+// insertedTables(), revokedSecretIds(), and deletedTokenSecretIds() are the
+// facts the tests need out of the mocked db: which tables received an
+// insert, which secrets got an explicit revoke, and which secret id a token
+// delete targeted. Everything else about the chain is a passthrough with no
+// behavior of its own.
+const insertedRows: string[] = [];
+const revokedIds: string[] = [];
+const deletedTokenSecretIds: string[] = [];
+const joins: Array<{ table: unknown; condition: unknown }> = [];
+const selectResult: Array<Record<string, unknown>> = [
+  { id: "sa-1", userId: "user-1", serviceAccountId: "sa-1" },
+];
+
+function tableName(table: unknown): string {
+  return (table as { name: string }).name;
+}
+
+function makeSelectChain() {
+  // biome-ignore lint/suspicious/noExplicitAny: a query-builder passthrough mock has no fixed shape.
+  const chain: any = {
+    from: () => chain,
+    innerJoin: (table: unknown, condition: unknown) => {
+      joins.push({ table, condition });
+      return chain;
+    },
+    leftJoin: () => chain,
+    where: () => chain,
+    limit: async () => selectResult,
+    // biome-ignore lint/suspicious/noThenProperty: a query with no `limit` is awaited straight off the builder, which is exactly what a thenable stands in for.
+    then: (resolve: (rows: unknown) => unknown) => resolve(selectResult),
+  };
+  return chain;
+}
+
+function makeExecutor() {
+  return {
+    insert: (table: unknown) => ({
+      values: async () => {
+        insertedRows.push(tableName(table));
+      },
+    }),
+    select: () => makeSelectChain(),
+    update: (table: unknown) => ({
+      set: (values: { revokedAt?: unknown }) => ({
+        where: async () => {
+          if (
+            tableName(table) === "service_account_secret" &&
+            values.revokedAt
+          ) {
+            revokedIds.push("revoked");
+          }
+        },
+      }),
+    }),
+    delete: (table: unknown) => ({
+      where: async (condition: { right?: unknown }) => {
+        if (tableName(table) === "service_account_token") {
+          deletedTokenSecretIds.push(String(condition?.right));
+        }
+      },
+    }),
+  };
+}
+
+vi.mock("@/db/client", () => ({
+  db: {
+    ...makeExecutor(),
+    transaction: async (fn: (tx: ReturnType<typeof makeExecutor>) => unknown) =>
+      fn(makeExecutor()),
+  },
+}));
+
+function insertedTables(): string[] {
+  return [...insertedRows];
+}
+
+function revokedSecretIds(): string[] {
+  return [...revokedIds];
+}
+
+function tokenDeletesForSecret(): string[] {
+  return [...deletedTokenSecretIds];
+}
+
+// The membership join is the whole tenant boundary, so the tests below read
+// back the condition each query joined `member` on.
+function memberJoinConditions(): unknown[] {
+  return joins
+    .filter((join) => tableName(join.table) === "member")
+    .map((join) => join.condition);
+}
+
+// The organization the authenticated server-function harness signs every
+// call in with (src/test-setup.ts).
+const CALLER_ORG = "test_org";
+
+const scopedToCallerOrg = {
+  type: "and",
+  args: [
+    { type: "eq", left: member.userId, right: serviceAccount.userId },
+    { type: "eq", left: member.organizationId, right: CALLER_ORG },
+  ],
+};
+
+beforeEach(() => {
+  insertedRows.length = 0;
+  revokedIds.length = 0;
+  deletedTokenSecretIds.length = 0;
+  joins.length = 0;
+  mocks.getActiveMemberRole.mockResolvedValue({ role: "admin" });
+});
+
+describe("SERVICE_ACCOUNT_ROLES", () => {
+  it("does not offer owner, which controls billing and deletion", () => {
+    expect(SERVICE_ACCOUNT_ROLES).not.toContain("owner");
+  });
+
+  it("offers admin and member", () => {
+    expect(SERVICE_ACCOUNT_ROLES).toEqual(["admin", "member"]);
+  });
+});
+
+describe("serviceAccountEmail", () => {
+  it("uses a domain that can never receive mail", () => {
+    expect(serviceAccountEmail("abc")).toBe("abc@svc.everr.invalid");
+  });
+});
+
+describe("createServiceAccount", () => {
+  it("refuses owner, which controls billing and deletion", async () => {
+    const { createServiceAccount } = await import("./service-accounts");
+
+    await expect(
+      createServiceAccount({ data: { name: "bot", role: "owner" } } as never),
+    ).rejects.toThrow(/role/i);
+  });
+
+  it("marks the synthetic user as a service account", async () => {
+    // The flag is what every guard reads, so the create path is the one
+    // place that has to set it.
+    const { createServiceAccount } = await import("./service-accounts");
+    await createServiceAccount({
+      data: { name: "bot", role: "member" },
+    } as never);
+
+    expect(mocks.createUser).toHaveBeenCalledWith(
+      expect.objectContaining({ isServiceAccount: true }),
+      expect.anything(),
+    );
+  });
+
+  it("creates no account row, so the account cannot sign in with a password", async () => {
+    // A password sign-in resolves through `account`. Creating none is the
+    // guard, so assert the creation path never writes one.
+    const { createServiceAccount } = await import("./service-accounts");
+    await createServiceAccount({
+      data: { name: "bot", role: "member" },
+    } as never);
+
+    // The three rows the creation path does write, asserted so the absence
+    // above means "no account row", not "the transaction never ran".
+    expect(insertedTables()).toEqual([
+      "member",
+      "service_account",
+      "service_account_secret",
+    ]);
+    expect(insertedTables()).not.toContain("account");
+  });
+});
+
+describe("rotateServiceAccountSecret", () => {
+  it("leaves the previous secret usable until it is revoked", async () => {
+    const { rotateServiceAccountSecret } = await import("./service-accounts");
+    const second = await rotateServiceAccountSecret({
+      data: { serviceAccountId: "sa-1" },
+    } as never);
+
+    expect(second.secret).toBeTruthy();
+    expect(revokedSecretIds()).toEqual([]);
+  });
+});
+
+describe("revokeServiceAccountSecret", () => {
+  it("deletes only that secret's tokens, not the account's other secrets", async () => {
+    const { revokeServiceAccountSecret } = await import("./service-accounts");
+
+    await revokeServiceAccountSecret({
+      data: { secretId: "secret-a" },
+    } as never);
+
+    // The delete must key off the secret the caller named, not off the
+    // owning account: keying off the account would also drop tokens for
+    // every other secret that account holds.
+    expect(tokenDeletesForSecret()).toEqual(["secret-a"]);
+  });
+});
+
+describe("tenant scoping", () => {
+  it("reaches an existing account only through a membership in the caller's organization", async () => {
+    // Without the organization half of this join, any admin could name any
+    // account id and act on another tenant's service account.
+    const { deleteServiceAccount } = await import("./service-accounts");
+
+    await deleteServiceAccount({
+      data: { serviceAccountId: "sa-1" },
+    } as never);
+
+    expect(memberJoinConditions()).toEqual([scopedToCallerOrg]);
+  });
+
+  it("scopes a secret's account lookup the same way", async () => {
+    const { revokeServiceAccountSecret } = await import("./service-accounts");
+
+    await revokeServiceAccountSecret({
+      data: { secretId: "secret-a" },
+    } as never);
+
+    expect(memberJoinConditions()).toEqual([scopedToCallerOrg]);
+  });
+
+  it("lists accounts and their secrets only for the caller's organization", async () => {
+    // Both queries carry the boundary on their own: the secrets query does
+    // not inherit it from the accounts query.
+    const { listServiceAccounts } = await import("./service-accounts");
+
+    await listServiceAccounts();
+
+    expect(memberJoinConditions()).toEqual([
+      scopedToCallerOrg,
+      scopedToCallerOrg,
+    ]);
+  });
+});
+
+describe("permission gate", () => {
+  it("refuses a plain member on every service account operation", async () => {
+    mocks.getActiveMemberRole.mockResolvedValue({ role: "member" });
+
+    const {
+      createServiceAccount,
+      listServiceAccounts,
+      rotateServiceAccountSecret,
+      revokeServiceAccountSecret,
+      deleteServiceAccount,
+    } = await import("./service-accounts");
+
+    await expect(
+      createServiceAccount({
+        data: { name: "bot", role: "member" },
+      } as never),
+    ).rejects.toThrow(/admin/i);
+    await expect(listServiceAccounts()).rejects.toThrow(/admin/i);
+    await expect(
+      rotateServiceAccountSecret({
+        data: { serviceAccountId: "sa-1" },
+      } as never),
+    ).rejects.toThrow(/admin/i);
+    await expect(
+      revokeServiceAccountSecret({
+        data: { secretId: "secret-a" },
+      } as never),
+    ).rejects.toThrow(/admin/i);
+    await expect(
+      deleteServiceAccount({
+        data: { serviceAccountId: "sa-1" },
+      } as never),
+    ).rejects.toThrow(/admin/i);
+  });
+});

--- a/packages/app/src/data/service-accounts.ts
+++ b/packages/app/src/data/service-accounts.ts
@@ -1,0 +1,367 @@
+import { getRequestHeaders } from "@tanstack/react-start/server";
+import { and, eq } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
+import { z } from "zod";
+import { db } from "@/db/client";
+import {
+  member,
+  serviceAccount,
+  serviceAccountSecret,
+  serviceAccountToken,
+  user,
+} from "@/db/schema";
+import { auth } from "@/lib/auth.server";
+import { createAuthenticatedServerFn } from "@/lib/serverFn";
+import { generateSecret } from "@/lib/service-account-credentials";
+
+export const SERVICE_ACCOUNT_ROLES = ["admin", "member"] as const;
+export type ServiceAccountRole = (typeof SERVICE_ACCOUNT_ROLES)[number];
+
+// RFC 2606 reserves .invalid, so an address on this domain can never receive
+// mail.
+const SERVICE_ACCOUNT_EMAIL_DOMAIN = "svc.everr.invalid";
+
+// Filler for a required column, not an identifier. `user.email` is NOT NULL
+// and unique in Better Auth's schema, so a synthetic user still needs an
+// address. What tells a service account apart is `user.isServiceAccount`.
+export function serviceAccountEmail(id: string): string {
+  return `${id}@${SERVICE_ACCOUNT_EMAIL_DOMAIN}`;
+}
+
+function isServiceAccountRole(value: string): value is ServiceAccountRole {
+  return (SERVICE_ACCOUNT_ROLES as readonly string[]).includes(value);
+}
+
+// A service account is a standing credential that can act as an admin- or
+// member-level principal, so creating, listing, or managing one must stay
+// restricted to the org's own admins and owner. Called first in every
+// handler below, the same shape as `ensureOrgAdmin` in
+// `data/alerts/server.ts`.
+async function ensureServiceAccountAdmin(): Promise<void> {
+  const { role } = await auth.api.getActiveMemberRole({
+    headers: getRequestHeaders(),
+  });
+  if (role !== "admin" && role !== "owner") {
+    throw new Error("Only organization admins can manage service accounts");
+  }
+}
+
+// The tenant-isolation check shared by every handler that acts on one
+// existing service account: confirm it exists and belongs to the caller's
+// organization before doing anything else with it. The membership is what
+// says which organization it belongs to, so the join is the check.
+async function requireServiceAccountInOrg(
+  organizationId: string,
+  serviceAccountId: string,
+): Promise<{ userId: string }> {
+  const [account] = await db
+    .select({ userId: serviceAccount.userId })
+    .from(serviceAccount)
+    .innerJoin(
+      member,
+      and(
+        eq(member.userId, serviceAccount.userId),
+        eq(member.organizationId, organizationId),
+      ),
+    )
+    .where(eq(serviceAccount.id, serviceAccountId))
+    .limit(1);
+
+  if (!account) {
+    throw new Error("Service account not found");
+  }
+
+  return account;
+}
+
+export type ServiceAccountSecretSummary = {
+  id: string;
+  start: string;
+  createdAt: Date;
+  lastUsedAt: Date | null;
+  revokedAt: Date | null;
+};
+
+export type ServiceAccountSummary = {
+  id: string;
+  // The synthetic user this account acts as. The members table matches on it
+  // to tell which of its rows are machines.
+  userId: string;
+  name: string;
+  role: string;
+  createdAt: Date;
+  lastUsedAt: Date | null;
+  createdByUserId: string | null;
+  createdByName: string | null;
+  secrets: ServiceAccountSecretSummary[];
+};
+
+const CreateServiceAccountInput = z
+  .object({
+    name: z.string().trim().min(1, "Name is required"),
+    role: z.string().trim().min(1, "Role is required"),
+  })
+  .strict();
+
+export const createServiceAccount = createAuthenticatedServerFn({
+  method: "POST",
+})
+  .inputValidator(CreateServiceAccountInput)
+  .handler(async ({ data, context: { session } }) => {
+    await ensureServiceAccountAdmin();
+
+    // Owner controls billing and organization deletion, which must not sit
+    // behind an unattended credential.
+    if (!isServiceAccountRole(data.role)) {
+      throw new Error(
+        `Unsupported role "${data.role}". Choose one of: ${SERVICE_ACCOUNT_ROLES.join(", ")}.`,
+      );
+    }
+
+    const organizationId = session.session.activeOrganizationId;
+    const authContext = await auth.$context;
+    const serviceAccountId = crypto.randomUUID();
+
+    // "Is this a machine" has two representations: `user.isServiceAccount`,
+    // which the guards read, and the existence of a `service_account` row,
+    // which the data layer reads. Only one direction would matter if they
+    // drifted: a `service_account` row over a user that is not flagged,
+    // because then no guard fires for a real service account. It cannot
+    // happen. This is the only statement in the app that writes the flag and
+    // the only one that writes a `service_account` row, the flag is written
+    // first and the row second, `service_account.user_id` cascades on user
+    // delete so the row can never outlive its user, and Better Auth refuses
+    // the field on every client-facing write (`input: false`, and on update
+    // it drops the field rather than defaulting it). The other direction, a
+    // flagged user with no `service_account` row, is what the compensating
+    // delete below leaves if it fails, and it is harmless: the guards still
+    // refuse and every org-scoped query joins through `service_account`.
+    //
+    // No password is linked here, so no `account` row is created. Better
+    // Auth resolves password sign-in through `account`; with none, there is
+    // nothing to sign in with. That absence is the guard.
+    const createdUser = await authContext.internalAdapter.createUser(
+      {
+        name: data.name,
+        email: serviceAccountEmail(serviceAccountId),
+        emailVerified: true,
+        // The flag every guard reads. This is the only path that sets it:
+        // Better Auth refuses it on every client-facing write.
+        isServiceAccount: true,
+      },
+      { method: "admin" },
+    );
+
+    try {
+      const secret = generateSecret();
+      const secretId = crypto.randomUUID();
+
+      await db.transaction(async (tx) => {
+        await tx.insert(member).values({
+          id: crypto.randomUUID(),
+          organizationId,
+          userId: createdUser.id,
+          role: data.role,
+          createdAt: new Date(),
+        });
+
+        await tx.insert(serviceAccount).values({
+          id: serviceAccountId,
+          userId: createdUser.id,
+          createdByUserId: session.user.id,
+        });
+
+        await tx.insert(serviceAccountSecret).values({
+          id: secretId,
+          serviceAccountId,
+          hash: secret.hash,
+          start: secret.start,
+        });
+      });
+
+      return {
+        id: serviceAccountId,
+        name: data.name,
+        role: data.role,
+        secretId,
+        secret: secret.value,
+        start: secret.start,
+      };
+    } catch (error) {
+      // The user row lives outside this transaction (Better Auth's internal
+      // adapter holds its own database handle), so a failure past this point
+      // would otherwise leave a user with no membership and no service
+      // account behind it. Best-effort cleanup; the original error still wins.
+      await authContext.internalAdapter
+        .deleteUser(createdUser.id)
+        .catch(() => {});
+      throw error;
+    }
+  });
+
+const RotateServiceAccountSecretInput = z
+  .object({ serviceAccountId: z.string().trim().min(1) })
+  .strict();
+
+export const rotateServiceAccountSecret = createAuthenticatedServerFn({
+  method: "POST",
+})
+  .inputValidator(RotateServiceAccountSecretInput)
+  .handler(async ({ data, context: { session } }) => {
+    await ensureServiceAccountAdmin();
+
+    const organizationId = session.session.activeOrganizationId;
+    await requireServiceAccountInOrg(organizationId, data.serviceAccountId);
+
+    // The previous secret stays live: rotation only adds a new one. A
+    // caller revokes the old secret explicitly once traffic has moved over.
+    const secret = generateSecret();
+    const secretId = crypto.randomUUID();
+    await db.insert(serviceAccountSecret).values({
+      id: secretId,
+      serviceAccountId: data.serviceAccountId,
+      hash: secret.hash,
+      start: secret.start,
+    });
+
+    return { id: secretId, secret: secret.value, start: secret.start };
+  });
+
+const RevokeServiceAccountSecretInput = z
+  .object({ secretId: z.string().trim().min(1) })
+  .strict();
+
+export const revokeServiceAccountSecret = createAuthenticatedServerFn({
+  method: "POST",
+})
+  .inputValidator(RevokeServiceAccountSecretInput)
+  .handler(async ({ data, context: { session } }) => {
+    await ensureServiceAccountAdmin();
+
+    const organizationId = session.session.activeOrganizationId;
+
+    const [secret] = await db
+      .select({
+        id: serviceAccountSecret.id,
+        serviceAccountId: serviceAccountSecret.serviceAccountId,
+      })
+      .from(serviceAccountSecret)
+      .where(eq(serviceAccountSecret.id, data.secretId))
+      .limit(1);
+
+    if (!secret) {
+      throw new Error("Service account secret not found");
+    }
+
+    await requireServiceAccountInOrg(organizationId, secret.serviceAccountId);
+
+    // A revoked secret takes its tokens with it, so revocation is immediate
+    // rather than waiting for each token to expire on its own.
+    await db.transaction(async (tx) => {
+      await tx
+        .delete(serviceAccountToken)
+        .where(eq(serviceAccountToken.serviceAccountSecretId, data.secretId));
+
+      await tx
+        .update(serviceAccountSecret)
+        .set({ revokedAt: new Date() })
+        .where(eq(serviceAccountSecret.id, data.secretId));
+    });
+
+    return { id: data.secretId };
+  });
+
+const DeleteServiceAccountInput = z
+  .object({ serviceAccountId: z.string().trim().min(1) })
+  .strict();
+
+export const deleteServiceAccount = createAuthenticatedServerFn({
+  method: "POST",
+})
+  .inputValidator(DeleteServiceAccountInput)
+  .handler(async ({ data, context: { session } }) => {
+    await ensureServiceAccountAdmin();
+
+    const organizationId = session.session.activeOrganizationId;
+    const account = await requireServiceAccountInOrg(
+      organizationId,
+      data.serviceAccountId,
+    );
+
+    // Deleting the user row cascades to its member row, its secrets, and
+    // their tokens (Task 2's foreign keys). It has no account row to cascade.
+    await db.delete(user).where(eq(user.id, account.userId));
+
+    return { id: data.serviceAccountId };
+  });
+
+export const listServiceAccounts = createAuthenticatedServerFn({
+  method: "GET",
+}).handler(
+  async ({ context: { session } }): Promise<ServiceAccountSummary[]> => {
+    await ensureServiceAccountAdmin();
+
+    const organizationId = session.session.activeOrganizationId;
+    const creator = alias(user, "creator");
+
+    // The membership scopes both queries to the caller's organization, the
+    // same way it does for a person.
+    const accounts = await db
+      .select({
+        id: serviceAccount.id,
+        userId: serviceAccount.userId,
+        name: user.name,
+        role: member.role,
+        createdAt: serviceAccount.createdAt,
+        lastUsedAt: serviceAccount.lastUsedAt,
+        createdByUserId: serviceAccount.createdByUserId,
+        createdByName: creator.name,
+      })
+      .from(serviceAccount)
+      .innerJoin(user, eq(user.id, serviceAccount.userId))
+      .innerJoin(
+        member,
+        and(
+          eq(member.userId, serviceAccount.userId),
+          eq(member.organizationId, organizationId),
+        ),
+      )
+      // Left join: the creator's own user row can be gone (`onDelete: "set
+      // null"` on `createdByUserId`), and the account itself must still list.
+      .leftJoin(creator, eq(creator.id, serviceAccount.createdByUserId));
+
+    const secrets = await db
+      .select({
+        id: serviceAccountSecret.id,
+        serviceAccountId: serviceAccountSecret.serviceAccountId,
+        start: serviceAccountSecret.start,
+        createdAt: serviceAccountSecret.createdAt,
+        lastUsedAt: serviceAccountSecret.lastUsedAt,
+        revokedAt: serviceAccountSecret.revokedAt,
+      })
+      .from(serviceAccountSecret)
+      .innerJoin(
+        serviceAccount,
+        eq(serviceAccount.id, serviceAccountSecret.serviceAccountId),
+      )
+      .innerJoin(
+        member,
+        and(
+          eq(member.userId, serviceAccount.userId),
+          eq(member.organizationId, organizationId),
+        ),
+      );
+
+    const secretsByAccountId = new Map<string, ServiceAccountSecretSummary[]>();
+    for (const { serviceAccountId, ...secret } of secrets) {
+      const list = secretsByAccountId.get(serviceAccountId) ?? [];
+      list.push(secret);
+      secretsByAccountId.set(serviceAccountId, list);
+    }
+
+    return accounts.map((account) => ({
+      ...account,
+      secrets: secretsByAccountId.get(account.id) ?? [],
+    }));
+  },
+);

--- a/packages/app/src/db/schema/auth.ts
+++ b/packages/app/src/db/schema/auth.ts
@@ -14,6 +14,12 @@ export const user = pgTable("user", {
   name: text("name").notNull(),
   email: text("email").notNull().unique(),
   emailVerified: boolean("email_verified").default(false).notNull(),
+  // A machine principal, not a person. It is a member like anyone else, so
+  // authorization never reads this; only the paths that assume a human do,
+  // and every one of them reads it back from this row. A service-account
+  // session is built by the plugin rather than loaded, so the flag is not on
+  // the session user and nothing may treat it as if it were.
+  isServiceAccount: boolean("is_service_account").default(false).notNull(),
   image: text("image"),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at")

--- a/packages/app/src/db/schema/index.ts
+++ b/packages/app/src/db/schema/index.ts
@@ -3,3 +3,4 @@ export * from "./app";
 export * from "./auth";
 export * from "./billing";
 export * from "./oauth";
+export * from "./service-accounts";

--- a/packages/app/src/db/schema/service-accounts.ts
+++ b/packages/app/src/db/schema/service-accounts.ts
@@ -1,0 +1,76 @@
+import {
+  index,
+  integer,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+import { user } from "./auth";
+
+// The machine-only facts about an account, plus the parent row its secrets
+// hang from. The organization and the name live on the `member` and `user`
+// rows, the same as for a person, so there is no second answer to "which
+// organization does this principal belong to?".
+export const serviceAccount = pgTable(
+  "service_account",
+  {
+    id: text("id").primaryKey(),
+    // The synthetic user this account authenticates as. Deleting it removes
+    // the member row too, which is how a service account loses all access.
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    createdByUserId: text("created_by_user_id").references(() => user.id, {
+      onDelete: "set null",
+    }),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    lastUsedAt: timestamp("last_used_at"),
+  },
+  (table) => [uniqueIndex("service_account_userId_uidx").on(table.userId)],
+);
+
+export const serviceAccountSecret = pgTable(
+  "service_account_secret",
+  {
+    id: text("id").primaryKey(),
+    serviceAccountId: text("service_account_id")
+      .notNull()
+      .references(() => serviceAccount.id, { onDelete: "cascade" }),
+    hash: text("hash").notNull(),
+    // First characters of the secret, so two secrets are tellable apart in the
+    // UI without storing either one.
+    start: text("start").notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    lastUsedAt: timestamp("last_used_at"),
+    revokedAt: timestamp("revoked_at"),
+    // The exchange rate limit lives on the secret rather than in one app
+    // process, so the bound is the same whatever number of instances serve
+    // the request and whatever headers the caller sends.
+    requestCount: integer("request_count").notNull().default(0),
+    lastRequest: timestamp("last_request"),
+  },
+  (table) => [
+    uniqueIndex("service_account_secret_hash_uidx").on(table.hash),
+    index("service_account_secret_accountId_idx").on(table.serviceAccountId),
+  ],
+);
+
+export const serviceAccountToken = pgTable(
+  "service_account_token",
+  {
+    id: text("id").primaryKey(),
+    serviceAccountSecretId: text("service_account_secret_id")
+      .notNull()
+      .references(() => serviceAccountSecret.id, { onDelete: "cascade" }),
+    hash: text("hash").notNull(),
+    expiresAt: timestamp("expires_at").notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex("service_account_token_hash_uidx").on(table.hash),
+    index("service_account_token_secretId_idx").on(
+      table.serviceAccountSecretId,
+    ),
+  ],
+);

--- a/packages/app/src/lib/auth.server.ts
+++ b/packages/app/src/lib/auth.server.ts
@@ -39,9 +39,14 @@ import {
   sendVerificationEmail,
 } from "@/lib/email.server";
 import { MCP_RESOURCE } from "@/lib/mcp-resource";
-import { deletePostgresOrganizationData } from "@/lib/organization-data-cleanup.server";
+import {
+  deleteOrganizationServiceAccounts,
+  deletePostgresOrganizationData,
+} from "@/lib/organization-data-cleanup.server";
 import { ensurePolarCustomerForOrg, polarClient } from "@/lib/polar.server";
 import { resolveRetention } from "@/lib/retention";
+import { serviceAccountOrganizationHooks } from "@/lib/service-account-member-guards.server";
+import { serviceAccountPlugin } from "@/lib/service-account-plugin";
 import { exceptionAttributes, serverLogger } from "@/telemetry/logger";
 
 type PolarSubscriptionPayload = {
@@ -217,6 +222,18 @@ export const auth = betterAuth({
     deleteUser: {
       enabled: true,
     },
+    additionalFields: {
+      // `input: false` plus a default keeps every client-facing write path
+      // (sign-up, update-user, an OAuth profile) from setting the flag: only
+      // the service-account create path writes it, through the internal
+      // adapter.
+      isServiceAccount: {
+        type: "boolean",
+        required: false,
+        defaultValue: false,
+        input: false,
+      },
+    },
   },
   onAPIError: {
     errorURL: "/auth/error",
@@ -346,6 +363,12 @@ export const auth = betterAuth({
         });
       },
       organizationHooks: {
+        // Every guard that keeps a machine principal out of the human
+        // membership paths. service-account-contract.test.ts runs this same
+        // object against a real better-auth instance, so an upgrade that
+        // renamed a hook or moved where it fires fails there rather than
+        // opening silently here.
+        ...serviceAccountOrganizationHooks,
         afterCreateOrganization: async ({ organization, user: creator }) => {
           try {
             await ensurePolarCustomerForOrg({
@@ -390,6 +413,12 @@ export const auth = betterAuth({
               "organization.id": organization.id,
             });
           }
+        },
+        // The member rows still exist here, which is what says which
+        // machine users belong to this organization. After the delete they
+        // are gone and those users would stay behind forever.
+        beforeDeleteOrganization: async ({ organization }) => {
+          await deleteOrganizationServiceAccounts(organization.id);
         },
         afterDeleteOrganization: async ({ organization }) => {
           try {
@@ -442,6 +471,7 @@ export const auth = betterAuth({
       },
     ]),
     bearer(),
+    serviceAccountPlugin(),
     polar({
       client: polarClient,
       createCustomerOnSignUp: false,

--- a/packages/app/src/lib/organization-data-cleanup.server.test.ts
+++ b/packages/app/src/lib/organization-data-cleanup.server.test.ts
@@ -1,22 +1,47 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockAnd, mockDelete, mockEq, mockTransaction, whereCalls } = vi.hoisted(
-  () => ({
-    mockAnd: vi.fn((...conditions: unknown[]) => ({ type: "and", conditions })),
-    mockDelete: vi.fn(),
-    mockEq: vi.fn((column: unknown, value: unknown) => ({
-      type: "eq",
-      column,
-      value,
-    })),
-    mockTransaction: vi.fn(),
-    whereCalls: [] as Array<{ table: unknown; condition: unknown }>,
-  }),
-);
+const {
+  mockAnd,
+  mockDelete,
+  mockEq,
+  mockInArray,
+  mockTransaction,
+  serviceAccountUserRows,
+  whereCalls,
+} = vi.hoisted(() => ({
+  mockAnd: vi.fn((...conditions: unknown[]) => ({ type: "and", conditions })),
+  mockDelete: vi.fn(),
+  mockEq: vi.fn((column: unknown, value: unknown) => ({
+    type: "eq",
+    column,
+    value,
+  })),
+  mockInArray: vi.fn((column: unknown, values: unknown) => ({
+    type: "inArray",
+    column,
+    values,
+  })),
+  mockTransaction: vi.fn(),
+  serviceAccountUserRows: [] as Array<{ userId: string }>,
+  whereCalls: [] as Array<{ table: unknown; condition: unknown }>,
+}));
+
+// The rows the service-account lookup finds. Only its result matters here;
+// the chain that produces it is a passthrough.
+function makeSelectChain() {
+  // biome-ignore lint/suspicious/noExplicitAny: a query-builder passthrough mock has no fixed shape.
+  const chain: any = {
+    from: () => chain,
+    innerJoin: async () => serviceAccountUserRows,
+  };
+  return chain;
+}
 
 vi.mock("@/db/client", () => ({
   db: {
     transaction: mockTransaction,
+    select: () => makeSelectChain(),
+    delete: (table: unknown) => mockDelete(table),
   },
 }));
 
@@ -26,22 +51,30 @@ vi.mock("drizzle-orm", async (importOriginal) => {
     ...actual,
     and: mockAnd,
     eq: mockEq,
+    inArray: mockInArray,
   };
 });
 
 import {
   apikey,
   githubInstallationOrganizations,
+  member,
+  serviceAccount,
+  user,
   workflowJobs,
   workflowRuns,
 } from "@/db/schema";
-import { deletePostgresOrganizationData } from "./organization-data-cleanup.server";
+import {
+  deleteOrganizationServiceAccounts,
+  deletePostgresOrganizationData,
+} from "./organization-data-cleanup.server";
 
 const ORG = "org42";
 
 beforeEach(() => {
   vi.clearAllMocks();
   whereCalls.length = 0;
+  serviceAccountUserRows.length = 0;
   mockTransaction.mockImplementation(async (callback) =>
     callback({
       delete: mockDelete,
@@ -77,5 +110,41 @@ describe("deletePostgresOrganizationData", () => {
       { type: "eq", column: apikey.configId, value: "ingest" },
       { type: "eq", column: apikey.referenceId, value: ORG },
     );
+  });
+});
+
+describe("deleteOrganizationServiceAccounts", () => {
+  it("deletes the machine users the organization's members point at", async () => {
+    // Deleting the organization cascades the member rows away but leaves
+    // the user rows, so the service accounts have to go first.
+    serviceAccountUserRows.push({ userId: "user-1" }, { userId: "user-2" });
+
+    await deleteOrganizationServiceAccounts(ORG);
+
+    expect(whereCalls).toEqual([
+      {
+        table: user,
+        condition: {
+          type: "inArray",
+          column: user.id,
+          values: ["user-1", "user-2"],
+        },
+      },
+    ]);
+  });
+
+  it("scopes the lookup to this organization's memberships", async () => {
+    serviceAccountUserRows.push({ userId: "user-1" });
+
+    await deleteOrganizationServiceAccounts(ORG);
+
+    expect(mockEq).toHaveBeenCalledWith(member.userId, serviceAccount.userId);
+    expect(mockEq).toHaveBeenCalledWith(member.organizationId, ORG);
+  });
+
+  it("deletes nothing when the organization holds no service accounts", async () => {
+    await deleteOrganizationServiceAccounts(ORG);
+
+    expect(whereCalls).toEqual([]);
   });
 });

--- a/packages/app/src/lib/organization-data-cleanup.server.ts
+++ b/packages/app/src/lib/organization-data-cleanup.server.ts
@@ -1,11 +1,49 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { db } from "@/db/client";
 import {
   apikey,
   githubInstallationOrganizations,
+  member,
+  serviceAccount,
+  user,
   workflowJobs,
   workflowRuns,
 } from "@/db/schema";
+
+// A service account belongs to an organization through its member row, so
+// deleting the organization leaves its machine users behind: the member rows
+// cascade away, the user rows do not. This deletes those users, which
+// cascades to their service accounts, secrets, and tokens. It runs before the
+// organization is deleted, while the member rows still say who belongs to it.
+export async function deleteOrganizationServiceAccounts(
+  organizationId: string,
+): Promise<void> {
+  if (!organizationId) {
+    throw new Error("Missing organization id");
+  }
+
+  const userIds = await db
+    .select({ userId: serviceAccount.userId })
+    .from(serviceAccount)
+    .innerJoin(
+      member,
+      and(
+        eq(member.userId, serviceAccount.userId),
+        eq(member.organizationId, organizationId),
+      ),
+    );
+
+  if (userIds.length === 0) {
+    return;
+  }
+
+  await db.delete(user).where(
+    inArray(
+      user.id,
+      userIds.map((row) => row.userId),
+    ),
+  );
+}
 
 export async function deletePostgresOrganizationData(
   organizationId: string,

--- a/packages/app/src/lib/service-account-contract.test.ts
+++ b/packages/app/src/lib/service-account-contract.test.ts
@@ -1,0 +1,319 @@
+import { betterAuth } from "better-auth";
+import { memoryAdapter } from "better-auth/adapters/memory";
+import { organization as organizationPlugin } from "better-auth/plugins";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateToken } from "./service-account-credentials";
+
+// Every refusal this feature relies on is a fact about better-auth 1.7.1
+// rather than about our code: which hook names the organization plugin
+// calls, where in each endpoint it calls them, that `/organization/leave`
+// has no hook at all, and that `/delete-user` re-reads the session from the
+// store. Typecheck cannot see any of that, and the guard unit tests call our
+// functions directly, so they would all stay green if an upgrade stopped
+// calling them. This file drives the real better-auth dispatcher and fails
+// when any of those facts stops holding.
+
+const findLiveToken = vi.fn();
+
+vi.mock("./service-account-store", () => ({
+  findLiveToken: (...args: unknown[]) => findLiveToken(...args),
+  deleteToken: vi.fn(),
+}));
+
+// The guards read `user.is_service_account` back from our own database. The
+// only user any of them is asked about here is the service account, because
+// the human's organizations and memberships are written straight through
+// better-auth's adapter, so one fixed answer is the whole of what the user
+// table has to supply. Whether the flag itself is read correctly is the
+// subject of service-account-member-guards.server.test.ts.
+vi.mock("@/db/client", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: a query-builder passthrough mock has no fixed shape.
+  const chain: any = {
+    from: () => chain,
+    where: () => chain,
+    limit: async () => [{ isServiceAccount: true }],
+  };
+  return { db: { select: () => chain } };
+});
+
+const HUMAN = { email: "owner@example.com", password: "owner-password-1" };
+const SERVICE_ACCOUNT_USER = {
+  id: "service-account-user",
+  name: "Deploy bot",
+  email: "deploy-bot@svc.everr.invalid",
+  emailVerified: true,
+  image: null,
+};
+
+type Fixture = Awaited<ReturnType<typeof buildFixture>>;
+
+async function buildFixture() {
+  const { serviceAccountOrganizationHooks } = await import(
+    "./service-account-member-guards.server"
+  );
+  const { serviceAccountPlugin } = await import("./service-account-plugin");
+
+  const auth = betterAuth({
+    baseURL: "http://localhost",
+    secret: "contract-secret-contract-secret-contract",
+    database: memoryAdapter({
+      account: [],
+      invitation: [],
+      member: [],
+      organization: [],
+      session: [],
+      user: [],
+      verification: [],
+    }),
+    emailAndPassword: { enabled: true },
+    // Enabled in our own configuration too, which is what makes the
+    // `/delete-user` case below worth asserting.
+    user: { deleteUser: { enabled: true } },
+    plugins: [
+      organizationPlugin({
+        organizationHooks: { ...serviceAccountOrganizationHooks },
+      }),
+      serviceAccountPlugin(),
+    ],
+  });
+
+  const { adapter } = await auth.$context;
+
+  const signUp = await auth.api.signUpEmail({
+    body: { ...HUMAN, name: "Owner" },
+    returnHeaders: true,
+  });
+  const humanId = signUp.response.user.id;
+  const humanHeaders = new Headers({
+    cookie: signUp.headers.get("set-cookie") ?? "",
+  });
+
+  // Written through the adapter rather than through `/organization/create`
+  // so that no guard runs for the human: every guard invocation in this
+  // file is then about the service account.
+  async function makeOrganization(id: string) {
+    await adapter.create({
+      model: "organization",
+      data: { id, name: id, slug: id, createdAt: new Date() },
+      forceAllowId: true,
+    });
+    await adapter.create({
+      model: "member",
+      data: {
+        organizationId: id,
+        userId: humanId,
+        role: "owner",
+        createdAt: new Date(),
+      },
+    });
+    return id;
+  }
+
+  // The account acts in `home`. `other` is an organization it has nothing to
+  // do with, which is where the paths that would give it a second membership
+  // have to be tried: better-auth refuses those outright for an existing
+  // member, before any hook runs.
+  const home = await makeOrganization("home-org");
+  const other = await makeOrganization("other-org");
+
+  await adapter.create({
+    model: "user",
+    data: {
+      ...SERVICE_ACCOUNT_USER,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    forceAllowId: true,
+  });
+  const serviceAccountMember = await adapter.create<{ id: string }>({
+    model: "member",
+    data: {
+      organizationId: home,
+      userId: SERVICE_ACCOUNT_USER.id,
+      role: "member",
+      createdAt: new Date(),
+    },
+  });
+
+  const token = generateToken();
+  findLiveToken.mockResolvedValue({
+    id: "token-row",
+    expiresAt: new Date(Date.now() + 3600 * 1000),
+    organizationId: home,
+    user: {
+      ...SERVICE_ACCOUNT_USER,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  });
+  const serviceAccountHeaders = new Headers({
+    authorization: `Bearer ${token.value}`,
+  });
+
+  return {
+    adapter,
+    auth,
+    home,
+    humanHeaders,
+    humanId,
+    other,
+    serviceAccountHeaders,
+    serviceAccountMember,
+  };
+}
+
+let fixture: Fixture;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  fixture = await buildFixture();
+});
+
+async function memberCount(userId: string) {
+  const rows = await fixture.adapter.findMany({
+    model: "member",
+    where: [{ field: "userId", value: userId }],
+  });
+  return rows.length;
+}
+
+describe("what better-auth refuses a service account", () => {
+  it("refuses to create an organization, before the organization row exists", async () => {
+    // The guard has to run on `beforeCreateOrganization`: the organization
+    // row is written before the creator's member row, and deleting an
+    // organization needs a membership, so a refusal any later leaves a row
+    // nobody can ever remove.
+    await expect(
+      fixture.auth.api.createOrganization({
+        headers: fixture.serviceAccountHeaders,
+        body: { name: "Agent org", slug: "agent-org" },
+      }),
+    ).rejects.toThrow(/cannot create an organization/i);
+
+    expect(
+      await fixture.adapter.findOne({
+        model: "organization",
+        where: [{ field: "slug", value: "agent-org" }],
+      }),
+    ).toBeNull();
+  });
+
+  it("refuses to add it to an organization", async () => {
+    await expect(
+      fixture.auth.api.addMember({
+        body: {
+          userId: SERVICE_ACCOUNT_USER.id,
+          organizationId: fixture.other,
+          role: "member",
+        },
+      }),
+    ).rejects.toThrow(/cannot be added to an organization/i);
+
+    expect(await memberCount(SERVICE_ACCOUNT_USER.id)).toBe(1);
+  });
+
+  it("refuses to invite it", async () => {
+    await expect(
+      fixture.auth.api.createInvitation({
+        headers: fixture.humanHeaders,
+        body: {
+          email: SERVICE_ACCOUNT_USER.email,
+          role: "member",
+          organizationId: fixture.other,
+        },
+      }),
+    ).rejects.toThrow(/cannot invite a service account/i);
+  });
+
+  it("refuses to let it accept an invitation", async () => {
+    // Written through the adapter because the guard above stops the endpoint
+    // from ever creating one. What this asserts is the other end of the
+    // flow: an invitation that exists, whichever path wrote it.
+    const invitation = await fixture.adapter.create<{ id: string }>({
+      model: "invitation",
+      data: {
+        email: SERVICE_ACCOUNT_USER.email,
+        role: "member",
+        organizationId: fixture.other,
+        inviterId: fixture.humanId,
+        status: "pending",
+        expiresAt: new Date(Date.now() + 3600 * 1000),
+        createdAt: new Date(),
+      },
+    });
+
+    await expect(
+      fixture.auth.api.acceptInvitation({
+        headers: fixture.serviceAccountHeaders,
+        body: { invitationId: invitation.id },
+      }),
+    ).rejects.toThrow(/cannot accept an invitation/i);
+
+    expect(await memberCount(SERVICE_ACCOUNT_USER.id)).toBe(1);
+  });
+
+  it("refuses to promote it to owner", async () => {
+    await expect(
+      fixture.auth.api.updateMemberRole({
+        headers: fixture.humanHeaders,
+        body: {
+          memberId: fixture.serviceAccountMember.id,
+          organizationId: fixture.home,
+          role: "owner",
+        },
+      }),
+    ).rejects.toThrow(/cannot hold the owner role/i);
+  });
+
+  it("refuses to remove its membership through the member path", async () => {
+    await expect(
+      fixture.auth.api.removeMember({
+        headers: fixture.humanHeaders,
+        body: {
+          memberIdOrEmail: fixture.serviceAccountMember.id,
+          organizationId: fixture.home,
+        },
+      }),
+    ).rejects.toThrow(/orphan its secrets/i);
+
+    expect(await memberCount(SERVICE_ACCOUNT_USER.id)).toBe(1);
+  });
+
+  it("refuses to let it leave its organization", async () => {
+    // `/organization/leave` has no hook of any kind, so the plugin refuses
+    // the path by name. A renamed path would let the call through, and the
+    // member row is what proves it did not.
+    await expect(
+      fixture.auth.api.leaveOrganization({
+        headers: fixture.serviceAccountHeaders,
+        body: { organizationId: fixture.home },
+      }),
+    ).rejects.toThrow(/cannot leave an organization/i);
+
+    expect(await memberCount(SERVICE_ACCOUNT_USER.id)).toBe(1);
+  });
+
+  it("refuses `/delete-user`, which nothing in this repository guards", async () => {
+    // Closed by better-auth's own `sensitiveSessionMiddleware`: it drops the
+    // session the plugin put in context and re-reads it from the session
+    // store, where a service account has no row. An upgrade that made it
+    // trust the session in context would hand an unattended credential the
+    // power to delete its own user.
+    // Unauthorized, not one of our messages: the refusal comes from the
+    // missing session row, so it stops meaning anything the moment
+    // better-auth trusts the session in context.
+    await expect(
+      fixture.auth.api.deleteUser({
+        headers: fixture.serviceAccountHeaders,
+        body: {},
+      }),
+    ).rejects.toThrow(/unauthorized/i);
+
+    expect(
+      await fixture.adapter.findOne({
+        model: "user",
+        where: [{ field: "id", value: SERVICE_ACCOUNT_USER.id }],
+      }),
+    ).not.toBeNull();
+  });
+});

--- a/packages/app/src/lib/service-account-credentials.test.ts
+++ b/packages/app/src/lib/service-account-credentials.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  generateSecret,
+  generateToken,
+  hashCredential,
+  isServiceAccountToken,
+  SECRET_PREFIX,
+  TOKEN_PREFIX,
+} from "./service-account-credentials";
+
+describe("generateSecret", () => {
+  it("issues a prefixed value whose hash is not the value", () => {
+    const secret = generateSecret();
+
+    expect(secret.value.startsWith(SECRET_PREFIX)).toBe(true);
+    expect(secret.hash).not.toContain(secret.value);
+    expect(secret.hash).toBe(hashCredential(secret.value));
+  });
+
+  it("issues a different value every time", () => {
+    expect(generateSecret().value).not.toBe(generateSecret().value);
+  });
+
+  it("keeps a start long enough to tell two secrets apart", () => {
+    const secret = generateSecret();
+
+    expect(secret.value.startsWith(secret.start)).toBe(true);
+    expect(secret.start.length).toBeGreaterThan(SECRET_PREFIX.length);
+  });
+});
+
+describe("generateToken", () => {
+  it("issues a prefixed value recognised as a service account token", () => {
+    const token = generateToken();
+
+    expect(token.value.startsWith(TOKEN_PREFIX)).toBe(true);
+    expect(isServiceAccountToken(token.value)).toBe(true);
+  });
+});
+
+describe("isServiceAccountToken", () => {
+  it("rejects a secret, so a secret can never be used as a token", () => {
+    expect(isServiceAccountToken(generateSecret().value)).toBe(false);
+  });
+});

--- a/packages/app/src/lib/service-account-credentials.ts
+++ b/packages/app/src/lib/service-account-credentials.ts
@@ -1,0 +1,34 @@
+import { createHash, randomBytes } from "node:crypto";
+
+export const SECRET_PREFIX = "sa_";
+export const TOKEN_PREFIX = "st_";
+export const TOKEN_TTL_SECONDS = 3600;
+
+const RANDOM_BYTES = 32;
+const START_LENGTH = SECRET_PREFIX.length + 6;
+
+export function hashCredential(value: string): string {
+  return createHash("sha256").update(value).digest("base64url");
+}
+
+function generate(prefix: string): string {
+  return `${prefix}${randomBytes(RANDOM_BYTES).toString("base64url")}`;
+}
+
+export function generateSecret() {
+  const value = generate(SECRET_PREFIX);
+  return {
+    value,
+    hash: hashCredential(value),
+    start: value.slice(0, START_LENGTH),
+  };
+}
+
+export function generateToken() {
+  const value = generate(TOKEN_PREFIX);
+  return { value, hash: hashCredential(value) };
+}
+
+export function isServiceAccountToken(value: string): boolean {
+  return value.startsWith(TOKEN_PREFIX);
+}

--- a/packages/app/src/lib/service-account-member-guards.server.test.ts
+++ b/packages/app/src/lib/service-account-member-guards.server.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The select result stands in for the `user` row the guards read, looked up
+// by id or by address. `isServiceAccount: true` is a machine principal,
+// `false` is a person, and an empty array is an address nobody holds.
+// Mutated per test, restored via beforeEach so tests stay independent.
+let selectResult: Array<{ isServiceAccount: boolean }> = [
+  { isServiceAccount: true },
+];
+
+function makeSelectChain() {
+  // biome-ignore lint/suspicious/noExplicitAny: a query-builder passthrough mock has no fixed shape.
+  const chain: any = {
+    from: () => chain,
+    innerJoin: () => chain,
+    where: () => chain,
+    limit: async () => selectResult,
+  };
+  return chain;
+}
+
+vi.mock("@/db/client", () => ({
+  db: {
+    select: () => makeSelectChain(),
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  user: {
+    id: "user.id",
+    email: "user.email",
+    isServiceAccount: "user.is_service_account",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: (left: unknown, right: unknown) => ({ type: "eq", left, right }),
+}));
+
+beforeEach(() => {
+  selectResult = [{ isServiceAccount: true }];
+});
+
+describe("assertRoleChangeAllowed", () => {
+  it("allows a role change that is not a promotion to owner", async () => {
+    const { assertRoleChangeAllowed } = await import(
+      "./service-account-member-guards.server"
+    );
+    await expect(
+      assertRoleChangeAllowed("user-1", "admin"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("refuses promoting a service account's member to owner", async () => {
+    const { assertRoleChangeAllowed } = await import(
+      "./service-account-member-guards.server"
+    );
+    await expect(assertRoleChangeAllowed("user-1", "owner")).rejects.toThrow(
+      /owner role/i,
+    );
+  });
+
+  it("allows promoting a human member to owner", async () => {
+    selectResult = [{ isServiceAccount: false }];
+    const { assertRoleChangeAllowed } = await import(
+      "./service-account-member-guards.server"
+    );
+    await expect(
+      assertRoleChangeAllowed("human-1", "owner"),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("assertOrganizationCreatorAllowed", () => {
+  it("refuses a service account creating an organization", async () => {
+    // The organization row is written before the creator's member row, so a
+    // refusal any later leaves an organization nobody can delete.
+    const { assertOrganizationCreatorAllowed } = await import(
+      "./service-account-member-guards.server"
+    );
+    await expect(assertOrganizationCreatorAllowed("user-1")).rejects.toThrow(
+      /organization/i,
+    );
+  });
+
+  it("allows a person creating an organization", async () => {
+    selectResult = [{ isServiceAccount: false }];
+    const { assertOrganizationCreatorAllowed } = await import(
+      "./service-account-member-guards.server"
+    );
+    await expect(
+      assertOrganizationCreatorAllowed("human-1"),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("assertMemberAdditionAllowed", () => {
+  it("refuses adding a service account to an organization, whatever the role", async () => {
+    // A second membership would leave the account with no defined
+    // organization, because the membership is what says which one it is.
+    const { assertMemberAdditionAllowed } = await import(
+      "./service-account-member-guards.server"
+    );
+    await expect(assertMemberAdditionAllowed("user-1")).rejects.toThrow(
+      /service account/i,
+    );
+  });
+
+  it("allows adding a human", async () => {
+    selectResult = [{ isServiceAccount: false }];
+    const { assertMemberAdditionAllowed } = await import(
+      "./service-account-member-guards.server"
+    );
+    await expect(
+      assertMemberAdditionAllowed("human-1"),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("assertInvitationRecipientAllowed", () => {
+  it("refuses an invitation addressed to a service account", async () => {
+    const { assertInvitationRecipientAllowed } = await import(
+      "./service-account-member-guards.server"
+    );
+    await expect(
+      assertInvitationRecipientAllowed("sa-1@svc.everr.invalid"),
+    ).rejects.toThrow(/service account/i);
+  });
+
+  it("allows an invitation addressed to a person", async () => {
+    selectResult = [{ isServiceAccount: false }];
+    const { assertInvitationRecipientAllowed } = await import(
+      "./service-account-member-guards.server"
+    );
+    await expect(
+      assertInvitationRecipientAllowed("gio@example.com"),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("assertInvitationAcceptorAllowed", () => {
+  it("refuses a service account accepting an invitation", async () => {
+    const { assertInvitationAcceptorAllowed } = await import(
+      "./service-account-member-guards.server"
+    );
+    await expect(assertInvitationAcceptorAllowed("user-1")).rejects.toThrow(
+      /service account/i,
+    );
+  });
+
+  it("allows a person accepting an invitation", async () => {
+    selectResult = [{ isServiceAccount: false }];
+    const { assertInvitationAcceptorAllowed } = await import(
+      "./service-account-member-guards.server"
+    );
+    await expect(
+      assertInvitationAcceptorAllowed("human-1"),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("assertMemberRemovalAllowed", () => {
+  it("refuses removing a service account's membership", async () => {
+    const { assertMemberRemovalAllowed } = await import(
+      "./service-account-member-guards.server"
+    );
+    await expect(assertMemberRemovalAllowed("user-1")).rejects.toThrow(
+      /orphan/i,
+    );
+  });
+
+  it("allows removing a human member's membership", async () => {
+    selectResult = [{ isServiceAccount: false }];
+    const { assertMemberRemovalAllowed } = await import(
+      "./service-account-member-guards.server"
+    );
+    await expect(
+      assertMemberRemovalAllowed("human-1"),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/app/src/lib/service-account-member-guards.server.ts
+++ b/packages/app/src/lib/service-account-member-guards.server.ts
@@ -1,0 +1,206 @@
+import { APIError } from "better-auth/api";
+import { eq } from "drizzle-orm";
+import { db } from "@/db/client";
+import { user } from "@/db/schema";
+
+// This module has no dependency on auth.server.ts or serverFn.ts on
+// purpose: auth.server.ts spreads the hooks at the end of this file into
+// the organization plugin, and a guard file that itself imported back into
+// auth.server.ts (through data/service-accounts.ts, which imports
+// serverFn.ts, which imports auth.server.ts) would create an import
+// cycle that breaks server startup.
+
+// Every guard below asks the same question of the user row, because the
+// flag is what tells a machine principal from a person.
+async function isServiceAccountUser(userId: string): Promise<boolean> {
+  const [row] = await db
+    .select({ isServiceAccount: user.isServiceAccount })
+    .from(user)
+    .where(eq(user.id, userId))
+    .limit(1);
+  return row?.isServiceAccount === true;
+}
+
+// An invitation names an address, not a user id, so this guard resolves the
+// address to a user row first. Addresses are stored lowercase, so a
+// lowercased equality catches every spelling of one.
+async function isServiceAccountEmail(email: string): Promise<boolean> {
+  const [row] = await db
+    .select({ isServiceAccount: user.isServiceAccount })
+    .from(user)
+    .where(eq(user.email, email.trim().toLowerCase()))
+    .limit(1);
+  return row?.isServiceAccount === true;
+}
+
+// Wired into the organization plugin's `beforeUpdateMemberRole` hook
+// (`serviceAccountOrganizationHooks`, below), so a promotion to owner is
+// refused there too, not only on the create path. The members table's role
+// selector already hides Owner for a service-account row, but the UI is not
+// a security boundary.
+export async function assertRoleChangeAllowed(
+  memberUserId: string,
+  newRole: string,
+): Promise<void> {
+  if (newRole !== "owner") return;
+  if (await isServiceAccountUser(memberUserId)) {
+    throw new APIError("BAD_REQUEST", {
+      message:
+        "A service account cannot hold the owner role. Promote by hand in the database if a real case appears.",
+    });
+  }
+}
+
+// Wired into the organization plugin's `beforeCreateOrganization` hook
+// (`serviceAccountOrganizationHooks`, below). Two reasons it has to sit
+// there and not later:
+//
+// `/organization/create` writes the organization row before it adds the
+// creator, so a refusal at `beforeAddMember` leaves an organization behind
+// that has no member. `/organization/delete` needs a membership, so nothing
+// can ever remove that row, and a caller holding a valid token could repeat
+// the call to grow the table without bound.
+//
+// It is also what holds a service account to one membership. The addition
+// guard below only refuses because the creator role is owner, so a
+// different `creatorRole` in the plugin configuration would let a second
+// membership through, and the organization the token resolves to would
+// start depending on row order.
+//
+// The plugin's `allowUserToCreateOrganization` option cannot do this job:
+// it is handed the session user object, which for a service-account
+// session is built by the plugin and carries no flag. Only the user row
+// answers the question.
+export async function assertOrganizationCreatorAllowed(
+  userId: string,
+): Promise<void> {
+  if (await isServiceAccountUser(userId)) {
+    throw new APIError("BAD_REQUEST", {
+      message:
+        "A service account cannot create an organization. It acts in the organization that created it.",
+    });
+  }
+}
+
+// Wired into the organization plugin's `beforeAddMember` hook
+// (`serviceAccountOrganizationHooks`, below). It fires for the creator's
+// own member row on `/organization/create` and for any `auth.api.addMember`
+// call, which writes a member row directly with no role check and no
+// invitation in the way.
+//
+// It refuses the addition whatever the role, not only owner. A service
+// account's own membership is written by `createServiceAccount`, never
+// here, so nothing legitimate reaches this hook with one. Refusing on the
+// role alone would hold only while the creator role stays `owner`: a
+// service account with a second membership has no defined organization,
+// because the membership is what says which organization it acts in.
+export async function assertMemberAdditionAllowed(
+  memberUserId: string,
+): Promise<void> {
+  if (await isServiceAccountUser(memberUserId)) {
+    throw new APIError("BAD_REQUEST", {
+      message:
+        "A service account cannot be added to an organization. It gets its membership when it is created, and a second one would leave it with no organization to act in.",
+    });
+  }
+}
+
+// Wired into the organization plugin's `beforeCreateInvitation` hook
+// (`serviceAccountOrganizationHooks`, below). `/organization/invite-member`
+// is an ordinary client-callable endpoint, so an owner of any organization
+// could otherwise invite a service account to any role, and
+// `acceptInvitation` writes the member row with no role hook in the way.
+export async function assertInvitationRecipientAllowed(
+  email: string,
+): Promise<void> {
+  if (await isServiceAccountEmail(email)) {
+    throw new APIError("BAD_REQUEST", {
+      message:
+        "Cannot invite a service account. Create one from the Service accounts section instead.",
+    });
+  }
+}
+
+// Wired into the organization plugin's `beforeAcceptInvitation` hook
+// (`serviceAccountOrganizationHooks`, below). The create guard above stops
+// new invitations; this stops any invitation that already exists, whichever
+// path wrote it.
+export async function assertInvitationAcceptorAllowed(
+  userId: string,
+): Promise<void> {
+  if (await isServiceAccountUser(userId)) {
+    throw new APIError("BAD_REQUEST", {
+      message:
+        "A service account cannot accept an invitation. Its membership comes from the service account itself.",
+    });
+  }
+}
+
+// Wired into the organization plugin's `beforeRemoveMember` hook
+// (`serviceAccountOrganizationHooks`, below). Removing the member row
+// through that path, rather than through `deleteServiceAccount`, would
+// leave the account, its secrets, and its user row behind with no
+// membership to act through.
+export async function assertMemberRemovalAllowed(
+  memberUserId: string,
+): Promise<void> {
+  if (await isServiceAccountUser(memberUserId)) {
+    throw new APIError("BAD_REQUEST", {
+      message:
+        "Removing a service account's membership would orphan its secrets and tokens. Delete the service account instead.",
+    });
+  }
+}
+
+// The organization plugin's wiring lives here, not inline in auth.server.ts,
+// so that one object is both what runs in production and what
+// service-account-contract.test.ts drives a real better-auth instance with.
+// Unwiring a guard therefore breaks that test, which is the only thing that
+// would notice a better-auth release renaming a hook or moving where it
+// fires.
+export const serviceAccountOrganizationHooks = {
+  beforeCreateOrganization: async ({
+    user: creator,
+  }: {
+    user: { id: string };
+  }) => {
+    await assertOrganizationCreatorAllowed(creator.id);
+  },
+  beforeAddMember: async ({
+    member: target,
+  }: {
+    member: { userId: string };
+  }) => {
+    await assertMemberAdditionAllowed(target.userId);
+  },
+  beforeCreateInvitation: async ({
+    invitation,
+  }: {
+    invitation: { email: string };
+  }) => {
+    await assertInvitationRecipientAllowed(invitation.email);
+  },
+  beforeAcceptInvitation: async ({
+    user: invitee,
+  }: {
+    user: { id: string };
+  }) => {
+    await assertInvitationAcceptorAllowed(invitee.id);
+  },
+  beforeUpdateMemberRole: async ({
+    member: target,
+    newRole,
+  }: {
+    member: { userId: string };
+    newRole: string;
+  }) => {
+    await assertRoleChangeAllowed(target.userId, newRole);
+  },
+  beforeRemoveMember: async ({
+    member: target,
+  }: {
+    member: { userId: string };
+  }) => {
+    await assertMemberRemovalAllowed(target.userId);
+  },
+};

--- a/packages/app/src/lib/service-account-plugin.test.ts
+++ b/packages/app/src/lib/service-account-plugin.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateToken } from "./service-account-credentials";
+
+const findToken = vi.fn();
+const deleteToken = vi.fn();
+
+vi.mock("./service-account-store", () => ({
+  findLiveToken: (...args: unknown[]) => findToken(...args),
+  deleteToken: (...args: unknown[]) => deleteToken(...args),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("resolveServiceAccountSession", () => {
+  it("returns a session carrying the token's own expiry", async () => {
+    const { resolveServiceAccountSession } = await import(
+      "./service-account-plugin"
+    );
+    const token = generateToken();
+    const expiresAt = new Date(Date.now() + 3600 * 1000);
+    findToken.mockResolvedValue({
+      expiresAt,
+      organizationId: "org-1",
+      user: { id: "user-1", name: "Deploy bot", email: "a@svc.everr.invalid" },
+    });
+
+    const session = await resolveServiceAccountSession(token.value);
+
+    expect(session?.session.expiresAt).toBe(expiresAt);
+    expect(session?.session.activeOrganizationId).toBe("org-1");
+    expect(session?.user.id).toBe("user-1");
+  });
+
+  it("rejects an expired token and deletes it", async () => {
+    const { resolveServiceAccountSession } = await import(
+      "./service-account-plugin"
+    );
+    const token = generateToken();
+    findToken.mockResolvedValue({
+      expiresAt: new Date(Date.now() - 1000),
+      organizationId: "org-1",
+      user: { id: "user-1", name: "n", email: "a@svc.everr.invalid" },
+      id: "token-1",
+    });
+
+    expect(await resolveServiceAccountSession(token.value)).toBeNull();
+    expect(deleteToken).toHaveBeenCalledWith("token-1");
+  });
+
+  it("ignores anything that is not a service account token", async () => {
+    const { resolveServiceAccountSession } = await import(
+      "./service-account-plugin"
+    );
+
+    expect(await resolveServiceAccountSession("sa_not_a_token")).toBeNull();
+    expect(findToken).not.toHaveBeenCalled();
+  });
+});
+
+describe("serviceAccountPlugin", () => {
+  async function callHook(path: string) {
+    const { serviceAccountPlugin } = await import("./service-account-plugin");
+    const token = generateToken();
+    findToken.mockResolvedValue({
+      id: "token-1",
+      expiresAt: new Date(Date.now() + 3600 * 1000),
+      organizationId: "org-1",
+      user: { id: "user-1", name: "Deploy bot", email: "a@svc.everr.invalid" },
+    });
+
+    const hook = serviceAccountPlugin().hooks?.before?.[0];
+    if (!hook) throw new Error("The plugin registered no before-hook.");
+    const ctx = {
+      path,
+      headers: new Headers({ authorization: `Bearer ${token.value}` }),
+      context: {} as { session?: { user: { id: string } } },
+    };
+    return { ctx, result: await hook.handler(ctx as never) };
+  }
+
+  it("refuses to let a service account leave its organization", async () => {
+    // Leaving deletes the member row with no organization hook in the way,
+    // which would strand the account's secrets and tokens.
+    await expect(callHook("/organization/leave")).rejects.toThrow(/leave/i);
+  });
+
+  it("answers /get-session with the session itself", async () => {
+    const { result } = await callHook("/get-session");
+
+    expect(result).toMatchObject({ user: { id: "user-1" } });
+  });
+
+  it("hands every other endpoint on to run with the session in context", async () => {
+    // The endpoint still has to run: the hook only supplies the caller it
+    // runs as. Returning the session here instead would answer every
+    // endpoint with a session payload.
+    const { ctx, result } = await callHook("/organization/list");
+
+    expect(ctx.context.session).toMatchObject({ user: { id: "user-1" } });
+    expect(result).toMatchObject({
+      context: { path: "/organization/list" },
+    });
+    // Answering with the session here, as /get-session does, would hand
+    // every endpoint a session payload instead of running it.
+    expect(result).not.toHaveProperty("user");
+  });
+});

--- a/packages/app/src/lib/service-account-plugin.ts
+++ b/packages/app/src/lib/service-account-plugin.ts
@@ -1,0 +1,104 @@
+import type { BetterAuthPlugin } from "better-auth";
+import { APIError, createAuthMiddleware } from "better-auth/api";
+import { isServiceAccountToken } from "./service-account-credentials";
+import { deleteToken, findLiveToken } from "./service-account-store";
+
+// `/organization/leave` deletes the caller's own member row through the
+// adapter, and the organization plugin has no before-hook on that path. A
+// service account that leaves keeps its secrets, its tokens, and its user
+// row, but drops off the Service accounts list, so it can never be deleted
+// through the UI while its secrets still exchange for working tokens.
+// Leaving is a human action, so the path is refused rather than guarded.
+const REFUSED_PATH = "/organization/leave";
+
+// `/delete-user` is enabled in our configuration and has no guard here on
+// purpose: better-auth closes it for us. Its `sensitiveSessionMiddleware`
+// drops `ctx.context.session` and re-reads the session from the session
+// store, and a service-account session has no row there, so the call is
+// refused before the handler runs. Nothing in this repository holds that
+// door shut, which is why service-account-contract.test.ts calls
+// `/delete-user` against a real better-auth instance: an upgrade that made
+// that middleware trust the session already in context would open the path
+// with no other sign.
+
+function bearerToken(headers: Headers | undefined): string | null {
+  const value = headers?.get("authorization");
+  if (!value?.startsWith("Bearer ")) {
+    return null;
+  }
+  const token = value.slice("Bearer ".length);
+  return isServiceAccountToken(token) ? token : null;
+}
+
+export async function resolveServiceAccountSession(tokenValue: string) {
+  if (!isServiceAccountToken(tokenValue)) {
+    return null;
+  }
+
+  const row = await findLiveToken(tokenValue);
+  if (!row) {
+    return null;
+  }
+
+  if (row.expiresAt.getTime() <= Date.now()) {
+    // An agent that keeps exchanging cleans up after itself, so expired rows
+    // never need a sweeper.
+    await deleteToken(row.id);
+    return null;
+  }
+
+  // `last_used_at` is stamped by the exchange, not here. Stamping on every
+  // authenticated request costs two UPDATEs per server function, and hourly
+  // granularity is all a noticeable leak needs.
+  return {
+    user: row.user,
+    session: {
+      id: row.id,
+      token: tokenValue,
+      userId: row.user.id,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      // The lifetime lives on the token row. Better Auth has no per-session
+      // expiry and rolls sessions on use, which is why no session row exists.
+      expiresAt: row.expiresAt,
+      activeOrganizationId: row.organizationId,
+    },
+  };
+}
+
+export function serviceAccountPlugin(): BetterAuthPlugin {
+  return {
+    id: "service-account",
+    hooks: {
+      before: [
+        {
+          matcher: (ctx) => bearerToken(ctx.headers) !== null,
+          handler: createAuthMiddleware(async (ctx) => {
+            const token = bearerToken(ctx.headers);
+            if (!token) {
+              return;
+            }
+
+            const session = await resolveServiceAccountSession(token);
+            if (!session) {
+              return;
+            }
+
+            if (ctx.path === REFUSED_PATH) {
+              throw new APIError("FORBIDDEN", {
+                message:
+                  "A service account cannot leave an organization. Delete the service account instead.",
+              });
+            }
+
+            ctx.context.session = session as never;
+            if (ctx.path === "/get-session") {
+              return session;
+            }
+            return { context: ctx };
+          }),
+        },
+      ],
+    },
+  };
+}

--- a/packages/app/src/lib/service-account-rate-limit.integration.test.ts
+++ b/packages/app/src/lib/service-account-rate-limit.integration.test.ts
@@ -1,0 +1,131 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const databaseUrl = process.env.TEST_DATABASE_URL;
+
+// A tiny allowance and a short window keep the test at a handful of
+// statements. The production numbers live on the route; what is under test
+// here is what the counter does at its edges, which is the same at any size.
+const LIMIT = { windowMs: 400, max: 3 };
+const ACCOUNT_USER_ID = "it-sa-user";
+
+describe.skipIf(!databaseUrl)("the exchange allowance on a secret", () => {
+  const load = async () => {
+    const { Pool } = await import("pg");
+    const { drizzle } = await import("drizzle-orm/node-postgres");
+    const schema = await import("@/db/schema");
+    const pool = new Pool({ connectionString: databaseUrl });
+    vi.resetModules();
+    vi.doMock("@/db/client", () => ({ db: drizzle(pool, { schema }) }));
+    const store = await import("./service-account-store");
+    return { pool, store };
+  };
+
+  let loaded: Awaited<ReturnType<typeof load>> | undefined;
+
+  const ctx = async () => {
+    if (!loaded) loaded = await load();
+    return loaded;
+  };
+
+  const seedSecret = async (secretId: string) => {
+    const { pool } = await ctx();
+    await pool.query(
+      `INSERT INTO service_account_secret
+         (id, service_account_id, hash, start)
+       VALUES ($1, 'it-sa', $1, 'sa_it')`,
+      [secretId],
+    );
+    return secretId;
+  };
+
+  beforeEach(async () => {
+    const { pool } = await ctx();
+    await pool.query("DELETE FROM service_account WHERE id = 'it-sa'");
+    await pool.query(`DELETE FROM "user" WHERE id = $1`, [ACCOUNT_USER_ID]);
+    await pool.query(
+      `INSERT INTO "user" (id, name, email) VALUES ($1, 'it', $2)`,
+      [ACCOUNT_USER_ID, `${ACCOUNT_USER_ID}@svc.everr.invalid`],
+    );
+    await pool.query(
+      "INSERT INTO service_account (id, user_id) VALUES ('it-sa', $1)",
+      [ACCOUNT_USER_ID],
+    );
+  });
+
+  afterAll(async () => {
+    if (!loaded) return;
+    await loaded.pool
+      .query("DELETE FROM service_account WHERE id = 'it-sa'")
+      .catch(() => {});
+    await loaded.pool
+      .query(`DELETE FROM "user" WHERE id = $1`, [ACCOUNT_USER_ID])
+      .catch(() => {});
+    vi.doUnmock("@/db/client");
+    vi.resetModules();
+    await loaded.pool.end();
+  });
+
+  it("lets a secret exchange while it is under the limit", async () => {
+    const { store } = await ctx();
+    const secret = await seedSecret("it-secret-under");
+
+    for (let attempt = 0; attempt < LIMIT.max; attempt += 1) {
+      expect(await store.consumeExchangeAllowance(secret, LIMIT)).toBe(true);
+    }
+  });
+
+  it("refuses the same secret once it is over the limit", async () => {
+    const { store } = await ctx();
+    const secret = await seedSecret("it-secret-over");
+
+    for (let attempt = 0; attempt < LIMIT.max; attempt += 1) {
+      await store.consumeExchangeAllowance(secret, LIMIT);
+    }
+
+    expect(await store.consumeExchangeAllowance(secret, LIMIT)).toBe(false);
+    expect(await store.consumeExchangeAllowance(secret, LIMIT)).toBe(false);
+  });
+
+  it("lets the same secret exchange again once the window has passed", async () => {
+    const { store } = await ctx();
+    const secret = await seedSecret("it-secret-window");
+
+    for (let attempt = 0; attempt < LIMIT.max; attempt += 1) {
+      await store.consumeExchangeAllowance(secret, LIMIT);
+    }
+    expect(await store.consumeExchangeAllowance(secret, LIMIT)).toBe(false);
+
+    await new Promise((resolve) => setTimeout(resolve, LIMIT.windowMs + 50));
+
+    expect(await store.consumeExchangeAllowance(secret, LIMIT)).toBe(true);
+  });
+
+  it("keeps one secret's limit off another secret", async () => {
+    const { store } = await ctx();
+    const busy = await seedSecret("it-secret-busy");
+    const quiet = await seedSecret("it-secret-quiet");
+
+    for (let attempt = 0; attempt <= LIMIT.max; attempt += 1) {
+      await store.consumeExchangeAllowance(busy, LIMIT);
+    }
+
+    expect(await store.consumeExchangeAllowance(busy, LIMIT)).toBe(false);
+    expect(await store.consumeExchangeAllowance(quiet, LIMIT)).toBe(true);
+  });
+
+  it("hands the last unit of the allowance to one exchange only", async () => {
+    // The point of doing this in one statement: exchanges that arrive
+    // together must not both read the same count and both pass.
+    const { store } = await ctx();
+    const secret = await seedSecret("it-secret-concurrent");
+
+    const together = 8;
+    const results = await Promise.all(
+      Array.from({ length: together }, () =>
+        store.consumeExchangeAllowance(secret, { windowMs: 60_000, max: 1 }),
+      ),
+    );
+
+    expect(results.filter(Boolean)).toHaveLength(1);
+  });
+});

--- a/packages/app/src/lib/service-account-session.test.ts
+++ b/packages/app/src/lib/service-account-session.test.ts
@@ -1,0 +1,59 @@
+import type { BetterAuthPlugin } from "better-auth";
+import { betterAuth } from "better-auth";
+import { createAuthMiddleware } from "better-auth/api";
+import { describe, expect, it } from "vitest";
+
+// The service account plugin turns a bearer token into a session without a
+// session row. That only works if server-side getSession runs plugin hooks.
+function probePlugin(): BetterAuthPlugin {
+  return {
+    id: "probe",
+    hooks: {
+      before: [
+        {
+          matcher: (ctx) =>
+            ctx.headers?.get("authorization") === "Bearer probe-token",
+          handler: createAuthMiddleware(async (ctx) => {
+            const session = {
+              user: {
+                id: "probe-user",
+                name: "Probe",
+                email: "probe@svc.everr.invalid",
+                emailVerified: true,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+              },
+              session: {
+                id: "probe-session",
+                token: "probe-token",
+                userId: "probe-user",
+                createdAt: new Date(),
+                updatedAt: new Date(),
+                expiresAt: new Date(Date.now() + 3600 * 1000),
+              },
+            };
+            ctx.context.session = session as never;
+            if (ctx.path === "/get-session") return session;
+            return { context: ctx };
+          }),
+        },
+      ],
+    },
+  };
+}
+
+describe("server-side getSession", () => {
+  it("runs plugin before-hooks, so a plugin can supply a session", async () => {
+    const auth = betterAuth({
+      baseURL: "http://localhost",
+      secret: "probe-secret-probe-secret-probe-secret",
+      plugins: [probePlugin()],
+    });
+
+    const result = await auth.api.getSession({
+      headers: new Headers({ authorization: "Bearer probe-token" }),
+    });
+
+    expect(result?.user.id).toBe("probe-user");
+  });
+});

--- a/packages/app/src/lib/service-account-store.test.ts
+++ b/packages/app/src/lib/service-account-store.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateToken } from "./service-account-credentials";
+
+// The rows the token-to-membership join returns. One row is a service
+// account with the single membership the guards hold it to; two rows are
+// what a membership written by hand would look like.
+let joinedRows: Array<{
+  id: string;
+  expiresAt: Date;
+  organizationId: string;
+  user: { id: string };
+}> = [];
+
+vi.mock("@/db/client", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: a query-builder passthrough mock has no fixed shape.
+  const chain: any = {
+    from: () => chain,
+    innerJoin: () => chain,
+    where: () => chain,
+    limit: async () => joinedRows,
+  };
+  return { db: { select: () => chain } };
+});
+
+function membership(organizationId: string) {
+  return {
+    id: "token-1",
+    expiresAt: new Date(Date.now() + 3600 * 1000),
+    organizationId,
+    user: { id: "user-1" },
+  };
+}
+
+beforeEach(() => {
+  joinedRows = [];
+});
+
+describe("findLiveToken", () => {
+  it("resolves the organization of a service account that holds one membership", async () => {
+    joinedRows = [membership("org-1")];
+    const { findLiveToken } = await import("./service-account-store");
+
+    const row = await findLiveToken(generateToken().value);
+
+    expect(row?.organizationId).toBe("org-1");
+  });
+
+  it("refuses to resolve a service account that holds two memberships", async () => {
+    // Which organization the agent acts in would come down to row order, and
+    // acting in the wrong tenant leaves no trace anyone would look for.
+    joinedRows = [membership("org-1"), membership("org-2")];
+    const { findLiveToken } = await import("./service-account-store");
+
+    expect(await findLiveToken(generateToken().value)).toBeNull();
+  });
+});

--- a/packages/app/src/lib/service-account-store.ts
+++ b/packages/app/src/lib/service-account-store.ts
@@ -1,0 +1,175 @@
+import { and, eq, isNull, lt, lte, or, sql } from "drizzle-orm";
+import { db } from "@/db/client";
+import {
+  member,
+  serviceAccount,
+  serviceAccountSecret,
+  serviceAccountToken,
+  user,
+} from "@/db/schema";
+import { serverLogger } from "@/telemetry/logger";
+import { hashCredential } from "./service-account-credentials";
+
+export async function findLiveToken(tokenValue: string) {
+  const rows = await db
+    .select({
+      id: serviceAccountToken.id,
+      expiresAt: serviceAccountToken.expiresAt,
+      // The organization comes from the membership, the same as for a person.
+      organizationId: member.organizationId,
+      user: {
+        id: user.id,
+        name: user.name,
+        email: user.email,
+        emailVerified: user.emailVerified,
+        image: user.image,
+        createdAt: user.createdAt,
+        updatedAt: user.updatedAt,
+      },
+    })
+    .from(serviceAccountToken)
+    .innerJoin(
+      serviceAccountSecret,
+      eq(serviceAccountSecret.id, serviceAccountToken.serviceAccountSecretId),
+    )
+    .innerJoin(
+      serviceAccount,
+      eq(serviceAccount.id, serviceAccountSecret.serviceAccountId),
+    )
+    .innerJoin(user, eq(user.id, serviceAccount.userId))
+    // An inner join: with no membership there is no organization to act in,
+    // so the token resolves to nothing rather than to a session with no
+    // tenant.
+    .innerJoin(member, eq(member.userId, serviceAccount.userId))
+    // A revoked secret takes its tokens with it, so revocation is immediate.
+    .where(
+      and(
+        eq(serviceAccountToken.hash, hashCredential(tokenValue)),
+        isNull(serviceAccountSecret.revokedAt),
+      ),
+    )
+    // Two rows are all it takes to see that the membership is ambiguous.
+    .limit(2);
+
+  const [row, second] = rows;
+  if (!row) {
+    return null;
+  }
+
+  if (second) {
+    // The guards hold a service account to one membership, but no database
+    // constraint can express "exactly one across all organizations", so a
+    // second row is possible. Picking one would let the agent act in an
+    // organization nobody chose, and nothing downstream would notice. A
+    // refused agent is an incident someone investigates; a silent
+    // cross-tenant one is not.
+    serverLogger.error("service_account.membership.ambiguous", {
+      "user.id": row.user.id,
+      "everr.organization.id": row.organizationId,
+      "everr.service_account.other_organization.id": second.organizationId,
+    });
+    return null;
+  }
+
+  return row;
+}
+
+export async function deleteToken(id: string) {
+  await db.delete(serviceAccountToken).where(eq(serviceAccountToken.id, id));
+}
+
+// Validation deletes a token row only when someone presents that token
+// after it expired, so a token nobody spends again would stay forever. The
+// exchange runs for every live secret in use, which makes it the place to
+// drop what that secret already burned through.
+export async function deleteExpiredTokensForSecret(secretId: string) {
+  await db
+    .delete(serviceAccountToken)
+    .where(
+      and(
+        eq(serviceAccountToken.serviceAccountSecretId, secretId),
+        lt(serviceAccountToken.expiresAt, new Date()),
+      ),
+    );
+}
+
+export async function touchLastUsed(
+  serviceAccountId: string,
+  secretId: string,
+) {
+  const now = new Date();
+  await Promise.all([
+    db
+      .update(serviceAccount)
+      .set({ lastUsedAt: now })
+      .where(eq(serviceAccount.id, serviceAccountId)),
+    db
+      .update(serviceAccountSecret)
+      .set({ lastUsedAt: now })
+      .where(eq(serviceAccountSecret.id, secretId)),
+  ]);
+}
+
+export async function findLiveSecret(secretValue: string) {
+  const [row] = await db
+    .select({
+      id: serviceAccountSecret.id,
+      serviceAccountId: serviceAccountSecret.serviceAccountId,
+    })
+    .from(serviceAccountSecret)
+    .where(
+      and(
+        eq(serviceAccountSecret.hash, hashCredential(secretValue)),
+        isNull(serviceAccountSecret.revokedAt),
+      ),
+    )
+    .limit(1);
+
+  return row ?? null;
+}
+
+// Returns false when the secret has already spent its allowance for the
+// window it is in, which is the caller's signal to refuse the exchange.
+export async function consumeExchangeAllowance(
+  secretId: string,
+  limit: { windowMs: number; max: number },
+): Promise<boolean> {
+  const now = new Date();
+  const windowStart = new Date(now.getTime() - limit.windowMs);
+  const windowExpired = sql`(${isNull(serviceAccountSecret.lastRequest)} or ${lte(serviceAccountSecret.lastRequest, windowStart)})`;
+
+  // One statement carries the whole decision: the same test that lets the row
+  // through the WHERE clause also decides whether the count restarts at one or
+  // grows by one. Postgres locks the row for the update and makes a second
+  // writer re-test the guard against the committed row, so two exchanges that
+  // arrive together cannot both take the last unit of the allowance. Reading
+  // the count and writing it back would let both read the same number.
+  const [row] = await db
+    .update(serviceAccountSecret)
+    .set({
+      requestCount: sql`case when ${windowExpired} then 1 else ${serviceAccountSecret.requestCount} + 1 end`,
+      lastRequest: now,
+    })
+    .where(
+      and(
+        eq(serviceAccountSecret.id, secretId),
+        or(windowExpired, lt(serviceAccountSecret.requestCount, limit.max)),
+      ),
+    )
+    .returning({ id: serviceAccountSecret.id });
+
+  // A refused exchange writes nothing, so `last_request` stops moving while
+  // the caller keeps trying. The window therefore runs out from the last
+  // exchange that was allowed, and a caller that never stops is not locked
+  // out for ever.
+  return row !== undefined;
+}
+
+export async function insertToken(row: {
+  id: string;
+  serviceAccountSecretId: string;
+  hash: string;
+  expiresAt: Date;
+}) {
+  await db.insert(serviceAccountToken).values(row);
+}

--- a/packages/app/src/routeTree.gen.ts
+++ b/packages/app/src/routeTree.gen.ts
@@ -40,6 +40,7 @@ import { Route as ApiCliRunsRouteImport } from './routes/api/cli/runs'
 import { Route as ApiCliSqlRouteImport } from './routes/api/cli/sql'
 import { Route as ApiEventsStreamRouteImport } from './routes/api/events/stream'
 import { Route as ApiInternalVerifyKeyRouteImport } from './routes/api/internal/verify-key'
+import { Route as ApiServiceAccountsTokenRouteImport } from './routes/api/service-accounts/token'
 import { Route as DotwellKnownOauthAuthorizationServerApiAuthRouteImport } from './routes/[.]well-known/oauth-authorization-server/api/auth'
 import { Route as AuthGuestAuthForgotPasswordRouteImport } from './routes/_auth/_guest/auth/forgot-password'
 import { Route as AuthGuestAuthResetPasswordRouteImport } from './routes/_auth/_guest/auth/reset-password'
@@ -242,6 +243,11 @@ const ApiEventsStreamRoute = ApiEventsStreamRouteImport.update({
 const ApiInternalVerifyKeyRoute = ApiInternalVerifyKeyRouteImport.update({
   id: '/api/internal/verify-key',
   path: '/api/internal/verify-key',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiServiceAccountsTokenRoute = ApiServiceAccountsTokenRouteImport.update({
+  id: '/api/service-accounts/token',
+  path: '/api/service-accounts/token',
   getParentRoute: () => rootRouteImport,
 } as any)
 const DotwellKnownOauthAuthorizationServerApiAuthRoute =
@@ -556,6 +562,7 @@ export interface FileRoutesByFullPath {
   '/api/cli/sql': typeof ApiCliSqlRoute
   '/api/events/stream': typeof ApiEventsStreamRoute
   '/api/internal/verify-key': typeof ApiInternalVerifyKeyRoute
+  '/api/service-accounts/token': typeof ApiServiceAccountsTokenRoute
   '/dashboards': typeof AuthenticatedDashboardPreviewableDashboardsRouteRouteWithChildren
   '/runbooks': typeof AuthenticatedDashboardPreviewableRunbooksRouteRouteWithChildren
   '/runs/$traceId': typeof AuthenticatedDashboardRunsTraceIdRouteRouteWithChildren
@@ -630,6 +637,7 @@ export interface FileRoutesByTo {
   '/api/cli/sql': typeof ApiCliSqlRoute
   '/api/events/stream': typeof ApiEventsStreamRoute
   '/api/internal/verify-key': typeof ApiInternalVerifyKeyRoute
+  '/api/service-accounts/token': typeof ApiServiceAccountsTokenRoute
   '/.well-known/oauth-authorization-server/api/auth': typeof DotwellKnownOauthAuthorizationServerApiAuthRoute
   '/auth/forgot-password': typeof AuthGuestAuthForgotPasswordRoute
   '/auth/reset-password': typeof AuthGuestAuthResetPasswordRoute
@@ -709,6 +717,7 @@ export interface FileRoutesById {
   '/api/cli/sql': typeof ApiCliSqlRoute
   '/api/events/stream': typeof ApiEventsStreamRoute
   '/api/internal/verify-key': typeof ApiInternalVerifyKeyRoute
+  '/api/service-accounts/token': typeof ApiServiceAccountsTokenRoute
   '/_authenticated/_dashboard/_previewable/dashboards': typeof AuthenticatedDashboardPreviewableDashboardsRouteRouteWithChildren
   '/_authenticated/_dashboard/_previewable/runbooks': typeof AuthenticatedDashboardPreviewableRunbooksRouteRouteWithChildren
   '/_authenticated/_dashboard/runs/$traceId': typeof AuthenticatedDashboardRunsTraceIdRouteRouteWithChildren
@@ -787,6 +796,7 @@ export interface FileRouteTypes {
     | '/api/cli/sql'
     | '/api/events/stream'
     | '/api/internal/verify-key'
+    | '/api/service-accounts/token'
     | '/dashboards'
     | '/runbooks'
     | '/runs/$traceId'
@@ -861,6 +871,7 @@ export interface FileRouteTypes {
     | '/api/cli/sql'
     | '/api/events/stream'
     | '/api/internal/verify-key'
+    | '/api/service-accounts/token'
     | '/.well-known/oauth-authorization-server/api/auth'
     | '/auth/forgot-password'
     | '/auth/reset-password'
@@ -939,6 +950,7 @@ export interface FileRouteTypes {
     | '/api/cli/sql'
     | '/api/events/stream'
     | '/api/internal/verify-key'
+    | '/api/service-accounts/token'
     | '/_authenticated/_dashboard/_previewable/dashboards'
     | '/_authenticated/_dashboard/_previewable/runbooks'
     | '/_authenticated/_dashboard/runs/$traceId'
@@ -1005,6 +1017,7 @@ export interface RootRouteChildren {
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
   ApiEventsStreamRoute: typeof ApiEventsStreamRoute
   ApiInternalVerifyKeyRoute: typeof ApiInternalVerifyKeyRoute
+  ApiServiceAccountsTokenRoute: typeof ApiServiceAccountsTokenRoute
   ApiGithubInstallCallbackRoute: typeof ApiGithubInstallCallbackRoute
   ApiGithubInstallStartRoute: typeof ApiGithubInstallStartRoute
 }
@@ -1226,6 +1239,13 @@ declare module '@tanstack/react-router' {
       path: '/api/internal/verify-key'
       fullPath: '/api/internal/verify-key'
       preLoaderRoute: typeof ApiInternalVerifyKeyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/service-accounts/token': {
+      id: '/api/service-accounts/token'
+      path: '/api/service-accounts/token'
+      fullPath: '/api/service-accounts/token'
+      preLoaderRoute: typeof ApiServiceAccountsTokenRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/.well-known/oauth-authorization-server/api/auth': {
@@ -1979,6 +1999,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiAuthSplatRoute: ApiAuthSplatRoute,
   ApiEventsStreamRoute: ApiEventsStreamRoute,
   ApiInternalVerifyKeyRoute: ApiInternalVerifyKeyRoute,
+  ApiServiceAccountsTokenRoute: ApiServiceAccountsTokenRoute,
   ApiGithubInstallCallbackRoute: ApiGithubInstallCallbackRoute,
   ApiGithubInstallStartRoute: ApiGithubInstallStartRoute,
 }

--- a/packages/app/src/routes/_authenticated/_dashboard/_padded/users-management.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_padded/users-management.tsx
@@ -9,6 +9,9 @@ import { Skeleton } from "@everr/ui/components/skeleton";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { getRequestHeaders } from "@tanstack/react-start/server";
+import { CreateServiceAccountDialog } from "@/components/service-accounts/create-service-account-dialog";
+import { serviceAccountsQueryOptions } from "@/components/service-accounts/queries";
+import { ServiceAccountsTable } from "@/components/service-accounts/service-accounts-table";
 import { InvitationsTable } from "@/components/users-management/invitations-table";
 import { InviteMemberDialog } from "@/components/users-management/invite-member-dialog";
 import { MembersTable } from "@/components/users-management/members-table";
@@ -66,6 +69,7 @@ function UsersManagementPage() {
   const currentUserId = session?.user?.id;
   const members = useQuery(membersQueryOptions());
   const invitations = useQuery(invitationsQueryOptions());
+  const serviceAccounts = useQuery(serviceAccountsQueryOptions());
 
   const pendingInvitations = invitations.data ?? [];
 
@@ -103,7 +107,24 @@ function UsersManagementPage() {
             <MembersTable
               members={members.data ?? []}
               currentUserId={currentUserId}
+              serviceAccounts={serviceAccounts.data}
             />
+          )}
+        </CardContent>
+      </Card>
+
+      <Card inset="flush-content">
+        <CardHeader>
+          <CardTitle>Service accounts</CardTitle>
+          <CardAction>
+            <CreateServiceAccountDialog />
+          </CardAction>
+        </CardHeader>
+        <CardContent>
+          {serviceAccounts.isPending ? (
+            <MembersSkeleton />
+          ) : (
+            <ServiceAccountsTable accounts={serviceAccounts.data ?? []} />
           )}
         </CardContent>
       </Card>

--- a/packages/app/src/routes/api/service-accounts/token.test.ts
+++ b/packages/app/src/routes/api/service-accounts/token.test.ts
@@ -1,0 +1,217 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const findSecret = vi.fn();
+const insertToken = vi.fn();
+const touchLastUsed = vi.fn();
+const deleteExpiredTokens = vi.fn();
+const consumeAllowance = vi.fn();
+
+vi.mock("@/lib/service-account-store", () => ({
+  findLiveSecret: (...a: unknown[]) => findSecret(...a),
+  insertToken: (...a: unknown[]) => insertToken(...a),
+  touchLastUsed: (...a: unknown[]) => touchLastUsed(...a),
+  deleteExpiredTokensForSecret: (...a: unknown[]) => deleteExpiredTokens(...a),
+  consumeExchangeAllowance: (...a: unknown[]) => consumeAllowance(...a),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  consumeAllowance.mockResolvedValue(true);
+});
+
+describe("exchangeSecret", () => {
+  it("returns a token that expires in an hour", async () => {
+    const { exchangeSecret } = await import("./token");
+    findSecret.mockResolvedValue({ id: "secret-1" });
+
+    const result = await exchangeSecret("sa_valid");
+
+    if (result.status !== "issued") throw new Error("expected a token");
+    expect(result.body.token.startsWith("st_")).toBe(true);
+    const ttl = new Date(result.body.expires_at).getTime() - Date.now();
+    expect(ttl).toBeGreaterThan(3500 * 1000);
+    expect(ttl).toBeLessThanOrEqual(3600 * 1000);
+  });
+
+  it("returns nothing for a secret that is unknown or revoked", async () => {
+    const { exchangeSecret } = await import("./token");
+    findSecret.mockResolvedValue(null);
+
+    expect((await exchangeSecret("sa_revoked")).status).toBe("invalid_secret");
+  });
+
+  it("returns nothing when handed a bearer token instead of a secret", async () => {
+    const { exchangeSecret } = await import("./token");
+
+    expect((await exchangeSecret("st_something")).status).toBe(
+      "invalid_secret",
+    );
+    expect(findSecret).not.toHaveBeenCalled();
+  });
+
+  it("stores only the hash, never the token", async () => {
+    const { exchangeSecret } = await import("./token");
+    findSecret.mockResolvedValue({ id: "secret-1" });
+
+    const result = await exchangeSecret("sa_valid");
+    if (result.status !== "issued") throw new Error("expected a token");
+
+    const stored = insertToken.mock.calls.at(-1)?.[0] as { hash: string };
+    expect(stored.hash).not.toBe(result.body.token);
+  });
+
+  it("stamps last_used_at on the secret and the account on success", async () => {
+    const { exchangeSecret } = await import("./token");
+    findSecret.mockResolvedValue({
+      id: "secret-1",
+      serviceAccountId: "account-1",
+    });
+
+    await exchangeSecret("sa_valid");
+
+    expect(touchLastUsed).toHaveBeenCalledWith("account-1", "secret-1");
+  });
+
+  it("does not stamp last_used_at when the secret is rejected", async () => {
+    const { exchangeSecret } = await import("./token");
+    findSecret.mockResolvedValue(null);
+
+    await exchangeSecret("sa_revoked");
+
+    expect(touchLastUsed).not.toHaveBeenCalled();
+  });
+
+  it("drops the secret's already expired tokens when it issues a new one", async () => {
+    // A token nobody presents again is never looked at, so nothing else
+    // would ever delete it and the table would grow with every exchange.
+    const { exchangeSecret } = await import("./token");
+    findSecret.mockResolvedValue({
+      id: "secret-1",
+      serviceAccountId: "account-1",
+    });
+
+    await exchangeSecret("sa_valid");
+
+    expect(deleteExpiredTokens).toHaveBeenCalledWith("secret-1");
+  });
+
+  it("drops no tokens when the secret is rejected", async () => {
+    const { exchangeSecret } = await import("./token");
+    findSecret.mockResolvedValue(null);
+
+    await exchangeSecret("sa_revoked");
+
+    expect(deleteExpiredTokens).not.toHaveBeenCalled();
+  });
+
+  it("mints no token for a secret that has spent its allowance", async () => {
+    const { exchangeSecret } = await import("./token");
+    findSecret.mockResolvedValue({
+      id: "secret-1",
+      serviceAccountId: "account-1",
+    });
+    consumeAllowance.mockResolvedValue(false);
+
+    const result = await exchangeSecret("sa_valid");
+
+    expect(result.status).toBe("rate_limited");
+    expect(insertToken).not.toHaveBeenCalled();
+  });
+
+  it("counts the allowance on the secret, never on the caller", async () => {
+    // Nothing the caller sends can move the count somewhere else.
+    const { exchangeSecret } = await import("./token");
+    findSecret.mockResolvedValue({ id: "secret-1" });
+
+    await exchangeSecret("sa_valid");
+
+    expect(consumeAllowance.mock.calls.at(-1)?.[0]).toBe("secret-1");
+  });
+});
+
+type PostHandler = (args: { request: Request }) => Promise<Response>;
+
+async function getHandler(): Promise<PostHandler> {
+  const { Route } = await import("./token");
+  const routeOptions = Route.options as unknown as {
+    server?: { handlers?: { POST?: PostHandler } };
+  };
+  const handler = routeOptions.server?.handlers?.POST;
+  if (!handler) throw new Error("Missing POST handler for token.");
+  return handler;
+}
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/service-accounts/token", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/service-accounts/token", () => {
+  it("issues a token for a live secret", async () => {
+    findSecret.mockResolvedValue({ id: "secret-1" });
+
+    const res = await (await getHandler())({
+      request: makeRequest({ secret: "sa_valid" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { token: string; expires_at: string };
+    expect(body.token.startsWith("st_")).toBe(true);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("answers a revoked secret and an unknown secret identically", async () => {
+    findSecret.mockResolvedValueOnce(null);
+    const revoked = await (await getHandler())({
+      request: makeRequest({ secret: "sa_revoked" }),
+    });
+
+    findSecret.mockResolvedValueOnce(null);
+    const unknown = await (await getHandler())({
+      request: makeRequest({ secret: "sa_unknown" }),
+    });
+
+    expect(revoked.status).toBe(401);
+    expect(unknown.status).toBe(401);
+    expect(await revoked.json()).toEqual(await unknown.json());
+  });
+
+  it("rejects a body without a string secret", async () => {
+    const res = await (await getHandler())({
+      request: makeRequest({ secret: 42 }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a literal null body", async () => {
+    const res = await (await getHandler())({
+      request: makeRequest(null),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a body that is not JSON", async () => {
+    const res = await (await getHandler())({
+      request: new Request("http://localhost/api/service-accounts/token", {
+        method: "POST",
+        body: "not json",
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("answers 429 with an empty body once the secret is over its limit", async () => {
+    findSecret.mockResolvedValue({ id: "secret-1" });
+    consumeAllowance.mockResolvedValue(false);
+
+    const res = await (await getHandler())({
+      request: makeRequest({ secret: "sa_valid" }),
+    });
+
+    expect(res.status).toBe(429);
+    expect(await res.text()).toBe("");
+  });
+});

--- a/packages/app/src/routes/api/service-accounts/token.ts
+++ b/packages/app/src/routes/api/service-accounts/token.ts
@@ -1,0 +1,116 @@
+import { randomUUID } from "node:crypto";
+import { createFileRoute } from "@tanstack/react-router";
+import {
+  generateToken,
+  isServiceAccountToken,
+  TOKEN_TTL_SECONDS,
+} from "@/lib/service-account-credentials";
+import {
+  consumeExchangeAllowance,
+  deleteExpiredTokensForSecret,
+  findLiveSecret,
+  insertToken,
+  touchLastUsed,
+} from "@/lib/service-account-store";
+
+// The limit is counted on the secret row, so every app instance counts into
+// the same place and the key is one the caller cannot choose. It therefore
+// reaches only a caller that holds a live secret: an unknown secret has no
+// row to count on, and traffic from unknown secrets has to be bounded at the
+// proxy or the edge, where an address has an identity behind it. That is not
+// a loss, because the limiter never was what stops guessing: the secret is 32
+// random bytes.
+//
+// One secret is shared by a whole CI fleet on purpose, so the number has to
+// cover a fleet's burst and not one agent's rate. `everr` exchanges once per
+// process, which makes 1200 a minute about 20 process starts a second on a
+// single secret: far above what a busy fleet does, and still a bound on what
+// one credential can cost in token rows and database work. The window stays
+// short because a refused caller has to go quiet for the whole of it, and the
+// CLI retries a refusal only once.
+const EXCHANGE_LIMIT = { windowMs: 60_000, max: 1200 };
+
+export type ExchangeResult =
+  | { status: "issued"; body: { token: string; expires_at: string } }
+  | { status: "invalid_secret" }
+  | { status: "rate_limited" };
+
+export async function exchangeSecret(secret: string): Promise<ExchangeResult> {
+  if (isServiceAccountToken(secret)) {
+    return { status: "invalid_secret" };
+  }
+
+  const row = await findLiveSecret(secret);
+  if (!row) {
+    return { status: "invalid_secret" };
+  }
+
+  if (!(await consumeExchangeAllowance(row.id, EXCHANGE_LIMIT))) {
+    return { status: "rate_limited" };
+  }
+
+  const token = generateToken();
+  const expiresAt = new Date(Date.now() + TOKEN_TTL_SECONDS * 1000);
+  await insertToken({
+    id: randomUUID(),
+    serviceAccountSecretId: row.id,
+    hash: token.hash,
+    expiresAt,
+  });
+  // The redeemed secret is "used" the moment it mints a token, not only
+  // when the token is later spent, so the stamp happens here.
+  await touchLastUsed(row.serviceAccountId, row.id);
+  // A token that is never spent after it expires would otherwise stay
+  // forever: validation only deletes a row it is asked to look at. The
+  // exchange is the one path that always runs for a busy account, so the
+  // cleanup rides along with it instead of needing a sweeper.
+  await deleteExpiredTokensForSecret(row.id);
+
+  return {
+    status: "issued",
+    body: { token: token.value, expires_at: expiresAt.toISOString() },
+  };
+}
+
+export const Route = createFileRoute("/api/service-accounts/token")({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        let body: unknown;
+        try {
+          body = await request.json();
+        } catch {
+          return Response.json({ error: "invalid_request" }, { status: 400 });
+        }
+
+        // "null" parses as valid JSON, so a non-object body reaches here
+        // without throwing and must be rejected before reading .secret.
+        if (typeof body !== "object" || body === null) {
+          return Response.json({ error: "invalid_request" }, { status: 400 });
+        }
+
+        const secret = (body as { secret?: unknown }).secret;
+        if (typeof secret !== "string") {
+          return Response.json({ error: "invalid_request" }, { status: 400 });
+        }
+
+        const result = await exchangeSecret(secret);
+
+        if (result.status === "rate_limited") {
+          return new Response(null, { status: 429 });
+        }
+
+        if (result.status === "invalid_secret") {
+          // Unknown, revoked and expired secrets all answer the same, so
+          // the response never says which one it was. Malformed bodies are
+          // rejected earlier with a 400 and never reach this branch.
+          return Response.json({ error: "invalid_secret" }, { status: 401 });
+        }
+
+        return Response.json(result.body, {
+          headers: { "cache-control": "no-store" },
+        });
+      },
+    },
+  },
+});

--- a/packages/desktop-app/src-cli/src/auth.rs
+++ b/packages/desktop-app/src-cli/src/auth.rs
@@ -3,16 +3,24 @@ use std::time::{Duration, Instant};
 use anyhow::{Result, anyhow, bail};
 use everr_core::api::ApiClient;
 use everr_core::auth::{
-    AuthConfig, DeviceAuthorization, DevicePollStatus, build_auth_http_client, login_with_prompt,
-    poll_device_authorization, session_from_device_token, start_device_authorization,
+    AuthConfig, DeviceAuthorization, DevicePollStatus, build_auth_http_client,
+    exchange_service_account_secret, login_with_prompt, poll_device_authorization,
+    session_from_device_token, start_device_authorization,
 };
 use everr_core::build;
 use everr_core::state::{AppStateStore, Session};
+use tokio::sync::OnceCell;
 use tokio::time::sleep;
 
 use crate::cli::LoginArgs;
 
 const API_BASE_URL_OVERRIDE_ENV: &str = "EVERR_API_BASE_URL_FOR_TESTS";
+const SERVICE_ACCOUNT_SECRET_ENV: &str = "EVERR_SERVICE_ACCOUNT_SECRET";
+
+// A CLI run is short and the exchanged token lives an hour, so one exchange
+// per process is enough. Caching it here also keeps it out of the state
+// file: it is short-lived, and persisting it would outlive its usefulness.
+static SERVICE_ACCOUNT_SESSION: OnceCell<Session> = OnceCell::const_new();
 
 pub async fn login(_args: LoginArgs) -> Result<()> {
     let config = resolve_auth_config()?;
@@ -166,10 +174,41 @@ pub fn logout() -> Result<()> {
     Ok(())
 }
 
+/// A 401 mid-run can mean the exchanged service-account token was refused
+/// (the secret got revoked, or `watch`'s reconnect hit a stale token). But
+/// `ReauthenticationRequired`'s message tells a human to `cloud login`, and no
+/// human is attending an unattended run to act on it. When the run is on a
+/// service-account session, replace that message with one that points at the
+/// secret instead. The token endpoint doesn't distinguish unknown, revoked,
+/// and expired secrets, so this doesn't guess which one applied either.
+pub fn rewrite_reauth_error_for_service_account(result: Result<()>) -> Result<()> {
+    rewrite_reauth_error(result, is_using_service_account())
+}
+
+fn rewrite_reauth_error(result: Result<()>, using_service_account: bool) -> Result<()> {
+    result.map_err(|error| {
+        if using_service_account && everr_core::api::is_reauthentication_required(&error) {
+            anyhow!(
+                "the service account's token was refused; check that \
+                 {SERVICE_ACCOUNT_SECRET_ENV} is set to a valid secret"
+            )
+        } else {
+            error
+        }
+    })
+}
+
+fn is_using_service_account() -> bool {
+    std::env::var(SERVICE_ACCOUNT_SECRET_ENV)
+        .map(|value| trimmed_non_empty(&value).is_some())
+        .unwrap_or(false)
+}
+
 pub async fn require_session_with_refresh() -> Result<Session> {
     let store = state_store();
     let api_base_url = current_api_base_url()?;
-    match store.load_session_for_api_base_url(&api_base_url) {
+    let exchanged = service_account_session(&api_base_url).await?;
+    match store.resolve_session(&api_base_url, exchanged.as_ref()) {
         Ok(session) => Ok(session),
         Err(error) => {
             if error.to_string().contains("no active session") {
@@ -179,6 +218,33 @@ pub async fn require_session_with_refresh() -> Result<Session> {
             }
         }
     }
+}
+
+/// Exchanges `EVERR_SERVICE_ACCOUNT_SECRET` for a session, if the variable is
+/// set. The exchange happens once per process; later calls reuse the cached
+/// session instead of hitting the token endpoint again.
+async fn service_account_session(api_base_url: &str) -> Result<Option<Session>> {
+    resolve_service_account_session(&SERVICE_ACCOUNT_SESSION, api_base_url).await
+}
+
+async fn resolve_service_account_session(
+    cache: &OnceCell<Session>,
+    api_base_url: &str,
+) -> Result<Option<Session>> {
+    let Ok(secret) = std::env::var(SERVICE_ACCOUNT_SECRET_ENV) else {
+        return Ok(None);
+    };
+    let Some(secret) = trimmed_non_empty(&secret) else {
+        return Ok(None);
+    };
+
+    let config = AuthConfig {
+        api_base_url: api_base_url.to_string(),
+    };
+    let session = cache
+        .get_or_try_init(|| exchange_service_account_secret(&config, secret))
+        .await?;
+    Ok(Some(session.clone()))
 }
 
 pub fn resolve_auth_config() -> Result<AuthConfig> {
@@ -329,6 +395,149 @@ mod tests {
         assert_eq!(session.token, "token-123");
     }
 
+    // ENV_LOCK must stay held for the whole test, including the await: it
+    // serializes environment mutation across concurrent test threads, and
+    // each test here both sets the environment and awaits with it set.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test(flavor = "current_thread")]
+    async fn service_account_session_is_none_when_env_var_unset() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        unsafe {
+            std::env::remove_var(super::SERVICE_ACCOUNT_SECRET_ENV);
+        }
+
+        let cache = tokio::sync::OnceCell::new();
+        let session = super::resolve_service_account_session(&cache, "https://app.everr.dev")
+            .await
+            .expect("no secret should not error");
+
+        assert!(session.is_none());
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test(flavor = "current_thread")]
+    async fn service_account_session_is_none_when_env_var_is_blank() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        unsafe {
+            std::env::set_var(super::SERVICE_ACCOUNT_SECRET_ENV, "   ");
+        }
+
+        let cache = tokio::sync::OnceCell::new();
+        let session = super::resolve_service_account_session(&cache, "https://app.everr.dev")
+            .await
+            .expect("a blank secret should not error");
+
+        assert!(session.is_none());
+
+        unsafe {
+            std::env::remove_var(super::SERVICE_ACCOUNT_SECRET_ENV);
+        }
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test(flavor = "current_thread")]
+    async fn service_account_session_exchanges_the_secret_for_a_session() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut server = Server::new_async().await;
+        let token_mock = server
+            .mock("POST", "/api/service-accounts/token")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"token":"sa-token-123","expires_at":"2026-01-01T00:00:00Z"}"#)
+            .create_async()
+            .await;
+
+        unsafe {
+            std::env::set_var(super::SERVICE_ACCOUNT_SECRET_ENV, "sa-secret");
+        }
+
+        let cache = tokio::sync::OnceCell::new();
+        let session = super::resolve_service_account_session(&cache, &server.url())
+            .await
+            .expect("exchange should succeed")
+            .expect("a set secret should produce a session");
+
+        token_mock.assert_async().await;
+        assert_eq!(session.token, "sa-token-123");
+        assert_eq!(session.api_base_url, server.url());
+
+        unsafe {
+            std::env::remove_var(super::SERVICE_ACCOUNT_SECRET_ENV);
+        }
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test(flavor = "current_thread")]
+    async fn service_account_session_reuses_the_cached_session() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut server = Server::new_async().await;
+        let token_mock = server
+            .mock("POST", "/api/service-accounts/token")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"token":"sa-token-123","expires_at":"2026-01-01T00:00:00Z"}"#)
+            .create_async()
+            .await;
+
+        unsafe {
+            std::env::set_var(super::SERVICE_ACCOUNT_SECRET_ENV, "sa-secret");
+        }
+
+        let cache = tokio::sync::OnceCell::new();
+        super::resolve_service_account_session(&cache, &server.url())
+            .await
+            .expect("first exchange should succeed");
+        super::resolve_service_account_session(&cache, &server.url())
+            .await
+            .expect("second call should reuse the cached session");
+
+        // The mock expects exactly one call; a second exchange would fail this.
+        token_mock.assert_async().await;
+
+        unsafe {
+            std::env::remove_var(super::SERVICE_ACCOUNT_SECRET_ENV);
+        }
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test(flavor = "current_thread")]
+    async fn service_account_session_rejection_does_not_leak_the_secret() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut server = Server::new_async().await;
+        server
+            .mock("POST", "/api/service-accounts/token")
+            .with_status(401)
+            .create_async()
+            .await;
+
+        unsafe {
+            std::env::set_var(super::SERVICE_ACCOUNT_SECRET_ENV, "super-secret-value");
+        }
+
+        let cache = tokio::sync::OnceCell::new();
+        let error = super::resolve_service_account_session(&cache, &server.url())
+            .await
+            .expect_err("a rejected secret should error");
+
+        let message = error.to_string();
+        assert!(!message.contains("super-secret-value"));
+        assert!(message.contains("rejected"));
+
+        unsafe {
+            std::env::remove_var(super::SERVICE_ACCOUNT_SECRET_ENV);
+        }
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn setup_login_stops_when_authorization_is_denied() {
         let _guard = ENV_LOCK
@@ -364,5 +573,95 @@ mod tests {
 
         token_mock.assert_async().await;
         assert_eq!(error.to_string(), "device authentication was denied");
+    }
+
+    async fn reauthentication_required_error(status: usize) -> anyhow::Error {
+        let mut server = Server::new_async().await;
+        server
+            .mock("GET", "/api/cli/runs/status")
+            .with_status(status)
+            .create_async()
+            .await;
+        let session = everr_core::state::Session {
+            api_base_url: server.url(),
+            token: "sa-token".to_string(),
+        };
+        let client = everr_core::api::ApiClient::from_session(&session).expect("client");
+        client
+            .get_status(&[])
+            .await
+            .expect_err("a 401 response should fail")
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn rewrite_reauth_error_points_at_the_secret_for_service_accounts() {
+        let error = reauthentication_required_error(401).await;
+
+        let rewritten = super::rewrite_reauth_error(Err(error), true)
+            .expect_err("a reauth error should stay an error");
+
+        let message = rewritten.to_string();
+        assert!(
+            message.contains("service account"),
+            "message was: {message}"
+        );
+        assert!(
+            message.contains(super::SERVICE_ACCOUNT_SECRET_ENV),
+            "message was: {message}"
+        );
+        assert!(!message.contains("cloud login"), "message was: {message}");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn rewrite_reauth_error_leaves_human_sessions_untouched() {
+        let error = reauthentication_required_error(401).await;
+        let original_message = error.to_string();
+
+        let rewritten = super::rewrite_reauth_error(Err(error), false)
+            .expect_err("a reauth error should stay an error");
+
+        assert_eq!(rewritten.to_string(), original_message);
+        assert!(rewritten.to_string().contains("cloud login"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn rewrite_reauth_error_leaves_unrelated_errors_untouched() {
+        let error = anyhow::anyhow!("some other failure");
+        let message = error.to_string();
+
+        let rewritten = super::rewrite_reauth_error(Err(error), true)
+            .expect_err("an unrelated error should stay an error");
+
+        assert_eq!(rewritten.to_string(), message);
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test(flavor = "current_thread")]
+    async fn is_using_service_account_is_true_when_the_secret_is_set() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        unsafe {
+            std::env::set_var(super::SERVICE_ACCOUNT_SECRET_ENV, "sa-secret");
+        }
+
+        assert!(super::is_using_service_account());
+
+        unsafe {
+            std::env::remove_var(super::SERVICE_ACCOUNT_SECRET_ENV);
+        }
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test(flavor = "current_thread")]
+    async fn is_using_service_account_is_false_when_the_secret_is_unset() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        unsafe {
+            std::env::remove_var(super::SERVICE_ACCOUNT_SECRET_ENV);
+        }
+
+        assert!(!super::is_using_service_account());
     }
 }

--- a/packages/desktop-app/src-cli/src/main.rs
+++ b/packages/desktop-app/src-cli/src/main.rs
@@ -38,6 +38,7 @@ async fn main() -> Result<()> {
         command_telemetry::record_invocation(&cli, argv);
         update_notice::maybe_print(&cli).await;
         let result = run_command(cli.command).await;
+        let result = auth::rewrite_reauth_error_for_service_account(result);
         command_telemetry::record_result(command, subcommand, &result);
         result
     }


### PR DESCRIPTION
Stacked on #417 (Better Auth 1.7.1). Review that one first.

An agent can now use Everr with no human present. Today it cannot: every credential the app issues is either tied to a person who signs in through a browser, or is an `ek_` key whose authority is a fixed scope set rather than a role in an organization.

## The model

> A service account is a user carrying a machine flag. It has a member row like anyone else. Its secrets belong to it.

Authorization is plain organization membership. `assertCurrentMember`, the roles in `orgAc`, the ClickHouse tenant policy, and the audit trail all keep working with no changes and no second code path, because the principal really is a member.

`service_account` holds only the machine-only facts: `id`, `user_id`, `created_by_user_id`, `created_at`, `last_used_at`. The organization comes from `member` and the name from `user.name`, so there is exactly one answer to "which organization does this principal belong to?".

## Credentials

Two levels, as in Google Cloud, AWS STS, and GitHub Apps: a long-lived secret the agent stores, exchanged for a short-lived credential it actually sends.

- **The secret** is `sa_` plus 32 random bytes. Shown once at creation, stored as a SHA-256 hash. An account can hold several at once, so rotation needs no downtime.
- **The token** is `st_` plus 32 random bytes, issued by `POST /api/service-accounts/token`, valid one hour, sent as `Authorization: Bearer`.

Revoking a secret deletes its tokens, so revocation is immediate rather than eventual. Each exchange also drops that secret's expired tokens, so a busy account does not grow the table without bound.

### Why the token is not a Better Auth session

The obvious implementation is a session with a one-hour `expiresAt`. It does not work. Better Auth refreshes sessions on use, and with the defaults of seven days and one day the condition is true on the first request, so a one-hour session would silently become seven days. There is no per-session lifetime in Better Auth.

The supported way out is the idiom the api-key plugin already uses: a `hooks.before` that validates its own credential and builds a session object without writing a session row. The hook returns before the refresh logic runs, so the token row's own `expiresAt` is the real lifetime. Human sessions are untouched, and no session rows accumulate for agents.

Because all seven `auth.api.getSession` call sites resolve this session, server functions, the CLI read path, `apply`, and the events stream work with no change at any boundary.

## Guards

Most follow from the model: no `account` row means no password sign-in, the reserved `.invalid` domain means the address can never receive mail, and `emailVerified` is true so verification never fires.

The rest sit at the auth layer, where every client reaches them, rather than in the app. A service account cannot hold `owner`, cannot be invited, cannot accept an invitation, cannot be added to an organization, cannot create one, cannot be removed through the member path, and cannot leave. Those guards are also what holds a service account to exactly one membership, which is what makes its organization deterministic when nobody is there to choose one.

Two of these were found by driving the running app rather than by reading code:

- The members table offered `Owner` on every row. Promoting a service account through it stuck, confirmed in Postgres.
- An owner of any other organization could invite the account's address as `owner` and the account could accept with its own token, because `acceptInvitation` writes the member row directly and never reaches the role-change guard.

A third came from the reviews: refusing organization creation used to leave a permanent memberless organization behind, because Better Auth writes that row before calling the hook. It is now refused before any row is written.

## Deleting

Deleting an account cascades to its member row, its user row, its secrets, and its tokens. Deleting an organization removes its service accounts first, while the member rows that identify them still exist, since the collapse of `organization_id` removed the foreign key that used to do this.

## CLI

`everr` reads `EVERR_SERVICE_ACCOUNT_SECRET` and exchanges it once per process, at the single point where every command resolves its session, retrying once if the exchange is rate limited. This is what makes `everr cloud query` work with no human present.

**Known gap:** it does not re-exchange on a 401. The request path has no retry for human sessions either, so wiring one means restructuring `ApiClient` around a re-auth callback. A one-hour token outlives the commands that use it. `everr watch` is the case that could outlive its token, though its stream does not re-send the header once open.

## Failing closed

`findLiveToken` refuses to resolve a session when a service account holds more than one membership, rather than picking one. The one-membership property is guaranteed by guards, and no database constraint can express "exactly one across all organizations". A refused agent is an incident someone investigates; an agent quietly acting in another organization is not.

## Testing

`src/lib/service-account-contract.test.ts` runs eight cases against a real Better Auth instance with only the database mocked, so it fails if Better Auth stops calling our guards, not merely if a guard returns the wrong answer. Every other test exercises the guard functions in isolation and would stay green through an upgrade that renamed a hook or changed hook ordering. Each case was checked by unwiring its guard and confirming exactly that case fails.

The rest is behavior: a valid secret exchanges, the token resolves to a session with the right user and organization, an expired token is rejected, a revoked secret is rejected, two secrets are both valid until one is revoked, a service account cannot sign in with a password, and `owner` is refused at creation. The tenant-scoping tests were each proven to fail when their `member.organizationId` predicate is removed.

Verified end to end against a real dev server and database: create, copy once, exchange (200, `st_`, 3600s), unknown secret refused with an identical body, rotate keeping the old secret live, revoke dropping tokens, the members-table guards, `/organization/leave` refused, and the organization-delete cascade proven with a throwaway organization.

## Seats

Out of scope. Billing counts service accounts by hand for now, and the `service_account` table makes the real count one query.