### PR TITLE
refactor(alerting): reuse the shared components on the silences page

### DIFF
--- a/packages/app/src/components/alerts/alert-detail-shell.tsx
+++ b/packages/app/src/components/alerts/alert-detail-shell.tsx
@@ -47,13 +47,6 @@ export const ALERT_PANEL_ROUTE = {
 } as const;
 
 /**
- * Under `lg` there is no width to split: a detail column narrow enough to fit
- * would leave the list unreadable, so the same panel arrives as a sheet
- * instead. The Explore rails move into a sheet at the same width.
- */
-const useAlertPanelIsNarrow = useIsNarrow;
-
-/**
  * Pausing a rule, from wherever its detail is open.
  *
  * Beside the panel rather than on each route for the same reason the silence
@@ -98,9 +91,8 @@ function useEscapeClosesPanel(active: boolean, onClose: () => void) {
 /**
  * Everything a route hosting the panel does with it: which rule is open, how
  * to open and close one, the detail read, the writes the panel offers, and the
- * panel element itself. Triage and Silences had each written this out, forty
- * lines apiece, and the two copies had already begun to disagree on which
- * conditions Escape answers under.
+ * panel element itself. One hook, so both routes open, close and Escape the
+ * panel the same way.
  *
  * `shellProps` spreads onto `AlertDetailShell`; `silence` is the same controls
  * the lists on the route write through, so a silence from a row and one from
@@ -110,9 +102,12 @@ export function useAlertDetail() {
   const navigate = useNavigate();
   // Loose search read: the hook mounts under two routes, and a `from`-bound
   // read would tie it to one of them.
-  const { alert: openPath }: { alert?: string } = useSearch({ strict: false });
+  const { alert: openPath }: Partial<z.infer<typeof ALERT_PANEL_SEARCH>> =
+    useSearch({ strict: false });
   const { timeRange } = useTimeRange();
-  const isNarrow = useAlertPanelIsNarrow();
+  // Under `lg` there is no width to split: a detail column narrow enough to
+  // fit would leave the list unreadable, so the panel arrives as a sheet.
+  const isNarrow = useIsNarrow();
   const detail = useQuery(alertDetailOptions(openPath, timeRange));
   const silence = useSilenceControls();
   const setPaused = useAlertRulePause();
@@ -163,7 +158,6 @@ export function useAlertDetail() {
     openPath: openPath ?? null,
     openAlert,
     silence,
-    timeRange,
     shellProps: { panel, isNarrow, onClosePanel: closePanel },
   };
 }

--- a/packages/app/src/components/alerts/alert-detail-shell.tsx
+++ b/packages/app/src/components/alerts/alert-detail-shell.tsx
@@ -10,14 +10,21 @@
  * drift on which reason the breakpoint exists for.
  */
 import { Sheet, SheetContent, SheetTitle } from "@everr/ui/components/sheet";
-import { useMediaQuery } from "@everr/ui/hooks/use-media-query";
+import { useIsNarrow } from "@everr/ui/hooks/use-mobile";
 import { cn } from "@everr/ui/lib/utils";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useEffect } from "react";
 import { toast } from "sonner";
 import { z } from "zod";
 import { setAlertRulePaused } from "@/data/alerting/triage/mutations";
-import { invalidateAlertTriage } from "@/data/alerting/triage/options";
+import {
+  alertDetailOptions,
+  invalidateAlertTriage,
+} from "@/data/alerting/triage/options";
+import { useSilenceControls } from "@/hooks/use-silence-controls";
+import { useTimeRange } from "@/hooks/use-time-range";
+import { AlertDetailPanel } from "./alert-detail-panel";
 
 /** The open rule lives in the URL, so the detail survives a reload and can be
  *  pasted into an incident channel. The panel is a route, not local UI state,
@@ -40,13 +47,11 @@ export const ALERT_PANEL_ROUTE = {
 } as const;
 
 /**
- * Under this there is no width to split: a detail column narrow enough to fit
+ * Under `lg` there is no width to split: a detail column narrow enough to fit
  * would leave the list unreadable, so the same panel arrives as a sheet
- * instead. The Explore grids put their inspector column behind `lg` too.
+ * instead. The Explore rails move into a sheet at the same width.
  */
-const NARROW_QUERY = "(max-width: 1023px)";
-
-export const useAlertPanelIsNarrow = () => useMediaQuery(NARROW_QUERY);
+const useAlertPanelIsNarrow = useIsNarrow;
 
 /**
  * Pausing a rule, from wherever its detail is open.
@@ -55,7 +60,7 @@ export const useAlertPanelIsNarrow = () => useMediaQuery(NARROW_QUERY);
  * writes are: both screens can reach it, and a write from either has to say the
  * same thing and refresh the same reads.
  */
