### PR TITLE
Refresh CLI command help and reference

### DIFF
--- a/.changeset/refresh-cli-help.md
+++ b/.changeset/refresh-cli-help.md
@@ -1,0 +1,5 @@
+---
+"@everr/desktop-app": patch
+---
+
+Refresh the CLI help text and command reference to match the current telemetry, CI, Skills, and resources-as-code command surface.

--- a/packages/desktop-app/src-cli/src/cli.rs
+++ b/packages/desktop-app/src-cli/src/cli.rs
@@ -33,19 +33,19 @@ pub enum Commands {
     Ci(CiArgs),
     /// Run and query the local telemetry Collector
     Local(LocalArgs),
-    /// Run a command and capture its output as local Logs
+    /// Run a command and capture its output as local logs
     Wrap(WrapArgs),
-    /// Set up local telemetry, Skills, and Everr Cloud
+    /// Set up local telemetry, skills, and Everr Cloud
     #[command(name = "setup")]
     Setup,
     /// Connect the current repository and import its CI history
     Init,
-    /// Manage bundled Everr Skills
+    /// Manage bundled Everr skills
     #[command(name = "skills")]
     Skills(SkillsArgs),
     /// Reconcile a directory of as-code resources with Everr
     Apply(ApplyArgs),
-    /// Inspect and manage live Dashboards, Runbooks, and Alerts
+    /// Inspect and manage live dashboards, runbooks, and alerts
     Resources(ResourcesArgs),
 }
 
