### PR TITLE
fix(otel-web): add navigation time to LCP and TTFB

### DIFF
--- a/.changeset/web-vital-occurrence-time.md
+++ b/.changeset/web-vital-occurrence-time.md
@@ -1,0 +1,5 @@
+---
+"@everr/otel-web": patch
+---
+
+Add the browser measurement time to delayed initial-navigation LCP and TTFB records as the `everr.navigation.time` epoch-millisecond attribute.

--- a/crates/everr-core/assets/skills/everr-use-telemetry/rules/browser-events.md
+++ b/crates/everr-core/assets/skills/everr-use-telemetry/rules/browser-events.md
@@ -44,6 +44,8 @@ Element attributes, shared by everything that names a DOM element: `everr.elemen
 
 Semconv names stay bare: `browser.web_vital.name` (`lcp`, `cls`, `ttfb`, `inp`), `browser.web_vital.value` (ms, except cls which is unitless), `browser.web_vital.delta` (always equal to value: one record per metric per navigation), `browser.web_vital.id`. Everr additions on every vital: `everr.browser.web_vital.rating` (`good`, `needs-improvement`, `poor`) and `everr.browser.web_vital.navigation_type`.
 
+For an initial navigation, TTFB and LCP carry `everr.navigation.time` as integer epoch milliseconds. TTFB uses the navigation response start and LCP uses the accepted largest-contentful-paint entry time. The log record timestamp remains the report time.
+
 Attribution for LCP, CLS, and TTFB rides under `everr.browser.web_vital.<metric>.*`:
 
 | Metric | Attribution attributes (`everr.browser.web_vital.<metric>.` prefix) |

--- a/packages/otel-web/src/instrumentations/performance/webvitals.test.ts
+++ b/packages/otel-web/src/instrumentations/performance/webvitals.test.ts
@@ -111,6 +111,7 @@ function stubTiming() {
   }
   vi.stubGlobal("PerformanceObserver", PO);
   vi.stubGlobal("performance", {
+    timeOrigin: 1_700_000_000_000,
     now: () => nowMs,
     getEntriesByType: (type: string) => perfEntries[type] ?? [],
   });
@@ -205,6 +206,7 @@ describe("ttfb", () => {
     expect(a["everr.browser.web_vital.ttfb.dns_duration"]).toBe(5);
     expect(a["everr.browser.web_vital.ttfb.connection_duration"]).toBe(20);
     expect(a["everr.browser.web_vital.ttfb.request_duration"]).toBe(85.5);
+    expect(a["everr.navigation.time"]).toBe(1_700_000_000_121);
   });
 
   it("counts service worker startup as cache time via workerStart", () => {
@@ -277,6 +279,7 @@ describe("lcp", () => {
     expect(a["everr.browser.web_vital.lcp.resource_load_delay"]).toBe(100);
     expect(a["everr.browser.web_vital.lcp.resource_load_duration"]).toBe(200);
     expect(a["everr.browser.web_vital.lcp.element_render_delay"]).toBe(600);
+    expect(a["everr.navigation.time"]).toBe(1_700_000_001_000);
   });
 
   it("finalizes on the first trusted input and stops observing", () => {

--- a/packages/otel-web/src/instrumentations/performance/webvitals.ts
+++ b/packages/otel-web/src/instrumentations/performance/webvitals.ts
@@ -84,11 +84,20 @@ export function startWebVitals(emit: Emit, vitals: Classic[]): () => void {
   let restored = false;
 
   // Each caller examines `stopped` before it sends a record.
-  const report = (name: Classic, value: number, attribution: Attrs) => {
+  const report = (
+    name: Classic,
+    value: number,
+    attribution: Attrs,
+    occurrenceTime?: number,
+  ) => {
     const extra: Attrs = {};
     for (const [key, v] of Object.entries(attribution)) {
       extra[`everr.browser.web_vital.${name}.${key}`] = v;
     }
+    if (occurrenceTime !== undefined)
+      extra["everr.navigation.time"] = Math.round(
+        performance.timeOrigin + occurrenceTime,
+      );
     emitVital(emit, name, value, restored, extra);
   };
 
@@ -119,13 +128,18 @@ export function startWebVitals(emit: Emit, vitals: Classic[]): () => void {
     const dnsStart = Math.max(nav.domainLookupStart - start, 0);
     const connectStart = Math.max(nav.connectStart - start, 0);
     const connectEnd = Math.max(nav.connectEnd - start, 0);
-    report("ttfb", value, {
-      waiting_duration: waitEnd,
-      cache_duration: dnsStart - waitEnd,
-      dns_duration: connectStart - dnsStart,
-      connection_duration: connectEnd - connectStart,
-      request_duration: value - connectEnd,
-    });
+    report(
+      "ttfb",
+      value,
+      {
+        waiting_duration: waitEnd,
+        cache_duration: dnsStart - waitEnd,
+        dns_duration: connectStart - dnsStart,
+        connection_duration: connectEnd - connectStart,
+        request_duration: value - connectEnd,
+      },
+      nav.responseStart,
+    );
   };
   const onLoad = () => setTimeout(reportTtfb);
   if (vitals.includes("ttfb")) {
@@ -199,7 +213,7 @@ export function startWebVitals(emit: Emit, vitals: Classic[]): () => void {
       attribution.resource_load_duration = responseEnd - requestStart;
       attribution.element_render_delay = value - responseEnd;
     }
-    report("lcp", value, attribution);
+    report("lcp", value, attribution, lcp.startTime);
   };
 
   // An input from the code is not trusted, and it must not complete the record.


### PR DESCRIPTION
## Summary

- add `everr.navigation.time` to delayed initial-navigation TTFB and LCP records
- encode the browser measurement time as integer epoch milliseconds
- leave the canonical OTLP log timestamp at report time
- document the attribute and add a patch changeset

## Validation

- `env NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @everr/otel-web test` (371 tests)
- `pnpm --filter @everr/otel-web typecheck`
- `pnpm --filter @everr/otel-web size` (full composition: 9.79 kB of 9.8 kB)
- Biome checks on changed source files
- real Chromium capture against the local collector, confirming TTFB and LCP carry `everr.navigation.time`, omit `everr.event.time`, and retain report time as the log timestamp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Initial-navigation TTFB and LCP records now include the browser measurement time through the `everr.navigation.time` attribute.
  * Measurement times are recorded as epoch milliseconds, while the record timestamp continues to reflect the reporting time.

* **Documentation**
  * Updated web-vitals documentation to describe the timing information included in TTFB and LCP records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
