### PR TITLE
feat(cli): compact query output for machine readers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,7 +1376,7 @@ dependencies = [
 
 [[package]]
 name = "everr-app"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -4943,6 +4943,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.13.0",
  "itoa",
  "memchr",
  "serde",

--- a/crates/everr-core/assets/skills/everr-use-telemetry/SKILL.md
+++ b/crates/everr-core/assets/skills/everr-use-telemetry/SKILL.md
@@ -19,7 +19,16 @@ Use Everr telemetry before guessing when real traces, logs, metrics, or captured
 
 ## Critical: Only Raw SQL
 
-The ONLY query command is `everr cloud query "<SQL>"` or `everr local query "<SQL>"`. The only optional flag is `--format` (values: `table`, `json`, `ndjson`).
+The ONLY query command is `everr cloud query "<SQL>"` or `everr local query "<SQL>"`. The only optional flag is `--format` (values: `compact`, `table`, `json`, `ndjson`).
+
+The default output is `compact` (JSONCompactEachRowWithNames): line 1 is the column-name array in SELECT order, then one JSON array per row. Read a value by its position in the header. Nested maps stay JSON objects, NULL is `null`.
+
+```
+["ServiceName","SpanName","c"]
+["everr-app","GET /api/health",1657]
+```
+
+Pass `--format ndjson` only when a script needs one object per row.
 
 ## Choose The Source
 
@@ -50,6 +59,7 @@ If an Everr command fails, investigate why: collector stopped, stale app, wrong 
 - **Always include a time window and LIMIT** for diagnostic queries. Cloud enforces a 1000-row hard limit and 30s timeout — queries without time windows will hit these limits. Local queries without windows are wasteful.
 - Freshness checks and schema discovery (`DESCRIBE`, `SHOW TABLES`) may omit the time window.
 - Use read-only SQL only: `SELECT`, `WITH`, `EXPLAIN`, `DESCRIBE`, `DESC`, `SHOW`.
+- **Do not select `SpanAttributes`, `LogAttributes`, or `ResourceAttributes` whole** in diagnostic queries: a full map is most of the output. Select the keys you need with `Column['key']`. To discover keys, use `arrayJoin(mapKeys(Column))` with a `GROUP BY` and a small `LIMIT`, or sample one or two rows.
 
 ## Tables And Columns
 
@@ -192,6 +202,7 @@ When a local query fails, always run `everr local status` to diagnose the collec
 | Mistake | Fix |
 | --- | --- |
 | Inventing subcommands or flags (`query traces`, `--filter`, `--window`) | Only `everr cloud query "<SQL>"` or `everr local query "<SQL>"` with optional `--format`. Everything else is in the SQL. |
+| Selecting a whole attributes map (`SELECT SpanAttributes`) across many rows | Select `SpanAttributes['key']`, or discover keys with `arrayJoin(mapKeys(SpanAttributes))` first. |
 | Writing queries without a time window | Always add `WHERE Timestamp > now() - INTERVAL N HOUR/MINUTE`. |
 | Writing cloud queries without LIMIT | Cloud enforces 1000-row limit. Always include `LIMIT`. |
 | Assuming attribute names without discovering them | Run `DESCRIBE TABLE` or sample rows first. Conventions vary. |

--- a/packages/desktop-app/src-cli/Cargo.toml
+++ b/packages/desktop-app/src-cli/Cargo.toml
@@ -25,7 +25,7 @@ opentelemetry_sdk = { version = "0.32", features = ["logs", "trace", "rt-tokio"]
 tracing-opentelemetry = "0.33"
 reqwest = { version = "0.12.15", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 serde = { version = "1.0.219", features = ["derive"] }
-serde_json = "1.0.140"
+serde_json = { version = "1.0.140", features = ["preserve_order"] }
 serde_yaml = "0.9"
 semver = "1"
 regex = "1"

--- a/packages/desktop-app/src-cli/src/cli.rs
+++ b/packages/desktop-app/src-cli/src/cli.rs
@@ -287,13 +287,16 @@ pub struct TelemetryStartArgs {
 pub struct TelemetryQueryArgs {
     /// The SQL query to run. Keep it quoted. Include LIMIT yourself.
     pub sql: String,
-    /// Output format. Default: table on TTY, ndjson otherwise.
+    /// Output format. Default: table on a TTY, compact otherwise.
+    /// compact is JSONCompactEachRowWithNames: line 1 is the column-name
+    /// array, then one JSON array per row.
     #[arg(long, value_enum)]
     pub format: Option<TelemetryFormat>,
 }
 
 #[derive(clap::ValueEnum, Debug, Clone, Copy)]
 pub enum TelemetryFormat {
+    Compact,
     Json,
     Ndjson,
     Table,
@@ -305,7 +308,7 @@ fn telemetry_query_prints_human_stdout(
 ) -> bool {
     match args.format {
         Some(TelemetryFormat::Table) => true,
-        Some(TelemetryFormat::Json | TelemetryFormat::Ndjson) => false,
+        Some(TelemetryFormat::Compact | TelemetryFormat::Json | TelemetryFormat::Ndjson) => false,
         None => stdout_is_terminal,
     }
 }
@@ -1015,6 +1018,11 @@ mod tests {
 
         let cli = Cli::try_parse_from(["everr", "local", "query", "SELECT 1", "--format", "json"])
             .expect("local query json command");
+        assert!(!cli.prints_human_stdout(true));
+
+        let cli =
+            Cli::try_parse_from(["everr", "local", "query", "SELECT 1", "--format", "compact"])
+                .expect("local query compact command");
         assert!(!cli.prints_human_stdout(true));
 
         let cli = Cli::try_parse_from(["everr", "local", "query", "SELECT 1"])

--- a/packages/desktop-app/src-cli/src/core.rs
+++ b/packages/desktop-app/src-cli/src/core.rs
@@ -12,8 +12,8 @@ use crate::api::{
 };
 use crate::auth;
 use crate::cli::{
-    GetLogsArgs, ListRunsArgs, LogPagingArgs, ShowRunArgs, StatusArgs, TelemetryFormat,
-    TelemetryQueryArgs, WatchArgs,
+    GetLogsArgs, ListRunsArgs, LogPagingArgs, ShowRunArgs, StatusArgs, TelemetryQueryArgs,
+    WatchArgs,
 };
 use crate::command_telemetry;
 use crate::telemetry;
@@ -85,13 +85,7 @@ pub async fn cloud_query(args: TelemetryQueryArgs) -> Result<()> {
     let client = ApiClient::from_session(&session)?;
     let body = client.post_sql(&args.sql).await?;
     let rows = telemetry::client::parse_ndjson(&body)?;
-    let format = args.format.unwrap_or_else(|| {
-        if io::stdout().is_terminal() {
-            TelemetryFormat::Table
-        } else {
-            TelemetryFormat::Ndjson
-        }
-    });
+    let format = telemetry::commands::default_format(args.format, io::stdout().is_terminal());
     telemetry::commands::render(&rows, format);
     Ok(())
 }

--- a/packages/desktop-app/src-cli/src/telemetry/commands.rs
+++ b/packages/desktop-app/src-cli/src/telemetry/commands.rs
@@ -68,15 +68,21 @@ fn run_query(args: TelemetryQueryArgs) -> Result<()> {
         }
     };
 
-    let format = args.format.unwrap_or_else(|| {
-        if io::stdout().is_terminal() {
-            TelemetryFormat::Table
-        } else {
-            TelemetryFormat::Ndjson
-        }
-    });
+    let format = default_format(args.format, io::stdout().is_terminal());
     render(&rows, format);
     Ok(())
+}
+
+/// Machine readers (agents, pipes) get compact rows; humans get a table.
+pub(crate) fn default_format(
+    requested: Option<TelemetryFormat>,
+    stdout_is_terminal: bool,
+) -> TelemetryFormat {
+    requested.unwrap_or(if stdout_is_terminal {
+        TelemetryFormat::Table
+    } else {
+        TelemetryFormat::Compact
+    })
 }
 
 fn is_connect_error(err: &anyhow::Error) -> bool {
@@ -106,37 +112,71 @@ fn is_permission_denied(err: &anyhow::Error) -> bool {
 }
 
 pub(crate) fn render(rows: &Rows, format: TelemetryFormat) {
+    print!("{}", render_to_string(rows, format));
+}
+
+fn render_to_string(rows: &Rows, format: TelemetryFormat) -> String {
+    let mut out = String::new();
     match format {
+        TelemetryFormat::Compact => render_compact(rows, &mut out),
         TelemetryFormat::Ndjson => {
             for row in &rows.values {
-                println!("{}", serde_json::to_string(row).unwrap());
+                out.push_str(&serde_json::to_string(row).unwrap());
+                out.push('\n');
             }
         }
         TelemetryFormat::Json => {
-            println!("{}", serde_json::to_string_pretty(&rows.values).unwrap());
+            out.push_str(&serde_json::to_string_pretty(&rows.values).unwrap());
+            out.push('\n');
         }
-        TelemetryFormat::Table => render_table(rows),
+        TelemetryFormat::Table => render_table(rows, &mut out),
+    }
+    out
+}
+
+/// JSONCompactEachRowWithNames: a column-name array, then one value array per
+/// row. Columns come from the first row, which keeps the SELECT order thanks to
+/// serde_json's preserve_order feature.
+fn render_compact(rows: &Rows, out: &mut String) {
+    let Some(cols) = column_names(rows) else {
+        return;
+    };
+    out.push_str(&serde_json::to_string(&cols).unwrap());
+    out.push('\n');
+    for row in &rows.values {
+        let cells: Vec<&Value> = cols
+            .iter()
+            .map(|key| row.get(*key).unwrap_or(&Value::Null))
+            .collect();
+        out.push_str(&serde_json::to_string(&cells).unwrap());
+        out.push('\n');
     }
 }
 
-fn render_table(rows: &Rows) {
-    let Some(first) = rows.values.first() else {
-        println!("(no rows)");
+fn column_names(rows: &Rows) -> Option<Vec<&str>> {
+    let object = rows.values.first()?.as_object()?;
+    Some(object.keys().map(String::as_str).collect())
+}
+
+fn render_table(rows: &Rows, out: &mut String) {
+    if rows.values.is_empty() {
+        out.push_str("(no rows)\n");
         return;
-    };
-    let Some(object) = first.as_object() else {
-        println!("(rows are not objects)");
+    }
+    let Some(cols) = column_names(rows) else {
+        out.push_str("(rows are not objects)\n");
         return;
     };
 
-    let cols: Vec<&str> = object.keys().map(String::as_str).collect();
-    println!("{}", cols.join(" | "));
+    out.push_str(&cols.join(" | "));
+    out.push('\n');
     for row in &rows.values {
         let cells: Vec<String> = cols
             .iter()
             .map(|key| row.get(*key).map(value_to_cell).unwrap_or_default())
             .collect();
-        println!("{}", cells.join(" | "));
+        out.push_str(&cells.join(" | "));
+        out.push('\n');
     }
 }
 
@@ -151,8 +191,57 @@ fn value_to_cell(value: &Value) -> String {
 #[cfg(test)]
 mod tests {
     use anyhow::anyhow;
+    use serde_json::json;
 
-    use super::connection_failure_message;
+    use super::{connection_failure_message, default_format, render_to_string};
+    use crate::cli::TelemetryFormat;
+    use crate::telemetry::client::Rows;
+
+    #[test]
+    fn compact_prints_header_then_one_array_per_row_keeping_types() {
+        let rows = Rows {
+            values: vec![
+                json!({"n": 1657, "svc": "app", "avg_ms": 1.2, "attrs": {"k": "v"}, "gone": null}),
+                json!({"n": 3, "svc": "db", "avg_ms": 0.0, "attrs": {}, "gone": "x"}),
+            ],
+        };
+
+        let out = render_to_string(&rows, TelemetryFormat::Compact);
+
+        assert_eq!(
+            out,
+            "[\"n\",\"svc\",\"avg_ms\",\"attrs\",\"gone\"]\n[1657,\"app\",1.2,{\"k\":\"v\"},null]\n[3,\"db\",0.0,{},\"x\"]\n"
+        );
+    }
+
+    #[test]
+    fn compact_prints_nothing_for_an_empty_result() {
+        let rows = Rows { values: vec![] };
+
+        assert_eq!(render_to_string(&rows, TelemetryFormat::Compact), "");
+    }
+
+    #[test]
+    fn compact_keeps_column_order_from_the_wire() {
+        let rows = crate::telemetry::client::parse_ndjson("{\"z\":1,\"a\":2}\n").unwrap();
+
+        let out = render_to_string(&rows, TelemetryFormat::Compact);
+
+        assert_eq!(out, "[\"z\",\"a\"]\n[1,2]\n");
+    }
+
+    #[test]
+    fn default_format_is_table_on_a_terminal_and_compact_otherwise() {
+        assert!(matches!(default_format(None, true), TelemetryFormat::Table));
+        assert!(matches!(
+            default_format(None, false),
+            TelemetryFormat::Compact
+        ));
+        assert!(matches!(
+            default_format(Some(TelemetryFormat::Ndjson), true),
+            TelemetryFormat::Ndjson
+        ));
+    }
 
     #[test]
     fn permission_denied_connection_mentions_sandbox_network_access() {

--- a/packages/desktop-app/src-cli/tests/api_commands.rs
+++ b/packages/desktop-app/src-cli/tests/api_commands.rs
@@ -485,6 +485,31 @@ fn cloud_query_posts_sql_and_renders_ndjson_rows() {
 }
 
 #[test]
+fn cloud_query_defaults_to_compact_rows_when_stdout_is_not_a_terminal() {
+    let env = CliTestEnv::new();
+    let mut server = mock_api_server();
+
+    env.write_session(&server.url(), "token-sql");
+
+    let mock = server
+        .mock("POST", "/api/cli/sql")
+        .match_body("SELECT 2 AS z, 'a' AS a")
+        .with_status(200)
+        .with_header("content-type", "application/x-ndjson")
+        .with_body("{\"z\":2,\"a\":\"a\"}\n{\"z\":3,\"a\":null}\n")
+        .create();
+
+    env.command_with_api_base_url(&server.url())
+        .args(["cloud", "query", "SELECT 2 AS z, 'a' AS a"])
+        .assert()
+        .success()
+        .stdout(predicate::str::diff("[\"z\",\"a\"]\n[2,\"a\"]\n[3,null]\n"))
+        .stderr(predicate::str::is_empty());
+
+    mock.assert();
+}
+
+#[test]
 fn cloud_query_surfaces_error_envelope() {
     let env = CliTestEnv::new();
     let mut server = mock_api_server();


### PR DESCRIPTION
## Why

`everr cloud query` / `everr local query` defaulted to ndjson when piped, which is how AI agents call it. Every row repeated every column name plus JSON punctuation, so agents spent a large share of their context on structure instead of data.

## What

- New `--format compact` (ClickHouse `JSONCompactEachRowWithNames` shape): line 1 is the column-name array in SELECT order, then one JSON array per row. Values keep their JSON types, NULL is `null`, maps stay nested objects.
- `compact` is the new default when stdout is not a TTY. `table` stays the TTY default. `ndjson` and `json` are unchanged as explicit options.
- `serde_json` now has `preserve_order`, so columns follow the SELECT order. `ndjson` used to sort keys alphabetically; it now keeps the wire order too.
- One `default_format` helper replaces the duplicated TTY check in `core.rs` and `telemetry/commands.rs`; `render` builds a string so it is testable.
- `everr-use-telemetry` skill: documents the default shape with an example, and adds a rule (plus an anti-pattern row) against selecting `SpanAttributes` / `LogAttributes` / `ResourceAttributes` whole. On real diagnostic queries the map column is about 80% of the bytes, so no format can recover that; the query has to.

Out of scope: the `/api/cli/sql` route and the collector `/sql` endpoint still speak ndjson on the wire. Nothing in the web UI changes.

## Measurements (dev cloud, bytes)

| Query | ndjson | compact |
| --- | --- | --- |
| 50 rows, 5 narrow columns | 1211 | 696 (-43%) |
| 20 rows incl. `SpanAttributes` | 7768 | 6288 (-19%) |

Example output:

```
["ServiceName","SpanName","n","avg_ms"]
["everr-dev-app","tcp.connect",1676,1.1]
["everr-dev-app","POST",857,2.1]
```

## Tests

- Unit: compact rendering with mixed types and null, empty result, wire order kept, default selection per TTY state, `--format compact` counts as machine stdout.
- CLI: `cloud query` with no `--format` under a non-TTY prints the header first and follows the server's column order.
- Full `everr-cli` crate: 256 passed. Manual run against the dev cloud, piped, matches the example above.