@@ -108,7 +108,7 @@ pub struct CiArgs {
 
 #[derive(Subcommand, Debug)]
 pub enum CiSubcommand {
-    /// Show CI runs for a commit or run ID
+    /// Show CI status for a commit or run ID
     Status(StatusArgs),
     /// Watch CI runs for a commit or run ID until completion
     Watch(WatchArgs),
@@ -116,7 +116,7 @@ pub enum CiSubcommand {
     Runs(ListRunsArgs),
     /// Show a CI run's jobs and steps
     Show(ShowRunArgs),
-    /// Show step Logs for a CI run
+    /// Show step logs for a CI run
     Logs(GetLogsArgs),
 }
 
@@ -200,8 +200,8 @@ pub struct SkillScopeArgs {
 pub struct SkillsListArgs {
     #[command(flatten)]
     pub scope: SkillScopeArgs,
-    /// Provider to inspect
-    #[arg(long = "agent", value_enum)]
+    /// Agent to inspect
+    #[arg(long = "agent", value_enum, value_name = "AGENT")]
     pub agents: Vec<SkillAgentArg>,
 }
 
@@ -212,8 +212,8 @@ pub struct SkillsInstallArgs {
     pub all: bool,
     #[command(flatten)]
     pub scope: SkillScopeArgs,
-    /// Provider to install for
-    #[arg(long = "agent", value_enum)]
+    /// Agent to install for
+    #[arg(long = "agent", value_enum, value_name = "AGENT")]
     pub agents: Vec<SkillAgentArg>,
     /// Preview without writing files
     #[arg(long)]
@@ -226,8 +226,8 @@ pub struct SkillsUpdateArgs {
     pub skills: Vec<String>,
     #[command(flatten)]
     pub scope: SkillScopeArgs,
-    /// Provider to update for
-    #[arg(long = "agent", value_enum)]
+    /// Agent to update
+    #[arg(long = "agent", value_enum, value_name = "AGENT")]
     pub agents: Vec<SkillAgentArg>,
     /// Preview without writing files
     #[arg(long)]
@@ -246,8 +246,8 @@ pub struct SkillsUninstallArgs {
     pub yes: bool,
     #[command(flatten)]
     pub scope: SkillScopeArgs,
-    /// Provider to uninstall for
-    #[arg(long = "agent", value_enum)]
+    /// Agent to uninstall from
+    #[arg(long = "agent", value_enum, value_name = "AGENT")]
     pub agents: Vec<SkillAgentArg>,
     /// Preview without removing files
     #[arg(long)]
@@ -264,9 +264,9 @@ pub struct ApplyArgs {
     /// Skip the confirmation prompt (required in non-interactive contexts)
     #[arg(long, short = 'y')]
     pub yes: bool,
-    /// Apply into a preview namespace instead of the live state. With no
-    /// value the current git branch is used; pass a name where no branch is
-    /// available (CI, detached HEAD).
+    /// Reconcile into a preview instead of live state. With no value the
+    /// current git branch is used; pass a name where no branch is available
+    /// (CI, detached HEAD).
     #[arg(long, value_name = "NAME", num_args = 0..=1, default_missing_value = "")]
     pub preview: Option<String>,
     /// Adopt resources owned by another Repoid into this repository. Without
@@ -537,7 +537,7 @@ pub struct ResourcesShowArgs {
     pub kind: ResourceKindArg,
     /// Resource slug (metadata.name)
     pub slug: String,
-    /// Project namespace
+    /// Project name
     #[arg(long, default_value = "default")]
     pub project: String,
     /// Output raw JSON instead of YAML
@@ -552,7 +552,7 @@ pub struct ResourcesDeleteArgs {
     pub kind: ResourceKindArg,
     /// Resource slug (metadata.name)
     pub slug: String,
-    /// Project namespace
+    /// Project name
     #[arg(long, default_value = "default")]
     pub project: String,
 }
@@ -564,7 +564,7 @@ pub struct ResourcesTargetArgs {
     pub kind: ResourceKindArg,
     /// Resource slug (metadata.name)
     pub slug: String,
-    /// Project namespace
+    /// Project name
     #[arg(long, default_value = "default")]
     pub project: String,
     /// Skip the confirmation prompt (required in non-interactive contexts)

--- a/packages/desktop-app/src-cli/src/cli.rs
+++ b/packages/desktop-app/src-cli/src/cli.rs
@@ -14,7 +14,7 @@ pub const MAX_LOG_PAGE_SIZE: u32 = 5000;
     name = "everr",
     version = VERSION_OUTPUT,
     long_version = VERSION_OUTPUT,
-    about = "CLI for observability in Everr, designed for humans and agent skills"
+    about = "Query telemetry, inspect CI, and manage resources as code in Everr"
 )]
 pub struct Cli {
     #[command(subcommand)]
@@ -23,29 +23,29 @@ pub struct Cli {
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
-    /// Remove local Everr setup artifacts
+    /// Remove local Everr state and globally installed skills
     Uninstall,
     /// Upgrade the Everr CLI (and the Everr app, if installed) to the latest version
     Upgrade,
-    /// Manage Everr Cloud authentication
+    /// Authenticate with and query Everr Cloud
     Cloud(CloudArgs),
     /// Inspect GitHub Actions CI runs
     Ci(CiArgs),
-    /// Inspect local diagnostic telemetry recorded by the Everr Desktop app
+    /// Run and query the local telemetry Collector
     Local(LocalArgs),
-    /// Run a command and send its stdout/stderr logs to the local collector
+    /// Run a command and capture its output as local Logs
     Wrap(WrapArgs),
-    /// Run the full setup wizard (login + org + import + skills installation)
+    /// Set up local telemetry, Skills, and Everr Cloud
     #[command(name = "setup")]
     Setup,
-    /// Initialize the current repository by importing recent runs
+    /// Connect the current repository and import its CI history
     Init,
-    /// Manage bundled Everr agent skills
+    /// Manage bundled Everr Skills
     #[command(name = "skills")]
     Skills(SkillsArgs),
-    /// Apply a directory of resource definitions (gitops)
+    /// Reconcile a directory of as-code resources with Everr
     Apply(ApplyArgs),
-    /// Inspect and manage live Cloud resources (dashboards, runbooks, alerts)
+    /// Inspect and manage live Dashboards, Runbooks, and Alerts
     Resources(ResourcesArgs),
 }
 
@@ -81,11 +81,11 @@ pub struct CloudArgs {
 
 #[derive(Subcommand, Debug)]
 pub enum CloudSubcommand {
-    /// Log in and persist a local session
+    /// Authenticate with Everr Cloud and save the session
     Login(LoginArgs),
-    /// Log out and clear the local session
+    /// Clear the saved Everr Cloud session
     Logout,
-    /// Run a read-only SQL query against cloud telemetry data
+    /// Run read-only SQL against CI and Production telemetry in Everr Cloud
     Query(TelemetryQueryArgs),
 }
 
@@ -108,15 +108,15 @@ pub struct CiArgs {
 
 #[derive(Subcommand, Debug)]
 pub enum CiSubcommand {
-    /// Show all pipeline runs for a specific commit
+    /// Show CI runs for a commit or run ID
     Status(StatusArgs),
-    /// Watch the current commit until pipeline runs complete
+    /// Watch CI runs for a commit or run ID until completion
     Watch(WatchArgs),
-    /// List recent runs
+    /// List recent CI runs
     Runs(ListRunsArgs),
-    /// Show run details
+    /// Show a CI run's jobs and steps
     Show(ShowRunArgs),
-    /// Show step logs for a run
+    /// Show step Logs for a CI run
     Logs(GetLogsArgs),
 }
 
@@ -140,11 +140,11 @@ pub struct LocalArgs {
 
 #[derive(Subcommand, Debug)]
 pub enum LocalSubcommand {
-    /// Start the local collector in the foreground.
+    /// Start the local Collector in the foreground
     Start(TelemetryStartArgs),
-    /// Run a SQL query against local telemetry.
+    /// Run read-only SQL against local telemetry
     Query(TelemetryQueryArgs),
-    /// Check whether the local collector is running.
+    /// Show the local Collector status and endpoints
     Status,
 }
 
@@ -269,25 +269,24 @@ pub struct ApplyArgs {
     /// available (CI, detached HEAD).
     #[arg(long, value_name = "NAME", num_args = 0..=1, default_missing_value = "")]
     pub preview: Option<String>,
-    /// Take over resources whose (project, slug) another repo already owns,
-    /// transferring ownership to this repo. Without it, such a collision aborts
-    /// the apply.
+    /// Adopt resources owned by another Repoid into this repository. Without
+    /// it, ownership collisions abort the apply.
     #[arg(long)]
     pub adopt: bool,
 }
 
 #[derive(Args, Debug, Default)]
 pub struct TelemetryStartArgs {
-    /// Suppress collector URL output after the collector is ready.
+    /// Suppress endpoint output after the Collector is ready
     #[arg(long)]
     pub quiet: bool,
 }
 
 #[derive(Args, Debug, Default)]
 pub struct TelemetryQueryArgs {
-    /// The SQL query to run. Keep it quoted. Include LIMIT yourself.
+    /// SQL query to run. Keep it quoted and include LIMIT yourself.
     pub sql: String,
-    /// Output format. Default: table on TTY, ndjson otherwise.
+    /// Output format. Default: table on a TTY, ndjson otherwise.
     #[arg(long, value_enum)]
     pub format: Option<TelemetryFormat>,
 }
@@ -315,59 +314,79 @@ pub struct LoginArgs {}
 
 #[derive(Args, Debug, Default)]
 pub struct StatusArgs {
+    /// Repository in owner/name form (default: inferred from origin)
     #[arg(long)]
     pub repo: Option<String>,
+    /// Branch name (default: current branch)
     #[arg(long)]
     pub branch: Option<String>,
+    /// Commit SHA or ref (default: HEAD)
     #[arg(long)]
     pub commit: Option<String>,
+    /// GitHub Actions run ID
     #[arg(long)]
     pub run_id: Option<String>,
 }
 
 #[derive(Args, Debug, Default)]
 pub struct WatchArgs {
+    /// Repository in owner/name form (default: inferred from origin)
     #[arg(long)]
     pub repo: Option<String>,
+    /// Branch name (default: current branch when watching HEAD)
     #[arg(long)]
     pub branch: Option<String>,
+    /// Commit SHA or ref (default: HEAD)
     #[arg(long)]
     pub commit: Option<String>,
+    /// CI run attempt number
     #[arg(long)]
     pub attempt: Option<u32>,
+    /// GitHub Actions run ID
     #[arg(long)]
     pub run_id: Option<String>,
+    /// Exit as soon as a CI run completes unsuccessfully
     #[arg(long)]
     pub fail_fast: bool,
 }
 
 #[derive(Args, Debug, Default)]
 pub struct ListRunsArgs {
+    /// Filter by repository in owner/name form
     #[arg(long)]
     pub repo: Option<String>,
+    /// Filter by branch name
     #[arg(long)]
     pub branch: Option<String>,
     /// Use the current git branch as the branch filter
     #[arg(long)]
     pub current_branch: bool,
+    /// Filter by conclusion
     #[arg(long)]
     pub conclusion: Option<String>,
+    /// Filter by workflow name
     #[arg(long)]
     pub workflow_name: Option<String>,
+    /// Filter by GitHub Actions run ID
     #[arg(long)]
     pub run_id: Option<String>,
+    /// Maximum number of runs to return
     #[arg(long, default_value_t = 20, value_parser = clap::value_parser!(u32).range(1..=100))]
     pub limit: u32,
+    /// Number of runs to skip
     #[arg(long, default_value_t = 0)]
     pub offset: u32,
+    /// Earliest run start time (date math, for example: now-7d)
     #[arg(long)]
     pub from: Option<String>,
+    /// Latest run start time (date math, for example: now)
     #[arg(long)]
     pub to: Option<String>,
 }
 
 #[derive(Args, Debug)]
 pub struct ShowRunArgs {
+    /// Trace ID of the CI run
     pub trace_id: String,
 
     /// Show only failed jobs and their failed steps
@@ -377,15 +396,19 @@ pub struct ShowRunArgs {
 
 #[derive(Args, Debug)]
 pub struct GetLogsArgs {
+    /// Trace ID of the CI run
     pub trace_id: String,
+    /// Job name
     #[arg(long, required_unless_present = "job_id", conflicts_with = "job_id")]
     pub job_name: Option<String>,
+    /// Job ID
     #[arg(
         long,
         required_unless_present = "job_name",
         conflicts_with = "job_name"
     )]
     pub job_id: Option<String>,
+    /// Step number
     #[arg(
         long,
         required_unless_present = "log_failed",
@@ -413,7 +436,7 @@ pub struct GetLogsArgs {
     /// Preserve ANSI color codes (stripped by default)
     #[arg(long)]
     pub color: bool,
-    /// Filter output to lines matching a re2 regex pattern; exits 1 if no lines match
+    /// Filter output to lines matching a RE2 regex pattern; exits 1 if no lines match
     #[arg(long)]
     pub egrep: Option<String>,
 }
@@ -478,9 +501,9 @@ pub enum ResourcesSubcommand {
     List(ResourcesListArgs),
     /// Print a resource's stored configuration
     Show(ResourcesShowArgs),
-    /// Delete a live resource
+    /// Delete a live resource without prompting
     Delete(ResourcesDeleteArgs),
-    /// Take ownership of a resource for this repository
+    /// Adopt a resource into this repository's ownership boundary
     Adopt(ResourcesTargetArgs),
 }
 
@@ -499,7 +522,7 @@ pub struct ResourcesListArgs {
     /// Only resources of this kind
     #[arg(long, value_enum)]
     pub kind: Option<ResourceKindArg>,
-    /// Only resources owned by this repoid (pass an empty string for UI-created)
+    /// Only resources owned by this Repoid (pass an empty string for UI-created)
     #[arg(long)]
     pub repoid: Option<String>,
     /// Output raw JSON instead of a table

--- a/packages/desktop-app/src-cli/tests/help_output.rs
+++ b/packages/desktop-app/src-cli/tests/help_output.rs
@@ -12,6 +12,9 @@ fn root_help_lists_main_commands() {
         .arg("--help")
         .assert()
         .success()
+        .stdout(contains(
+            "Query telemetry, inspect CI, and manage resources as code in Everr",
+        ))
         .stdout(contains("Usage: everr <COMMAND>"))
         .stdout(predicates::str::contains("\n  install").not())
         .stdout(predicates::str::contains("\n  login").not())
@@ -32,11 +35,16 @@ fn root_help_lists_main_commands() {
         .stdout(predicates::str::contains("\n  logs").not())
         .stdout(contains("wrap"))
         .stdout(contains("skills"))
-        .stdout(contains("upgrade"));
+        .stdout(contains("upgrade"))
+        .stdout(contains("apply"))
+        .stdout(contains("resources"))
+        .stdout(contains("Authenticate with and query Everr Cloud"))
+        .stdout(contains("Run and query the local telemetry Collector"))
+        .stdout(contains("Reconcile a directory of as-code resources"));
 }
 
 #[test]
-fn ci_help_lists_pipeline_subcommands() {
+fn ci_help_lists_ci_subcommands() {
     let env = CliTestEnv::new();
 
     env.command()
@@ -47,7 +55,9 @@ fn ci_help_lists_pipeline_subcommands() {
         .stdout(contains("watch"))
         .stdout(contains("runs"))
         .stdout(contains("show"))
-        .stdout(contains("logs"));
+        .stdout(contains("logs"))
+        .stdout(contains("Show CI runs for a commit or run ID"))
+        .stdout(contains("List recent CI runs"));
 }
 
 #[test]
@@ -83,6 +93,9 @@ fn cloud_query_help_lists_format_option() {
         .args(["cloud", "query", "--help"])
         .assert()
         .success()
+        .stdout(contains(
+            "Run read-only SQL against CI and Production telemetry",
+        ))
         .stdout(contains("<SQL>"))
         .stdout(contains("--format <FORMAT>"));
 }
@@ -111,11 +124,14 @@ fn runs_logs_help_lists_paging_flags_and_default_page_size() {
         .stdout(contains("--limit <LIMIT>"))
         .stdout(contains("--offset <OFFSET>"))
         .stdout(contains("default: 1000"))
-        .stdout(contains("--egrep"));
+        .stdout(contains("--egrep"))
+        .stdout(contains("Trace ID of the CI run"))
+        .stdout(contains("Job name"))
+        .stdout(contains("Step number"));
 }
 
 #[test]
-fn telemetry_help_lists_start_command() {
+fn local_help_lists_collector_commands() {
     let env = CliTestEnv::new();
 
     env.command()
@@ -125,7 +141,7 @@ fn telemetry_help_lists_start_command() {
         .stdout(contains("start"))
         .stdout(contains("query"))
         .stdout(contains("status"))
-        .stdout(predicates::str::contains("endpoint").not());
+        .stdout(predicates::str::contains("\n  endpoint").not());
 
     env.command()
         .args(["local", "start", "--help"])
@@ -143,9 +159,7 @@ fn wrap_help_describes_command_capture() {
         .assert()
         .success()
         .stdout(contains("<COMMAND>"))
-        .stdout(contains(
-            "send its stdout/stderr logs to the local collector",
-        ));
+        .stdout(contains("capture its output as local Logs"));
 }
 
 #[test]
@@ -172,12 +186,40 @@ fn skills_help_describes_skill_management() {
         .args(["skills", "--help"])
         .assert()
         .success()
-        .stdout(contains("Manage bundled Everr agent skills"))
+        .stdout(contains("Manage bundled Everr Skills"))
         .stdout(contains("list"))
         .stdout(contains("install"))
         .stdout(contains("update"))
         .stdout(contains("uninstall"))
         .stdout(predicates::str::contains("--json").not());
+}
+
+#[test]
+fn resource_help_describes_reconciliation_and_live_resource_management() {
+    let env = CliTestEnv::new();
+
+    env.command()
+        .args(["apply", "--help"])
+        .assert()
+        .success()
+        .stdout(contains(
+            "Reconcile a directory of as-code resources with Everr",
+        ))
+        .stdout(contains("--preview [<NAME>]"))
+        .stdout(contains("--dry-run"))
+        .stdout(contains("--adopt"));
+
+    env.command()
+        .args(["resources", "--help"])
+        .assert()
+        .success()
+        .stdout(contains(
+            "Inspect and manage live Dashboards, Runbooks, and Alerts",
+        ))
+        .stdout(contains("list"))
+        .stdout(contains("show"))
+        .stdout(contains("delete"))
+        .stdout(contains("adopt"));
 }
 
 #[test]

--- a/packages/desktop-app/src-cli/tests/help_output.rs
+++ b/packages/desktop-app/src-cli/tests/help_output.rs
@@ -56,7 +56,7 @@ fn ci_help_lists_ci_subcommands() {
         .stdout(contains("runs"))
         .stdout(contains("show"))
         .stdout(contains("logs"))
-        .stdout(contains("Show CI runs for a commit or run ID"))
+        .stdout(contains("Show CI status for a commit or run ID"))
         .stdout(contains("List recent CI runs"));
 }
 
@@ -159,7 +159,7 @@ fn wrap_help_describes_command_capture() {
         .assert()
         .success()
         .stdout(contains("<COMMAND>"))
-        .stdout(contains("capture its output as local Logs"));
+        .stdout(contains("capture its output as local logs"));
 }
 
 #[test]
@@ -186,7 +186,7 @@ fn skills_help_describes_skill_management() {
         .args(["skills", "--help"])
         .assert()
         .success()
-        .stdout(contains("Manage bundled Everr Skills"))
+        .stdout(contains("Manage bundled Everr skills"))
         .stdout(contains("list"))
         .stdout(contains("install"))
         .stdout(contains("update"))
@@ -214,7 +214,7 @@ fn resource_help_describes_reconciliation_and_live_resource_management() {
         .assert()
         .success()
         .stdout(contains(
-            "Inspect and manage live Dashboards, Runbooks, and Alerts",
+            "Inspect and manage live dashboards, runbooks, and alerts",
         ))
         .stdout(contains("list"))
         .stdout(contains("show"))

--- a/packages/docs/content/docs/guides/publishing-resources.mdx
+++ b/packages/docs/content/docs/guides/publishing-resources.mdx
@@ -86,4 +86,4 @@ Preview: https://app.everr.dev/dashboards?preview=my-branch
 
 The preview is a full copy of the tree under a name (your git branch by default), deployed without touching live resources. Open the link: each resource is badged added, changed, removed, or unchanged against live state, and the link is shareable with anyone in the org. Previews expire on their own 7 days after their last apply.
 
-Full flag and environment list: [`everr apply` CLI reference](/docs/reference/cli#dashboards-gitops).
+Full flag and environment list: [`everr apply` CLI reference](/docs/reference/cli#apply).

--- a/packages/docs/content/docs/reference/alert-spec.mdx
+++ b/packages/docs/content/docs/reference/alert-spec.mdx
@@ -54,7 +54,7 @@ repoid: "my-explicit-id"
 
 If there is neither an `origin` remote nor an `everr.yaml` manifest, apply errors and tells you to add a remote or create `everr.yaml`.
 
-Declarations sit flat in `everr/`, named by kind: `*.alert.yaml`, `*.dashboard.yaml`, `*.runbook.yaml` (the legacy `*.notebook.yaml` suffix is still recognized). `everr apply ./everr` discovers every `kind: Dashboard`, `kind: AlertRule`, and `kind: Runbook` document under the directory and makes the live resources for that repoid exactly match the tree: new documents are created, changed ones updated, and removed ones **deleted**. The kind suffix is a naming convention only — apply routes by the `kind:` field. Use `--preview` to stage the changes for review without touching the live state (preview rules evaluate but never notify). See the [`everr apply` reference](/docs/reference/cli#dashboards-gitops).
+Declarations sit flat in `everr/`, named by kind: `*.alert.yaml`, `*.dashboard.yaml`, `*.runbook.yaml` (the legacy `*.notebook.yaml` suffix is still recognized). `everr apply ./everr` discovers every `kind: Dashboard`, `kind: AlertRule`, and `kind: Runbook` document under the directory and makes the live resources for that repoid exactly match the tree: new documents are created, changed ones updated, and removed ones **deleted**. The kind suffix is a naming convention only; apply routes by the `kind:` field. Use `--preview` to stage the changes for review without touching the live state (preview rules evaluate but never notify). See the [`everr apply` reference](/docs/reference/cli#apply).
 
 ## Constraints and errors
 

--- a/packages/docs/content/docs/reference/cli.mdx
+++ b/packages/docs/content/docs/reference/cli.mdx
@@ -3,82 +3,99 @@ title: CLI
 description: Reference for all Everr CLI commands.
 ---
 
+The Everr CLI queries local and Cloud telemetry, inspects GitHub Actions CI runs, manages bundled Skills, and reconciles resources as code. Run `everr --help` or `everr <command> --help` for the help included with your installed version.
+
 ## Cloud
 
-- `everr cloud login` — authenticate with your Everr account
-- `everr cloud logout` — sign out
-- `everr cloud query "<SQL>"` — run a read-only SQL query against your cloud telemetry and CI data
-  - `--format <json|ndjson|table>` output format (default: `table` in a terminal, `ndjson` otherwise)
+- `everr cloud login`: authenticate with Everr Cloud and save the local session
+- `everr cloud logout`: clear the saved Everr Cloud session
+- `everr cloud query "<SQL>"`: run read-only SQL against CI and Production telemetry stored in Everr Cloud
+  - `--format <json|ndjson|table>`: choose the output format (default: `table` in a terminal, `ndjson` otherwise)
 
-## Setup
+## Setup and maintenance
 
-- `everr setup` — run the guided setup wizard, including optional skills installation
-- `everr init` — import runs for the current repository
+- `everr setup`: set up local telemetry, bundled Skills, and Everr Cloud
+- `everr init`: connect the current GitHub repository and import its CI history
+- `everr upgrade`: upgrade the CLI and, when installed, the Everr Desktop app
+- `everr uninstall`: remove local Everr state and globally installed Skills, then print the command that removes the CLI binary
 
 ## Skills
 
-- `everr skills list [--project|--global] [--agent <codex|claude-code|cursor|all>]` — list bundled Everr skills
-- `everr skills install [--all] [--project|--global] [--agent ...] [--force] [--dry-run]` — install all bundled skills; omitting `--all` in a terminal asks for confirmation
-- `everr skills update [SKILL]... [--project|--global] [--agent ...] [--dry-run]` — update installed bundled skills
-- `everr skills uninstall [SKILL]... [--all] [--project|--global] [--agent ...] [--yes] [--dry-run]` — uninstall bundled skills
+- `everr skills list [--project|--global] [--agent <codex|claude-code|cursor|all>]`: list bundled Everr Skills for a scope and Agent
+- `everr skills install [--all] [--project|--global] [--agent <agent>] [--dry-run]`: install all bundled Skills. In an interactive terminal, omitted choices are prompted. In a non-interactive context, `--all` is required and the scope defaults to the project.
+- `everr skills update [SKILL]... [--project|--global] [--agent <agent>] [--dry-run]`: update bundled Skills already installed in the selected scope. With no scope, update matching installations in both project and global scopes.
+- `everr skills uninstall [SKILL]... [--all] [--project|--global] [--agent <agent>] [--yes] [--dry-run]`: uninstall named bundled Skills. `--all` requires `--yes`.
 
-## CI/CD status
+The `--agent` option can be repeated. With no Agent filter, a command targets all supported Agents.
 
-- `everr ci status` — show the current commit's pipeline state (`state`, `active`, `completed`)
-  - `--commit <sha>` target a specific commit
-  - `--run-id <id>` target a specific run
-  - `--branch <name>` / `--repo <repo>` override repository context
+## CI
 
-- `everr ci watch` — wait until the current `HEAD` commit finishes; exits non-zero if any run fails
-  - `--commit <sha>` target a specific commit
-  - `--attempt <n>` target a specific retry attempt
-  - `--run-id <id>` target a specific run
-  - `--fail-fast` exit immediately when any run fails
+- `everr ci status`: show CI runs for the current commit
+  - `--commit <sha-or-ref>`: target another commit
+  - `--run-id <id>`: target a GitHub Actions run ID
+  - `--branch <name>` and `--repo <owner/name>`: override repository context
 
-- `everr ci runs` — list recent runs
-  - `--branch <name>` / `--current-branch` filter by branch
-  - `--conclusion <success|failure|cancellation>` filter by outcome
-  - `--workflow-name <name>` filter by workflow
-  - `--run-id <id>` fetch a specific run
-  - `--from <expr>` / `--to <expr>` restrict to a time range (accepts [date math](/docs/reference/datemath), e.g. `now-7d`)
+- `everr ci watch`: watch the current commit's CI runs until completion, then exit non-zero if any run was unsuccessful
+  - `--commit <sha-or-ref>`: target another commit
+  - `--run-id <id>`: target a GitHub Actions run ID
+  - `--attempt <n>`: target a specific run attempt
+  - `--branch <name>` and `--repo <owner/name>`: override repository context
+  - `--fail-fast`: exit as soon as a CI run completes unsuccessfully
 
-- `everr ci show <trace_id>` — show jobs and steps for a run
-  - `--failed` show only failed jobs and their failed steps
+- `everr ci runs`: list recent CI runs
+  - `--repo <owner/name>`: filter by repository
+  - `--branch <name>` or `--current-branch`: filter by branch
+  - `--conclusion <value>`: filter by conclusion
+  - `--workflow-name <name>`: filter by workflow
+  - `--run-id <id>`: filter by GitHub Actions run ID
+  - `--from <expr>` and `--to <expr>`: restrict the start time using [date math](/docs/reference/datemath), for example `now-7d`
+  - `--limit <n>` and `--offset <n>`: paginate results (`--limit` defaults to 20 and accepts 1 through 100)
 
-- `everr ci logs <trace_id> --job-name <job> --step-number <n>` — print step logs (last 1000 lines by default)
-  - `--job-name <job>` / `--job-id <id>` select a job (required)
-  - `--step-number <n>` / `--log-failed` select a step (exactly one required)
-  - `--tail <n>` how many lines from the bottom
-  - `--limit <n>` / `--offset <n>` raw paging
-  - `--egrep <pattern>` keep only lines matching a re2 regex (exits non-zero if none match)
-  - `--color` preserve ANSI color codes (stripped by default)
+- `everr ci show <trace-id>`: show a CI run's jobs and steps
+  - `--failed`: show only failed jobs and their failed steps
 
-Collection-style commands accept `--limit <n>` and `--offset <n>` for pagination.
+- `everr ci logs <trace-id> --job-name <job> --step-number <n>`: print Logs for one CI step (the last 1000 lines by default)
+  - `--job-name <job>` or `--job-id <id>`: select one job
+  - `--step-number <n>` or `--log-failed`: select one step
+  - `--tail <n>`: print lines from the bottom
+  - `--limit <n>` and `--offset <n>`: fetch a raw page from the top
+  - `--egrep <pattern>`: keep only lines matching a RE2 regex, exiting non-zero when no lines match
+  - `--color`: preserve ANSI color codes (stripped by default)
 
 ## Local telemetry
 
-- `everr local start` — start the local OpenTelemetry collector
-  - `--quiet` suppress the collector URL output after startup
-- `everr local status` — check whether the local OpenTelemetry collector is running and print local OTLP/SQL URLs
-- `everr local query "<SQL>"` — query local telemetry with read-only SQL
-  - `--format <json|ndjson|table>` output format (default: `table` in a terminal, `ndjson` otherwise)
-- `everr wrap -- <command>` — run a command normally and mirror stdout/stderr into local telemetry
-  - Requires a running collector; if unavailable, the command is not run
-  - Preserves the wrapped command's non-zero exit code
+- `everr local start`: start the local Collector in the foreground
+  - `--quiet`: suppress endpoint output after startup
+- `everr local status`: show the local Collector status and its OTLP and SQL endpoints
+- `everr local query "<SQL>"`: run read-only SQL against local telemetry
+  - `--format <json|ndjson|table>`: choose the output format (default: `table` in a terminal, `ndjson` otherwise)
+- `everr wrap -- <command>`: run a command and capture its stdout, stderr, and exit status as local Logs
+  - The command only starts when the local Collector is available.
+  - The CLI preserves the command's exit code.
 
-## Dashboards (gitops)
+## Resources as code
 
-- `everr apply <dir>` — reconcile a directory of resource definitions (`.yaml`/`.yml`/`.json`) into Everr. By convention the directory is `everr/` at your repo root, holding flat, kind-suffixed files: `*.dashboard.yaml`, `*.alert.yaml`, `*.runbook.yaml` (the legacy `*.notebook.yaml` suffix is still recognized). Apply discovers `kind: Dashboard`, `kind: AlertRule`, and `kind: Runbook` documents under the directory, routing by the `kind:` field (the suffix is a naming convention only). The `repoid` is inferred from the repository's `origin` remote, normalized to the slug `host/owner/repo` (for example `git@github.com:Acme/API.git` becomes `github.com/acme/api`). No manifest is needed. An optional `everr.yaml` (or `everr.yml`) at the apply root overrides the inferred identity; it accepts exactly one key, `repoid`, a non-empty string. Apply errors only when there is neither a usable `origin` remote nor an `everr.yaml` manifest. The repoid is the authoritative reconcile scope, the apply ownership boundary. Within that repoid it makes the live resources match the tree: new files are created, changed files updated, and removed files **deleted**. Dashboards may set an optional `metadata.project` (defaults to `default`) to namespace identity and URL. See [Observability as code](/docs/concepts/observability-as-code).
-  - `<dir>` directory to read resource files from (recursively), e.g. `./everr`; any subdirectories become folder paths
-  - `--preview [NAME]` apply into a preview namespace instead of the live state and print a shareable link; `NAME` defaults to the current git branch (pass it explicitly in CI or on a detached HEAD). Previews apply without confirmation, alert rules in them evaluate but never notify, and each preview expires automatically 7 days after its last apply
-  - `--dry-run` compute and print the diff without writing
-  - `--yes`, `-y` skip the confirmation prompt (required in non-interactive contexts such as CI or pipes)
-  - `--adopt` take ownership of resources another repoid currently owns when deliberately moving them between repos. Only the resources in the applied tree transfer; anything else stays with its current owner. Use with `--dry-run` first to preview the transfer.
+### Apply
 
-  Authentication: apply uses your `everr cloud login` session by default, and prints the destination organization. In GitHub Actions, install the CLI with `everr-action` before calling `everr apply`. For CI or non-interactive use, set `EVERR_API_KEY` to an organization API key with the `apply` scope. With changes to apply, it shows a confirmation prompt before writing; pass `--yes` (or run with `EVERR_API_KEY` in a non-interactive context) to skip it.
-  - `EVERR_API_KEY` an organization API key (prefix `ek_`) with the `apply` scope, used as a bearer token; when set it takes precedence over the session. The legacy `EVERR_API_TOKEN` is accepted as a deprecated alias.
-  - `EVERR_API_URL` API base URL (falls back to the URL persisted by a prior `everr cloud login`)
+`everr apply <dir>` reconciles the Dashboard, Alert, and Runbook definitions under a directory with Everr. Files can use `.yaml`, `.yml`, or `.json` and are discovered recursively. Apply creates and updates definitions present in the directory and deletes live resources that were previously applied by the same Repoid but are now absent.
 
-## Other
+By convention, use an `everr/` directory with files such as `*.dashboard.yaml`, `*.alert.yaml`, and `*.runbook.yaml`. The `kind` field, not the filename suffix, determines the resource kind. `kind: Notebook` and the `*.notebook.yaml` suffix remain supported for compatibility, but Runbook is the current name.
 
-- `everr uninstall` — remove all config files, log out, and print the command to remove the CLI binary
+The Repoid is inferred from the repository's `origin` remote and normalized to `host/owner/repo`. An optional `everr.yaml` or `everr.yml` Manifest at the apply root can override it with a single non-empty `repoid` key. See [Observability as code](/docs/concepts/observability-as-code).
+
+- `<dir>`: directory to read recursively, for example `./everr`
+- `--preview [NAME]`: reconcile into a preview instead of live state and print a shareable link. `NAME` defaults to the current branch and must be explicit in CI or a detached HEAD. Previews do not prompt, never send alert notifications, and expire seven days after their latest apply.
+- `--dry-run`: compute and print the diff without writing
+- `--yes`, `-y`: skip confirmation for a live apply (required in non-interactive contexts)
+- `--adopt`: adopt resources in the applied directory that another Repoid currently owns. Use `--dry-run` first to review the ownership changes.
+
+Apply uses the saved `everr cloud login` session by default. In CI, set `EVERR_API_KEY` to an Organization API Key with the `apply` capability. `EVERR_API_TOKEN` remains available as a deprecated alias. When either variable is set, `EVERR_API_URL` can override the API base URL.
+
+### Inspect and manage live resources
+
+- `everr resources list [--kind <dashboard|runbook|alert>] [--repoid <id>] [--json]`: list live resources across the active Organization. Pass an empty `--repoid` value to select UI-created resources.
+- `everr resources show <kind> <slug> [--project <name>] [--json]`: print a resource's stored YAML, or raw JSON with `--json`
+- `everr resources delete <kind> <slug> [--project <name>]`: delete a live resource immediately, without prompting
+- `everr resources adopt <kind> <slug> [--project <name>] [--yes]`: adopt a live resource into the current repository's Repoid. Interactive terminals prompt for confirmation; non-interactive contexts require `--yes`.
+
+`--project` defaults to `default`. These commands require a saved `everr cloud login` session and do not accept `EVERR_API_KEY`.

--- a/packages/docs/content/docs/reference/cli.mdx
+++ b/packages/docs/content/docs/reference/cli.mdx
@@ -3,7 +3,7 @@ title: CLI
 description: Reference for all Everr CLI commands.
 ---
 
-The Everr CLI queries local and Cloud telemetry, inspects GitHub Actions CI runs, manages bundled Skills, and reconciles resources as code. Run `everr --help` or `everr <command> --help` for the help included with your installed version.
+The Everr CLI queries local and Cloud telemetry, inspects GitHub Actions CI runs, manages bundled skills, and reconciles resources as code. Run `everr --help` or `everr <command> --help` for the help included with your installed version.
 
 ## Cloud
 
@@ -14,23 +14,23 @@ The Everr CLI queries local and Cloud telemetry, inspects GitHub Actions CI runs
 
 ## Setup and maintenance
 
-- `everr setup`: set up local telemetry, bundled Skills, and Everr Cloud
+- `everr setup`: set up local telemetry, bundled skills, and Everr Cloud
 - `everr init`: connect the current GitHub repository and import its CI history
 - `everr upgrade`: upgrade the CLI and, when installed, the Everr Desktop app
-- `everr uninstall`: remove local Everr state and globally installed Skills, then print the command that removes the CLI binary
+- `everr uninstall`: remove local Everr state and globally installed skills, then print the command that removes the CLI binary
 
 ## Skills
 
-- `everr skills list [--project|--global] [--agent <codex|claude-code|cursor|all>]`: list bundled Everr Skills for a scope and Agent
-- `everr skills install [--all] [--project|--global] [--agent <agent>] [--dry-run]`: install all bundled Skills. In an interactive terminal, omitted choices are prompted. In a non-interactive context, `--all` is required and the scope defaults to the project.
-- `everr skills update [SKILL]... [--project|--global] [--agent <agent>] [--dry-run]`: update bundled Skills already installed in the selected scope. With no scope, update matching installations in both project and global scopes.
-- `everr skills uninstall [SKILL]... [--all] [--project|--global] [--agent <agent>] [--yes] [--dry-run]`: uninstall named bundled Skills. `--all` requires `--yes`.
+- `everr skills list [--project|--global] [--agent <codex|claude-code|cursor|all>]`: list bundled Everr skills for a scope and Agent
+- `everr skills install [--all] [--project|--global] [--agent <agent>] [--dry-run]`: install all bundled skills. In an interactive terminal, omitted choices are prompted. In a non-interactive context, `--all` is required and the scope defaults to the project.
+- `everr skills update [SKILL]... [--project|--global] [--agent <agent>] [--dry-run]`: update bundled skills already installed in the selected scope. With no scope, update matching installations in both project and global scopes.
+- `everr skills uninstall [SKILL]... [--all] [--project|--global] [--agent <agent>] [--yes] [--dry-run]`: uninstall named bundled skills. `--all` requires `--yes`.
 
 The `--agent` option can be repeated. With no Agent filter, a command targets all supported Agents.
 
 ## CI
 
-- `everr ci status`: show CI runs for the current commit
+- `everr ci status`: show CI status for the current commit
   - `--commit <sha-or-ref>`: target another commit
   - `--run-id <id>`: target a GitHub Actions run ID
   - `--branch <name>` and `--repo <owner/name>`: override repository context
@@ -54,7 +54,7 @@ The `--agent` option can be repeated. With no Agent filter, a command targets al
 - `everr ci show <trace-id>`: show a CI run's jobs and steps
   - `--failed`: show only failed jobs and their failed steps
 
-- `everr ci logs <trace-id> --job-name <job> --step-number <n>`: print Logs for one CI step (the last 1000 lines by default)
+- `everr ci logs <trace-id> --job-name <job> --step-number <n>`: print logs for one CI step (the last 1000 lines by default)
   - `--job-name <job>` or `--job-id <id>`: select one job
   - `--step-number <n>` or `--log-failed`: select one step
   - `--tail <n>`: print lines from the bottom
@@ -69,7 +69,7 @@ The `--agent` option can be repeated. With no Agent filter, a command targets al
 - `everr local status`: show the local Collector status and its OTLP and SQL endpoints
 - `everr local query "<SQL>"`: run read-only SQL against local telemetry
   - `--format <json|ndjson|table>`: choose the output format (default: `table` in a terminal, `ndjson` otherwise)
-- `everr wrap -- <command>`: run a command and capture its stdout, stderr, and exit status as local Logs
+- `everr wrap -- <command>`: run a command and capture its stdout, stderr, and exit status as local logs
   - The command only starts when the local Collector is available.
   - The CLI preserves the command's exit code.
 

--- a/packages/docs/content/docs/reference/runbook-spec.mdx
+++ b/packages/docs/content/docs/reference/runbook-spec.mdx
@@ -122,7 +122,7 @@ Runbooks reconcile through the same apply tree as dashboards and alerts:
 repoid: "2f8e3f90-9d1c-5d5f-a0f9-2d8e7f4a25d1"
 ```
 
-Declarations sit flat in `everr/` as `*.runbook.yaml` (the legacy `*.notebook.yaml` suffix is still recognized; apply routes by the `kind:` field). `everr apply ./everr` makes the live runbooks for that repoid exactly match the tree, delete-by-default. Use `--preview` to review first without touching the live state. See the [`everr apply` reference](/docs/reference/cli#dashboards-gitops).
+Declarations sit flat in `everr/` as `*.runbook.yaml` (the legacy `*.notebook.yaml` suffix is still recognized; apply routes by the `kind:` field). `everr apply ./everr` makes the live runbooks for that repoid exactly match the tree, delete-by-default. Use `--preview` to review first without touching the live state. See the [`everr apply` reference](/docs/reference/cli#apply).
 
 ## Constraints and errors
 


### PR DESCRIPTION
## Summary

- update CLI command and option descriptions to match the current telemetry, CI, Skills, and resources-as-code surface
- refresh the CLI reference with the complete command set, including `upgrade` and `resources`, and remove the retired `--force` option
- update affected documentation anchors and add help-output coverage plus a patch changeset

## Testing

- `cargo test -p everr-cli`
- `pnpm --filter @everr/docs types:check`
- `pnpm --filter @everr/docs build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed CLI help text and command descriptions for telemetry, CI, Skills, and resource management.
  * Reorganized the CLI reference with updated commands, flags, and resource-management guidance.
  * Updated publishing, alert, and runbook documentation links to the current `everr apply` reference.
* **Tests**
  * Updated help-output coverage for revised commands and descriptions, including resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->