-export function useAlertRulePause() {
+function useAlertRulePause() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: setAlertRulePaused,
@@ -74,11 +79,11 @@ export function useAlertRulePause() {
  *
  * The column is not a modal, so nothing dismisses it for us, and Escape is what
  * a reader who just opened a rule reaches for. The sheet answers it on a narrow
- * window, so the column has to answer it on a wide one. Callers pass `active:
- * false` while a dialog is up: that dialog is the innermost thing on screen and
+ * window, so the column has to answer it on a wide one. `active` is false
+ * while a dialog is up: that dialog is the innermost thing on screen and
  * answers the key itself.
  */
-export function useEscapeClosesPanel(active: boolean, onClose: () => void) {
+function useEscapeClosesPanel(active: boolean, onClose: () => void) {
   useEffect(() => {
     if (!active) return;
     const onKeyDown = (event: KeyboardEvent) => {
@@ -88,6 +93,79 @@ export function useEscapeClosesPanel(active: boolean, onClose: () => void) {
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [active, onClose]);
+}
+
+/**
+ * Everything a route hosting the panel does with it: which rule is open, how
+ * to open and close one, the detail read, the writes the panel offers, and the
+ * panel element itself. Triage and Silences had each written this out, forty
+ * lines apiece, and the two copies had already begun to disagree on which
+ * conditions Escape answers under.
+ *
+ * `shellProps` spreads onto `AlertDetailShell`; `silence` is the same controls
+ * the lists on the route write through, so a silence from a row and one from
+ * the panel go through one dialog and one pending flag.
+ */
+export function useAlertDetail() {
+  const navigate = useNavigate();
+  // Loose search read: the hook mounts under two routes, and a `from`-bound
+  // read would tie it to one of them.
+  const { alert: openPath }: { alert?: string } = useSearch({ strict: false });
+  const { timeRange } = useTimeRange();
+  const isNarrow = useAlertPanelIsNarrow();
+  const detail = useQuery(alertDetailOptions(openPath, timeRange));
+  const silence = useSilenceControls();
+  const setPaused = useAlertRulePause();
+
+  const setOpen = (path: string | undefined) =>
+    navigate({
+      to: ".",
+      // Merge, never replace: `from`/`to` and the active preview live on the
+      // dashboard layout's search, and a bare object would drop them.
+      search: (prev) => ({ ...prev, alert: path }),
+      replace: true,
+    });
+
+  // A row is a selection, not a toggle. Clicking the row that is already open
+  // leaves it open: the click that lands on the row you are reading is nearly
+  // always aim, not a request to close, and losing the panel to it costs a
+  // reload of everything in it. Escape and the panel's own close button are
+  // the ways out, and both stay one gesture away.
+  const openAlert = (path: string) => {
+    if (path !== openPath) void setOpen(path);
+  };
+  const closePanel = () => void setOpen(undefined);
+
+  useEscapeClosesPanel(
+    Boolean(openPath) && !isNarrow && silence.seed === null,
+    closePanel,
+  );
+
+  // Built once, in one subtree, so the same panel moves between the column and
+  // the sheet rather than being mounted twice.
+  const panel = openPath ? (
+    <AlertDetailPanel
+      path={openPath}
+      detail={detail.data ?? null}
+      onClose={closePanel}
+      onCancelSilence={silence.cancel}
+      onSilence={silence.openSilence}
+      silencePending={silence.pending}
+      pausePending={setPaused.isPending}
+      onTogglePaused={(paused) =>
+        setPaused.mutate({ data: { path: openPath, paused } })
+      }
+    />
+  ) : null;
+
+  return {
+    /** The rule the panel is open on, for the lists to mark their row. */
+    openPath: openPath ?? null,
+    openAlert,
+    silence,
+    timeRange,
+    shellProps: { panel, isNarrow, onClosePanel: closePanel },
+  };
 }
 
 /**

--- a/packages/app/src/components/alerts/alert-status.tsx
+++ b/packages/app/src/components/alerts/alert-status.tsx
@@ -132,7 +132,7 @@ export function StatusChip({
   children: React.ReactNode;
 }) {
   return (
-    <Badge variant="outline" size="md" className="rounded-md bg-input/40">
+    <Badge variant="outline" size="md">
       <StatusIcon status={status} className="text-muted-foreground" />
       {children}
     </Badge>

--- a/packages/app/src/components/alerts/alert-status.tsx
+++ b/packages/app/src/components/alerts/alert-status.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Badge } from "@everr/ui/components/badge";
+import type { GroupBandTone } from "@everr/ui/components/group-band";
 import { cn } from "@everr/ui/lib/utils";
 import {
   BellOff,
@@ -26,8 +27,9 @@ type StatusMeta = {
   /** Foreground tone in the lists. Written out in full because Tailwind only
    *  keeps classes it can see as literals. */
   text: string;
-  /** Band-header wash behind the same tone. */
-  band: string;
+  /** The band that heads this status's group, in the ui library's tone
+   *  vocabulary: the wash and the icon take it, the words stay muted. */
+  tone: GroupBandTone;
   /** Fill for a stretch of this state on a state chart, and the matching
    *  foreground tone for the legend glyph that keys it.
    *
@@ -48,7 +50,7 @@ export const STATUS_META: Record<RuleInventoryState, StatusMeta> = {
     icon: TriangleAlert,
     label: "Not evaluating",
     text: "text-muted-foreground",
-    band: "bg-muted/30",
+    tone: "neutral",
     fill: "bg-[repeating-linear-gradient(135deg,var(--muted-foreground)_0_2px,transparent_2px_5px)] opacity-70",
     chartText: "text-muted-foreground",
     stroke: "var(--muted-foreground)",
@@ -57,7 +59,7 @@ export const STATUS_META: Record<RuleInventoryState, StatusMeta> = {
     icon: Flame,
     label: "Firing",
     text: "text-destructive",
-    band: "bg-destructive/8",
+    tone: "danger",
     fill: "bg-destructive",
     chartText: "text-destructive",
     stroke: "var(--destructive)",
@@ -66,7 +68,7 @@ export const STATUS_META: Record<RuleInventoryState, StatusMeta> = {
     icon: Clock,
     label: "Pending",
     text: "text-chart-2",
-    band: "bg-chart-2/8",
+    tone: "warning",
     fill: "bg-chart-2",
     chartText: "text-chart-2",
     stroke: "var(--chart-2)",
@@ -75,7 +77,7 @@ export const STATUS_META: Record<RuleInventoryState, StatusMeta> = {
     icon: BellOff,
     label: "Silenced",
     text: "text-muted-foreground",
-    band: "bg-muted/30",
+    tone: "neutral",
     fill: "bg-destructive/35",
     chartText: "text-destructive/50",
     stroke: "var(--destructive)",
@@ -84,7 +86,7 @@ export const STATUS_META: Record<RuleInventoryState, StatusMeta> = {
     icon: Circle,
     label: "Inactive",
     text: "text-muted-foreground",
-    band: "bg-muted/30",
+    tone: "neutral",
     fill: "",
     chartText: "text-muted-foreground/60",
     stroke: "var(--muted-foreground)",
@@ -95,7 +97,7 @@ export const STATUS_META: Record<RuleInventoryState, StatusMeta> = {
     icon: Pause,
     label: "Paused",
     text: "text-muted-foreground",
-    band: "bg-muted/30",
+    tone: "neutral",
     fill: "",
     chartText: "text-muted-foreground",
     stroke: "var(--muted-foreground)",

--- a/packages/app/src/components/alerts/alert-status.tsx
+++ b/packages/app/src/components/alerts/alert-status.tsx
@@ -5,6 +5,7 @@
  * list the reader is looking at.
  */
 
+import { Badge } from "@everr/ui/components/badge";
 import { cn } from "@everr/ui/lib/utils";
 import {
   BellOff,
@@ -131,10 +132,10 @@ export function StatusChip({
   children: React.ReactNode;
 }) {
   return (
-    <span className="inline-flex w-fit items-center gap-1.5 rounded-md border bg-input/40 px-2 py-0.5 text-xs font-medium whitespace-nowrap">
+    <Badge variant="outline" size="md" className="rounded-md bg-input/40">
       <StatusIcon status={status} className="text-muted-foreground" />
       {children}
-    </span>
+    </Badge>
   );
 }
 

--- a/packages/app/src/components/alerts/list-columns.ts
+++ b/packages/app/src/components/alerts/list-columns.ts
@@ -1,8 +1,0 @@
-/**
- * The column heading type for the alerting lists. Small, mono and spaced out,
- * so a strip of labels reads as the table's frame rather than as another row
- * of facts. Shared because the rule inventory and the Silences page print the
- * same strip and must not drift a size apart.
- */
-export const COLUMN_LABEL =
-  "font-mono text-[0.6875rem] tracking-wider text-muted-foreground uppercase";

--- a/packages/app/src/components/alerts/list-row.tsx
+++ b/packages/app/src/components/alerts/list-row.tsx
@@ -2,7 +2,9 @@
  * The row idiom the alerting lists share: the whole row is a pointer
  * convenience that opens the rule, and the rule's name inside it is the real
  * control, so keyboard and screen-reader users get one clear target rather
- * than a click handler they cannot reach.
+ * than a click handler they cannot reach. The target has no handler of its
+ * own: a click on it, from a pointer or from Enter on the focused button,
+ * bubbles to the row, so the row is the one place that opens.
  */
 import { cn } from "@everr/ui/lib/utils";
 
@@ -38,28 +40,18 @@ export function SelectableRow({
   );
 }
 
-/** The row's real control. Stops the click so the row does not open twice. */
+/** The row's real control. Must sit inside a `SelectableRow`. */
 export function RowTarget({
-  onOpen,
   title,
   className,
   children,
 }: {
-  onOpen: () => void;
   title?: string;
   className?: string;
   children: React.ReactNode;
 }) {
   return (
-    <button
-      type="button"
-      title={title}
-      onClick={(e) => {
-        e.stopPropagation();
-        onOpen();
-      }}
-      className={cn(ROW_TARGET, className)}
-    >
+    <button type="button" title={title} className={cn(ROW_TARGET, className)}>
       {children}
     </button>
   );

--- a/packages/app/src/components/alerts/list-row.tsx
+++ b/packages/app/src/components/alerts/list-row.tsx
@@ -1,0 +1,66 @@
+/**
+ * The row idiom the alerting lists share: the whole row is a pointer
+ * convenience that opens the rule, and the rule's name inside it is the real
+ * control, so keyboard and screen-reader users get one clear target rather
+ * than a click handler they cannot reach.
+ */
+import { cn } from "@everr/ui/lib/utils";
+
+/** The look of the one focusable target in a row: the rule's name. Also worn
+ *  by the Silences page's rule links, which open the same panel. */
+export const ROW_TARGET =
+  "truncate text-left outline-2 outline-dotted outline-transparent hover:underline focus-visible:outline-primary";
+
+export function SelectableRow({
+  selected,
+  onOpen,
+  className,
+  children,
+}: {
+  selected: boolean;
+  onOpen: () => void;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: pointer-only row convenience, the RowTarget inside is the real button
+    // biome-ignore lint/a11y/useKeyWithClickEvents: pointer-only row convenience, the RowTarget inside is the real button
+    <div
+      onClick={onOpen}
+      className={cn(
+        "cursor-pointer transition-colors hover:bg-muted/25",
+        selected && "bg-muted/40",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** The row's real control. Stops the click so the row does not open twice. */
+export function RowTarget({
+  onOpen,
+  title,
+  className,
+  children,
+}: {
+  onOpen: () => void;
+  title?: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      title={title}
+      onClick={(e) => {
+        e.stopPropagation();
+        onOpen();
+      }}
+      className={cn(ROW_TARGET, className)}
+    >
+      {children}
+    </button>
+  );
+}

--- a/packages/app/src/components/alerts/rule-inventory.tsx
+++ b/packages/app/src/components/alerts/rule-inventory.tsx
@@ -7,6 +7,7 @@ import type {
 } from "@/data/alerting/triage/view";
 import { SeverityLabel, StatusIcon } from "./alert-status";
 import { COLUMN_LABEL } from "./list-columns";
+import { RowTarget, SelectableRow } from "./list-row";
 import {
   RuleStateChart,
   StateChartAxis,
@@ -85,36 +86,19 @@ export function RuleInventory({
       </div>
 
       {rules.map((row) => (
-        // The row is a pointer convenience; the rule name below is the real
-        // control, so keyboard and screen-reader users get one clear target
-        // rather than a click handler they cannot reach. Same idiom as the
-        // triage rows.
-        // biome-ignore lint/a11y/noStaticElementInteractions: pointer-only row convenience, the rule name inside is the real button
-        // biome-ignore lint/a11y/useKeyWithClickEvents: pointer-only row convenience, the rule name inside is the real button
-        <div
+        <SelectableRow
           key={row.path}
-          onClick={() => onOpen(row.path)}
-          className={cn(
-            COLUMNS,
-            "cursor-pointer border-t px-3 py-2.5 text-sm transition-colors hover:bg-muted/25",
-            openPath === row.path && "bg-muted/40",
-          )}
+          selected={openPath === row.path}
+          onOpen={() => onOpen(row.path)}
+          className={cn(COLUMNS, "border-t px-3 py-2.5 text-sm")}
         >
           <div className="flex min-w-0 items-center gap-2">
             <StatusIcon status={row.state} className="size-3.5" />
             {/* The same panel the triage rows open, at the same URL. A rule
                 has one detail view, whichever list you reached it from. */}
-            <button
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation();
-                onOpen(row.path);
-              }}
-              title={row.path}
-              className="truncate text-left outline-2 outline-dotted outline-transparent hover:underline focus-visible:outline-primary"
-            >
+            <RowTarget onOpen={() => onOpen(row.path)} title={row.path}>
               {row.name}
-            </button>
+            </RowTarget>
           </div>
           <div className="hidden @[44rem]/list:block">
             {history ? (
@@ -138,7 +122,7 @@ export function RuleInventory({
           <span className="text-right font-mono text-xs text-muted-foreground tabular-nums">
             {row.silence}
           </span>
-        </div>
+        </SelectableRow>
       ))}
     </section>
   );

--- a/packages/app/src/components/alerts/rule-inventory.tsx
+++ b/packages/app/src/components/alerts/rule-inventory.tsx
@@ -96,9 +96,7 @@ export function RuleInventory({
             <StatusIcon status={row.state} className="size-3.5" />
             {/* The same panel the triage rows open, at the same URL. A rule
                 has one detail view, whichever list you reached it from. */}
-            <RowTarget onOpen={() => onOpen(row.path)} title={row.path}>
-              {row.name}
-            </RowTarget>
+            <RowTarget title={row.path}>{row.name}</RowTarget>
           </div>
           <div className="hidden @[44rem]/list:block">
             {history ? (

--- a/packages/app/src/components/alerts/rule-inventory.tsx
+++ b/packages/app/src/components/alerts/rule-inventory.tsx
@@ -1,3 +1,4 @@
+import { kickerClass } from "@everr/ui/components/group-band";
 import { Skeleton } from "@everr/ui/components/skeleton";
 import { cn } from "@everr/ui/lib/utils";
 import type {
@@ -6,7 +7,6 @@ import type {
   RuleStateHistoryData,
 } from "@/data/alerting/triage/view";
 import { SeverityLabel, StatusIcon } from "./alert-status";
-import { COLUMN_LABEL } from "./list-columns";
 import { RowTarget, SelectableRow } from "./list-row";
 import {
   RuleStateChart,
@@ -76,13 +76,13 @@ export function RuleInventory({
             <Skeleton className="h-3 w-full rounded-sm" />
           )}
         </div>
-        <span className={cn(COLUMN_LABEL, "hidden @[50rem]/list:block")}>
+        <span className={cn(kickerClass, "hidden @[50rem]/list:block")}>
           Severity
         </span>
-        <span className={cn(COLUMN_LABEL, "hidden @[50rem]/list:block")}>
+        <span className={cn(kickerClass, "hidden @[50rem]/list:block")}>
           Every
         </span>
-        <span className={cn(COLUMN_LABEL, "text-right")}>Silence</span>
+        <span className={cn(kickerClass, "text-right")}>Silence</span>
       </div>
 
       {rules.map((row) => (

--- a/packages/app/src/components/alerts/rule-inventory.tsx
+++ b/packages/app/src/components/alerts/rule-inventory.tsx
@@ -1,5 +1,5 @@
-import { kickerClass } from "@everr/ui/components/group-band";
 import { Skeleton } from "@everr/ui/components/skeleton";
+import { kickerClass } from "@everr/ui/lib/typography";
 import { cn } from "@everr/ui/lib/utils";
 import type {
   RuleInventoryRow,

--- a/packages/app/src/components/alerts/rule-state-chart.tsx
+++ b/packages/app/src/components/alerts/rule-state-chart.tsx
@@ -26,17 +26,12 @@ const SEGMENT_STATES: RuleStateSegment["state"][] = [
   "degraded",
 ];
 
-/** Minutes under 90, then hours, then days past two of them: "168h ago" is a
- *  number a reader has to divide before it means anything. */
-function formatAgo(minutes: number) {
-  if (minutes <= 0) return "now";
-  if (minutes < 90) return `${Math.round(minutes)}m`;
-  const hours = minutes / 60;
-  if (hours < 48) {
-    return `${hours < 10 ? hours.toFixed(hours % 1 ? 1 : 0) : Math.round(hours)}h`;
-  }
-  const days = hours / 24;
-  return `${days < 10 ? days.toFixed(days % 1 ? 1 : 0) : Math.round(days)}d`;
+/** "3d 4h ago", or the bare "just now", which takes no suffix. The same
+ *  elapsed formatter the rest of the feature prints with, so the description
+ *  and the tooltip cannot call one stretch two different lengths. */
+function startedAgo(minutes: number) {
+  const elapsed = formatElapsed(minutes * 60_000);
+  return elapsed === "just now" ? elapsed : `${elapsed} ago`;
 }
 
 /**
@@ -89,7 +84,7 @@ export const RuleStateChart = memo(function RuleStateChart({
         : `${name}: ${visible
             .map(
               (s) =>
-                `${STATUS_META[s.state].label.toLowerCase()} for ${formatElapsed(s.minutes * 60_000)} starting ${formatAgo(s.from)} ago`,
+                `${STATUS_META[s.state].label.toLowerCase()} for ${formatElapsed(s.minutes * 60_000)} starting ${startedAgo(s.from)}`,
             )
             .join(", ")}`,
     [visible, name],

--- a/packages/app/src/components/alerts/rule-state-chart.tsx
+++ b/packages/app/src/components/alerts/rule-state-chart.tsx
@@ -2,7 +2,7 @@ import { CursorTooltip } from "@everr/ui/components/cursor-tooltip";
 import { SeriesTooltipContent } from "@everr/ui/components/series-tooltip";
 import { cn } from "@everr/ui/lib/utils";
 import { memo, useMemo } from "react";
-import { formatElapsed } from "@/data/alerting/triage/format";
+import { formatAgoPhrase, formatElapsed } from "@/data/alerting/triage/format";
 import type {
   ChartWindow,
   InstanceValueSeries,
@@ -25,14 +25,6 @@ const SEGMENT_STATES: RuleStateSegment["state"][] = [
   "silenced",
   "degraded",
 ];
-
-/** "3d 4h ago", or the bare "just now", which takes no suffix. The same
- *  elapsed formatter the rest of the feature prints with, so the description
- *  and the tooltip cannot call one stretch two different lengths. */
-function startedAgo(minutes: number) {
-  const elapsed = formatElapsed(minutes * 60_000);
-  return elapsed === "just now" ? elapsed : `${elapsed} ago`;
-}
 
 /**
  * One rule's state over the selected window, as a chart rather than a
@@ -84,7 +76,7 @@ export const RuleStateChart = memo(function RuleStateChart({
         : `${name}: ${visible
             .map(
               (s) =>
-                `${STATUS_META[s.state].label.toLowerCase()} for ${formatElapsed(s.minutes * 60_000)} starting ${startedAgo(s.from)}`,
+                `${STATUS_META[s.state].label.toLowerCase()} for ${formatElapsed(s.minutes * 60_000)} starting ${formatAgoPhrase(s.from * 60_000)}`,
             )
             .join(", ")}`,
     [visible, name],

--- a/packages/app/src/components/alerts/silence-dialog.tsx
+++ b/packages/app/src/components/alerts/silence-dialog.tsx
@@ -1,13 +1,5 @@
 import { Button } from "@everr/ui/components/button";
 import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@everr/ui/components/command";
-import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -18,10 +10,9 @@ import {
 import { Input } from "@everr/ui/components/input";
 import { Label } from "@everr/ui/components/label";
 import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@everr/ui/components/popover";
+  OptionCombobox,
+  type OptionComboboxItem,
+} from "@everr/ui/components/option-combobox";
 import {
   Select,
   SelectContent,
@@ -30,7 +21,6 @@ import {
   SelectValue,
 } from "@everr/ui/components/select";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronDownIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 import { alertRuleOptionsOptions } from "@/data/alerting/triage/options";
 import {
@@ -63,115 +53,23 @@ type SilenceDuration = (typeof SILENCE_DURATIONS)[number];
 const DEFAULT_DURATION: SilenceDuration = SILENCE_DURATIONS[1];
 
 /**
- * The rule the silence is written against, by the name the rest of the product
- * calls it, grouped under its project and searchable.
- *
- * A plain select was fine for the handful of rules a demo org has and stops
- * being fine at the first customer: the list is every live rule, unbounded, and
- * it printed `project/slug` paths where triage prints display names. Search and
- * grouping come free from `Command`, and every path is already `project/slug`,
- * so the grouping needs no new data.
+ * The rules the silence can be written against, as the closed set the
+ * picker offers: by the name the rest of the product calls each rule, grouped
+ * under its project, and found by either that name or the `project/slug` path
+ * a reader pasted.
  *
  * Closed set, deliberately: `SuggestCombobox` would let a typed path through,
  * and a silence against a rule that does not exist mutes nothing while looking
  * like it mutes something.
  */
-function RulePicker({
-  id,
-  value,
-  rules,
-  loading,
-  onChange,
-}: {
-  id: string;
-  value: string | null;
-  rules: AlertRuleOption[];
-  loading: boolean;
-  onChange: (path: string) => void;
-}) {
-  const [open, setOpen] = useState(false);
-  const selected = rules.find((rule) => rule.path === value);
-  // Insertion order of a Map is the order the groups were met, and the read
-  // already sorted by project then slug, so the groups come out ordered
-  // without a second sort. Memoized because this sits under the dialog's text
-  // fields, and every character typed into them re-renders it.
-  const groups = useMemo(() => {
-    const byProject = new Map<string, AlertRuleOption[]>();
-    for (const rule of rules) {
-      const bucket = byProject.get(rule.project);
-      if (bucket) bucket.push(rule);
-      else byProject.set(rule.project, [rule]);
-    }
-    return [...byProject];
-  }, [rules]);
-  return (
-    // The wrapper keeps Base UI's focus-guard spans, which are siblings of the
-    // trigger while the popover is open, out of the field stack: in a `space-y`
-    // parent their presence changes which child is last and shifts what
-    // follows.
-    <div>
-      <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger
-          render={
-            <Button
-              id={id}
-              variant="outline"
-              role="combobox"
-              aria-expanded={open}
-              disabled={loading}
-              className="h-9 w-full justify-between font-normal"
-            />
-          }
-        >
-          {selected ? (
-            <span className="min-w-0 flex-1 truncate text-left text-sm">
-              {selected.name}
-            </span>
-          ) : (
-            <span className="min-w-0 flex-1 truncate text-left text-sm text-muted-foreground">
-              {loading ? "Loading rules…" : "Choose a rule"}
-            </span>
-          )}
-          <ChevronDownIcon
-            aria-hidden
-            className="size-3.5 shrink-0 text-muted-foreground"
-          />
-        </PopoverTrigger>
-        <PopoverContent align="start" className="w-(--anchor-width) p-0">
-          <Command className="p-0">
-            <CommandInput placeholder="Search rules…" />
-            <CommandList>
-              <CommandEmpty>No rule matches.</CommandEmpty>
-              {groups.map(([project, items]) => (
-                <CommandGroup key={project} heading={project}>
-                  {items.map((rule) => (
-                    <CommandItem
-                      // Searched against both, so typing either the name a
-                      // reader knows or the path they pasted finds the rule.
-                      key={rule.path}
-                      value={`${rule.name} ${rule.path}`}
-                      data-checked={rule.path === value || undefined}
-                      onSelect={() => {
-                        onChange(rule.path);
-                        setOpen(false);
-                      }}
-                    >
-                      <span className="min-w-0 flex-1">
-                        <span className="block truncate">{rule.name}</span>
-                        <span className="block truncate font-mono text-xs text-muted-foreground">
-                          {rule.path}
-                        </span>
-                      </span>
-                    </CommandItem>
-                  ))}
-                </CommandGroup>
-              ))}
-            </CommandList>
-          </Command>
-        </PopoverContent>
-      </Popover>
-    </div>
-  );
+function ruleOptions(rules: AlertRuleOption[]): OptionComboboxItem[] {
+  return rules.map((rule) => ({
+    value: rule.path,
+    label: rule.name,
+    description: <span className="font-mono">{rule.path}</span>,
+    group: rule.project,
+    keywords: [rule.name],
+  }));
 }
 
 /**
@@ -244,6 +142,12 @@ function SilenceForm({
   // Only fetched when there is a choice to offer: with a rule in hand the
   // list is never read.
   const choices = useQuery({ ...alertRuleOptionsOptions(), enabled: choosing });
+  // Memoized because this sits under the dialog's text fields, and every
+  // character typed into them re-renders the form.
+  const options = useMemo(
+    () => ruleOptions(choices.data ?? []),
+    [choices.data],
+  );
   // The whole entry, not its label: the confirm hands on `minutes`, and
   // nothing has to turn a label back into a number on the way out.
   const [duration, setDuration] = useState<SilenceDuration>(DEFAULT_DURATION);
@@ -277,11 +181,16 @@ function SilenceForm({
         <div className="space-y-1.5">
           <Label htmlFor={choosing ? "silence-rule" : undefined}>Rule</Label>
           {choosing ? (
-            <RulePicker
+            <OptionCombobox
               id="silence-rule"
               value={rulePath}
-              rules={choices.data ?? []}
-              loading={choices.isPending}
+              options={options}
+              disabled={choices.isPending}
+              placeholder={
+                choices.isPending ? "Loading rules…" : "Choose a rule"
+              }
+              searchPlaceholder="Search rules…"
+              emptyMessage="No rule matches."
               onChange={setRulePath}
             />
           ) : (

--- a/packages/app/src/components/alerts/silence-dialog.tsx
+++ b/packages/app/src/components/alerts/silence-dialog.tsx
@@ -68,7 +68,6 @@ function ruleOptions(rules: AlertRuleOption[]): OptionComboboxItem[] {
     label: rule.name,
     description: <span className="font-mono">{rule.path}</span>,
     group: rule.project,
-    keywords: [rule.name],
   }));
 }
 
@@ -189,6 +188,7 @@ function SilenceForm({
               placeholder={
                 choices.isPending ? "Loading rules…" : "Choose a rule"
               }
+              searchable
               searchPlaceholder="Search rules…"
               emptyMessage="No rule matches."
               onChange={setRulePath}

--- a/packages/app/src/components/alerts/silence-history.tsx
+++ b/packages/app/src/components/alerts/silence-history.tsx
@@ -8,7 +8,7 @@ import type { SilenceCancelTarget } from "@/hooks/use-silence-controls";
 import { Section } from "./detail-section";
 import type { SilenceSeed } from "./silence-dialog";
 import { SilenceRowAction, SilenceWindow } from "./silence-row";
-import { isOpen, STATE_META, windowBounds } from "./silence-state";
+import { isOpen, STATE_META, windowBounds, windowText } from "./silence-state";
 
 /** Active first, then what is coming, then history. Within each group the
  *  server's newest-first order stands, except for scheduled silences, which
@@ -74,7 +74,7 @@ function SilenceRow({
   // Named by its window: every row here belongs to the one rule the panel is
   // open on, so the window is what tells them apart out loud.
   const bounds = windowBounds(record);
-  const spoken = `${bounds.start.text} to ${bounds.end.text}`;
+  const spoken = windowText(bounds);
   // Only the facts this silence actually carries, so the row never prints a
   // placeholder for one it does not. A silence with no matchers is an
   // unnarrowed one, which the row already says by not narrowing it, and "no
@@ -101,7 +101,7 @@ function SilenceRow({
           <span className={cn("shrink-0 text-xs font-medium", meta.text)}>
             {meta.label}
           </span>
-          <SilenceWindow record={record} />
+          <SilenceWindow bounds={bounds} />
           {inForce && (
             <Badge variant="secondary" className="rounded-sm">
               in force

--- a/packages/app/src/components/alerts/silence-history.tsx
+++ b/packages/app/src/components/alerts/silence-history.tsx
@@ -1,3 +1,4 @@
+import { Badge } from "@everr/ui/components/badge";
 import { Button } from "@everr/ui/components/button";
 import { cn } from "@everr/ui/lib/utils";
 import { BellOff } from "lucide-react";
@@ -6,14 +7,8 @@ import type { AlertSilenceRecord } from "@/data/alerting/triage/view";
 import type { SilenceCancelTarget } from "@/hooks/use-silence-controls";
 import { Section } from "./detail-section";
 import type { SilenceSeed } from "./silence-dialog";
-import {
-  cancelLabel,
-  cancelTargetFor,
-  isOpen,
-  STATE_META,
-  silenceAgainLabel,
-  windowBounds,
-} from "./silence-state";
+import { SilenceRowAction, SilenceWindow } from "./silence-row";
+import { isOpen, STATE_META, windowBounds } from "./silence-state";
 
 /** Active first, then what is coming, then history. Within each group the
  *  server's newest-first order stands, except for scheduled silences, which
@@ -76,10 +71,8 @@ function SilenceRow({
   onSilence: (seed: SilenceSeed) => void;
 }) {
   const meta = STATE_META[record.state];
-  // A window that is still open can be closed early; one that has closed can
-  // only be written again. Both are one button, in the same place, so the row
-  // never has to explain which of the two it is offering.
-  const open = isOpen(record.state);
+  // Named by its window: every row here belongs to the one rule the panel is
+  // open on, so the window is what tells them apart out loud.
   const bounds = windowBounds(record);
   const spoken = `${bounds.start.text} to ${bounds.end.text}`;
   // Only the facts this silence actually carries, so the row never prints a
@@ -108,18 +101,11 @@ function SilenceRow({
           <span className={cn("shrink-0 text-xs font-medium", meta.text)}>
             {meta.label}
           </span>
-          {/* The bounds themselves, not a phrase about them. The row is read
-              against a timestamp from somewhere else, so it prints the two
-              numbers that comparison needs. */}
-          <span className="font-mono text-xs tabular-nums text-muted-foreground">
-            <time dateTime={bounds.start.iso}>{bounds.start.text}</time>
-            {" → "}
-            <time dateTime={bounds.end.iso}>{bounds.end.text}</time>
-          </span>
+          <SilenceWindow record={record} />
           {inForce && (
-            <span className="shrink-0 rounded-sm bg-muted px-1.5 py-0.5 text-[0.6875rem] leading-none text-muted-foreground">
+            <Badge variant="secondary" className="rounded-sm">
               in force
-            </span>
+            </Badge>
           )}
           {/* Everything else the row knows, as one more item in the same wrap
               group. Most silences carry one or two short facts, and a row that
@@ -146,35 +132,16 @@ function SilenceRow({
             </span>
           )}
         </div>
-        {/* Repeating a closed silence is offered on every past row, so it is
-            toned to match them. Ending a live one is the single consequential
-            action in the section and keeps full weight. */}
-        <Button
-          size="sm"
-          variant="ghost"
-          disabled={pending}
-          aria-label={open ? cancelLabel(spoken) : silenceAgainLabel(spoken)}
-          className={cn(
-            "-my-1 -mr-2 shrink-0",
-            !open && "font-normal text-muted-foreground hover:text-foreground",
-          )}
-          onClick={() =>
-            open
-              ? // Built in `silence-state`, so this row and the Silences page
-                // cancel the same silence the same way. It used to substitute
-                // the rule the panel happens to be open on when the silence
-                // named none, which made Undo write a silence scoped to a rule
-                // the reader had never muted.
-                onCancel(cancelTargetFor(record, () => ruleLabel))
-              : onSilence({
-                  rule: record.rule ?? rulePath,
-                  matchers: record.scope,
-                  comment: record.comment,
-                })
-          }
-        >
-          {open ? "Cancel" : "Silence again"}
-        </Button>
+        <SilenceRowAction
+          record={record}
+          spoken={spoken}
+          ruleName={() => ruleLabel}
+          seedRule={rulePath}
+          pending={pending}
+          className="-my-1 -mr-2 shrink-0"
+          onCancel={onCancel}
+          onSilence={onSilence}
+        />
       </div>
     </li>
   );

--- a/packages/app/src/components/alerts/silence-row.tsx
+++ b/packages/app/src/components/alerts/silence-row.tsx
@@ -13,7 +13,7 @@ import {
   cancelTargetFor,
   isOpen,
   silenceAgainLabel,
-  windowBounds,
+  type WindowBounds,
 } from "./silence-state";
 
 /**
@@ -22,13 +22,13 @@ import {
  * needs.
  */
 export function SilenceWindow({
-  record,
+  bounds,
   className,
 }: {
-  record: Pick<AlertSilenceRecord, "startsAt" | "endsAt" | "canceledAt">;
+  /** From `windowBounds`, which the row already computed for its label. */
+  bounds: WindowBounds;
   className?: string;
 }) {
-  const bounds = windowBounds(record);
   return (
     <span
       className={cn(
@@ -95,10 +95,8 @@ export function SilenceRowAction({
       onClick={() =>
         open
           ? // Built in `silence-state`, so every list cancels the same silence
-            // the same way. The detail's list used to substitute the rule the
-            // panel happens to be open on when the silence named none, which
-            // made Undo write a silence scoped to a rule the reader had never
-            // muted.
+            // the same way, and Undo restores only the scope the silence
+            // itself named.
             onCancel(cancelTargetFor(record, ruleName))
           : onSilence({
               rule: record.rule ?? seedRule,

--- a/packages/app/src/components/alerts/silence-row.tsx
+++ b/packages/app/src/components/alerts/silence-row.tsx
@@ -1,0 +1,113 @@
+/**
+ * The two cells every list of silences prints the same way: the window a
+ * silence covers, and the one button a row offers. Shared so the detail's
+ * list and the Silences page cannot drift apart on what a row lets you do.
+ */
+import { Button } from "@everr/ui/components/button";
+import { cn } from "@everr/ui/lib/utils";
+import type { AlertSilenceRecord } from "@/data/alerting/triage/view";
+import type { SilenceCancelTarget } from "@/hooks/use-silence-controls";
+import type { SilenceSeed } from "./silence-dialog";
+import {
+  cancelLabel,
+  cancelTargetFor,
+  isOpen,
+  silenceAgainLabel,
+  windowBounds,
+} from "./silence-state";
+
+/**
+ * Both bounds, not a phrase about them. A silence row is read against a
+ * timestamp from somewhere else, so it prints the two numbers that comparison
+ * needs.
+ */
+export function SilenceWindow({
+  record,
+  className,
+}: {
+  record: Pick<AlertSilenceRecord, "startsAt" | "endsAt" | "canceledAt">;
+  className?: string;
+}) {
+  const bounds = windowBounds(record);
+  return (
+    <span
+      className={cn(
+        "font-mono text-xs tabular-nums text-muted-foreground",
+        className,
+      )}
+    >
+      <time dateTime={bounds.start.iso}>{bounds.start.text}</time>
+      {" → "}
+      <time dateTime={bounds.end.iso}>{bounds.end.text}</time>
+    </span>
+  );
+}
+
+/**
+ * A window that is still open can be closed early; one that has closed can
+ * only be written again. Both are one button, in the same place, so the row
+ * never has to explain which of the two it is offering.
+ *
+ * Repeating a closed silence is offered on every past row, so it is toned to
+ * match them. Ending a live one is the single consequential action in the
+ * list and keeps full weight.
+ */
+export function SilenceRowAction({
+  record,
+  spoken,
+  ruleName,
+  seedRule,
+  pending,
+  className,
+  ref,
+  onCancel,
+  onSilence,
+}: {
+  record: AlertSilenceRecord;
+  /** What the button's label calls this silence out loud. Every row offers
+   *  the same two words, so the label has to carry the silence it belongs to. */
+  spoken: string;
+  /** The rule's display name, for what the cancel toast calls the silence. */
+  ruleName: (path: string) => string;
+  /** The rule a repeat is written against when the silence itself names none.
+   *  The detail panel is open on one, which is what "the same again" can mean
+   *  there; the Silences page has none to assume, and the dialog offers the
+   *  choice itself. */
+  seedRule: string | null;
+  pending: boolean;
+  className?: string;
+  ref?: React.Ref<HTMLButtonElement>;
+  onCancel: (target: SilenceCancelTarget) => void;
+  onSilence: (seed: SilenceSeed) => void;
+}) {
+  const open = isOpen(record.state);
+  return (
+    <Button
+      ref={ref}
+      size="sm"
+      variant="ghost"
+      disabled={pending}
+      aria-label={open ? cancelLabel(spoken) : silenceAgainLabel(spoken)}
+      className={cn(
+        className,
+        !open && "font-normal text-muted-foreground hover:text-foreground",
+      )}
+      onClick={() =>
+        open
+          ? // Built in `silence-state`, so every list cancels the same silence
+            // the same way. The detail's list used to substitute the rule the
+            // panel happens to be open on when the silence named none, which
+            // made Undo write a silence scoped to a rule the reader had never
+            // muted.
+            onCancel(cancelTargetFor(record, ruleName))
+          : onSilence({
+              rule: record.rule ?? seedRule,
+              matchers: record.scope,
+              comment: record.comment,
+            })
+      }
+    >
+      {open ? "Cancel" : "Silence again"}
+    </Button>
+  );
+}

--- a/packages/app/src/components/alerts/silence-state.ts
+++ b/packages/app/src/components/alerts/silence-state.ts
@@ -68,9 +68,14 @@ const CLOCK = new Intl.DateTimeFormat(undefined, {
  * and repeating it wraps the second bound onto its own line in a column this
  * narrow.
  */
+export type WindowBounds = ReturnType<typeof windowBounds>;
+
 export function windowBounds(
   record: Pick<AlertSilenceRecord, "startsAt" | "endsAt" | "canceledAt">,
-) {
+): {
+  start: { iso: string; text: string };
+  end: { iso: string; text: string };
+} {
   const start = new Date(record.startsAt);
   // Cancelling collapses `ends_at` to the cancel instant, give or take the
   // transaction that wrote it. That jitter is under a second and invisible
@@ -93,6 +98,10 @@ export function windowBounds(
   };
 }
 
+/** The window as one phrase, for a label or a toast. */
+export const windowText = (bounds: WindowBounds) =>
+  `${bounds.start.text} to ${bounds.end.text}`;
+
 /**
  * What names one silence out loud, on either screen.
  *
@@ -106,11 +115,8 @@ export function spokenSilence(
   record: AlertSilenceRecord,
   ruleName?: (path: string) => string,
 ): string {
-  const bounds = windowBounds(record);
   const named = record.rule ? (ruleName?.(record.rule) ?? record.rule) : "";
-  return (
-    named || record.matchers || `${bounds.start.text} to ${bounds.end.text}`
-  );
+  return named || record.matchers || windowText(windowBounds(record));
 }
 
 /**

--- a/packages/app/src/components/alerts/silences-page.tsx
+++ b/packages/app/src/components/alerts/silences-page.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@everr/ui/components/button";
+import { GroupBand } from "@everr/ui/components/group-band";
 import { Skeleton } from "@everr/ui/components/skeleton";
 import { cn } from "@everr/ui/lib/utils";
 import { Link } from "@tanstack/react-router";
@@ -10,7 +11,6 @@ import {
   SILENCE_PAGE_LIMIT,
 } from "@/data/alerting/triage/view";
 import type { SilenceCancelTarget } from "@/hooks/use-silence-controls";
-import { COLUMN_LABEL } from "./list-columns";
 import { ROW_TARGET } from "./list-row";
 import type { SilenceSeed } from "./silence-dialog";
 import { SilenceRowAction, SilenceWindow } from "./silence-row";
@@ -230,59 +230,6 @@ function Row({
   );
 }
 
-/**
- * The band that names a group and counts it.
- *
- * Both groups get one, and they are built the same, because the seam between
- * them is the page's one structural claim: these are muting, those are over.
- * A group marked only by a two-pixel rule on its rows was invisible at a
- * glance, which is the only distance this page is read from.
- *
- * Sticky at the top, and each inside its own wrapper, so a group's name stays
- * on screen for exactly as long as its rows do and the next one takes over
- * rather than piling on top.
- *
- * The band can carry a control at its right end. The page's one control, the
- * way to write a silence, sits on the Active band: over the buttons that end
- * silences, and at the head of the group a new silence would join.
- */
-function GroupHeading({
-  id,
-  label,
-  count,
-  hint,
-  action,
-}: {
-  id: string;
-  label: string;
-  count?: string;
-  /** Only for what the reader cannot see from the rows. */
-  hint: string;
-  action?: React.ReactNode;
-}) {
-  return (
-    // The opaque layer is the sticky one: the band's own tint is translucent,
-    // and translucent over scrolling rows smears them.
-    <div className="sticky top-0 z-10 bg-background">
-      {/* `px-3` on the same edge the rows use, so the headings and the rows
-          all start on one left edge. `h-9` on both bands, so the one without
-          a control stands as tall as the one with. */}
-      <div className="flex h-9 items-center justify-between gap-3 bg-muted/20 px-3">
-        <h2 id={id} className="flex items-baseline gap-2">
-          <span className={COLUMN_LABEL}>{label}</span>
-          {count && (
-            <span className="font-mono text-xs tabular-nums text-muted-foreground">
-              {count}
-            </span>
-          )}
-          <span className="text-xs text-muted-foreground">{hint}</span>
-        </h2>
-        {action}
-      </div>
-    </div>
-  );
-}
-
 /** Sized to a real two-line row, so the list does not resettle under the
  *  reader when the rows it was standing in for arrive. */
 function LoadingRows() {
@@ -427,7 +374,7 @@ export function SilencesPage({
           with it and double that one whenever the band is stuck. */}
       <div className="divide-y">
         <div>
-          <GroupHeading
+          <GroupBand
             id="silences-active"
             label="Active"
             count={activeCount}
@@ -474,7 +421,7 @@ export function SilencesPage({
         </div>
 
         <div>
-          <GroupHeading
+          <GroupBand
             id="silences-history"
             label="History"
             count={historyCount}

--- a/packages/app/src/components/alerts/silences-page.tsx
+++ b/packages/app/src/components/alerts/silences-page.tsx
@@ -11,16 +11,10 @@ import {
 } from "@/data/alerting/triage/view";
 import type { SilenceCancelTarget } from "@/hooks/use-silence-controls";
 import { COLUMN_LABEL } from "./list-columns";
+import { ROW_TARGET } from "./list-row";
 import type { SilenceSeed } from "./silence-dialog";
-import {
-  cancelLabel,
-  cancelTargetFor,
-  isOpen,
-  STATE_META,
-  silenceAgainLabel,
-  spokenSilence,
-  windowBounds,
-} from "./silence-state";
+import { SilenceRowAction, SilenceWindow } from "./silence-row";
+import { isOpen, STATE_META, spokenSilence } from "./silence-state";
 
 /**
  * Measured against the list column rather than the window, the same way the
@@ -97,7 +91,6 @@ function Row({
   onSilenceAgain: (seed: SilenceSeed) => void;
 }) {
   const open = isOpen(row.state);
-  const bounds = windowBounds(row);
   const meta = STATE_META[row.state];
   const action = useRef<HTMLButtonElement>(null);
   // The row the cancel moved is where the reader's attention already is, so
@@ -162,7 +155,7 @@ function Row({
             search={(prev) => ({ ...prev, alert: row.rule ?? undefined })}
             replace
             title={row.rule}
-            className="block truncate text-sm font-medium outline-2 outline-dotted outline-transparent hover:underline focus-visible:outline-primary"
+            className={cn(ROW_TARGET, "block text-sm font-medium")}
           >
             {ruleName(row.rule)}
           </Link>
@@ -187,47 +180,23 @@ function Row({
       {/* Second in the markup so it lands beside the rule on a narrow list,
           last in the table once there are columns to be last of. */}
       <div className="justify-self-end @[52rem]/list:order-last">
-        {open ? (
-          <Button
-            ref={action}
-            size="sm"
-            variant="ghost"
-            className="-my-1"
-            disabled={pending}
-            aria-label={cancelLabel(spoken)}
-            onClick={() => onCancel(cancelTargetFor(row, ruleName))}
-          >
-            Cancel
-          </Button>
-        ) : (
-          <Button
-            ref={action}
-            size="sm"
-            variant="ghost"
-            className="-my-1 font-normal text-muted-foreground"
-            disabled={pending}
-            aria-label={silenceAgainLabel(spoken)}
-            onClick={() =>
-              onSilenceAgain({
-                rule: row.rule,
-                matchers: row.scope,
-                comment: row.comment,
-              })
-            }
-          >
-            Silence again
-          </Button>
-        )}
+        <SilenceRowAction
+          ref={action}
+          record={row}
+          spoken={spoken}
+          ruleName={ruleName}
+          seedRule={null}
+          pending={pending}
+          className="-my-1"
+          onCancel={onCancel}
+          onSilence={onSilenceAgain}
+        />
       </div>
       {/* One wrapped line under the rule while the list is narrow; the table's
           own columns once it is not. `contents` is what lets the same elements
           be both without being written twice. */}
       <div className="col-span-2 flex min-w-0 flex-wrap items-baseline gap-x-3 @[52rem]/list:contents">
-        <span className="truncate font-mono text-xs tabular-nums text-muted-foreground">
-          <time dateTime={bounds.start.iso}>{bounds.start.text}</time>
-          {" → "}
-          <time dateTime={bounds.end.iso}>{bounds.end.text}</time>
-        </span>
+        <SilenceWindow record={row} className="truncate" />
         {/* A dot on the rows that are still open, where it separates active
             from scheduled: two states the accent alone cannot tell apart. */}
         <span className="flex items-baseline gap-1.5 font-mono text-xs tabular-nums">

--- a/packages/app/src/components/alerts/silences-page.tsx
+++ b/packages/app/src/components/alerts/silences-page.tsx
@@ -329,12 +329,12 @@ export function SilencesPage({
   // reaches it. Only then is the closed count a floor rather than the answer:
   // a page of 190 open and 12 closed knows both exactly.
   const truncated = rows.length >= SILENCE_PAGE_LIMIT;
-  const activeCount = open.length > 0 ? `${open.length}` : undefined;
+  const activeCount = open.length || undefined;
   const historyCount = !closed.length
     ? undefined
     : truncated
       ? `${closed.length}+`
-      : `${closed.length}`;
+      : closed.length;
 
   const row = (record: AlertSilenceRecord) => (
     <Row
@@ -367,29 +367,23 @@ export function SilencesPage({
           does not repeat a word the shell already said. */}
       <h1 className="sr-only">Silences</h1>
 
-      {/* Each group is its own sticky context, so its heading stays for
-          exactly as long as its rows and the next one replaces it. The rule
-          between them is the wrapper's, not a band's: the first band sits
-          under the shell's own rule, and a rule drawn on a band would ride
-          with it and double that one whenever the band is stuck. */}
       <div className="divide-y">
-        <div>
-          <GroupBand
-            id="silences-active"
-            label="Active"
-            count={activeCount}
-            // The range bounds history and not this: a silence muting right now
-            // is muting whatever window the reader happens to be looking at.
-            hint="now"
-            // Always drawn, whatever the list holds and whatever is loading: a
-            // page with nothing on it is exactly when this has to be reachable.
-            action={
-              <Button size="sm" disabled={pending} onClick={onNew}>
-                <Plus className="size-4" />
-                New silence
-              </Button>
-            }
-          />
+        <GroupBand
+          id="silences-active"
+          label="Active"
+          count={activeCount}
+          // The range bounds history and not this: a silence muting right now
+          // is muting whatever window the reader happens to be looking at.
+          hint="now"
+          // Always drawn, whatever the list holds and whatever is loading: a
+          // page with nothing on it is exactly when this has to be reachable.
+          action={
+            <Button size="sm" disabled={pending} onClick={onNew}>
+              <Plus className="size-4" />
+              New silence
+            </Button>
+          }
+        >
           {loading ? (
             <LoadingRows />
           ) : open.length === 0 ? (
@@ -418,15 +412,14 @@ export function SilencesPage({
           ) : (
             <ul aria-labelledby="silences-active">{open.map(row)}</ul>
           )}
-        </div>
+        </GroupBand>
 
-        <div>
-          <GroupBand
-            id="silences-history"
-            label="History"
-            count={historyCount}
-            hint="in range"
-          />
+        <GroupBand
+          id="silences-history"
+          label="History"
+          count={historyCount}
+          hint="in range"
+        >
           {loading ? (
             <LoadingRows />
           ) : closed.length === 0 ? (
@@ -436,7 +429,7 @@ export function SilencesPage({
           ) : (
             <ul aria-labelledby="silences-history">{closed.map(row)}</ul>
           )}
-        </div>
+        </GroupBand>
       </div>
     </div>
   );

--- a/packages/app/src/components/alerts/silences-page.tsx
+++ b/packages/app/src/components/alerts/silences-page.tsx
@@ -14,7 +14,12 @@ import { COLUMN_LABEL } from "./list-columns";
 import { ROW_TARGET } from "./list-row";
 import type { SilenceSeed } from "./silence-dialog";
 import { SilenceRowAction, SilenceWindow } from "./silence-row";
-import { isOpen, STATE_META, spokenSilence } from "./silence-state";
+import {
+  isOpen,
+  STATE_META,
+  spokenSilence,
+  windowBounds,
+} from "./silence-state";
 
 /**
  * Measured against the list column rather than the window, the same way the
@@ -91,6 +96,7 @@ function Row({
   onSilenceAgain: (seed: SilenceSeed) => void;
 }) {
   const open = isOpen(row.state);
+  const bounds = windowBounds(row);
   const meta = STATE_META[row.state];
   const action = useRef<HTMLButtonElement>(null);
   // The row the cancel moved is where the reader's attention already is, so
@@ -196,7 +202,7 @@ function Row({
           own columns once it is not. `contents` is what lets the same elements
           be both without being written twice. */}
       <div className="col-span-2 flex min-w-0 flex-wrap items-baseline gap-x-3 @[52rem]/list:contents">
-        <SilenceWindow record={row} className="truncate" />
+        <SilenceWindow bounds={bounds} className="truncate" />
         {/* A dot on the rows that are still open, where it separates active
             from scheduled: two states the accent alone cannot tell apart. */}
         <span className="flex items-baseline gap-1.5 font-mono text-xs tabular-nums">

--- a/packages/app/src/components/alerts/triage-list.tsx
+++ b/packages/app/src/components/alerts/triage-list.tsx
@@ -5,6 +5,7 @@ import { BellOff, Send } from "lucide-react";
 import type { TriageAlert, TriageStatus } from "@/data/alerting/triage/view";
 import { AlertSparkline } from "./alert-sparkline";
 import { STATUS_META, StatusChip } from "./alert-status";
+import { RowTarget, SelectableRow } from "./list-row";
 
 /** "firing for", not "since": the row already says how long, and the verb
  *  names which clock is running. */
@@ -59,35 +60,23 @@ function TriageRow({
   const partialSilence = alert.silence && !alert.silence.wholeRule;
 
   return (
-    // The row is a pointer convenience, not the control: the rule name below
-    // is the real button, so keyboard and screen-reader users get one clear
-    // target instead of a click handler they cannot reach.
-    // biome-ignore lint/a11y/noStaticElementInteractions: pointer-only row convenience, the rule name inside is the real button
-    // biome-ignore lint/a11y/useKeyWithClickEvents: pointer-only row convenience, the rule name inside is the real button
-    <div
-      onClick={onOpen}
+    <SelectableRow
+      selected={selected}
+      onOpen={onOpen}
       className={cn(
         // Two tiers, both measured against the list column rather than the
         // window: the first drops the sparkline and tightens the measured
         // column, the second is the full table. Without them, opening the
         // detail panel would keep five columns in half the width and crush
         // the rule name, the one thing the reader is scanning for.
-        "grid cursor-pointer grid-cols-1 items-center gap-x-6 gap-y-3 border-t px-3 py-3.5 transition-colors hover:bg-muted/25 @[44rem]/list:grid-cols-[minmax(0,1fr)_10rem_7rem_6.5rem] @[53rem]/list:grid-cols-[minmax(0,1fr)_12rem_7rem_5rem_6.5rem]",
-        selected && "bg-muted/40",
+        "grid grid-cols-1 items-center gap-x-6 gap-y-3 border-t px-3 py-3.5 @[44rem]/list:grid-cols-[minmax(0,1fr)_10rem_7rem_6.5rem] @[53rem]/list:grid-cols-[minmax(0,1fr)_12rem_7rem_5rem_6.5rem]",
         dimmed && "opacity-60",
       )}
     >
       <div className="flex min-w-0 flex-col gap-1">
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onOpen();
-          }}
-          className="truncate text-left text-sm font-medium outline-2 outline-dotted outline-transparent hover:underline focus-visible:outline-primary"
-        >
+        <RowTarget onOpen={onOpen} className="text-sm font-medium">
           {alert.name}
-        </button>
+        </RowTarget>
         {/* The failure code gets its own line rather than sitting beside the
             name: these identifiers are long, and squeezing them onto the name
             line truncates the one word the reader is scanning for. */}
@@ -183,7 +172,7 @@ function TriageRow({
           </Button>
         )}
       </div>
-    </div>
+    </SelectableRow>
   );
 }
 

--- a/packages/app/src/components/alerts/triage-list.tsx
+++ b/packages/app/src/components/alerts/triage-list.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@everr/ui/components/button";
+import { GroupBand } from "@everr/ui/components/group-band";
 import { Meter } from "@everr/ui/components/meter";
 import { cn } from "@everr/ui/lib/utils";
 import { BellOff, Send } from "lucide-react";
@@ -14,34 +15,6 @@ const SINCE_LABEL: Record<TriageStatus, string> = {
   firing: "firing for",
   pending: "pending for",
 };
-
-function BandHeader({
-  status,
-  count,
-  first,
-}: {
-  status: TriageStatus;
-  count: number;
-  /** The list already has a top border; the first band must not draw a second. */
-  first: boolean;
-}) {
-  const meta = STATUS_META[status];
-  const Icon = meta.icon;
-  return (
-    <div
-      className={cn(
-        "flex items-center gap-2 px-3 py-1.5",
-        !first && "border-t",
-        meta.band,
-      )}
-    >
-      <Icon aria-hidden className={cn("size-3", meta.text)} />
-      <h2 className={cn("text-xs font-semibold tracking-wide", meta.text)}>
-        {meta.label} · {count}
-      </h2>
-    </div>
-  );
-}
 
 function TriageRow({
   alert,
@@ -196,32 +169,38 @@ export function TriageList({
   onSilence: (path: string) => void;
   onExpireSilence: (path: string) => void;
 }) {
-  const counts = new Map<TriageStatus, number>();
-  for (const a of alerts) counts.set(a.status, (counts.get(a.status) ?? 0) + 1);
-
-  let band: TriageStatus | null = null;
+  // One group per run of a status, in the order the server returned them.
+  const groups: { status: TriageStatus; alerts: TriageAlert[] }[] = [];
+  for (const alert of alerts) {
+    const last = groups[groups.length - 1];
+    if (last?.status === alert.status) last.alerts.push(alert);
+    else groups.push({ status: alert.status, alerts: [alert] });
+  }
 
   return (
-    <div className="border-b">
-      {alerts.map((alert, index) => {
-        const startsBand = alert.status !== band;
-        band = alert.status;
+    // Each band is wrapped with its rows, so it sticks for exactly those rows
+    // and the wrapper's rule, not the band's, separates the groups.
+    <div className="divide-y border-b">
+      {groups.map(({ status, alerts: rows }, index) => {
+        const meta = STATUS_META[status];
         return (
-          <div key={alert.path}>
-            {startsBand && (
-              <BandHeader
-                status={band}
-                count={counts.get(band) ?? 0}
-                first={index === 0}
-              />
-            )}
-            <TriageRow
-              alert={alert}
-              selected={openPath === alert.path}
-              onOpen={() => onOpen(alert.path)}
-              onSilence={() => onSilence(alert.path)}
-              onExpireSilence={() => onExpireSilence(alert.path)}
+          <div key={`${status}-${index}`}>
+            <GroupBand
+              label={meta.label}
+              count={rows.length}
+              icon={meta.icon}
+              tone={meta.tone}
             />
+            {rows.map((alert) => (
+              <TriageRow
+                key={alert.path}
+                alert={alert}
+                selected={openPath === alert.path}
+                onOpen={() => onOpen(alert.path)}
+                onSilence={() => onSilence(alert.path)}
+                onExpireSilence={() => onExpireSilence(alert.path)}
+              />
+            ))}
           </div>
         );
       })}

--- a/packages/app/src/components/alerts/triage-list.tsx
+++ b/packages/app/src/components/alerts/triage-list.tsx
@@ -74,9 +74,7 @@ function TriageRow({
       )}
     >
       <div className="flex min-w-0 flex-col gap-1">
-        <RowTarget onOpen={onOpen} className="text-sm font-medium">
-          {alert.name}
-        </RowTarget>
+        <RowTarget className="text-sm font-medium">{alert.name}</RowTarget>
         {/* The failure code gets its own line rather than sitting beside the
             name: these identifiers are long, and squeezing them onto the name
             line truncates the one word the reader is scanning for. */}

--- a/packages/app/src/components/alerts/triage-list.tsx
+++ b/packages/app/src/components/alerts/triage-list.tsx
@@ -169,28 +169,27 @@ export function TriageList({
   onSilence: (path: string) => void;
   onExpireSilence: (path: string) => void;
 }) {
-  // One group per run of a status, in the order the server returned them.
-  const groups: { status: TriageStatus; alerts: TriageAlert[] }[] = [];
+  // One group per status, in the order the server returned them: triage
+  // order sorts by status first, so each status is one contiguous run.
+  const groups: { status: TriageStatus; rows: TriageAlert[] }[] = [];
   for (const alert of alerts) {
     const last = groups[groups.length - 1];
-    if (last?.status === alert.status) last.alerts.push(alert);
-    else groups.push({ status: alert.status, alerts: [alert] });
+    if (last?.status === alert.status) last.rows.push(alert);
+    else groups.push({ status: alert.status, rows: [alert] });
   }
 
   return (
-    // Each band is wrapped with its rows, so it sticks for exactly those rows
-    // and the wrapper's rule, not the band's, separates the groups.
     <div className="divide-y border-b">
-      {groups.map(({ status, alerts: rows }, index) => {
+      {groups.map(({ status, rows }) => {
         const meta = STATUS_META[status];
         return (
-          <div key={`${status}-${index}`}>
-            <GroupBand
-              label={meta.label}
-              count={rows.length}
-              icon={meta.icon}
-              tone={meta.tone}
-            />
+          <GroupBand
+            key={status}
+            label={meta.label}
+            count={rows.length}
+            icon={meta.icon}
+            tone={meta.tone}
+          >
             {rows.map((alert) => (
               <TriageRow
                 key={alert.path}
@@ -201,7 +200,7 @@ export function TriageList({
                 onExpireSilence={() => onExpireSilence(alert.path)}
               />
             ))}
-          </div>
+          </GroupBand>
         );
       })}
     </div>

--- a/packages/app/src/data/alerting/triage/format.ts
+++ b/packages/app/src/data/alerting/triage/format.ts
@@ -32,6 +32,12 @@ export function formatSincePhrase(from: Date | null, now: Date): string | null {
   return since === "just now" ? since : `since ${since}`;
 }
 
+/** "3d 4h ago", or the bare "just now", which takes no suffix either. */
+export function formatAgoPhrase(ms: number): string {
+  const elapsed = formatElapsed(ms);
+  return elapsed === "just now" ? elapsed : `${elapsed} ago`;
+}
+
 /**
  * Evaluated values keep the precision they were measured at, capped: a p99 of
  * 412.38176 is noise past the first decimal, and an integer count must not

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/index.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/index.tsx
@@ -1,27 +1,21 @@
 import { RetryError } from "@everr/ui/components/retry-error";
 import { Skeleton } from "@everr/ui/components/skeleton";
 import { useQuery } from "@tanstack/react-query";
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { AlertDetailPanel } from "@/components/alerts/alert-detail-panel";
+import { createFileRoute } from "@tanstack/react-router";
 import {
   ALERT_PANEL_ROUTE,
   ALERT_PANEL_SEARCH,
   AlertDetailShell,
-  useAlertPanelIsNarrow,
-  useAlertRulePause,
-  useEscapeClosesPanel,
+  useAlertDetail,
 } from "@/components/alerts/alert-detail-shell";
 import { RuleInventory } from "@/components/alerts/rule-inventory";
 import { SilenceDialog } from "@/components/alerts/silence-dialog";
 import { TriageList } from "@/components/alerts/triage-list";
 import { ResourceEmptyState } from "@/components/resource-empty-state";
 import {
-  alertDetailOptions,
   alertTriageOptions,
   ruleStateHistoryOptions,
 } from "@/data/alerting/triage/options";
-import { useSilenceControls } from "@/hooks/use-silence-controls";
-import { useTimeRange } from "@/hooks/use-time-range";
 
 export const Route = createFileRoute(
   "/_authenticated/_dashboard/_previewable/alerts/",
@@ -58,47 +52,10 @@ function TriageSkeleton() {
 }
 
 function AlertingTriagePage() {
-  const navigate = useNavigate({ from: Route.fullPath });
-  const { alert: openPath } = Route.useSearch();
-  const { timeRange } = useTimeRange();
-  const isNarrow = useAlertPanelIsNarrow();
-
+  const { openPath, openAlert, silence, timeRange, shellProps } =
+    useAlertDetail();
   const triage = useQuery(alertTriageOptions(timeRange));
   const history = useQuery(ruleStateHistoryOptions(timeRange));
-  const detail = useQuery(alertDetailOptions(openPath, timeRange));
-
-  const {
-    cancel,
-    pending: silencePending,
-    seed: silenceTarget,
-    openSilence,
-    dialogProps,
-  } = useSilenceControls();
-
-  const setPaused = useAlertRulePause();
-
-  const setOpen = (path: string | undefined) =>
-    navigate({
-      // Merge, never replace: `from`/`to` and the active preview live on the
-      // dashboard layout's search, and a bare object would drop them.
-      search: (prev) => ({ ...prev, alert: path }),
-      replace: true,
-    });
-
-  // A row is a selection, not a toggle. Clicking the row that is already open
-  // leaves it open: the click that lands on the row you are reading is nearly
-  // always aim, not a request to close, and losing the panel to it costs a
-  // reload of everything in it. Escape and the panel's own close button are
-  // the ways out, and both stay one gesture away.
-  const openAlert = (path: string) => {
-    if (path !== openPath) setOpen(path);
-  };
-
-  const closePanel = () => setOpen(undefined);
-  useEscapeClosesPanel(
-    Boolean(openPath) && !isNarrow && silenceTarget === null,
-    closePanel,
-  );
 
   if (triage.isError) {
     return (
@@ -114,8 +71,8 @@ function AlertingTriagePage() {
 
   const alerts = triage.data?.alerts ?? [];
   const rules = triage.data?.rules ?? [];
-  const silenceAlert = silenceTarget
-    ? alerts.find((a) => a.path === silenceTarget.rule)
+  const silenceAlert = silence.seed
+    ? alerts.find((a) => a.path === silence.seed?.rule)
     : undefined;
 
   if (!triage.isPending && rules.length === 0) {
@@ -131,30 +88,9 @@ function AlertingTriagePage() {
     );
   }
 
-  // Built once, in one subtree, so the same panel moves between the column and
-  // the sheet rather than being mounted twice.
-  const panel = openPath ? (
-    <AlertDetailPanel
-      path={openPath}
-      detail={detail.data ?? null}
-      onClose={() => setOpen(undefined)}
-      onCancelSilence={cancel}
-      onSilence={openSilence}
-      silencePending={silencePending}
-      pausePending={setPaused.isPending}
-      onTogglePaused={(paused) =>
-        setPaused.mutate({ data: { path: openPath, paused } })
-      }
-    />
-  ) : null;
-
   return (
     <>
-      <AlertDetailShell
-        panel={panel}
-        isNarrow={isNarrow}
-        onClosePanel={closePanel}
-      >
+      <AlertDetailShell {...shellProps}>
         {/* The lists inside measure themselves against this column rather than
           the window: opening the panel takes width away from them, and a
           viewport breakpoint cannot see that happen. */}
@@ -165,10 +101,10 @@ function AlertingTriagePage() {
             alerts.length > 0 && (
               <TriageList
                 alerts={alerts}
-                openPath={openPath ?? null}
+                openPath={openPath}
                 onOpen={openAlert}
                 onSilence={(path) =>
-                  openSilence({ rule: path, matchers: "", comment: "" })
+                  silence.openSilence({ rule: path, matchers: "", comment: "" })
                 }
                 onExpireSilence={(path) => {
                   const alert = alerts.find((a) => a.path === path);
@@ -176,7 +112,7 @@ function AlertingTriagePage() {
                   // not how it was written, and an Undo that guessed the scope
                   // would mute more than the reader muted.
                   if (alert?.silence)
-                    cancel({
+                    silence.cancel({
                       id: alert.silence.id,
                       label: alert.name,
                       restore: null,
@@ -193,14 +129,14 @@ function AlertingTriagePage() {
             <RuleInventory
               rules={rules}
               history={history.data}
-              openPath={openPath ?? null}
+              openPath={openPath}
               onOpen={openAlert}
             />
           )}
         </div>
       </AlertDetailShell>
       <SilenceDialog
-        {...dialogProps}
+        {...silence.dialogProps}
         instanceCount={silenceAlert?.instances ?? 0}
       />
     </>

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/index.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/index.tsx
@@ -16,6 +16,7 @@ import {
   alertTriageOptions,
   ruleStateHistoryOptions,
 } from "@/data/alerting/triage/options";
+import { useTimeRange } from "@/hooks/use-time-range";
 
 export const Route = createFileRoute(
   "/_authenticated/_dashboard/_previewable/alerts/",
@@ -52,8 +53,8 @@ function TriageSkeleton() {
 }
 
 function AlertingTriagePage() {
-  const { openPath, openAlert, silence, timeRange, shellProps } =
-    useAlertDetail();
+  const { openPath, openAlert, silence, shellProps } = useAlertDetail();
+  const { timeRange } = useTimeRange();
   const triage = useQuery(alertTriageOptions(timeRange));
   const history = useQuery(ruleStateHistoryOptions(timeRange));
 
@@ -71,9 +72,7 @@ function AlertingTriagePage() {
 
   const alerts = triage.data?.alerts ?? [];
   const rules = triage.data?.rules ?? [];
-  const silenceAlert = silence.seed
-    ? alerts.find((a) => a.path === silence.seed?.rule)
-    : undefined;
+  const silenceAlert = alerts.find((a) => a.path === silence.seed?.rule);
 
   if (!triage.isPending && rules.length === 0) {
     return (

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/silences.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/silences.tsx
@@ -1,24 +1,18 @@
 import { RetryError } from "@everr/ui/components/retry-error";
 import { useQuery } from "@tanstack/react-query";
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { AlertDetailPanel } from "@/components/alerts/alert-detail-panel";
+import { createFileRoute } from "@tanstack/react-router";
 import {
   ALERT_PANEL_ROUTE,
   ALERT_PANEL_SEARCH,
   AlertDetailShell,
-  useAlertPanelIsNarrow,
-  useAlertRulePause,
-  useEscapeClosesPanel,
+  useAlertDetail,
 } from "@/components/alerts/alert-detail-shell";
 import { SilenceDialog } from "@/components/alerts/silence-dialog";
 import { SilencesPage } from "@/components/alerts/silences-page";
 import {
-  alertDetailOptions,
   alertRuleNamesOptions,
   alertSilencesOptions,
 } from "@/data/alerting/triage/options";
-import { useSilenceControls } from "@/hooks/use-silence-controls";
-import { useTimeRange } from "@/hooks/use-time-range";
 
 export const Route = createFileRoute(
   "/_authenticated/_dashboard/_previewable/alerts/silences",
@@ -32,34 +26,12 @@ export const Route = createFileRoute(
 const EMPTY_RULE_NAMES = new Map<string, string>();
 
 function AlertingSilencesPage() {
-  const navigate = useNavigate({ from: Route.fullPath });
-  const { alert: openPath } = Route.useSearch();
-  const { timeRange } = useTimeRange();
-  const isNarrow = useAlertPanelIsNarrow();
-
+  const { silence, timeRange, shellProps } = useAlertDetail();
   const silences = useQuery(alertSilencesOptions(timeRange));
   // A silence stores its rule as a path; every other alerting surface calls
   // that rule by name. The map is built by the query rather than in render, so
   // it is rebuilt when the rules change and not on every poll of the list.
   const ruleNames = useQuery(alertRuleNamesOptions());
-  const detail = useQuery(alertDetailOptions(openPath, timeRange));
-
-  const { cancel, pending, seed, openSilence, dialogProps } =
-    useSilenceControls();
-  const setPaused = useAlertRulePause();
-
-  const closePanel = () =>
-    navigate({
-      // Merge, never replace: `from`/`to` and the active preview live on the
-      // dashboard layout's search, and a bare object would drop them.
-      search: (prev) => ({ ...prev, alert: undefined }),
-      replace: true,
-    });
-
-  useEscapeClosesPanel(
-    Boolean(openPath) && !isNarrow && seed === null,
-    closePanel,
-  );
 
   if (silences.isError) {
     return (
@@ -73,42 +45,23 @@ function AlertingSilencesPage() {
     );
   }
 
-  // Built once, in one subtree, so the same panel moves between the column and
-  // the sheet rather than being mounted twice.
-  const panel = openPath ? (
-    <AlertDetailPanel
-      path={openPath}
-      detail={detail.data ?? null}
-      onClose={closePanel}
-      onCancelSilence={cancel}
-      onSilence={openSilence}
-      silencePending={pending}
-      pausePending={setPaused.isPending}
-      onTogglePaused={(paused) =>
-        setPaused.mutate({ data: { path: openPath, paused } })
-      }
-    />
-  ) : null;
-
   return (
     <>
-      <AlertDetailShell
-        panel={panel}
-        isNarrow={isNarrow}
-        onClosePanel={closePanel}
-      >
+      <AlertDetailShell {...shellProps}>
         <div className="min-h-0 min-w-0 overflow-auto overscroll-y-contain pb-6">
           <SilencesPage
             silences={silences.data ?? null}
             ruleNames={ruleNames.data ?? EMPTY_RULE_NAMES}
-            pending={pending}
-            onNew={() => openSilence({ rule: null, matchers: "", comment: "" })}
-            onCancel={cancel}
-            onSilenceAgain={openSilence}
+            pending={silence.pending}
+            onNew={() =>
+              silence.openSilence({ rule: null, matchers: "", comment: "" })
+            }
+            onCancel={silence.cancel}
+            onSilenceAgain={silence.openSilence}
           />
         </div>
       </AlertDetailShell>
-      <SilenceDialog {...dialogProps} />
+      <SilenceDialog {...silence.dialogProps} />
     </>
   );
 }

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/silences.tsx
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/alerts/silences.tsx
@@ -13,6 +13,7 @@ import {
   alertRuleNamesOptions,
   alertSilencesOptions,
 } from "@/data/alerting/triage/options";
+import { useTimeRange } from "@/hooks/use-time-range";
 
 export const Route = createFileRoute(
   "/_authenticated/_dashboard/_previewable/alerts/silences",
@@ -26,7 +27,8 @@ export const Route = createFileRoute(
 const EMPTY_RULE_NAMES = new Map<string, string>();
 
 function AlertingSilencesPage() {
-  const { silence, timeRange, shellProps } = useAlertDetail();
+  const { silence, shellProps } = useAlertDetail();
+  const { timeRange } = useTimeRange();
   const silences = useQuery(alertSilencesOptions(timeRange));
   // A silence stores its rule as a path; every other alerting surface calls
   // that rule by name. The map is built by the query rather than in render, so

--- a/packages/storybook/src/stories/badge.stories.tsx
+++ b/packages/storybook/src/stories/badge.stories.tsx
@@ -82,3 +82,24 @@ export const AllVariants: Story = {
     </div>
   ),
 };
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3 text-xs">
+      <p className="flex items-center gap-2">
+        Default: a pill beside a heading or in a toolbar
+        <Badge variant="outline">
+          <CheckIcon data-icon="inline-start" />
+          checkout-api
+        </Badge>
+      </p>
+      <p className="flex items-center gap-2">
+        Medium: a chip set in a row at the row's own text size
+        <Badge variant="outline" size="md">
+          <AlertTriangleIcon data-icon="inline-start" />
+          silenced · 14m left
+        </Badge>
+      </p>
+    </div>
+  ),
+};

--- a/packages/storybook/src/stories/group-band.stories.tsx
+++ b/packages/storybook/src/stories/group-band.stories.tsx
@@ -2,6 +2,7 @@ import { Button } from "@everr/ui/components/button";
 import { GroupBand } from "@everr/ui/components/group-band";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { ClockIcon, FlameIcon, PlusIcon } from "lucide-react";
+import type { ReactNode } from "react";
 
 function Rows({ names }: { names: string[] }) {
   return (
@@ -15,15 +16,31 @@ function Rows({ names }: { names: string[] }) {
   );
 }
 
+/** The list around the groups: the rule between them is the frame's. */
+function Frame({
+  className,
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className={`w-[36rem] divide-y border-y ${className ?? ""}`}>
+      {children}
+    </div>
+  );
+}
+
 const meta = {
   title: "Data/GroupBand",
   component: GroupBand,
   args: { label: "Active", count: 1, hint: "now" },
   render: (args) => (
-    <div className="w-[36rem] border-y">
-      <GroupBand {...args} />
-      <Rows names={["Collector pod memory spike"]} />
-    </div>
+    <Frame>
+      <GroupBand {...args}>
+        <Rows names={["Collector pod memory spike"]} />
+      </GroupBand>
+    </Frame>
   ),
 } satisfies Meta<typeof GroupBand>;
 
@@ -47,33 +64,29 @@ export const WithAction: Story = {
 /** Toned bands carry an icon; the words stay muted in both. */
 export const Toned: Story = {
   render: () => (
-    <div className="w-[36rem] divide-y border-y">
-      <div>
-        <GroupBand label="Firing" count={2} icon={FlameIcon} tone="danger" />
+    <Frame>
+      <GroupBand label="Firing" count={2} icon={FlameIcon} tone="danger">
         <Rows names={["Always firing (demo)", "Flapping (demo)"]} />
-      </div>
-      <div>
-        <GroupBand label="Pending" count={1} icon={ClockIcon} tone="warning" />
+      </GroupBand>
+      <GroupBand label="Pending" count={1} icon={ClockIcon} tone="warning">
         <Rows names={["Always pending (demo)"]} />
-      </div>
-    </div>
+      </GroupBand>
+    </Frame>
   ),
 };
 
-/** Each band wrapped with its rows, so it sticks for exactly those rows. */
+/** Each band sticks for exactly its own rows. */
 export const Sticky: Story = {
   render: () => (
-    <div className="h-64 w-[36rem] divide-y overflow-auto border-y">
-      <div>
-        <GroupBand label="Active" count={2} hint="now" />
+    <Frame className="h-64 overflow-auto">
+      <GroupBand label="Active" count={2} hint="now">
         <Rows names={["Collector pod memory spike", "Checkout latency"]} />
-      </div>
-      <div>
-        <GroupBand label="History" count="200+" hint="in range" />
+      </GroupBand>
+      <GroupBand label="History" count="200+" hint="in range">
         <Rows
           names={Array.from({ length: 12 }, (_, i) => `Silence ${i + 1}`)}
         />
-      </div>
-    </div>
+      </GroupBand>
+    </Frame>
   ),
 };

--- a/packages/storybook/src/stories/group-band.stories.tsx
+++ b/packages/storybook/src/stories/group-band.stories.tsx
@@ -1,0 +1,79 @@
+import { Button } from "@everr/ui/components/button";
+import { GroupBand } from "@everr/ui/components/group-band";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ClockIcon, FlameIcon, PlusIcon } from "lucide-react";
+
+function Rows({ names }: { names: string[] }) {
+  return (
+    <ul>
+      {names.map((name) => (
+        <li key={name} className="border-t px-3 py-2.5 text-sm">
+          {name}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+const meta = {
+  title: "Data/GroupBand",
+  component: GroupBand,
+  args: { label: "Active", count: 1, hint: "now" },
+  render: (args) => (
+    <div className="w-[36rem] border-y">
+      <GroupBand {...args} />
+      <Rows names={["Collector pod memory spike"]} />
+    </div>
+  ),
+} satisfies Meta<typeof GroupBand>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+/** A neutral band with the page's one control on its right. */
+export const WithAction: Story = {
+  args: {
+    action: (
+      <Button size="sm">
+        <PlusIcon className="size-4" />
+        New silence
+      </Button>
+    ),
+  },
+};
+
+/** Toned bands carry an icon; the words stay muted in both. */
+export const Toned: Story = {
+  render: () => (
+    <div className="w-[36rem] divide-y border-y">
+      <div>
+        <GroupBand label="Firing" count={2} icon={FlameIcon} tone="danger" />
+        <Rows names={["Always firing (demo)", "Flapping (demo)"]} />
+      </div>
+      <div>
+        <GroupBand label="Pending" count={1} icon={ClockIcon} tone="warning" />
+        <Rows names={["Always pending (demo)"]} />
+      </div>
+    </div>
+  ),
+};
+
+/** Each band wrapped with its rows, so it sticks for exactly those rows. */
+export const Sticky: Story = {
+  render: () => (
+    <div className="h-64 w-[36rem] divide-y overflow-auto border-y">
+      <div>
+        <GroupBand label="Active" count={2} hint="now" />
+        <Rows names={["Collector pod memory spike", "Checkout latency"]} />
+      </div>
+      <div>
+        <GroupBand label="History" count="200+" hint="in range" />
+        <Rows
+          names={Array.from({ length: 12 }, (_, i) => `Silence ${i + 1}`)}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/storybook/src/stories/option-combobox.stories.tsx
+++ b/packages/storybook/src/stories/option-combobox.stories.tsx
@@ -1,0 +1,100 @@
+import {
+  OptionCombobox,
+  type OptionComboboxItem,
+} from "@everr/ui/components/option-combobox";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MailIcon, WebhookIcon } from "lucide-react";
+import { useState } from "react";
+
+const channelTypes: OptionComboboxItem[] = [
+  {
+    value: "webhook",
+    label: "Webhook",
+    description: "Send alerts to an HTTP endpoint.",
+    icon: WebhookIcon,
+  },
+  {
+    value: "email",
+    label: "Email",
+    description: "Send alerts to an email address.",
+    icon: MailIcon,
+  },
+];
+
+/** Grouped under their project, with the path as menu-only supporting copy. */
+const rules: OptionComboboxItem[] = [
+  ["default", "cloud-query-system-errors", "Cloud query system errors"],
+  ["default", "collector-oom", "Collector pod memory spike"],
+  ["default", "eventloop-delay", "Node.js event loop delay"],
+  ["demo", "demo-always-firing", "Always firing (demo)"],
+  ["demo", "demo-flapping", "Flapping (demo)"],
+].map(([project, slug, name]) => ({
+  value: `${project}/${slug}`,
+  label: name,
+  description: (
+    <span className="font-mono">
+      {project}/{slug}
+    </span>
+  ),
+  group: project,
+}));
+
+function StatefulCombobox({
+  initialValue = null,
+  ...props
+}: Omit<Parameters<typeof OptionCombobox>[0], "value" | "onChange"> & {
+  initialValue?: string | null;
+}) {
+  const [value, setValue] = useState<string | null>(initialValue);
+  return <OptionCombobox {...props} value={value} onChange={setValue} />;
+}
+
+const meta = {
+  title: "Data/OptionCombobox",
+  component: OptionCombobox,
+  args: {
+    label: "Channel type",
+    options: channelTypes,
+    value: "webhook",
+    onChange: () => {},
+  },
+  render: ({ value, onChange, ...args }) => (
+    <div className="h-72 w-72">
+      <StatefulCombobox {...args} initialValue={value} />
+    </div>
+  ),
+} satisfies Meta<typeof OptionCombobox>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Placeholder: Story = {
+  args: { value: null, placeholder: "Pick a channel type" },
+};
+
+export const Grouped: Story = {
+  args: {
+    label: "Rule",
+    options: rules,
+    value: null,
+    placeholder: "Choose a rule",
+  },
+};
+
+export const Searchable: Story = {
+  args: {
+    label: "Rule",
+    options: rules,
+    value: null,
+    placeholder: "Choose a rule",
+    searchable: true,
+    searchPlaceholder: "Search rules…",
+    emptyMessage: "No rule matches.",
+  },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true, placeholder: "Loading…", value: null },
+};

--- a/packages/telemetry-explorer/src/filters/ui/explore-filter-rail.tsx
+++ b/packages/telemetry-explorer/src/filters/ui/explore-filter-rail.tsx
@@ -36,9 +36,7 @@ export function ExploreFilterRail({
   onClear: () => void;
   children: ReactNode;
 }) {
-  // The same width as the `lg:` column rules on the three Explore grids. Below
-  // it there is no space for a 260px rail next to the results, and the rail
-  // moves into a sheet.
+  // Below `lg` there is no space for a 260px rail next to the results.
   const isNarrow = useIsNarrow();
   const [open, setOpen] = useState(false);
 

--- a/packages/telemetry-explorer/src/filters/ui/explore-filter-rail.tsx
+++ b/packages/telemetry-explorer/src/filters/ui/explore-filter-rail.tsx
@@ -1,15 +1,10 @@
 import { Badge } from "@everr/ui/components/badge";
 import { Button } from "@everr/ui/components/button";
 import { Sheet, SheetContent, SheetTitle } from "@everr/ui/components/sheet";
-import { useMediaQuery } from "@everr/ui/hooks/use-media-query";
+import { useIsNarrow } from "@everr/ui/hooks/use-mobile";
 import { ListFilter } from "lucide-react";
 import { type ReactNode, useState } from "react";
 import { FilterSidebar } from "./filter-sidebar";
-
-// The same width as the `lg:` column rules on the three Explore grids. Below
-// this width there is no space for a 260px rail next to the results. The rail
-// then moves into a sheet.
-const NARROW_QUERY = "(max-width: 1023px)";
 
 /**
  * Puts the Explore filter rail in position.
@@ -41,7 +36,10 @@ export function ExploreFilterRail({
   onClear: () => void;
   children: ReactNode;
 }) {
-  const isNarrow = useMediaQuery(NARROW_QUERY);
+  // The same width as the `lg:` column rules on the three Explore grids. Below
+  // it there is no space for a 260px rail next to the results, and the rail
+  // moves into a sheet.
+  const isNarrow = useIsNarrow();
   const [open, setOpen] = useState(false);
 
   const rail = (

--- a/packages/ui/src/components/badge.tsx
+++ b/packages/ui/src/components/badge.tsx
@@ -4,9 +4,15 @@ import { cn } from "@everr/ui/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";
 
 const badgeVariants = cva(
-  "h-5 gap-1 rounded-full border border-transparent px-2 py-0.5 text-[0.625rem] font-medium transition-all duration-200 ease-[cubic-bezier(0.19,1,0.22,1)] has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-2.5! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none outline-2 outline-dotted outline-transparent outline-offset-2 ring-offset-background focus-visible:border-ring focus-visible:ring-primary focus-visible:ring-2 focus-visible:ring-offset-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge",
+  "rounded-full border border-transparent px-2 py-0.5 font-medium transition-all duration-200 ease-[cubic-bezier(0.19,1,0.22,1)] has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none outline-2 outline-dotted outline-transparent outline-offset-2 ring-offset-background focus-visible:border-ring focus-visible:ring-primary focus-visible:ring-2 focus-visible:ring-offset-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge",
   {
     variants: {
+      size: {
+        default: "h-5 gap-1 text-[0.625rem] [&>svg]:size-2.5!",
+        // A chip that sits in running text or a table row, at that text's own
+        // size: the glyph and the word are read together with the line.
+        md: "gap-1.5 text-xs [&>svg]:size-3!",
+      },
       variant: {
         default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
         secondary:
@@ -26,6 +32,7 @@ const badgeVariants = cva(
       },
     },
     defaultVariants: {
+      size: "default",
       variant: "default",
     },
   },
@@ -34,6 +41,7 @@ const badgeVariants = cva(
 function Badge({
   className,
   variant = "default",
+  size = "default",
   render,
   ...props
 }: useRender.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
@@ -41,7 +49,7 @@ function Badge({
     defaultTagName: "span",
     props: mergeProps<"span">(
       {
-        className: cn(badgeVariants({ className, variant })),
+        className: cn(badgeVariants({ className, variant, size })),
       },
       props,
     ),
@@ -49,6 +57,7 @@ function Badge({
     state: {
       slot: "badge",
       variant,
+      size,
     },
   });
 }

--- a/packages/ui/src/components/badge.tsx
+++ b/packages/ui/src/components/badge.tsx
@@ -10,8 +10,9 @@ const badgeVariants = cva(
       size: {
         default: "h-5 gap-1 text-[0.625rem] [&>svg]:size-2.5!",
         // A chip that sits in running text or a table row, at that text's own
-        // size: the glyph and the word are read together with the line.
-        md: "gap-1.5 text-xs [&>svg]:size-3!",
+        // size and with the row's corner radius rather than a pill's: the
+        // glyph and the word are read together with the line.
+        md: "gap-1.5 rounded-md text-xs [&>svg]:size-3!",
       },
       variant: {
         default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",

--- a/packages/ui/src/components/group-band.tsx
+++ b/packages/ui/src/components/group-band.tsx
@@ -1,13 +1,7 @@
+import { kickerClass } from "@everr/ui/lib/typography";
 import { cn } from "@everr/ui/lib/utils";
-import type { ComponentType, ReactNode, SVGProps } from "react";
-
-/**
- * The small mono uppercase label that heads a group of rows or a column of
- * them. One token, so a list's bands and its column strip read as one frame
- * rather than two sizes of the same idea.
- */
-export const kickerClass =
-  "font-mono text-[0.6875rem] tracking-wider text-muted-foreground uppercase";
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
 
 const TONE = {
   neutral: { wash: "bg-muted/20", icon: "text-muted-foreground" },
@@ -18,18 +12,18 @@ const TONE = {
 export type GroupBandTone = keyof typeof TONE;
 
 /**
- * The band that names a group of rows and counts it.
+ * A group of rows under the band that names and counts it.
  *
- * Sticky, inside its own opaque layer: the wash is translucent, and
- * translucent over scrolling rows smears them. The caller wraps each band
- * with its rows, so a band stays on screen for exactly as long as its rows do
- * and the next one takes over rather than piling on top. Borders belong to
- * that wrapper too (`divide-y`), never to the band: a rule drawn on a band
- * rides with it while it is stuck.
+ * The band sticks inside its own opaque layer for exactly as long as the
+ * group's rows are on screen, and the next group's band takes over rather
+ * than piling on top. That is why the band and its rows are one element:
+ * the sticky context is the group. Borders belong to the parent (`divide-y`),
+ * never to the band, because a rule drawn on the band would ride with it
+ * while it is stuck.
  *
- * Colour lands on the wash and the icon, never on the words, so two lists
- * with and without tones still read in one typeface. `h-9` whether or not
- * there is an action, so bands on one page stand the same height.
+ * Colour lands on the wash and the icon, never on the words, so lists with
+ * and without tones read in one typeface. `h-9` with or without an action,
+ * so bands on one page stand the same height.
  */
 export function GroupBand({
   id,
@@ -39,40 +33,40 @@ export function GroupBand({
   icon: Icon,
   tone = "neutral",
   action,
-  className,
+  children,
 }: {
-  /** For the list's `aria-labelledby`. */
+  /** For the rows' `aria-labelledby`. */
   id?: string;
   label: string;
   /** A string where the count is a floor ("200+") rather than a total. */
   count?: number | string;
   /** Only for what the reader cannot see from the rows. */
   hint?: string;
-  icon?: ComponentType<SVGProps<SVGSVGElement>>;
+  icon?: LucideIcon;
   tone?: GroupBandTone;
   /** A control at the band's right end. */
   action?: ReactNode;
-  className?: string;
+  /** The group's rows, or what stands in for them. */
+  children?: ReactNode;
 }) {
   return (
-    <div className="sticky top-0 z-10 bg-background">
-      {/* `px-3` on the same edge the rows use, so bands and rows all start on
-          one left edge. */}
-      <div
-        className={cn(
-          "flex h-9 items-center justify-between gap-3 px-3",
-          TONE[tone].wash,
-          className,
-        )}
-      >
-        <h2 id={id} className="flex min-w-0 items-center gap-2">
-          {Icon && (
-            <Icon
-              aria-hidden
-              className={cn("size-3 shrink-0", TONE[tone].icon)}
-            />
+    <section>
+      <div className="sticky top-0 z-10 bg-background">
+        {/* `px-3` on the same edge the rows use, so bands and rows all start
+            on one left edge. */}
+        <div
+          className={cn(
+            "flex h-9 items-center justify-between gap-3 px-3",
+            TONE[tone].wash,
           )}
-          <span className="flex min-w-0 items-baseline gap-2">
+        >
+          <h2 id={id} className="flex items-center gap-2">
+            {Icon && (
+              <Icon
+                aria-hidden
+                className={cn("size-3 shrink-0", TONE[tone].icon)}
+              />
+            )}
             <span className={kickerClass}>{label}</span>
             {count != null && (
               <span className="font-mono text-xs tabular-nums text-muted-foreground">
@@ -80,14 +74,13 @@ export function GroupBand({
               </span>
             )}
             {hint && (
-              <span className="truncate text-xs text-muted-foreground">
-                {hint}
-              </span>
+              <span className="text-xs text-muted-foreground">{hint}</span>
             )}
-          </span>
-        </h2>
-        {action}
+          </h2>
+          {action}
+        </div>
       </div>
-    </div>
+      {children}
+    </section>
   );
 }

--- a/packages/ui/src/components/group-band.tsx
+++ b/packages/ui/src/components/group-band.tsx
@@ -1,0 +1,93 @@
+import { cn } from "@everr/ui/lib/utils";
+import type { ComponentType, ReactNode, SVGProps } from "react";
+
+/**
+ * The small mono uppercase label that heads a group of rows or a column of
+ * them. One token, so a list's bands and its column strip read as one frame
+ * rather than two sizes of the same idea.
+ */
+export const kickerClass =
+  "font-mono text-[0.6875rem] tracking-wider text-muted-foreground uppercase";
+
+const TONE = {
+  neutral: { wash: "bg-muted/20", icon: "text-muted-foreground" },
+  warning: { wash: "bg-chart-2/8", icon: "text-chart-2" },
+  danger: { wash: "bg-destructive/8", icon: "text-destructive" },
+} as const;
+
+export type GroupBandTone = keyof typeof TONE;
+
+/**
+ * The band that names a group of rows and counts it.
+ *
+ * Sticky, inside its own opaque layer: the wash is translucent, and
+ * translucent over scrolling rows smears them. The caller wraps each band
+ * with its rows, so a band stays on screen for exactly as long as its rows do
+ * and the next one takes over rather than piling on top. Borders belong to
+ * that wrapper too (`divide-y`), never to the band: a rule drawn on a band
+ * rides with it while it is stuck.
+ *
+ * Colour lands on the wash and the icon, never on the words, so two lists
+ * with and without tones still read in one typeface. `h-9` whether or not
+ * there is an action, so bands on one page stand the same height.
+ */
+export function GroupBand({
+  id,
+  label,
+  count,
+  hint,
+  icon: Icon,
+  tone = "neutral",
+  action,
+  className,
+}: {
+  /** For the list's `aria-labelledby`. */
+  id?: string;
+  label: string;
+  /** A string where the count is a floor ("200+") rather than a total. */
+  count?: number | string;
+  /** Only for what the reader cannot see from the rows. */
+  hint?: string;
+  icon?: ComponentType<SVGProps<SVGSVGElement>>;
+  tone?: GroupBandTone;
+  /** A control at the band's right end. */
+  action?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className="sticky top-0 z-10 bg-background">
+      {/* `px-3` on the same edge the rows use, so bands and rows all start on
+          one left edge. */}
+      <div
+        className={cn(
+          "flex h-9 items-center justify-between gap-3 px-3",
+          TONE[tone].wash,
+          className,
+        )}
+      >
+        <h2 id={id} className="flex min-w-0 items-center gap-2">
+          {Icon && (
+            <Icon
+              aria-hidden
+              className={cn("size-3 shrink-0", TONE[tone].icon)}
+            />
+          )}
+          <span className="flex min-w-0 items-baseline gap-2">
+            <span className={kickerClass}>{label}</span>
+            {count != null && (
+              <span className="font-mono text-xs tabular-nums text-muted-foreground">
+                {count}
+              </span>
+            )}
+            {hint && (
+              <span className="truncate text-xs text-muted-foreground">
+                {hint}
+              </span>
+            )}
+          </span>
+        </h2>
+        {action}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/option-combobox.test.tsx
+++ b/packages/ui/src/components/option-combobox.test.tsx
@@ -110,13 +110,11 @@ const GROUPED: OptionComboboxItem[] = [
     value: "demo/always-firing",
     label: "Always firing",
     group: "demo",
-    keywords: ["Always firing"],
   },
   {
     value: "checkout/latency",
     label: "Checkout latency",
     group: "checkout",
-    keywords: ["Checkout latency"],
   },
 ];
 
@@ -146,6 +144,7 @@ it("finds a rule by its label, not only its value, when searchable", async () =>
       value={null}
       onChange={vi.fn()}
       options={GROUPED}
+      searchable
       searchPlaceholder="Search rules…"
       emptyMessage="No rule matches."
     />,

--- a/packages/ui/src/components/option-combobox.test.tsx
+++ b/packages/ui/src/components/option-combobox.test.tsx
@@ -104,3 +104,64 @@ it("marks the current value's row as checked", async () => {
     "data-checked",
   );
 });
+
+const GROUPED: OptionComboboxItem[] = [
+  {
+    value: "demo/always-firing",
+    label: "Always firing",
+    group: "demo",
+    keywords: ["Always firing"],
+  },
+  {
+    value: "checkout/latency",
+    label: "Checkout latency",
+    group: "checkout",
+    keywords: ["Checkout latency"],
+  },
+];
+
+it("lists options under their group headings", async () => {
+  const user = userEvent.setup();
+  render(
+    <OptionCombobox
+      label="Rule"
+      value={null}
+      onChange={vi.fn()}
+      options={GROUPED}
+    />,
+  );
+
+  await user.click(screen.getByRole("combobox", { name: "Rule" }));
+
+  await screen.findByRole("option", { name: /Always firing/ });
+  const headings = [...document.querySelectorAll("[cmdk-group-heading]")];
+  expect(headings.map((h) => h.textContent)).toEqual(["demo", "checkout"]);
+});
+
+it("finds a rule by its label, not only its value, when searchable", async () => {
+  const user = userEvent.setup();
+  render(
+    <OptionCombobox
+      label="Rule"
+      value={null}
+      onChange={vi.fn()}
+      options={GROUPED}
+      searchPlaceholder="Search rules…"
+      emptyMessage="No rule matches."
+    />,
+  );
+
+  await user.click(screen.getByRole("combobox", { name: "Rule" }));
+  await user.type(screen.getByPlaceholderText("Search rules…"), "checkout lat");
+
+  expect(
+    screen.getByRole("option", { name: /Checkout latency/ }),
+  ).toBeVisible();
+  expect(
+    screen.queryByRole("option", { name: /Always firing/ }),
+  ).not.toBeInTheDocument();
+
+  await user.clear(screen.getByPlaceholderText("Search rules…"));
+  await user.type(screen.getByPlaceholderText("Search rules…"), "nothing here");
+  expect(await screen.findByText("No rule matches.")).toBeVisible();
+});

--- a/packages/ui/src/components/option-combobox.tsx
+++ b/packages/ui/src/components/option-combobox.tsx
@@ -3,10 +3,18 @@ import {
   type ComponentType,
   type ReactNode,
   type SVGProps,
+  useMemo,
   useState,
 } from "react";
 import { Button } from "./button";
-import { Command, CommandGroup, CommandItem, CommandList } from "./command";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "./command";
 import { Popover, PopoverContent, PopoverTrigger } from "./popover";
 
 /** One closed-set choice with an optional explanation for the menu row. */
@@ -18,12 +26,19 @@ export interface OptionComboboxItem {
   description?: ReactNode;
   /** Any svg-props component: lucide icons and inlined brand marks alike. */
   icon?: ComponentType<SVGProps<SVGSVGElement>>;
+  /** Heading the row is listed under. Groups appear in the order their first
+   *  item does; items without one are listed first, unheaded. */
+  group?: string;
+  /** What the search matches besides `value`. A row whose visible label is
+   *  not its value wants that label here, or typing it finds nothing. */
+  keywords?: string[];
 }
 
 /**
  * The closed-set sibling of SuggestCombobox: holds exactly one value from a
- * fixed option list, with no free text and no search. Options can carry an
- * icon and menu-only supporting copy.
+ * fixed option list, with no free text. Options can carry an icon, menu-only
+ * supporting copy and a group heading; a `searchPlaceholder` adds a search
+ * field for lists too long to scan.
  */
 export function OptionCombobox({
   id,
@@ -32,22 +47,41 @@ export function OptionCombobox({
   onChange,
   options,
   placeholder,
+  searchPlaceholder,
+  emptyMessage = "No match.",
   className,
   disabled,
 }: {
   id?: string;
   /** Accessible name for the trigger when no <Label htmlFor={id}> names it. */
   label?: string;
-  value: string;
+  /** `null` while nothing is picked. */
+  value: string | null;
   onChange: (value: string) => void;
   options: OptionComboboxItem[];
   /** Muted trigger text while no value is picked. */
   placeholder?: string;
+  /** Given, the menu opens with a search field bearing this placeholder. */
+  searchPlaceholder?: string;
+  /** What the menu says when a search matches nothing. */
+  emptyMessage?: string;
   className?: string;
   disabled?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const selected = options.find((o) => o.value === value);
+
+  // Insertion order of a Map is the order the groups were met, so a caller
+  // that hands the options in sorted order gets sorted groups for free.
+  const groups = useMemo(() => {
+    const byGroup = new Map<string | undefined, OptionComboboxItem[]>();
+    for (const option of options) {
+      const bucket = byGroup.get(option.group);
+      if (bucket) bucket.push(option);
+      else byGroup.set(option.group, [option]);
+    }
+    return [...byGroup];
+  }, [options]);
 
   return (
     // The wrapper keeps Base UI's focus-guard spans (siblings of the trigger
@@ -90,35 +124,42 @@ export function OptionCombobox({
         </PopoverTrigger>
         <PopoverContent align="start" className="w-(--anchor-width) p-0">
           <Command className="p-0">
+            {searchPlaceholder && (
+              <CommandInput placeholder={searchPlaceholder} />
+            )}
             <CommandList>
-              <CommandGroup>
-                {options.map((o) => (
-                  <CommandItem
-                    key={o.value}
-                    value={o.value}
-                    data-checked={o.value === value || undefined}
-                    onSelect={() => {
-                      onChange(o.value);
-                      setOpen(false);
-                    }}
-                  >
-                    {o.icon && (
-                      <o.icon
-                        className="text-muted-foreground mt-0.5 self-start"
-                        aria-hidden
-                      />
-                    )}
-                    <span className="min-w-0 flex-1">
-                      <span className="block truncate">{o.label}</span>
-                      {o.description && (
-                        <span className="text-muted-foreground block whitespace-normal text-xs leading-snug">
-                          {o.description}
-                        </span>
+              {searchPlaceholder && <CommandEmpty>{emptyMessage}</CommandEmpty>}
+              {groups.map(([group, items]) => (
+                <CommandGroup key={group ?? ""} heading={group}>
+                  {items.map((o) => (
+                    <CommandItem
+                      key={o.value}
+                      value={o.value}
+                      keywords={o.keywords}
+                      data-checked={o.value === value || undefined}
+                      onSelect={() => {
+                        onChange(o.value);
+                        setOpen(false);
+                      }}
+                    >
+                      {o.icon && (
+                        <o.icon
+                          className="text-muted-foreground mt-0.5 self-start"
+                          aria-hidden
+                        />
                       )}
-                    </span>
-                  </CommandItem>
-                ))}
-              </CommandGroup>
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate">{o.label}</span>
+                        {o.description && (
+                          <span className="text-muted-foreground block whitespace-normal text-xs leading-snug">
+                            {o.description}
+                          </span>
+                        )}
+                      </span>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              ))}
             </CommandList>
           </Command>
         </PopoverContent>

--- a/packages/ui/src/components/option-combobox.tsx
+++ b/packages/ui/src/components/option-combobox.tsx
@@ -29,16 +29,13 @@ export interface OptionComboboxItem {
   /** Heading the row is listed under. Groups appear in the order their first
    *  item does; items without one are listed first, unheaded. */
   group?: string;
-  /** What the search matches besides `value`. A row whose visible label is
-   *  not its value wants that label here, or typing it finds nothing. */
-  keywords?: string[];
 }
 
 /**
  * The closed-set sibling of SuggestCombobox: holds exactly one value from a
  * fixed option list, with no free text. Options can carry an icon, menu-only
- * supporting copy and a group heading; a `searchPlaceholder` adds a search
- * field for lists too long to scan.
+ * supporting copy and a group heading; `searchable` adds a search field for
+ * lists too long to scan, matching on the value and on a string label.
  */
 export function OptionCombobox({
   id,
@@ -47,7 +44,8 @@ export function OptionCombobox({
   onChange,
   options,
   placeholder,
-  searchPlaceholder,
+  searchable = false,
+  searchPlaceholder = "Search…",
   emptyMessage = "No match.",
   className,
   disabled,
@@ -61,7 +59,7 @@ export function OptionCombobox({
   options: OptionComboboxItem[];
   /** Muted trigger text while no value is picked. */
   placeholder?: string;
-  /** Given, the menu opens with a search field bearing this placeholder. */
+  searchable?: boolean;
   searchPlaceholder?: string;
   /** What the menu says when a search matches nothing. */
   emptyMessage?: string;
@@ -124,18 +122,20 @@ export function OptionCombobox({
         </PopoverTrigger>
         <PopoverContent align="start" className="w-(--anchor-width) p-0">
           <Command className="p-0">
-            {searchPlaceholder && (
-              <CommandInput placeholder={searchPlaceholder} />
-            )}
+            {searchable && <CommandInput placeholder={searchPlaceholder} />}
             <CommandList>
-              {searchPlaceholder && <CommandEmpty>{emptyMessage}</CommandEmpty>}
+              {searchable && <CommandEmpty>{emptyMessage}</CommandEmpty>}
               {groups.map(([group, items]) => (
                 <CommandGroup key={group ?? ""} heading={group}>
                   {items.map((o) => (
                     <CommandItem
                       key={o.value}
                       value={o.value}
-                      keywords={o.keywords}
+                      // cmdk matches the value alone; the word on the row is
+                      // what a reader types.
+                      keywords={
+                        typeof o.label === "string" ? [o.label] : undefined
+                      }
                       data-checked={o.value === value || undefined}
                       onSelect={() => {
                         onChange(o.value);

--- a/packages/ui/src/hooks/use-mobile.ts
+++ b/packages/ui/src/hooks/use-mobile.ts
@@ -5,3 +5,14 @@ const MOBILE_BREAKPOINT = 768;
 export function useIsMobile() {
   return useMediaQuery(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
 }
+
+/**
+ * Below Tailwind's `lg`. The width under which a page cannot afford a second
+ * column beside its main one: the Explore rails move into a sheet here, and so
+ * does the alerting detail panel. One number, so the two cannot drift apart.
+ */
+const NARROW_BREAKPOINT = 1024;
+
+export function useIsNarrow() {
+  return useMediaQuery(`(max-width: ${NARROW_BREAKPOINT - 1}px)`);
+}

--- a/packages/ui/src/hooks/use-mobile.ts
+++ b/packages/ui/src/hooks/use-mobile.ts
@@ -7,9 +7,9 @@ export function useIsMobile() {
 }
 
 /**
- * Below Tailwind's `lg`. The width under which a page cannot afford a second
- * column beside its main one: the Explore rails move into a sheet here, and so
- * does the alerting detail panel. One number, so the two cannot drift apart.
+ * Below Tailwind's `lg` (1024px): the width under which a page cannot afford a
+ * second column beside its main one, and a rail or a detail column becomes a
+ * sheet. Callers pairing this with `lg:` classes read the same number.
  */
 const NARROW_BREAKPOINT = 1024;
 

--- a/packages/ui/src/lib/typography.ts
+++ b/packages/ui/src/lib/typography.ts
@@ -1,0 +1,7 @@
+/**
+ * The small mono uppercase label that heads a group of rows or a column of
+ * them. One token, so a list's bands and its column strip read as one frame
+ * rather than two sizes of the same idea.
+ */
+export const kickerClass =
+  "font-mono text-[0.6875rem] tracking-wider text-muted-foreground uppercase";


### PR DESCRIPTION
Stacked on #422. Reuses what already existed instead of the copies the silences page introduced, and folds the blocks the page had duplicated between its two screens.

## Reuse of existing components

- **`OptionCombobox` picks the rule.** The dialog's `RulePicker` was a copy of the combobox's trigger with a search field and project headings added, while the combobox itself had no consumer left. It now takes `searchPlaceholder`, a per-item `group` and `keywords`, and the picker is an options mapper. The trigger is h-8, which matches the dialog's other fields (the copy was h-9). Two tests cover grouping and label search.
- **`Badge` for the chips.** A `size="md"` variant at the row's own text size. The status chip and the "in force" tag use it. The error code chip stays hand-rolled: it would need eight overrides, which is no longer reuse.
- **`useIsNarrow`** in `packages/ui`, beside `useIsMobile`. The alert panel and the Explore filter rail both declared the same 1023px query by hand.

- **`GroupBand`** in `packages/ui` heads both the triage list and the silences page. The triage bands used a coloured sans, the silences bands the mono kicker; now both use the kicker, with colour on the wash and the icon only. Sticky in both, h-9 in both, borders from the wrapper's `divide-y`. The kicker token moved to ui with it.

## Storybook

Preview: https://everr-storybook-git-guido-alerts-c-85ab84-guido-dorsis-projects.vercel.app/

**GroupBand** (new)
- [Default](https://everr-storybook-git-guido-alerts-c-85ab84-guido-dorsis-projects.vercel.app/?path=/story/data-groupband--default): label, count and hint, the silences History band.
- [With action](https://everr-storybook-git-guido-alerts-c-85ab84-guido-dorsis-projects.vercel.app/?path=/story/data-groupband--with-action): the Active band with New silence on its right.
- [Toned](https://everr-storybook-git-guido-alerts-c-85ab84-guido-dorsis-projects.vercel.app/?path=/story/data-groupband--toned): the triage Firing and Pending bands, icon and wash coloured, words muted.
- [Sticky](https://everr-storybook-git-guido-alerts-c-85ab84-guido-dorsis-projects.vercel.app/?path=/story/data-groupband--sticky): two groups in a scrolling list, each band stuck for its own rows.

**OptionCombobox** (search, groups, label matching)
- [Default](https://everr-storybook-git-guido-alerts-c-85ab84-guido-dorsis-projects.vercel.app/?path=/story/data-optioncombobox--default), [Placeholder](https://everr-storybook-git-guido-alerts-c-85ab84-guido-dorsis-projects.vercel.app/?path=/story/data-optioncombobox--placeholder), [Disabled](https://everr-storybook-git-guido-alerts-c-85ab84-guido-dorsis-projects.vercel.app/?path=/story/data-optioncombobox--disabled)
- [Grouped](https://everr-storybook-git-guido-alerts-c-85ab84-guido-dorsis-projects.vercel.app/?path=/story/data-optioncombobox--grouped): rules under their project headings with the mono path.
- [Searchable](https://everr-storybook-git-guido-alerts-c-85ab84-guido-dorsis-projects.vercel.app/?path=/story/data-optioncombobox--searchable): the search field, matching on the visible label.

**Badge** (`size="md"`)
- [Sizes](https://everr-storybook-git-guido-alerts-c-85ab84-guido-dorsis-projects.vercel.app/?path=/story/data-badge--sizes): the `md` chip beside the default pill.
