### PR TITLE
fix(clickhouse): rebuild every app table in the cut-over

### DIFF
--- a/clickhouse/migrations/2026-09-03-direct-ingest.sh
+++ b/clickhouse/migrations/2026-09-03-direct-ingest.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 # Cut the write path over to direct ingest: otel.* become Null landing
 # tables, the views stamp tenant_id and retention_days from the resource
-# attributes the collector sets, the dictionary goes away. app.* is untouched.
+# attributes the collector sets, the dictionary goes away.
+#
+# Every app.* table is rebuilt empty. There is no backfill.
 #
 # Run AFTER the app and the collector that stamp everr.retention.* are
 # deployed. Per table there is a sub-second window between dropping the old
@@ -33,15 +35,25 @@ CLIENT_ARGS=("$@")
 
 TABLES=(traces logs metrics_gauge metrics_sum metrics_histogram metrics_exponential_histogram metrics_summary)
 
-# The metrics tables are rebuilt, not altered. Their sort key becomes
-# (tenant_id, ServiceName, MetricName, toStartOfHour(TimeUnix),
-# cityHash64(Attributes), TimeUnix) and TimeUnix narrows from DateTime64(9) to
-# DateTime. ALTER can do neither: a sort key cannot be rewritten, and the type
-# of a column the sort key uses cannot change. Stored metrics history goes;
-# app.logs and app.traces keep theirs. Row policies and grants survive the
-# drop because ClickHouse keys them by database and table name, not by the
-# table UUID, so tenant isolation and the per-org /sql API users are unharmed.
-REBUILD=(metrics_gauge metrics_sum metrics_histogram metrics_exponential_histogram metrics_summary)
+# The app.* tables are rebuilt, not altered, and app.alert_events with them.
+# Two reasons, either one enough on its own:
+#
+#   The tables that are live carry a TTL built from dictGetOrDefault. Any ALTER
+#   re-validates that expression and fails with "TTL expression cannot contain
+#   non-deterministic functions", so the codec and index blocks in init/10
+#   cannot run against them at all.
+#
+#   The metrics sort key becomes (tenant_id, ServiceName, MetricName,
+#   toStartOfHour(TimeUnix), cityHash64(Attributes), TimeUnix) and TimeUnix
+#   narrows to DateTime. ALTER can do neither: a sort key cannot be rewritten,
+#   and the type of a column the sort key uses cannot change.
+#
+# CREATE TABLE IF NOT EXISTS is a no-op on a table that is already there, so
+# without the drop init/10 would silently leave the old shape in place.
+#
+# Row policies and grants survive the drop, because ClickHouse keys access
+# control by database and table name and not by the table UUID, so tenant
+# isolation and the per-org /sql API users need no repair.
 
 # After the landing tables become Null and before their views exist, an insert
 # is accepted and discarded. If the swap stops half way, drop the Null tables
@@ -54,42 +66,37 @@ drop_landing_tables() {
   done
 }
 
-echo "1/4 guard: the collector must already stamp retention"
+echo "1/3 guard: the collector must already stamp retention"
 run_sql "SELECT throwIf(
   (SELECT count() FROM otel.otel_logs WHERE TimestampTime > now() - INTERVAL 10 MINUTE AND ResourceAttributes['everr.retention.days'] = '') > 0,
   'rows without everr.retention.days arrived in the last 10 minutes: deploy the collector first')"
 
-echo "2/4 swap landing tables and views"
+echo "2/3 rebuild the tables, the landing tables and the views"
 # The stored otel.* copies go with the tables. They hold seven days of raw
 # rows that nothing reads: app.* is the read model.
 trap drop_landing_tables ERR
+# alert_events_logs_mv writes into app.logs, so it goes before app.logs does.
+run_sql "DROP VIEW IF EXISTS app.alert_events_logs_mv"
 for t in "${TABLES[@]}"; do
   run_sql "DROP VIEW IF EXISTS app.${t}_mv"
   run_sql "DROP TABLE IF EXISTS otel.otel_${t}"
-done
-for t in "${REBUILD[@]}"; do
   run_sql "DROP TABLE IF EXISTS app.${t}"
 done
