### PR TITLE
fix(alerting): a silence written from the screen mutes the rule

### DIFF
--- a/packages/app/src/data/alerting/silences/matching.test.ts
+++ b/packages/app/src/data/alerting/silences/matching.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
+import type { alertEvents } from "@/db/schema";
 import type { AlertingMatcher } from "../types";
 import {
-  alertingMatcherMatches,
-  alertingMatchersMatch,
-  alertingMatchingSilence,
-  alertingSyntheticLabels,
+  eventSubject,
+  matchingSilence,
+  ruleSubject,
+  silenceIsInForce,
+  silenceSelects,
 } from "./matching";
 
 function matcher(
@@ -15,98 +17,163 @@ function matcher(
   return { label, op, value };
 }
 
-describe("alertingMatcherMatches", () => {
-  // A missing label reads as the empty string, so `ne` matches it.
-  it.each<[AlertingMatcher["op"], string, Record<string, string>, boolean]>([
-    ["eq", "pay", { team: "pay" }, true],
-    ["eq", "pay", { team: "core" }, false],
-    ["eq", "pay", {}, false],
-    ["eq", "", {}, true],
-    ["ne", "pay", { team: "core" }, true],
-    ["ne", "pay", {}, true],
-    ["ne", "pay", { team: "pay" }, false],
-  ])("team %s %s against %j is %s", (op, value, labels, expected) => {
-    expect(alertingMatcherMatches(matcher(op, value), labels)).toBe(expected);
+const RULE_ID = "0e1c2b8f-4a3d-4c2b-9f11-5a7c9d2e8b41";
+
+function event(
+  overrides: Partial<typeof alertEvents.$inferSelect> = {},
+): typeof alertEvents.$inferSelect {
+  return {
+    sourceDefinitionId: RULE_ID,
+    severity: "critical",
+    eventType: "instance_fired",
+    instanceLabels: { team: "pay" },
+    ...overrides,
+  } as typeof alertEvents.$inferSelect;
+}
+
+describe("the subject a silence is matched against", () => {
+  it("names the rule by its row id from either side", () => {
+    // The one fact both sides have to agree on. They each built their own
+    // label set once, and they spelled the rule differently: a silence written
+    // from the screen then matched nothing the pipeline evaluated, and the
+    // screen still said the rule was silenced.
+    const fromEvent = eventSubject(event());
+    const fromRule = ruleSubject(RULE_ID, "critical");
+
+    expect(fromEvent.rule).toBe(RULE_ID);
+    expect(fromRule.rule).toBe(RULE_ID);
   });
 
-  // Matching is exact: a value that reads as a pattern is compared literally.
-  it("compares pattern-looking values literally", () => {
-    expect(
-      alertingMatcherMatches(matcher("eq", "^pay.*"), { team: "pay" }),
-    ).toBe(false);
-    expect(
-      alertingMatcherMatches(matcher("eq", "^pay.*"), { team: "^pay.*" }),
-    ).toBe(true);
-  });
-});
+  it("lets the synthetics win over a user label of the same name", () => {
+    const subject = eventSubject(
+      event({
+        severity: "critical",
+        instanceLabels: { team: "pay", severity: "user-set", rule: "user-set" },
+      }),
+    );
 
-describe("alertingMatchersMatch", () => {
-  it("requires every matcher to match, and is vacuously true with none", () => {
-    expect(alertingMatchersMatch([], { team: "pay" })).toBe(true);
-
-    const matchers = [
-      matcher("eq", "pay"),
-      matcher("eq", "critical", "severity"),
-    ];
-    expect(
-      alertingMatchersMatch(matchers, { team: "pay", severity: "critical" }),
-    ).toBe(true);
-    expect(
-      alertingMatchersMatch(matchers, { team: "pay", severity: "warning" }),
-    ).toBe(false);
-  });
-});
-
-describe("alertingSyntheticLabels", () => {
-  it("adds severity/status/rule, letting synthetics win over same-named user labels", () => {
-    expect(
-      alertingSyntheticLabels(
-        { team: "pay", severity: "user-set" },
-        { severity: "critical", status: "firing", rule: "r-1" },
-      ),
-    ).toEqual({
+    expect(subject).toEqual({
       team: "pay",
       severity: "critical",
       status: "firing",
-      rule: "r-1",
+      rule: RULE_ID,
+    });
+  });
+
+  it("reads a resolve as resolved, so a silence may scope to one or the other", () => {
+    const subject = eventSubject(event({ eventType: "instance_resolved" }));
+
+    expect(subject.status).toBe("resolved");
+  });
+
+  // A rule has no instance labels of its own, so a silence scoped to one
+  // instance does not select the whole rule.
+  it("gives a rule the rule's own labels and nothing else", () => {
+    const subject = ruleSubject(RULE_ID, "warning");
+
+    expect(subject).toEqual({
+      rule: RULE_ID,
+      severity: "warning",
+      status: "firing",
     });
   });
 });
 
-describe("alertingMatchingSilence", () => {
-  const now = Date.parse("2026-07-01T12:00:00Z");
-  const active = {
-    id: "s-active",
-    matchers: [matcher("eq", "pay")],
-    starts_at: "2026-07-01T11:00:00Z",
-    ends_at: "2026-07-01T13:00:00Z",
-  };
+describe("silenceSelects", () => {
+  const subject = eventSubject(event());
 
-  it("returns the active silence whose matchers all match, ignoring the rest", () => {
-    expect(alertingMatchingSilence({ team: "pay" }, [active], now)).toBe(
-      active,
-    );
-
-    const expired = { ...active, ends_at: "2026-07-01T11:30:00Z" };
-    const scheduled = { ...active, starts_at: "2026-07-01T12:30:00Z" };
-    expect(
-      alertingMatchingSilence({ team: "pay" }, [expired, scheduled], now),
-    ).toBe(null);
-    expect(alertingMatchingSilence({ team: "core" }, [active], now)).toBe(null);
+  // A missing label reads as the empty string, so `ne` selects it.
+  it.each<[AlertingMatcher["op"], string, string, boolean]>([
+    ["eq", "pay", "team", true],
+    ["eq", "pay", "squad", false],
+    ["eq", "", "squad", true],
+    ["ne", "pay", "team", false],
+    ["ne", "pay", "squad", true],
+  ])("%s %s on %s is %s", (op, value, label, expected) => {
+    expect(silenceSelects([matcher(op, value, label)], subject)).toBe(expected);
   });
 
-  it("matches rule-scoped matchers against synthetic labels", () => {
-    const ruleScoped = {
-      ...active,
-      matchers: [matcher("eq", "pay"), matcher("eq", "r-1", "rule")],
+  it("requires every matcher, and selects everything with none", () => {
+    expect(silenceSelects([], subject)).toBe(true);
+    expect(
+      silenceSelects(
+        [matcher("eq", "pay"), matcher("eq", "critical", "severity")],
+        subject,
+      ),
+    ).toBe(true);
+    expect(
+      silenceSelects(
+        [matcher("eq", "pay"), matcher("eq", "warning", "severity")],
+        subject,
+      ),
+    ).toBe(false);
+  });
+
+  // Matching is exact: a value that reads as a pattern is compared literally.
+  it("compares pattern-looking values literally", () => {
+    expect(silenceSelects([matcher("eq", "^pay.*")], subject)).toBe(false);
+    expect(
+      silenceSelects(
+        [matcher("eq", "^pay.*")],
+        eventSubject(event({ instanceLabels: { team: "^pay.*" } })),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("silenceIsInForce", () => {
+  const now = new Date("2026-07-01T12:00:00Z");
+
+  // Half-open: the start instant is covered, the end instant is not.
+  it.each<[string, string, boolean]>([
+    ["2026-07-01T11:00:00Z", "2026-07-01T13:00:00Z", true],
+    ["2026-07-01T12:00:00Z", "2026-07-01T13:00:00Z", true],
+    ["2026-07-01T11:00:00Z", "2026-07-01T12:00:00Z", false],
+    ["2026-07-01T12:30:00Z", "2026-07-01T13:00:00Z", false],
+  ])("%s to %s covers noon: %s", (startsAt, endsAt, expected) => {
+    expect(
+      silenceIsInForce(
+        { startsAt: new Date(startsAt), endsAt: new Date(endsAt) },
+        now,
+      ),
+    ).toBe(expected);
+  });
+});
+
+describe("matchingSilence", () => {
+  const now = new Date("2026-07-01T12:00:00Z");
+  const inForce = {
+    id: "s-active",
+    matchers: [matcher("eq", "pay")],
+    startsAt: new Date("2026-07-01T11:00:00Z"),
+    endsAt: new Date("2026-07-01T13:00:00Z"),
+  };
+  const subject = eventSubject(event());
+
+  it("returns the silence in force whose matchers all select, ignoring the rest", () => {
+    expect(matchingSilence(subject, [inForce], now)).toBe(inForce);
+
+    const expired = { ...inForce, endsAt: new Date("2026-07-01T11:30:00Z") };
+    const scheduled = {
+      ...inForce,
+      startsAt: new Date("2026-07-01T12:30:00Z"),
     };
-    const labels = alertingSyntheticLabels(
-      { team: "pay" },
-      { severity: "critical", status: "firing", rule: "r-1" },
-    );
-    expect(alertingMatchingSilence(labels, [ruleScoped], now)).toBe(ruleScoped);
-    expect(alertingMatchingSilence({ team: "pay" }, [ruleScoped], now)).toBe(
-      null,
-    );
+    expect(matchingSilence(subject, [expired, scheduled], now)).toBe(null);
+    expect(
+      matchingSilence(
+        eventSubject(event({ instanceLabels: { team: "core" } })),
+        [inForce],
+        now,
+      ),
+    ).toBe(null);
+  });
+
+  it("selects a whole-rule silence by the id the dialog wrote", () => {
+    const wholeRule = {
+      ...inForce,
+      matchers: [matcher("eq", RULE_ID, "rule")],
+    };
+
+    expect(matchingSilence(subject, [wholeRule], now)).toBe(wholeRule);
   });
 });

--- a/packages/app/src/data/alerting/silences/matching.ts
+++ b/packages/app/src/data/alerting/silences/matching.ts
@@ -1,63 +1,108 @@
+/**
+ * What a silence applies to, for both sides that have to decide it: delivery,
+ * which asks per event, and the alerting screens, which ask per rule.
+ *
+ * The label set a silence is tested against is built by the two functions here
+ * and nowhere else. Each side used to assemble its own, and the two spelled the
+ * rule differently, so a silence written from the screen matched nothing the
+ * pipeline ever evaluated: the board said "Silenced" and the notification went
+ * out anyway.
+ *
+ * The label they have to agree on is `rule`, and its value is the definition's
+ * row id: the only name for a rule that survives being renamed, and the only
+ * one that tells a live rule apart from a preview of it, which share
+ * `project/slug`. A person never types it and never reads it. The dialog
+ * resolves the path they picked, and the screens resolve it back to a name
+ * before printing.
+ */
+import type { alertEvents } from "@/db/schema";
 import type { AlertingMatcher } from "../types";
 
-/** Missing labels match as empty strings. Matching is exact only. */
-export function alertingMatcherMatches(
-  m: AlertingMatcher,
-  labels: Record<string, string>,
-): boolean {
-  const v = labels[m.label] ?? "";
-  switch (m.op) {
-    case "eq":
-      return v === m.value;
-    case "ne":
-      return v !== m.value;
-  }
-}
+/** What delivery holds about the event being decided on. */
+type EventSubject = Pick<
+  typeof alertEvents.$inferSelect,
+  "instanceLabels" | "severity" | "eventType" | "sourceDefinitionId"
+>;
 
-export function alertingMatchersMatch(
-  matchers: AlertingMatcher[],
-  labels: Record<string, string>,
-): boolean {
-  return matchers.every((m) => alertingMatcherMatches(m, labels));
-}
+/**
+ * The labels one silence decision is taken against.
+ *
+ * `eventSubject` and `ruleSubject` below build every one of these, and no
+ * caller names the rule itself: that, and not the type, is what keeps the two
+ * askers spelling it the same way.
+ */
+export type SilenceSubject = Record<string, string>;
 
-/** Dispatcher labels, with system-owned values winning on collision. */
-export function alertingSyntheticLabels(
-  labels: Record<string, string>,
-  opts: {
-    severity: string;
-    status: string;
-    rule: string;
-  },
-): Record<string, string> {
+/** A silence's window. Half-open: it covers its start instant and not its
+ *  end instant. */
+export type SilenceWindow = { startsAt: Date; endsAt: Date };
+
+type SilenceCandidate = SilenceWindow & { matchers: AlertingMatcher[] };
+
+/**
+ * Delivery's subject: the instance's own labels with the synthetics laid over
+ * them, so a user label named `severity` cannot dress an instance up as
+ * something it is not.
+ */
+export function eventSubject(event: EventSubject): SilenceSubject {
   return {
-    ...labels,
-    severity: opts.severity,
-    status: opts.status,
-    rule: opts.rule,
+    ...event.instanceLabels,
+    rule: event.sourceDefinitionId,
+    severity: event.severity,
+    status: event.eventType === "instance_resolved" ? "resolved" : "firing",
   };
 }
 
-/** Half-open: a silence covers its start instant and not its end instant. */
-function alertingSilenceIsActive(
-  silence: { starts_at: string; ends_at: string },
-  now: number,
-): boolean {
-  return (
-    new Date(silence.starts_at).getTime() <= now &&
-    now < new Date(silence.ends_at).getTime()
-  );
+/**
+ * The screens' subject: a rule carries no instance labels of its own, so a
+ * silence scoped to one instance does not select the rule, and a rule reads as
+ * silenced only when something mutes all of it. `status` is `firing` because
+ * the question a screen asks is whether this rule's pages are being held.
+ */
+export function ruleSubject(ruleId: string, severity: string): SilenceSubject {
+  return { rule: ruleId, severity, status: "firing" };
 }
 
-/** First active silence whose matchers all match `labels`. */
-export function alertingMatchingSilence<
-  S extends { matchers: AlertingMatcher[]; starts_at: string; ends_at: string },
->(labels: Record<string, string>, silences: S[], now: number): S | null {
+/** Missing labels match as empty strings. Matching is exact only: a value
+ *  that reads as a pattern is compared literally. */
+function matcherSelects(
+  matcher: AlertingMatcher,
+  subject: SilenceSubject,
+): boolean {
+  const value = subject[matcher.label] ?? "";
+  switch (matcher.op) {
+    case "eq":
+      return value === matcher.value;
+    case "ne":
+      return value !== matcher.value;
+  }
+}
+
+/** Every matcher has to select the subject. A silence with none selects
+ *  everything, which is what an org-wide mute is. */
+export function silenceSelects(
+  matchers: AlertingMatcher[],
+  subject: SilenceSubject,
+): boolean {
+  return matchers.every((m) => matcherSelects(m, subject));
+}
+
+/** Whether the silence's window covers `now`. Distinct from the screens'
+ *  `isOpen`, which counts a window that has not started yet: this one is
+ *  about muting, and a silence that has not started mutes nothing. */
+export function silenceIsInForce(window: SilenceWindow, now: Date): boolean {
+  return window.startsAt <= now && now < window.endsAt;
+}
+
+/** The first silence in force whose matchers all select the subject. */
+export function matchingSilence<S extends SilenceCandidate>(
+  subject: SilenceSubject,
+  silences: S[],
+  now: Date,
+): S | null {
   return (
     silences.find(
-      (s) =>
-        alertingSilenceIsActive(s, now) &&
-        alertingMatchersMatch(s.matchers, labels),
+      (s) => silenceIsInForce(s, now) && silenceSelects(s.matchers, subject),
     ) ?? null
   );
 }

--- a/packages/app/src/data/alerting/triage/assemble.test.ts
+++ b/packages/app/src/data/alerting/triage/assemble.test.ts
@@ -103,17 +103,18 @@ function instance(
   };
 }
 
-/** A silence on `path`, whole-rule unless given more matchers. */
+/** A silence on the rule with this row id, whole-rule unless given more
+ *  matchers. Definitions here are built with `id-${slug}`. */
 function silence(
-  path: string,
+  ruleId: string,
   overrides: Partial<SilenceRow> = {},
 ): SilenceRow {
   return {
-    id: `silence-${path}`,
+    id: `silence-${ruleId}`,
     organizationId: "org",
     startsAt: minutesAgo(5),
     endsAt: minutesAgo(-55),
-    matchers: [{ label: "rule", op: "eq", value: path }],
+    matchers: [{ label: "rule", op: "eq", value: ruleId }],
     comment: "",
     author: "",
     authorPrincipal: "",
@@ -191,7 +192,7 @@ describe("assembleTriage", () => {
     ];
     const { alerts, rules } = triage({
       definitions,
-      silences: [silence("demo/d")],
+      silences: [silence("id-d")],
     });
 
     expect(alerts.map((a) => a.path)).toEqual([
@@ -285,19 +286,19 @@ describe("assembleTriage", () => {
 
   it("attributes a rule to the whole-rule silence over an instance-scoped one", () => {
     const rule = definition({ slug: "latency", currentState: "firing" });
-    const partial = silence("demo/latency", {
+    const partial = silence("id-latency", {
       id: "partial",
       startsAt: minutesAgo(10),
       matchers: [
-        { label: "rule", op: "eq", value: "demo/latency" },
+        { label: "rule", op: "eq", value: "id-latency" },
         { label: "host", op: "eq", value: "a" },
       ],
     });
-    const whole = silence("demo/latency", { id: "whole" });
+    const whole = silence("id-latency", { id: "whole" });
     const paused = definition({ slug: "paused", active: false });
     const { alerts, rules } = triage({
       definitions: [rule, paused],
-      silences: [partial, whole, silence("demo/paused")],
+      silences: [partial, whole, silence("id-paused")],
       held: new Map([[rule.id, 2]]),
     });
 
@@ -400,7 +401,7 @@ describe("assembleRuleStateHistory", () => {
     const b = definition({ slug: "b", currentState: "firing" });
     const out = history({
       definitions: [a, b],
-      silences: [silence("demo/a", { startsAt: minutesAgo(20) })],
+      silences: [silence("id-a", { startsAt: minutesAgo(20) })],
       events: [
         {
           slug: "demo/a",
@@ -475,15 +476,15 @@ describe("assembleAlertDetail", () => {
 
   it("counts a silenced rule's clock from the silence and says evaluation goes on", () => {
     const rule = definition({ slug: "latency", currentState: "firing" });
-    const partial = silence("demo/latency", {
+    const partial = silence("id-latency", {
       id: "partial",
       startsAt: minutesAgo(30),
       matchers: [
-        { label: "rule", op: "eq", value: "demo/latency" },
+        { label: "rule", op: "eq", value: "id-latency" },
         { label: "host", op: "eq", value: "a" },
       ],
     });
-    const whole = silence("demo/latency", { id: "whole" });
+    const whole = silence("id-latency", { id: "whole" });
     const out = detail({
       definition: rule,
       instances: [instance(rule.id, { activeSince: minutesAgo(40) })],
@@ -552,23 +553,23 @@ describe("assembleAlertDetail", () => {
 
   it("lists every silence that overlapped the window with its state and what it withheld", () => {
     const scoped = [
-      { label: "rule", op: "eq", value: "demo/latency" },
+      { label: "rule", op: "eq", value: "id-latency" },
       { label: "host", op: "ne", value: "a" },
     ] as const;
     const out = detail({
       windowSilences: [
-        silence("demo/latency", { id: "active", matchers: [...scoped] }),
-        silence("demo/latency", {
+        silence("id-latency", { id: "active", matchers: [...scoped] }),
+        silence("id-latency", {
           id: "scheduled",
           startsAt: minutesAgo(-10),
           endsAt: minutesAgo(-70),
         }),
-        silence("demo/latency", {
+        silence("id-latency", {
           id: "expired",
           startsAt: minutesAgo(120),
           endsAt: minutesAgo(60),
         }),
-        silence("demo/latency", {
+        silence("id-latency", {
           id: "cancelled",
           startsAt: minutesAgo(50),
           endsAt: minutesAgo(45),

--- a/packages/app/src/data/alerting/triage/assemble.ts
+++ b/packages/app/src/data/alerting/triage/assemble.ts
@@ -100,12 +100,11 @@ export type DeliverySource = {
 
 function deliveryFor(
   row: DefinitionRow,
-  path: string,
   source: DeliverySource,
 ): DeliveryFacts {
   return {
     latest: source.notifications.get(row.id),
-    silence: silenceFor(path, row.spec.severity, source.silences, source.now),
+    silence: silenceFor(row.id, row.spec.severity, source.silences, source.now),
     held: source.held.get(row.id) ?? 0,
     hasTarget: hasDeliveryTarget(row, source.defaultTiers),
   };
@@ -197,7 +196,7 @@ export function assembleTriage(input: TriageInput): AlertTriageData {
   for (const row of input.definitions) {
     const path = rulePath(row);
     const own = byDefinition.get(row.id) ?? [];
-    const delivery = deliveryFor(row, path, input);
+    const delivery = deliveryFor(row, input);
     const { silence } = delivery;
 
     rules.push({
@@ -310,7 +309,7 @@ export function assembleRuleStateHistory(
   for (const definition of input.definitions) {
     const path = rulePath(definition);
     const silence = silenceFor(
-      path,
+      definition.id,
       definition.spec.severity,
       input.silences,
       input.now,
@@ -376,7 +375,7 @@ export function assembleAlertDetail(input: AlertDetailInput): AlertDetail {
   const { now, definition } = input;
   const spec = definition.spec;
   const path = rulePath(definition);
-  const delivery = deliveryFor(definition, path, input);
+  const delivery = deliveryFor(definition, input);
   const { silence } = delivery;
   const status = inventoryState(definition, silence !== null);
   const worst = worstInstance(input.instances);

--- a/packages/app/src/data/alerting/triage/mutations.integration.test.ts
+++ b/packages/app/src/data/alerting/triage/mutations.integration.test.ts
@@ -49,7 +49,7 @@ async function storedSilence(id: string) {
 
 describe("silencing an Alert rule from the Triage screen", () => {
   it("scopes the Silence to the rule, never to the label alone", async () => {
-    await insertRule(harness().db, {
+    const rule = await insertRule(harness().db, {
       organizationId: SESSION_ORG,
       slug: "checkout-latency",
     });
@@ -66,14 +66,17 @@ describe("silencing an Alert rule from the Triage screen", () => {
     // The rule Matcher comes first and is always present. Without it this
     // Silence would mute host=web-1 across every Alert rule the Organization
     // has, not one rule on one host.
+    // Its value is the rule's row id, not the path the caller sent: the
+    // mutation resolves the one into the other, and delivery matches on the
+    // id it stored.
     expect((await storedSilence(id)).matchers).toEqual([
-      { label: "rule", op: "eq", value: PATH },
+      { label: "rule", op: "eq", value: rule.id },
       { label: "host", op: "eq", value: "web-1" },
     ]);
   });
 
   it("writes a whole-rule Silence when no Matchers were typed", async () => {
-    await insertRule(harness().db, {
+    const rule = await insertRule(harness().db, {
       organizationId: SESSION_ORG,
       slug: "checkout-latency",
     });
@@ -83,7 +86,7 @@ describe("silencing an Alert rule from the Triage screen", () => {
     });
 
     expect((await storedSilence(id)).matchers).toEqual([
-      { label: "rule", op: "eq", value: PATH },
+      { label: "rule", op: "eq", value: rule.id },
     ]);
   });
 

--- a/packages/app/src/data/alerting/triage/mutations.ts
+++ b/packages/app/src/data/alerting/triage/mutations.ts
@@ -14,7 +14,6 @@ import {
 import type { AlertingMatcher } from "@/data/alerting/types";
 import { createAuthenticatedServerFn } from "@/lib/serverFn";
 import { loadRule } from "./rules";
-import { RULE_LABEL } from "./silences";
 
 /** Free-form `key=value` pairs, space or comma separated. Anything that is not
  *  a pair is rejected rather than silently widening the silence. */
@@ -51,13 +50,13 @@ export const silenceAlertRule = createAuthenticatedServerFn({ method: "POST" })
     // The rule has to exist in this org before anything is muted by its name,
     // and the path has to be one before it reaches the database. Same
     // resolution as pausing: the two must not disagree about what a path is.
-    await loadRule(scope.organizationId, data.path);
+    const rule = await loadRule(scope.organizationId, data.path);
     const now = new Date();
     const silence = await createSilence(scope, {
       // The rule matcher is always present: a silence with only instance
       // matchers would mute that label across every rule in the org.
       matchers: [
-        { label: RULE_LABEL, op: "eq", value: data.path },
+        { label: "rule", op: "eq", value: rule.id },
         ...parseMatchers(data.matchers),
       ],
       starts_at: now.toISOString(),

--- a/packages/app/src/data/alerting/triage/server.ts
+++ b/packages/app/src/data/alerting/triage/server.ts
@@ -36,7 +36,7 @@ import {
   rulePath,
   triageStatus,
 } from "./rules";
-import { loadActiveSilences, loadSilencesInWindow } from "./silences";
+import { loadOpenSilences, loadSilencesInWindow } from "./silences";
 import { loadInstanceValues, parseSamples, type ValueRule } from "./values";
 import type {
   AlertDetail,
@@ -70,7 +70,7 @@ export const getAlertTriage = createAuthenticatedServerFn({
     const [instances, silences, notifications, held, defaultTiers, values] =
       await Promise.all([
         loadInstances(organizationId, ids),
-        loadActiveSilences(organizationId),
+        loadOpenSilences(organizationId),
         loadLatestNotifications(organizationId, ids),
         loadHeldCounts(organizationId, ids),
         loadDefaultTiers(organizationId),
@@ -109,7 +109,7 @@ export const getRuleStateHistory = createAuthenticatedServerFn({
 
     const [definitions, silences, events, prior] = await Promise.all([
       loadRules(organizationId),
-      loadActiveSilences(organizationId),
+      loadOpenSilences(organizationId),
       loadLifecycleEvents(context.clickhouse.query, { fromISO, toISO }),
       loadPriorStates(context.clickhouse.query, { fromDate, fromISO }),
     ]);
@@ -159,7 +159,7 @@ export const getAlertDetail = createAuthenticatedServerFn({ method: "GET" })
       instanceLabels,
     ] = await Promise.all([
       loadRuleInstances(organizationId, definition.id),
-      loadActiveSilences(organizationId),
+      loadOpenSilences(organizationId),
       loadSilencesInWindow(
         organizationId,
         definition.id,

--- a/packages/app/src/data/alerting/triage/server.ts
+++ b/packages/app/src/data/alerting/triage/server.ts
@@ -162,7 +162,7 @@ export const getAlertDetail = createAuthenticatedServerFn({ method: "GET" })
       loadActiveSilences(organizationId),
       loadSilencesInWindow(
         organizationId,
-        path,
+        definition.id,
         spec.severity,
         fromDate,
         toDate,

--- a/packages/app/src/data/alerting/triage/silences.integration.test.ts
+++ b/packages/app/src/data/alerting/triage/silences.integration.test.ts
@@ -28,11 +28,7 @@ vi.mock(
   async () => import("@/server/alerting/testing/test-clickhouse"),
 );
 
-import {
-  loadActiveSilences,
-  loadSilencesInWindow,
-  silenceFor,
-} from "./silences";
+import { loadOpenSilences, loadSilencesInWindow, silenceFor } from "./silences";
 
 const harness = useAlertingHarness();
 
@@ -54,7 +50,7 @@ describe("the Silences the Triage screen reads", () => {
     });
     await insertSilence(harness().db, { startsAt: at(-4), endsAt: at(-1) });
 
-    const silences = await loadActiveSilences(TEST_ORG);
+    const silences = await loadOpenSilences(TEST_ORG);
 
     expect(silences.map((row) => row.id)).toEqual([open.id]);
   });
@@ -66,7 +62,7 @@ describe("the Silences the Triage screen reads", () => {
       matchers: ruleMatcher,
     });
 
-    const silences = await loadActiveSilences(TEST_ORG);
+    const silences = await loadOpenSilences(TEST_ORG);
 
     // Open by the window test, so a caller can list it as scheduled...
     expect(silences.map((row) => row.id)).toEqual([scheduled.id]);

--- a/packages/app/src/data/alerting/triage/silences.ts
+++ b/packages/app/src/data/alerting/triage/silences.ts
@@ -3,10 +3,7 @@
  * what it looks like on a row, and the record the detail lists.
  */
 import { and, desc, eq, gt, gte, lte, sql } from "drizzle-orm";
-import {
-  alertingMatchersMatch,
-  alertingSyntheticLabels,
-} from "@/data/alerting/silences/matching";
+import { ruleSubject, silenceSelects } from "@/data/alerting/silences/matching";
 import type { AlertingMatcher } from "@/data/alerting/types";
 import { db } from "@/db/client";
 import { alertSilences } from "@/db/schema";
@@ -14,11 +11,6 @@ import { formatElapsed, silenceImpact } from "./format";
 import type { AlertSilenceRecord, AlertSilenceView } from "./view";
 
 export type SilenceRow = typeof alertSilences.$inferSelect;
-
-/** The label a silence matches a whole rule on. Dispatch labels carry the
- *  rule's `project/slug` under this key, so a silence scoped to it and nothing
- *  else is a whole-rule silence. */
-export const RULE_LABEL = "rule";
 
 /** What a silence did to delivery: notifications it is still sitting on, and
  *  ones it dropped for good. */
@@ -48,7 +40,7 @@ export async function loadActiveSilences(
  */
 export async function loadSilencesInWindow(
   organizationId: string,
-  path: string,
+  ruleId: string,
   severity: string,
   from: Date,
   to: Date,
@@ -64,20 +56,12 @@ export async function loadSilencesInWindow(
       ),
     )
     .orderBy(desc(alertSilences.startsAt));
-  const labels = ruleLabels(path, severity);
-  return rows.filter((row) => alertingMatchersMatch(row.matchers, labels));
+  const subject = ruleSubject(ruleId, severity);
+  return rows.filter((row) => silenceSelects(row.matchers, subject));
 }
 
 function isWholeRuleSilence(matchers: AlertingMatcher[]): boolean {
-  return matchers.every((m) => m.label === RULE_LABEL);
-}
-
-/** What a rule's silence matchers are tested against. */
-function ruleLabels(path: string, severity: string): Record<string, string> {
-  return alertingSyntheticLabels(
-    {},
-    { rule: path, severity, status: "firing" },
-  );
+  return matchers.every((m) => m.label === "rule");
 }
 
 /**
@@ -86,14 +70,14 @@ function ruleLabels(path: string, severity: string): Record<string, string> {
  * being muted, and the row says so differently.
  */
 export function silenceFor(
-  path: string,
+  ruleId: string,
   severity: string,
   silences: SilenceRow[],
   now: Date,
 ): SilenceRow | null {
-  const labels = ruleLabels(path, severity);
+  const subject = ruleSubject(ruleId, severity);
   const matching = silences.filter(
-    (s) => s.startsAt <= now && alertingMatchersMatch(s.matchers, labels),
+    (s) => s.startsAt <= now && silenceSelects(s.matchers, subject),
   );
   return (
     matching.find((s) => isWholeRuleSilence(s.matchers)) ?? matching[0] ?? null
@@ -129,7 +113,7 @@ export function silenceRecord(
           : "active";
   // The rule matcher is on every silence this screen writes and is what
   // selected the row in the first place, so listing it back says nothing.
-  const scoped = row.matchers.filter((m) => m.label !== RULE_LABEL);
+  const scoped = row.matchers.filter((m) => m.label !== "rule");
   return {
     id: row.id,
     startsAt: row.startsAt.toISOString(),

--- a/packages/app/src/data/alerting/triage/silences.ts
+++ b/packages/app/src/data/alerting/triage/silences.ts
@@ -3,7 +3,11 @@
  * what it looks like on a row, and the record the detail lists.
  */
 import { and, desc, eq, gt, gte, lte, sql } from "drizzle-orm";
-import { ruleSubject, silenceSelects } from "@/data/alerting/silences/matching";
+import {
+  ruleSubject,
+  silenceIsInForce,
+  silenceSelects,
+} from "@/data/alerting/silences/matching";
 import type { AlertingMatcher } from "@/data/alerting/types";
 import { db } from "@/db/client";
 import { alertSilences } from "@/db/schema";
@@ -16,9 +20,16 @@ export type SilenceRow = typeof alertSilences.$inferSelect;
  *  ones it dropped for good. */
 export type SilenceImpactCounts = { held: number; dropped: number };
 
-/** Silences whose window covers now. A cancelled silence has its window
- *  collapsed by `expireSilence`, so `ends_at > now()` already excludes it. */
-export async function loadActiveSilences(
+/**
+ * Every silence that has not closed yet, the ones still to start included: the
+ * screens list a scheduled window as well as a muting one. A cancelled silence
+ * has its window collapsed by `expireSilence`, so `ends_at > now()` already
+ * excludes it.
+ *
+ * Not `loadActiveSilences`: delivery has a loader by that name and it means
+ * the narrower thing, the silences in force this instant.
+ */
+export async function loadOpenSilences(
   organizationId: string,
 ): Promise<SilenceRow[]> {
   return db
@@ -68,6 +79,12 @@ function isWholeRuleSilence(matchers: AlertingMatcher[]): boolean {
  * The silence in force for a rule right now, preferring one that covers the
  * whole rule: a rule muted outright is a different fact from one instance
  * being muted, and the row says so differently.
+ *
+ * The window is checked here rather than assumed of the caller's list. It used
+ * to test only that the silence had started, which was right for the rows
+ * `loadOpenSilences` returns and wrong for any other list: handed the window
+ * loader's rows, it called a silence that expired last Tuesday the one in
+ * force.
  */
 export function silenceFor(
   ruleId: string,
@@ -77,7 +94,7 @@ export function silenceFor(
 ): SilenceRow | null {
   const subject = ruleSubject(ruleId, severity);
   const matching = silences.filter(
-    (s) => s.startsAt <= now && silenceSelects(s.matchers, subject),
+    (s) => silenceIsInForce(s, now) && silenceSelects(s.matchers, subject),
   );
   return (
     matching.find((s) => isWholeRuleSilence(s.matchers)) ?? matching[0] ?? null

--- a/packages/app/src/server/alerting/delivery/process-event.ts
+++ b/packages/app/src/server/alerting/delivery/process-event.ts
@@ -16,7 +16,7 @@ import { claimDeliverableEvent } from "./journal-reader";
 import {
   deferSuppressedEvent,
   eventStillFiring,
-  matchingSilence,
+  silenceForEvent,
 } from "./suppression";
 import { dispatchTargetForEvent } from "./targeting";
 
@@ -58,7 +58,7 @@ export async function processAlertEvent(rawPayload: unknown): Promise<void> {
     await endChainWithTerminal(event, now, "no_longer_firing");
     return;
   }
-  const silence = await matchingSilence(event, now);
+  const silence = await silenceForEvent(event, now);
   if (silence) {
     await deferSuppressedEvent(event, silence, now);
     setAlertSpanAttributes({ outcome: "silenced" });

--- a/packages/app/src/server/alerting/delivery/suppression.test.ts
+++ b/packages/app/src/server/alerting/delivery/suppression.test.ts
@@ -84,7 +84,7 @@ describe("deferSuppressedEvent", () => {
   const now = new Date("2026-08-10T10:00:00Z");
   const silence = {
     id: "5cbb1c68-5cc9-4444-8000-000000000001",
-    ends_at: "2026-08-10T11:00:00Z",
+    endsAt: new Date("2026-08-10T11:00:00Z"),
   } as unknown as NonNullable<Parameters<typeof deferSuppressedEvent>[1]>;
   const event = {
     id: "019c3aba-29f8-7d6e-9e55-301cf47fa80d",
@@ -107,7 +107,7 @@ describe("deferSuppressedEvent", () => {
       {
         eventId: event.id,
         keySuffix: "2026-08-10T11:00:00.000Z",
-        runAt: new Date(silence.ends_at),
+        runAt: silence.endsAt,
       },
     ]);
     // The hold is recorded even though the notification is not decided: a

--- a/packages/app/src/server/alerting/delivery/suppression.ts
+++ b/packages/app/src/server/alerting/delivery/suppression.ts
@@ -1,6 +1,9 @@
 import { and, eq, gt, inArray, isNull, lte } from "drizzle-orm";
 import { enqueueProcessAlertEvent } from "@/data/alerting/delivery/tasks";
-import { alertingMatchingSilence } from "@/data/alerting/silences/matching";
+import {
+  eventSubject,
+  matchingSilence,
+} from "@/data/alerting/silences/matching";
 import { db } from "@/db/client";
 import { alertEvents, alertInstances, alertSilences } from "@/db/schema";
 import {
@@ -9,7 +12,6 @@ import {
   recordAlertHistory,
 } from "../history/clickhouse";
 import { instanceKey } from "./grouping";
-import { alertEventDispatchLabels } from "./targeting";
 
 type ActiveSilence = Awaited<ReturnType<typeof loadActiveSilences>>[number];
 
@@ -20,7 +22,7 @@ type ActiveSilence = Awaited<ReturnType<typeof loadActiveSilences>>[number];
  * issue hundreds of identical org-wide scans.
  */
 export async function loadActiveSilences(organizationId: string, now: Date) {
-  const silences = await db
+  return db
     .select()
     .from(alertSilences)
     .where(
@@ -30,11 +32,6 @@ export async function loadActiveSilences(organizationId: string, now: Date) {
         gt(alertSilences.endsAt, now),
       ),
     );
-  return silences.map((silence) => ({
-    ...silence,
-    starts_at: silence.startsAt.toISOString(),
-    ends_at: silence.endsAt.toISOString(),
-  }));
 }
 
 export function matchSilence(
@@ -42,14 +39,12 @@ export function matchSilence(
   silences: ActiveSilence[],
   now: Date,
 ) {
-  return alertingMatchingSilence(
-    alertEventDispatchLabels(event),
-    silences,
-    now.getTime(),
-  );
+  return matchingSilence(eventSubject(event), silences, now);
 }
 
-export async function matchingSilence(
+/** The silence covering this event right now, loading the org's own. Use
+ *  `matchSilence` where a batch is being weighed, so the scan happens once. */
+export async function silenceForEvent(
   event: typeof alertEvents.$inferSelect,
   now: Date,
 ) {
@@ -126,7 +121,7 @@ export async function loadFiringInstanceKeys(
 
 export async function deferSuppressedEvent(
   event: typeof alertEvents.$inferSelect,
-  silence: NonNullable<Awaited<ReturnType<typeof matchingSilence>>>,
+  silence: NonNullable<Awaited<ReturnType<typeof silenceForEvent>>>,
   now: Date,
 ) {
   const shouldRetry =
@@ -157,7 +152,7 @@ export async function deferSuppressedEvent(
       .returning({ id: alertEvents.id });
     if (stamped.length === 0) return false;
     if (shouldRetry) {
-      const runAt = new Date(silence.ends_at);
+      const runAt = silence.endsAt;
       await enqueueProcessAlertEvent(tx, event.id, {
         keySuffix: runAt.toISOString(),
         runAt,

--- a/packages/app/src/server/alerting/delivery/targeting.ts
+++ b/packages/app/src/server/alerting/delivery/targeting.ts
@@ -4,7 +4,6 @@ import {
   ALERTING_DEFAULT_GROUP_BY,
   type AlertingDefaultTier,
 } from "@/data/alerting/delivery/defaults";
-import { alertingSyntheticLabels } from "@/data/alerting/silences/matching";
 import { db } from "@/db/client";
 import {
   alertDefaultChannels,
@@ -24,24 +23,30 @@ export function alertDeliveryHash(...parts: string[]) {
   return createHash("sha256").update(parts.join("\0")).digest("hex");
 }
 
-export function alertEventDispatchLabels(
-  event: typeof alertEvents.$inferSelect,
-) {
-  return alertingSyntheticLabels(event.instanceLabels, {
-    severity: event.severity,
-    status: event.eventType === "instance_resolved" ? "resolved" : "firing",
-    rule: event.sourceDefinitionId,
-  });
-}
-
 type DispatchTarget = {
   defaultTier: AlertingDefaultTier | null;
   directAlertDefinitionId: string | null;
   groupKey: string;
 };
 
+/**
+ * The labels a notification batches by. `rule` is the definition's row id,
+ * because a group key has to be unique and a live rule and a preview of it
+ * legitimately share `project/slug`.
+ *
+ * `eventSubject` reaches the same value for its own reason, and the two stay
+ * separate anyway. They answer different questions, and only one of them picks
+ * a subset of the labels; a single function serving both is what let them
+ * drift apart before, and agreeing today is a decision each states for itself
+ * rather than a coupling.
+ */
 function groupLabelsFor(event: typeof alertEvents.$inferSelect) {
-  const labels = alertEventDispatchLabels(event);
+  const labels: Record<string, string> = {
+    ...event.instanceLabels,
+    rule: event.sourceDefinitionId,
+    severity: event.severity,
+    status: event.eventType === "instance_resolved" ? "resolved" : "firing",
+  };
   return Object.fromEntries(
     ALERTING_DEFAULT_GROUP_BY.map((key) => [key, labels[key] ?? ""]),
   );

--- a/packages/app/src/server/alerting/pipeline-suppression.integration.test.ts
+++ b/packages/app/src/server/alerting/pipeline-suppression.integration.test.ts
@@ -70,6 +70,35 @@ describe("the alerting pipeline's suppression", () => {
     expect(firedEvent.processedAt).toBeNull();
   });
 
+  // The case the whole Silence dialog exists to produce, and the one nothing
+  // covered: every other case here scopes by an instance label, which both
+  // sides always spelled the same way. The rule label is the one they did not:
+  // the screen wrote the rule's path while delivery matched on the row id, so
+  // a rule silenced from the board kept paging and the board said it was
+  // muted. Both name the row id now, and this is the test that says so.
+  it("a whole-rule silence, written as the Silences dialog writes it, holds the notification", async () => {
+    const rule = await insertDirectRule(harness().db, {
+      forSecs: 0,
+      channelType: "slack",
+    });
+    await insertSilence(harness().db, {
+      matchers: [{ label: "rule", op: "eq", value: rule.id }],
+    });
+    harness().clickhouse.setSignal([{ service: "checkout", value: 42 }]);
+
+    await harness().runDueJobs();
+
+    expect(harness().fetchCalls()).toHaveLength(0);
+    // Not just "nothing was sent yet": the event carries the silence that
+    // held it, which is the only proof the match actually happened rather
+    // than the group wait not having elapsed.
+    const [fired] = await harness()
+      .db.select()
+      .from(alertEvents)
+      .where(eq(alertEvents.eventType, "instance_fired"));
+    expect(fired.silenceId).not.toBeNull();
+  });
+
   it("records the hold when the silence arrives between dispatch and flush", async () => {
     await insertDirectRule(harness().db, { forSecs: 0, channelType: "slack" });
     harness().clickhouse.setSignal([{ service: "checkout", value: 42 }]);


### PR DESCRIPTION
In simple terms, before the silence was written using the slug as rule identifier, while the engine was using the rule id to look for silence matches.

With this PR the silences are created using the rule id.