-run_file init/03-create-otel-tables.sql   # Null engines
-run_file init/10-create-mvs.sql           # app.* CREATE IF NOT EXISTS rebuilds the metrics tables; views are recreated
+run_sql "DROP TABLE IF EXISTS app.alert_events"
+run_file init/03-create-otel-tables.sql     # Null engines
+run_file init/10-create-mvs.sql             # app.* and their views
+run_file init/12-create-alert-events.sql    # app.alert_events and its view into app.logs
 trap - ERR
 
 # Every landing table must have its view back before ingestion resumes.
 mv_names=$(printf ",'%s_mv'" "${TABLES[@]}")
 run_sql "SELECT throwIf(
   (SELECT count() FROM system.tables
-     WHERE database = 'app' AND engine = 'MaterializedView' AND name IN (${mv_names#,})) != ${#TABLES[@]},
-  'a landing table has no materialized view: rows would be discarded')"
+     WHERE database = 'app' AND engine = 'MaterializedView'
+       AND name IN (${mv_names#,}, 'alert_events_logs_mv')) != $(( ${#TABLES[@]} + 1 )),
+  'a table is missing its materialized view: rows would be discarded')"
 
-echo "3/4 alert events keep their retention from the app"
-# REMOVE DEFAULT, not MODIFY COLUMN ... UInt16: a modify that does not name a
-# default keeps the one the column has, and the dictionary then still has a
-# dependent table and cannot be dropped in step 4.
-# Safe in either order: the app deploy that writes retention_days explicitly
-# comes first, and the old DEFAULT still works until this runs.
-run_sql "ALTER TABLE app.alert_events MODIFY COLUMN retention_days REMOVE DEFAULT"
-
-echo "4/4 remove the dictionary"
+echo "3/3 remove the dictionary"
 run_sql "DROP DICTIONARY IF EXISTS app.tenant_retention"
 run_sql "DROP TABLE IF EXISTS app.tenant_retention_source"
 run_sql "REVOKE dictGet ON app.tenant_retention FROM collector_rw, web_app_admin" || true

--- a/docs/clickhouse-retention-rollout.md
+++ b/docs/clickhouse-retention-rollout.md
@@ -145,9 +145,9 @@ one high-cardinality series over a long range reads 820k rows where the old key
 read 326k. No built-in dashboard does that; all 232 metric reads aggregate
 across series.
 
-On an existing install the cut-over rebuilds these five tables empty rather
-than altering them, which is where the stored metrics history goes. See
-"Production rollout".
+The cut-over rebuilds these tables rather than altering them: a sort key
+cannot be rewritten, and `TimeUnix` cannot change type while the old key uses
+it. See "Production rollout".
 
 `DateTime` instead of `DateTime64(9)` drops sub-second precision that nothing
 reads: every query buckets with `toStartOfInterval`. On the same data the
@@ -263,19 +263,22 @@ because a new view needs the attributes to already be on the wire.
    ```
 
    What it does: refuses to start if rows without the attribute arrived in the
-   last 10 minutes, then per table drops the view and the stored landing
-   table, drops the five `app.metrics_*` tables, re-runs `init/03` (Null
-   engines) and `init/10` (which rebuilds the metrics tables and recreates the
-   views), removes the `app.alert_events` default, and drops the dictionary and
-   its source table. It then checks that all seven views are back.
+   last 10 minutes, then drops every view, every stored landing table and
+   every `app.*` table including `app.alert_events`, and re-runs `init/03`
+   (Null engines), `init/10` (`app.*` and their views) and `init/12`
+   (`app.alert_events` and its projection into `app.logs`). It then drops the
+   dictionary and its source table, and checks that all eight views are back.
 
    Effects to expect:
-   - **`app.logs` and `app.traces` keep every row.**
-   - **The five `app.metrics_*` tables are rebuilt empty.** Stored metrics
-     history goes. The new sort key cannot be reached with `ALTER`: a sort key
-     cannot be rewritten, and `TimeUnix` cannot change type while the old key
-     uses it. Row policies and grants survive the drop, because ClickHouse
-     keys them by database and table name and not by the table UUID, so tenant
+   - **Every `app.*` table is rebuilt empty. There is no backfill.** The
+     tables that are live carry a TTL built from `dictGetOrDefault`, and any
+     `ALTER` re-validates that expression and fails with `TTL expression
+     cannot contain non-deterministic functions`, so they cannot be altered
+     into the new shape at all. `CREATE TABLE IF NOT EXISTS` is a no-op on a
+     table that is already there, so without the drop the old shape would
+     stay in place silently.
+   - Row policies and grants survive the drop, because ClickHouse keys access
+     control by database and table name and not by the table UUID, so tenant
      isolation and the per-org `/sql` users need no repair.
    - The stored `otel.*` copies are dropped, up to seven days of raw rows
      that nothing reads.


### PR DESCRIPTION
Fixes the blocker recorded in #426.

The cut-over rebuilt only the five `app.metrics_*` tables. That was correct
while the retention work and direct ingest were separate PRs: the retention
work shipped first, so `app.logs`, `app.traces` and `app.alert_events` already
had `retention_days` by the time the cut-over ran. They are one PR now, so the
cut-over has to run against the schema that is live, and there it aborted at
the first `ALTER TABLE app.traces`:

```
Code: 36. DB::Exception: TTL expression cannot contain non-deterministic
functions, but contains function dictGetOrDefault. (BAD_ARGUMENTS)
```

The live tables carry a TTL built from the dictionary, and any `ALTER`
re-validates that expression. `CREATE TABLE IF NOT EXISTS` is a no-op on a
table that is already there, so nothing would have added the column either.

Every `app.*` table is now dropped and recreated, `app.alert_events` included,
and `init/12` runs for it and its projection into `app.logs`.
`alert_events_logs_mv` is dropped first, because it writes into `app.logs`.
Rebuilding `alert_events` also makes the step that removed its `DEFAULT`
unnecessary, so the script is three steps instead of four.

There is no backfill, which this work already accepted.

## Verified

Against a container built from `main`'s schema, which is what production runs:

- the cut-over completes, exit 0, no exception;
- every table comes back with `retention_days` in its partition key, including
  `app.alert_events` at `(toStartOfMonth(event_date), retention_days)`;
- `alert_events.retention_days` has no `DEFAULT`, the dictionary is gone, and
  all eight views are back;
- two tenants ingest and are stamped 30 and 14 with the retention key stripped;
- an alert event inserts and projects into `app.logs` through the rebuilt view;
- a per-org `/sql` user provisioned before the rebuild still sees only its own
  tenant's rows, so row policies survived the drop;
- a deliberately broken run still drops the landing tables, so a partial swap
  fails loudly instead of discarding rows.
