### PR TITLE
fix(otel-web): preserve event occurrence timestamps

### DIFF
--- a/crates/everr-core/assets/skills/everr-use-telemetry/rules/browser-events.md
+++ b/crates/everr-core/assets/skills/everr-use-telemetry/rules/browser-events.md
@@ -27,8 +27,6 @@ Use this rule when investigating web-app behavior: page views, clicks, web vital
 
 ## Log Events (`EventName` column)
 
-`Timestamp` is the time the event occurred, not the time a delayed observer reported it or a batch sent it. TTFB uses `responseStart`, LCP uses the chosen paint, CLS uses the last contributing shift in the selected session window, and INP uses the initial input. Click, change, and submit use the DOM event time. A rage click uses the first click in its burst. A custom instrumentation can pass any OpenTelemetry time input with `ctx.emit(name, attributes, timestamp)`; omission defaults to the instant `emit` is called. Records are ordered oldest to newest within each OTLP logs payload. Spans are ordered by start time within each traces payload.
-
 | EventName | Meaning | Key attributes |
 | --- | --- | --- |
 | `everr.browser.page_view` | One per hard navigation and per SPA navigation | `everr.navigation.type` (`initial` or `history_change`) |

--- a/crates/everr-core/assets/skills/everr-use-telemetry/rules/browser-events.md
+++ b/crates/everr-core/assets/skills/everr-use-telemetry/rules/browser-events.md
@@ -27,7 +27,7 @@ Use this rule when investigating web-app behavior: page views, clicks, web vital
 
 ## Log Events (`EventName` column)
 
-`Timestamp` is the time the event occurred, not the time a delayed observer reported it or a batch sent it. TTFB uses `responseStart`, LCP uses the chosen paint, CLS uses the last contributing shift in the selected session window, and INP uses the initial input. Click, change, and submit use the DOM event time. A rage click uses the first click in its burst. A custom instrumentation can pass any OpenTelemetry time input with `ctx.emit(name, attributes, timestamp)`; omission defaults to the instant `emit` is called.
+`Timestamp` is the time the event occurred, not the time a delayed observer reported it or a batch sent it. TTFB uses `responseStart`, LCP uses the chosen paint, CLS uses the last contributing shift in the selected session window, and INP uses the initial input. Click, change, and submit use the DOM event time. A rage click uses the first click in its burst. A custom instrumentation can pass any OpenTelemetry time input with `ctx.emit(name, attributes, timestamp)`; omission defaults to the instant `emit` is called. Records are ordered oldest to newest within each OTLP logs payload. Spans are ordered by start time within each traces payload.
 
 | EventName | Meaning | Key attributes |
 | --- | --- | --- |

--- a/crates/everr-core/assets/skills/everr-use-telemetry/rules/browser-events.md
+++ b/crates/everr-core/assets/skills/everr-use-telemetry/rules/browser-events.md
@@ -27,6 +27,8 @@ Use this rule when investigating web-app behavior: page views, clicks, web vital
 
 ## Log Events (`EventName` column)
 
+`Timestamp` is the time the event occurred, not the time a delayed observer reported it or a batch sent it. TTFB uses `responseStart`, LCP uses the chosen paint, CLS uses the last contributing shift in the selected session window, and INP uses the initial input. Click, change, and submit use the DOM event time. A rage click uses the first click in its burst. A custom instrumentation can pass any OpenTelemetry time input with `ctx.emit(name, attributes, timestamp)`; omission defaults to the instant `emit` is called.
+
 | EventName | Meaning | Key attributes |
 | --- | --- | --- |
 | `everr.browser.page_view` | One per hard navigation and per SPA navigation | `everr.navigation.type` (`initial` or `history_change`) |

--- a/packages/otel-web/.size-limit.cjs
+++ b/packages/otel-web/.size-limit.cjs
@@ -12,7 +12,7 @@ module.exports = [
     path: "dist/index.js",
     import: "{ WebSDK }",
     gzip: true,
-    limit: "3.5 KB",
+    limit: "3.6 KB",
   },
   {
     // Raised for the parent span support in the tracer.
@@ -20,7 +20,7 @@ module.exports = [
     path: "dist/index.js",
     import: "{ WebSDK, errors }",
     gzip: true,
-    limit: "4.1 KB",
+    limit: "4.2 KB",
   },
   {
     // Raised for the exit-flush budget code (refer to pipeline/emitter.ts)
@@ -29,7 +29,7 @@ module.exports = [
     path: "dist/index.js",
     import: "{ WebSDK, pageviews }",
     gzip: true,
-    limit: "3.7 KB",
+    limit: "3.8 KB",
   },
   {
     // Raised for the naming attributes in the element selector.
@@ -64,7 +64,7 @@ module.exports = [
     path: "dist/index.js",
     import: "{ WebSDK, network }",
     gzip: true,
-    limit: "4 KB",
+    limit: "4.1 KB",
   },
   {
     // All instrumentation factories composed: verifies the sampled runtime is
@@ -75,6 +75,6 @@ module.exports = [
     import:
       "{ WebSDK, errors, pageviews, interactions, performance, pageLoad, network, sampled }",
     gzip: true,
-    limit: "9.8 KB",
+    limit: "10 KB",
   },
 ];

--- a/packages/otel-web/.size-limit.cjs
+++ b/packages/otel-web/.size-limit.cjs
@@ -12,7 +12,7 @@ module.exports = [
     path: "dist/index.js",
     import: "{ WebSDK }",
     gzip: true,
-    limit: "3.6 KB",
+    limit: "3.5 KB",
   },
   {
     // Raised for the parent span support in the tracer.
@@ -20,7 +20,7 @@ module.exports = [
     path: "dist/index.js",
     import: "{ WebSDK, errors }",
     gzip: true,
-    limit: "4.3 KB",
+    limit: "4.2 KB",
   },
   {
     // Raised for the exit-flush budget code (refer to pipeline/emitter.ts)
@@ -29,7 +29,7 @@ module.exports = [
     path: "dist/index.js",
     import: "{ WebSDK, pageviews }",
     gzip: true,
-    limit: "3.9 KB",
+    limit: "3.8 KB",
   },
   {
     // Raised for the naming attributes in the element selector.
@@ -47,7 +47,7 @@ module.exports = [
     path: "dist/index.js",
     import: "{ WebSDK, performance }",
     gzip: true,
-    limit: "7.35 KB",
+    limit: "7.25 KB",
   },
   {
     // The load window: the PageLoad root that ends at LCP, the asset
@@ -57,14 +57,14 @@ module.exports = [
     path: "dist/index.js",
     import: "{ WebSDK, pageLoad }",
     gzip: true,
-    limit: "4.7 KB",
+    limit: "4.6 KB",
   },
   {
     name: "core + network",
     path: "dist/index.js",
     import: "{ WebSDK, network }",
     gzip: true,
-    limit: "4.2 KB",
+    limit: "4.1 KB",
   },
   {
     // All instrumentation factories composed: verifies the sampled runtime is
@@ -75,6 +75,6 @@ module.exports = [
     import:
       "{ WebSDK, errors, pageviews, interactions, performance, pageLoad, network, sampled }",
     gzip: true,
-    limit: "10 KB",
+    limit: "9.9 KB",
   },
 ];

--- a/packages/otel-web/.size-limit.cjs
+++ b/packages/otel-web/.size-limit.cjs
@@ -20,7 +20,7 @@ module.exports = [
     path: "dist/index.js",
     import: "{ WebSDK, errors }",
     gzip: true,
-    limit: "4.2 KB",
+    limit: "4.3 KB",
   },
   {
     // Raised for the exit-flush budget code (refer to pipeline/emitter.ts)
@@ -29,7 +29,7 @@ module.exports = [
     path: "dist/index.js",
     import: "{ WebSDK, pageviews }",
     gzip: true,
-    limit: "3.8 KB",
+    limit: "3.9 KB",
   },
   {
     // Raised for the naming attributes in the element selector.
@@ -47,7 +47,7 @@ module.exports = [
     path: "dist/index.js",
     import: "{ WebSDK, performance }",
     gzip: true,
-    limit: "7.25 KB",
+    limit: "7.35 KB",
   },
   {
     // The load window: the PageLoad root that ends at LCP, the asset
@@ -57,14 +57,14 @@ module.exports = [
     path: "dist/index.js",
     import: "{ WebSDK, pageLoad }",
     gzip: true,
-    limit: "4.6 KB",
+    limit: "4.7 KB",
   },
   {
     name: "core + network",
     path: "dist/index.js",
     import: "{ WebSDK, network }",
     gzip: true,
-    limit: "4.1 KB",
+    limit: "4.2 KB",
   },
   {
     // All instrumentation factories composed: verifies the sampled runtime is

--- a/packages/otel-web/CHANGELOG.md
+++ b/packages/otel-web/CHANGELOG.md
@@ -27,7 +27,7 @@
 
 ### Fixes
 
-- Events now carry the time they occurred instead of the later reporting time. `InstrumentationContext.emit` accepts an optional timestamp, and the tracer supports every OpenTelemetry `TimeInput` form. Web vitals and user interactions use their browser performance or DOM event timestamps.
+- Events now carry the time they occurred instead of the later reporting time. `InstrumentationContext.emit` accepts an optional timestamp, and the tracer supports every OpenTelemetry `TimeInput` form. Web vitals and user interactions use their browser performance or DOM event timestamps. Logs and traces are ordered by occurrence time within each payload.
 
 ### Breaking: capture is opt-in only
 

--- a/packages/otel-web/CHANGELOG.md
+++ b/packages/otel-web/CHANGELOG.md
@@ -25,6 +25,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Events now carry the time they occurred instead of the later reporting time. `InstrumentationContext.emit` accepts an optional timestamp, and the tracer supports every OpenTelemetry `TimeInput` form. Web vitals and user interactions use their browser performance or DOM event timestamps.
+
 ### Breaking: capture is opt-in only
 
 `init` now wires pipeline, transport, and identity and captures nothing by

--- a/packages/otel-web/CHANGELOG.md
+++ b/packages/otel-web/CHANGELOG.md
@@ -27,7 +27,7 @@
 
 ### Fixes
 
-- Events now carry the time they occurred instead of the later reporting time. `InstrumentationContext.emit` accepts an optional timestamp, and the tracer supports every OpenTelemetry `TimeInput` form. Web vitals and user interactions use their browser performance or DOM event timestamps. Logs and traces are ordered by occurrence time within each payload.
+- Events now carry the time they occurred instead of the later reporting time. `InstrumentationContext.emit` and the tracer accept epoch milliseconds. The exported `epoch()` helper converts standard browser timestamps at their capture site. Web vitals and user interactions use their browser performance or DOM event timestamps. Logs and traces are ordered by occurrence time within each payload.
 
 ### Breaking: capture is opt-in only
 

--- a/packages/otel-web/README.md
+++ b/packages/otel-web/README.md
@@ -68,7 +68,7 @@ const checkoutTiming: Instrumentation = ({ emit, tracer }) => {
 };
 ```
 
-The tracer follows the same OpenTelemetry contract through `startTime` and `span.end(endTime)`. Built-in instrumentations timestamp web vitals and interactions from their browser performance entries or DOM events, even when the SDK reports them later.
+The tracer follows the same OpenTelemetry contract through `startTime` and `span.end(endTime)`. Built-in instrumentations timestamp web vitals and interactions from their browser performance entries or DOM events, even when the SDK reports them later. Each logs payload is ordered by event timestamp, and each traces payload is ordered by span start time. Records with the same timestamp keep their capture order.
 
 ## Manual capture
 

--- a/packages/otel-web/README.md
+++ b/packages/otel-web/README.md
@@ -50,15 +50,17 @@ Wrap any instrumentation in `sampled(instrumentation, rate)` to capture a fracti
 
 ### Event and span timestamps
 
-Custom instrumentations can set the time when an event happened. The timestamp accepts the OpenTelemetry `TimeInput` forms: epoch milliseconds, a DOM high-resolution timestamp such as `Event.timeStamp` or `PerformanceEntry.startTime`, a `Date`, or an HrTime tuple. Without it, the timestamp is the instant `emit` is called.
+Custom instrumentations can set the time when an event happened as integer epoch milliseconds. Browser APIs expose values such as `Event.timeStamp` and `PerformanceEntry.startTime` relative to `performance.timeOrigin`; convert those values with `epoch()`. Without a timestamp, the SDK uses the instant `emit` is called.
 
 ```ts
+import { epoch, type Instrumentation } from "@everr/otel-web";
+
 const checkoutTiming: Instrumentation = ({ emit, tracer }) => {
   const onClick = (event: MouseEvent) => {
-    emit("checkout.started", {}, event.timeStamp);
+    emit("checkout.started", {}, epoch(event.timeStamp));
 
     const span = tracer.startSpan("prepare checkout", {
-      startTime: event.timeStamp,
+      startTime: epoch(event.timeStamp),
     });
     prepareCheckout().finally(() => span.end());
   };
@@ -68,7 +70,7 @@ const checkoutTiming: Instrumentation = ({ emit, tracer }) => {
 };
 ```
 
-The tracer follows the same OpenTelemetry contract through `startTime` and `span.end(endTime)`. Built-in instrumentations timestamp web vitals and interactions from their browser performance entries or DOM events, even when the SDK reports them later. Each logs payload is ordered by event timestamp, and each traces payload is ordered by span start time. Records with the same timestamp keep their capture order.
+The tracer uses the same epoch-millisecond contract through `startTime` and `span.end(endTime)`. Timestamp normalization belongs at the capture site; the pipeline does not guess the source or unit of a value. Built-in instrumentations normalize their browser performance entries and DOM events when they capture them, even when the SDK reports them later. Each logs payload is ordered by event timestamp, and each traces payload is ordered by span start time. Records with the same timestamp keep their capture order.
 
 ## Manual capture
 

--- a/packages/otel-web/README.md
+++ b/packages/otel-web/README.md
@@ -48,6 +48,28 @@ Without a key or an endpoint, a production build resolves to an inert client tha
 
 Wrap any instrumentation in `sampled(instrumentation, rate)` to capture a fraction of sessions, for example `sampled(pageLoad(), 0.1)`.
 
+### Event and span timestamps
+
+Custom instrumentations can set the time when an event happened. The timestamp accepts the OpenTelemetry `TimeInput` forms: epoch milliseconds, a DOM high-resolution timestamp such as `Event.timeStamp` or `PerformanceEntry.startTime`, a `Date`, or an HrTime tuple. Without it, the timestamp is the instant `emit` is called.
+
+```ts
+const checkoutTiming: Instrumentation = ({ emit, tracer }) => {
+  const onClick = (event: MouseEvent) => {
+    emit("checkout.started", {}, event.timeStamp);
+
+    const span = tracer.startSpan("prepare checkout", {
+      startTime: event.timeStamp,
+    });
+    prepareCheckout().finally(() => span.end());
+  };
+
+  addEventListener("click", onClick);
+  return () => removeEventListener("click", onClick);
+};
+```
+
+The tracer follows the same OpenTelemetry contract through `startTime` and `span.end(endTime)`. Built-in instrumentations timestamp web vitals and interactions from their browser performance entries or DOM events, even when the SDK reports them later.
+
 ## Manual capture
 
 ```ts

--- a/packages/otel-web/src/errors.ts
+++ b/packages/otel-web/src/errors.ts
@@ -122,6 +122,7 @@ export const captureError = (
         "exception.message": message,
         "exception.stacktrace": stack,
       },
+      undefined,
       17,
       message ? `${type}: ${message}` : type,
     );

--- a/packages/otel-web/src/index.ts
+++ b/packages/otel-web/src/index.ts
@@ -57,4 +57,5 @@ export {
   revoke,
   setPersistence,
 } from "./state/session.js";
+export { epoch } from "./time.js";
 export type { Persistence, UserTraits, WebSDKOptions } from "./types.js";

--- a/packages/otel-web/src/instrumentations/interactions/interactions.test.ts
+++ b/packages/otel-web/src/instrumentations/interactions/interactions.test.ts
@@ -1,12 +1,17 @@
+import type { TimeInput } from "@opentelemetry/api";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Emit } from "../../pipeline/emitter.js";
 import { startInteractions } from "./interactions.js";
 
-let emitted: Array<{ name: string; attrs?: Record<string, unknown> }>;
+let emitted: Array<{
+  name: string;
+  attrs?: Record<string, unknown>;
+  timestamp?: TimeInput;
+}>;
 let stop: () => void;
 
-const emit: Emit = (name, attrs) => {
-  emitted.push({ name, attrs });
+const emit: Emit = (name, attrs, timestamp) => {
+  emitted.push({ name, attrs, timestamp });
 };
 
 function names() {
@@ -21,10 +26,15 @@ function countOf(name: string) {
 const rageClicks = () => countOf("everr.browser.interaction.rage_click");
 const clicks = () => countOf("everr.browser.interaction.click");
 
-function click(el: Element, x = 10, y = 20) {
-  el.dispatchEvent(
-    new MouseEvent("click", { bubbles: true, clientX: x, clientY: y }),
-  );
+function click(el: Element, x = 10, y = 20, at?: number) {
+  const event = new MouseEvent("click", {
+    bubbles: true,
+    clientX: x,
+    clientY: y,
+  });
+  if (at !== undefined)
+    Object.defineProperty(event, "timeStamp", { value: at });
+  el.dispatchEvent(event);
 }
 
 /** Three clicks in the area and in the interval for a rage click. */
@@ -68,6 +78,12 @@ describe("startInteractions", () => {
       expect(a).not.toHaveProperty("everr.browser.interaction.duration");
     });
 
+    it("timestamps a click at the DOM action", () => {
+      document.body.innerHTML = "<button>Go</button>";
+      click(document.querySelector("button") as Element, 10, 20, 123.5);
+      expect(emitted[0].timestamp).toBe(123.5);
+    });
+
     it("a rage burst adds a rage_click, and it keeps the click of that third click", () => {
       document.body.innerHTML = "<button>broken</button>";
       const button = document.querySelector("button") as Element;
@@ -87,6 +103,18 @@ describe("startInteractions", () => {
       expect(rage["everr.element.tag"]).toBe("button");
       // The two records of the third click carry the same data.
       expect(emitted[3].attrs).toEqual(rage);
+    });
+
+    it("timestamps a rage click at the first click in its burst", () => {
+      document.body.innerHTML = "<button>broken</button>";
+      const button = document.querySelector("button") as Element;
+      click(button, 10, 20, 100);
+      click(button, 12, 21, 200);
+      click(button, 13, 22, 300);
+      const rage = emitted.find(
+        (event) => event.name === "everr.browser.interaction.rage_click",
+      );
+      expect(rage?.timestamp).toBe(100);
     });
 
     it("makes one rage_click for one continuous burst, whatever its length", () => {

--- a/packages/otel-web/src/instrumentations/interactions/interactions.test.ts
+++ b/packages/otel-web/src/instrumentations/interactions/interactions.test.ts
@@ -1,4 +1,3 @@
-import type { TimeInput } from "@opentelemetry/api";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Emit } from "../../pipeline/emitter.js";
 import { startInteractions } from "./interactions.js";
@@ -6,7 +5,7 @@ import { startInteractions } from "./interactions.js";
 let emitted: Array<{
   name: string;
   attrs?: Record<string, unknown>;
-  timestamp?: TimeInput;
+  timestamp?: number;
 }>;
 let stop: () => void;
 
@@ -81,7 +80,9 @@ describe("startInteractions", () => {
     it("timestamps a click at the DOM action", () => {
       document.body.innerHTML = "<button>Go</button>";
       click(document.querySelector("button") as Element, 10, 20, 123.5);
-      expect(emitted[0].timestamp).toBe(123.5);
+      expect(emitted[0].timestamp).toBe(
+        Math.round(performance.timeOrigin + 123.5),
+      );
     });
 
     it("a rage burst adds a rage_click, and it keeps the click of that third click", () => {
@@ -114,7 +115,7 @@ describe("startInteractions", () => {
       const rage = emitted.find(
         (event) => event.name === "everr.browser.interaction.rage_click",
       );
-      expect(rage?.timestamp).toBe(100);
+      expect(rage?.timestamp).toBe(Math.round(performance.timeOrigin + 100));
     });
 
     it("makes one rage_click for one continuous burst, whatever its length", () => {

--- a/packages/otel-web/src/instrumentations/interactions/interactions.ts
+++ b/packages/otel-web/src/instrumentations/interactions/interactions.ts
@@ -34,7 +34,9 @@ const TEXT_SELECTION_TARGET =
 export function startInteractions(emit: Emit): () => void {
   // The limits for a rage click. Three clicks in an area of 30 px, with an
   // interval of a maximum of 1 s between them, make a rage click.
-  let rage: [x: number, y: number, at: number, count: number] | undefined;
+  let rage:
+    | [x: number, y: number, at: number, count: number, first: number]
+    | undefined;
 
   const onClick = (event: MouseEvent) => {
     const el = targetOf(event);
@@ -49,27 +51,28 @@ export function startInteractions(emit: Emit): () => void {
 
     // The position and the time are always the values of this click: the
     // window follows the pointer. Only the count carries the history.
-    const now = Date.now();
-    rage = [
-      x,
-      y,
-      now,
+    const now = event.timeStamp;
+    let count = 1;
+    let first = now;
+    if (
       rage &&
       now - rage[2] <= 1_000 &&
       Math.hypot(x - rage[0], y - rage[1]) <= 30
-        ? rage[3] + 1
-        : 1,
-    ];
+    ) {
+      count = rage[3] + 1;
+      first = rage[4];
+    }
+    rage = [x, y, now, count, first];
     // The test is on the count of exactly 3, and the code does not remove the
     // window after it sends the record. Thus one continuous burst makes one
     // rage click and not one for each three clicks: the count continues to 4,
     // to 5, and more, and it agrees with 3 no more.
     if (rage[3] === 3 && !el.closest(TEXT_SELECTION_TARGET)) {
-      emit("everr.browser.interaction.rage_click", attributes);
+      emit("everr.browser.interaction.rage_click", attributes, rage[4]);
     }
     // The rage click does not replace the click. Each click makes its own
     // record, and thus a count of the clicks on an element is correct.
-    emit("everr.browser.interaction.click", attributes);
+    emit("everr.browser.interaction.click", attributes, event.timeStamp);
   };
 
   // The listener uses the capture phase. Thus it receives a click also when a
@@ -85,7 +88,7 @@ export function startInteractions(emit: Emit): () => void {
     // The record carries no content of the DOM in the two conditions.
     const el = targetOf(event);
     if (!el) return;
-    emit("everr.browser.interaction.change", elementAttrs(el));
+    emit("everr.browser.interaction.change", elementAttrs(el), event.timeStamp);
   };
 
   const onSubmit = (event: Event) => {
@@ -97,7 +100,7 @@ export function startInteractions(emit: Emit): () => void {
     const submitter = (event as SubmitEvent).submitter;
     const el = submitter ? guardOf(submitter) : null;
     if (!el) return;
-    emit("everr.browser.interaction.submit", elementAttrs(el));
+    emit("everr.browser.interaction.submit", elementAttrs(el), event.timeStamp);
   };
 
   addEventListener("change", onChange, true);

--- a/packages/otel-web/src/instrumentations/interactions/interactions.ts
+++ b/packages/otel-web/src/instrumentations/interactions/interactions.ts
@@ -1,4 +1,5 @@
 import type { Emit } from "../../pipeline/emitter.js";
+import { epoch } from "../../time.js";
 import { elementAttrs, guardOf, targetOf } from "../element.js";
 
 // The interactions signal. It captures the data for the product analytics
@@ -51,7 +52,7 @@ export function startInteractions(emit: Emit): () => void {
 
     // The position and the time are always the values of this click: the
     // window follows the pointer. Only the count carries the history.
-    const now = event.timeStamp;
+    const now = epoch(event.timeStamp);
     let count = 1;
     let first = now;
     if (
@@ -72,7 +73,7 @@ export function startInteractions(emit: Emit): () => void {
     }
     // The rage click does not replace the click. Each click makes its own
     // record, and thus a count of the clicks on an element is correct.
-    emit("everr.browser.interaction.click", attributes, event.timeStamp);
+    emit("everr.browser.interaction.click", attributes, now);
   };
 
   // The listener uses the capture phase. Thus it receives a click also when a
@@ -88,7 +89,11 @@ export function startInteractions(emit: Emit): () => void {
     // The record carries no content of the DOM in the two conditions.
     const el = targetOf(event);
     if (!el) return;
-    emit("everr.browser.interaction.change", elementAttrs(el), event.timeStamp);
+    emit(
+      "everr.browser.interaction.change",
+      elementAttrs(el),
+      epoch(event.timeStamp),
+    );
   };
 
   const onSubmit = (event: Event) => {
@@ -100,7 +105,11 @@ export function startInteractions(emit: Emit): () => void {
     const submitter = (event as SubmitEvent).submitter;
     const el = submitter ? guardOf(submitter) : null;
     if (!el) return;
-    emit("everr.browser.interaction.submit", elementAttrs(el), event.timeStamp);
+    emit(
+      "everr.browser.interaction.submit",
+      elementAttrs(el),
+      epoch(event.timeStamp),
+    );
   };
 
   addEventListener("change", onChange, true);

--- a/packages/otel-web/src/instrumentations/pageload/pageload.test.ts
+++ b/packages/otel-web/src/instrumentations/pageload/pageload.test.ts
@@ -36,9 +36,9 @@ const tracer = createTracer(
       spanId,
       parentSpanId,
       name,
-      start,
-      end,
-      duration: end - start,
+      start: start as number,
+      end: end as number,
+      duration: (end as number) - (start as number),
       attrs: a,
     });
   },

--- a/packages/otel-web/src/instrumentations/pageload/pageload.ts
+++ b/packages/otel-web/src/instrumentations/pageload/pageload.ts
@@ -1,5 +1,6 @@
 /// <reference path="../../dom.d.ts" />
 import type { Tracer } from "@opentelemetry/api";
+import { epoch } from "../../time.js";
 import { scriptAttrs } from "../performance/shared.js";
 
 // The window of the page load. The code makes one `pageLoad` root span for the
@@ -67,9 +68,6 @@ export function startPageLoad(
   settleMs: number,
   ceilingMs: number,
 ): () => void {
-  // The timestamps of an entry are relative to the time origin, but a span uses
-  // milliseconds from the epoch.
-  const epoch = (time: number) => Math.round(performance.timeOrigin + time);
   // The root is the active span until its end. The function gives the span
   // back, because the observers below start later, and the span stays active
   // for them.

--- a/packages/otel-web/src/instrumentations/performance/inp.test.ts
+++ b/packages/otel-web/src/instrumentations/performance/inp.test.ts
@@ -1,3 +1,4 @@
+import type { TimeInput } from "@opentelemetry/api";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Emit } from "../../pipeline/emitter.js";
 import { createTracer } from "../../pipeline/tracer.js";
@@ -11,7 +12,11 @@ import { startInp } from "./inp.js";
 // period, which uses setTimeout here, and a slow record waits on a timer of
 // 1 s.
 
-let emitted: Array<{ name: string; attrs?: Record<string, unknown> }>;
+let emitted: Array<{
+  name: string;
+  attrs?: Record<string, unknown>;
+  timestamp?: TimeInput;
+}>;
 let spans: Array<{
   name: string;
   duration: number;
@@ -19,14 +24,18 @@ let spans: Array<{
 }>;
 let stop: () => void;
 
-const emit: Emit = (name, attrs) => {
-  emitted.push({ name, attrs });
+const emit: Emit = (name, attrs, timestamp) => {
+  emitted.push({ name, attrs, timestamp });
 };
 
 // The true tracer that sends its spans to a test function. A slow interaction
 // is a span. Its duration is the latency, and the latency is not an attribute.
 const tracer = createTracer((_traceId, _spanId, name, start, end, attrs) => {
-  spans.push({ name, duration: end - start, attrs });
+  spans.push({
+    name,
+    duration: (end as number) - (start as number),
+    attrs,
+  });
 });
 
 const slow = () => spans.filter((s) => s.name === "slow_interaction");
@@ -310,7 +319,7 @@ describe("INP vital", () => {
     document.body.innerHTML = '<button id="b">Go</button>';
     feed([
       { duration: 250, interactionId: 7, target: document.getElementById("b") },
-      { duration: 620, interactionId: 14 },
+      { duration: 620, interactionId: 14, startTime: 2_000 },
       { duration: 90, interactionId: 21 },
     ]);
     settle();
@@ -328,6 +337,7 @@ describe("INP vital", () => {
     expect(a["everr.browser.interaction.id"]).toBe(14);
     expect(a["everr.browser.interaction.input_delay"]).toBe(20);
     expect(a["everr.browser.interaction.type"]).toBe("pointer");
+    expect(vitals()[0].timestamp).toBe(2_000);
   });
 
   it("carries the element payload of its candidate interaction", () => {

--- a/packages/otel-web/src/instrumentations/performance/inp.test.ts
+++ b/packages/otel-web/src/instrumentations/performance/inp.test.ts
@@ -1,4 +1,3 @@
-import type { TimeInput } from "@opentelemetry/api";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Emit } from "../../pipeline/emitter.js";
 import { createTracer } from "../../pipeline/tracer.js";
@@ -15,7 +14,7 @@ import { startInp } from "./inp.js";
 let emitted: Array<{
   name: string;
   attrs?: Record<string, unknown>;
-  timestamp?: TimeInput;
+  timestamp?: number;
 }>;
 let spans: Array<{
   name: string;
@@ -337,7 +336,9 @@ describe("INP vital", () => {
     expect(a["everr.browser.interaction.id"]).toBe(14);
     expect(a["everr.browser.interaction.input_delay"]).toBe(20);
     expect(a["everr.browser.interaction.type"]).toBe("pointer");
-    expect(vitals()[0].timestamp).toBe(2_000);
+    expect(vitals()[0].timestamp).toBe(
+      Math.round(performance.timeOrigin + 2_000),
+    );
   });
 
   it("carries the element payload of its candidate interaction", () => {

--- a/packages/otel-web/src/instrumentations/performance/inp.ts
+++ b/packages/otel-web/src/instrumentations/performance/inp.ts
@@ -1,6 +1,7 @@
 /// <reference path="../../dom.d.ts" />
 import type { Tracer } from "@opentelemetry/api";
 import type { AttrValue, Emit } from "../../pipeline/emitter.js";
+import { epoch } from "../../time.js";
 import { elementAttrs, guardOf } from "../element.js";
 import { emitVital, scriptAttrs, whenIdleOrHidden } from "./shared.js";
 
@@ -298,7 +299,7 @@ export function startInp(
     // The span goes from the input to the next paint. The startTime value gives
     // its position on the trace timeline, and the latency is its duration. Thus
     // the span needs no attribute for the duration.
-    const start = Math.round(performance.timeOrigin + entry.startTime);
+    const start = epoch(entry.startTime);
     tracer
       .startSpan("slow_interaction", {
         startTime: start,
@@ -339,7 +340,7 @@ export function startInp(
         ...attrs,
         ...phaseAttrs(entry, frame, intersectingLoAFs),
       },
-      entry.startTime,
+      epoch(entry.startTime),
     );
   };
 

--- a/packages/otel-web/src/instrumentations/performance/inp.ts
+++ b/packages/otel-web/src/instrumentations/performance/inp.ts
@@ -328,12 +328,19 @@ export function startInp(
     // including the element data. It does not use the key names from
     // web-vitals. Thus the vital and the slow record that it connects to give
     // the same information with the same keys.
-    emitVital(emit, "inp", latency, restored, {
-      "everr.browser.interaction.id": id,
-      "everr.browser.interaction.name": entry.name,
-      ...attrs,
-      ...phaseAttrs(entry, frame, intersectingLoAFs),
-    });
+    emitVital(
+      emit,
+      "inp",
+      latency,
+      restored,
+      {
+        "everr.browser.interaction.id": id,
+        "everr.browser.interaction.name": entry.name,
+        ...attrs,
+        ...phaseAttrs(entry, frame, intersectingLoAFs),
+      },
+      entry.startTime,
+    );
   };
 
   let po: PerformanceObserver | undefined;

--- a/packages/otel-web/src/instrumentations/performance/shared.ts
+++ b/packages/otel-web/src/instrumentations/performance/shared.ts
@@ -1,3 +1,4 @@
+import type { TimeInput } from "@opentelemetry/api";
 import type { AttrValue, Emit } from "../../pipeline/emitter.js";
 import { uniqueId } from "../../state/session.js";
 import type { WebVitalName } from "./index.js";
@@ -27,21 +28,26 @@ export function emitVital(
   value: number,
   restored: boolean,
   extra: Attrs,
+  timestamp?: TimeInput,
 ): void {
   const [ni, poor] = THRESHOLDS[name];
-  emit("browser.web_vital", {
-    "browser.web_vital.name": name,
-    "browser.web_vital.value": value,
-    "browser.web_vital.delta": value,
-    // The SDK sends a maximum of one record for each metric in each navigation
-    // period. Thus the code can make the id when it sends the record, and the
-    // result is the same as an id that it makes at the start of the period.
-    "browser.web_vital.id": uniqueId(),
-    "everr.browser.web_vital.rating":
-      value > poor ? "poor" : value > ni ? "needs-improvement" : "good",
-    "everr.browser.web_vital.navigation_type": navigationType(restored),
-    ...extra,
-  });
+  emit(
+    "browser.web_vital",
+    {
+      "browser.web_vital.name": name,
+      "browser.web_vital.value": value,
+      "browser.web_vital.delta": value,
+      // The SDK sends a maximum of one record for each metric in each navigation
+      // period. Thus the code can make the id when it sends the record, and the
+      // result is the same as an id that it makes at the start of the period.
+      "browser.web_vital.id": uniqueId(),
+      "everr.browser.web_vital.rating":
+        value > poor ? "poor" : value > ni ? "needs-improvement" : "good",
+      "everr.browser.web_vital.navigation_type": navigationType(restored),
+      ...extra,
+    },
+    timestamp,
+  );
 }
 
 /**

--- a/packages/otel-web/src/instrumentations/performance/shared.ts
+++ b/packages/otel-web/src/instrumentations/performance/shared.ts
@@ -1,4 +1,3 @@
-import type { TimeInput } from "@opentelemetry/api";
 import type { AttrValue, Emit } from "../../pipeline/emitter.js";
 import { uniqueId } from "../../state/session.js";
 import type { WebVitalName } from "./index.js";
@@ -28,7 +27,7 @@ export function emitVital(
   value: number,
   restored: boolean,
   extra: Attrs,
-  timestamp?: TimeInput,
+  timestamp?: number,
 ): void {
   const [ni, poor] = THRESHOLDS[name];
   emit(

--- a/packages/otel-web/src/instrumentations/performance/webvitals.test.ts
+++ b/packages/otel-web/src/instrumentations/performance/webvitals.test.ts
@@ -1,3 +1,4 @@
+import type { TimeInput } from "@opentelemetry/api";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { WebSDK } from "../../client.js";
 import type { Emit } from "../../pipeline/emitter.js";
@@ -17,11 +18,15 @@ import { startWebVitals } from "./webvitals.js";
 // coverage as the end-to-end tests of the web-vitals library, for the
 // implementation in this package.
 
-let emitted: Array<{ name: string; attrs?: Record<string, unknown> }>;
+let emitted: Array<{
+  name: string;
+  attrs?: Record<string, unknown>;
+  timestamp?: TimeInput;
+}>;
 let stop: () => void;
 
-const emit: Emit = (name, a) => {
-  emitted.push({ name, attrs: a });
+const emit: Emit = (name, a, timestamp) => {
+  emitted.push({ name, attrs: a, timestamp });
 };
 
 const vitals = (name?: string) =>
@@ -111,6 +116,7 @@ function stubTiming() {
   }
   vi.stubGlobal("PerformanceObserver", PO);
   vi.stubGlobal("performance", {
+    timeOrigin: 1_700_000_000_000,
     now: () => nowMs,
     getEntriesByType: (type: string) => perfEntries[type] ?? [],
   });
@@ -205,6 +211,7 @@ describe("ttfb", () => {
     expect(a["everr.browser.web_vital.ttfb.dns_duration"]).toBe(5);
     expect(a["everr.browser.web_vital.ttfb.connection_duration"]).toBe(20);
     expect(a["everr.browser.web_vital.ttfb.request_duration"]).toBe(85.5);
+    expect(record.timestamp).toBe(120.5);
   });
 
   it("counts service worker startup as cache time via workerStart", () => {
@@ -277,6 +284,7 @@ describe("lcp", () => {
     expect(a["everr.browser.web_vital.lcp.resource_load_delay"]).toBe(100);
     expect(a["everr.browser.web_vital.lcp.resource_load_duration"]).toBe(200);
     expect(a["everr.browser.web_vital.lcp.element_render_delay"]).toBe(600);
+    expect(record.timestamp).toBe(1_000);
   });
 
   it("finalizes on the first trusted input and stops observing", () => {
@@ -359,6 +367,7 @@ describe("cls", () => {
     expect(a["everr.browser.web_vital.cls.largest_shift_time"]).toBe(800);
     expect(a["everr.browser.web_vital.cls.largest_shift_target"]).toBe("img");
     expect(a["everr.browser.web_vital.cls.load_state"]).toBe("complete");
+    expect(record.timestamp).toBe(1_200);
   });
 
   it("starts a new session after a 1s gap and keeps the worst one", () => {
@@ -527,6 +536,7 @@ describe("through the client pipeline", () => {
     const a = attrs(records[0]);
     expect(a["browser.web_vital.name"]).toBe("ttfb");
     expect(a["browser.web_vital.value"]).toBe(120.5);
+    expect(records[0].timeUnixNano).toBe("1700000000120500000");
     expect(a["everr.browser.web_vital.ttfb.request_duration"]).toBe(85.5);
     expect(a["url.path"]).toBe("/pricing");
     // The landing url gives the page of the vital. It is on the resource, and

--- a/packages/otel-web/src/instrumentations/performance/webvitals.test.ts
+++ b/packages/otel-web/src/instrumentations/performance/webvitals.test.ts
@@ -1,4 +1,3 @@
-import type { TimeInput } from "@opentelemetry/api";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { WebSDK } from "../../client.js";
 import type { Emit } from "../../pipeline/emitter.js";
@@ -21,7 +20,7 @@ import { startWebVitals } from "./webvitals.js";
 let emitted: Array<{
   name: string;
   attrs?: Record<string, unknown>;
-  timestamp?: TimeInput;
+  timestamp?: number;
 }>;
 let stop: () => void;
 
@@ -211,7 +210,7 @@ describe("ttfb", () => {
     expect(a["everr.browser.web_vital.ttfb.dns_duration"]).toBe(5);
     expect(a["everr.browser.web_vital.ttfb.connection_duration"]).toBe(20);
     expect(a["everr.browser.web_vital.ttfb.request_duration"]).toBe(85.5);
-    expect(record.timestamp).toBe(120.5);
+    expect(record.timestamp).toBe(1_700_000_000_121);
   });
 
   it("counts service worker startup as cache time via workerStart", () => {
@@ -284,7 +283,7 @@ describe("lcp", () => {
     expect(a["everr.browser.web_vital.lcp.resource_load_delay"]).toBe(100);
     expect(a["everr.browser.web_vital.lcp.resource_load_duration"]).toBe(200);
     expect(a["everr.browser.web_vital.lcp.element_render_delay"]).toBe(600);
-    expect(record.timestamp).toBe(1_000);
+    expect(record.timestamp).toBe(1_700_000_001_000);
   });
 
   it("finalizes on the first trusted input and stops observing", () => {
@@ -367,7 +366,7 @@ describe("cls", () => {
     expect(a["everr.browser.web_vital.cls.largest_shift_time"]).toBe(800);
     expect(a["everr.browser.web_vital.cls.largest_shift_target"]).toBe("img");
     expect(a["everr.browser.web_vital.cls.load_state"]).toBe("complete");
-    expect(record.timestamp).toBe(1_200);
+    expect(record.timestamp).toBe(1_700_000_001_200);
   });
 
   it("starts a new session after a 1s gap and keeps the worst one", () => {
@@ -536,7 +535,7 @@ describe("through the client pipeline", () => {
     const a = attrs(records[0]);
     expect(a["browser.web_vital.name"]).toBe("ttfb");
     expect(a["browser.web_vital.value"]).toBe(120.5);
-    expect(records[0].timeUnixNano).toBe("1700000000120500000");
+    expect(records[0].timeUnixNano).toBe("1700000000121000000");
     expect(a["everr.browser.web_vital.ttfb.request_duration"]).toBe(85.5);
     expect(a["url.path"]).toBe("/pricing");
     // The landing url gives the page of the vital. It is on the resource, and

--- a/packages/otel-web/src/instrumentations/performance/webvitals.ts
+++ b/packages/otel-web/src/instrumentations/performance/webvitals.ts
@@ -1,6 +1,7 @@
 /// <reference path="../../dom.d.ts" />
 
 import type { AttrValue, Emit } from "../../pipeline/emitter.js";
+import { epoch } from "../../time.js";
 import { selectorOf } from "../element.js";
 import type { WebVitalName } from "./index.js";
 import { emitVital, whenIdleOrHidden } from "./shared.js";
@@ -134,7 +135,7 @@ export function startWebVitals(emit: Emit, vitals: Classic[]): () => void {
         connection_duration: connectEnd - connectStart,
         request_duration: value - connectEnd,
       },
-      nav.responseStart,
+      epoch(nav.responseStart),
     );
   };
   const onLoad = () => setTimeout(reportTtfb);
@@ -209,7 +210,7 @@ export function startWebVitals(emit: Emit, vitals: Classic[]): () => void {
       attribution.resource_load_duration = responseEnd - requestStart;
       attribution.element_render_delay = value - responseEnd;
     }
-    report("lcp", value, attribution, lcp.startTime);
+    report("lcp", value, attribution, epoch(lcp.startTime));
   };
 
   // An input from the code is not trusted, and it must not complete the record.
@@ -317,7 +318,7 @@ export function startWebVitals(emit: Emit, vitals: Classic[]): () => void {
             load_state: loadStateAt(clsLargest.time),
           }
         : {},
-      clsTime ?? firstHidden,
+      epoch(clsTime ?? firstHidden),
     );
   };
 
@@ -360,7 +361,7 @@ export function startWebVitals(emit: Emit, vitals: Classic[]): () => void {
           connection_duration: 0,
           request_duration: 0,
         },
-        event.timeStamp,
+        epoch(event.timeStamp),
       );
     }
     if (lcpPo) {
@@ -368,7 +369,7 @@ export function startWebVitals(emit: Emit, vitals: Classic[]): () => void {
         requestAnimationFrame(() => {
           if (!stopped) {
             const now = performance.now();
-            report("lcp", now - event.timeStamp, {}, now);
+            report("lcp", now - event.timeStamp, {}, epoch(now));
           }
         }),
       );

--- a/packages/otel-web/src/instrumentations/performance/webvitals.ts
+++ b/packages/otel-web/src/instrumentations/performance/webvitals.ts
@@ -84,12 +84,17 @@ export function startWebVitals(emit: Emit, vitals: Classic[]): () => void {
   let restored = false;
 
   // Each caller examines `stopped` before it sends a record.
-  const report = (name: Classic, value: number, attribution: Attrs) => {
+  const report = (
+    name: Classic,
+    value: number,
+    attribution: Attrs,
+    timestamp?: number,
+  ) => {
     const extra: Attrs = {};
     for (const [key, v] of Object.entries(attribution)) {
       extra[`everr.browser.web_vital.${name}.${key}`] = v;
     }
-    emitVital(emit, name, value, restored, extra);
+    emitVital(emit, name, value, restored, extra, timestamp);
   };
 
   // The first time in the life of the page when the page was hidden. The code
@@ -119,13 +124,18 @@ export function startWebVitals(emit: Emit, vitals: Classic[]): () => void {
     const dnsStart = Math.max(nav.domainLookupStart - start, 0);
     const connectStart = Math.max(nav.connectStart - start, 0);
     const connectEnd = Math.max(nav.connectEnd - start, 0);
-    report("ttfb", value, {
-      waiting_duration: waitEnd,
-      cache_duration: dnsStart - waitEnd,
-      dns_duration: connectStart - dnsStart,
-      connection_duration: connectEnd - connectStart,
-      request_duration: value - connectEnd,
-    });
+    report(
+      "ttfb",
+      value,
+      {
+        waiting_duration: waitEnd,
+        cache_duration: dnsStart - waitEnd,
+        dns_duration: connectStart - dnsStart,
+        connection_duration: connectEnd - connectStart,
+        request_duration: value - connectEnd,
+      },
+      nav.responseStart,
+    );
   };
   const onLoad = () => setTimeout(reportTtfb);
   if (vitals.includes("ttfb")) {
@@ -199,7 +209,7 @@ export function startWebVitals(emit: Emit, vitals: Classic[]): () => void {
       attribution.resource_load_duration = responseEnd - requestStart;
       attribution.element_render_delay = value - responseEnd;
     }
-    report("lcp", value, attribution);
+    report("lcp", value, attribution, lcp.startTime);
   };
 
   // An input from the code is not trusted, and it must not complete the record.
@@ -238,6 +248,7 @@ export function startWebVitals(emit: Emit, vitals: Classic[]): () => void {
   };
   let clsValue = 0;
   let clsLargest: Shift | undefined;
+  let clsTime: number | undefined;
   let clsDone = !vitals.includes("cls");
   let clsPo: PerformanceObserver | undefined;
 
@@ -278,6 +289,7 @@ export function startWebVitals(emit: Emit, vitals: Classic[]): () => void {
       if (session.value > clsValue) {
         clsValue = session.value;
         clsLargest = session.largest;
+        clsTime = session.last;
       }
     }
   };
@@ -305,6 +317,7 @@ export function startWebVitals(emit: Emit, vitals: Classic[]): () => void {
             load_state: loadStateAt(clsLargest.time),
           }
         : {},
+      clsTime ?? firstHidden,
     );
   };
 
@@ -337,18 +350,26 @@ export function startWebVitals(emit: Emit, vitals: Classic[]): () => void {
     if (!event.persisted || stopped) return;
     restored = true;
     if (vitals.includes("ttfb") && navEntry()) {
-      report("ttfb", 0, {
-        waiting_duration: 0,
-        cache_duration: 0,
-        dns_duration: 0,
-        connection_duration: 0,
-        request_duration: 0,
-      });
+      report(
+        "ttfb",
+        0,
+        {
+          waiting_duration: 0,
+          cache_duration: 0,
+          dns_duration: 0,
+          connection_duration: 0,
+          request_duration: 0,
+        },
+        event.timeStamp,
+      );
     }
     if (lcpPo) {
       requestAnimationFrame(() =>
         requestAnimationFrame(() => {
-          if (!stopped) report("lcp", performance.now() - event.timeStamp, {});
+          if (!stopped) {
+            const now = performance.now();
+            report("lcp", now - event.timeStamp, {}, now);
+          }
         }),
       );
     }
@@ -356,6 +377,7 @@ export function startWebVitals(emit: Emit, vitals: Classic[]): () => void {
       session = { value: 0, first: 0, last: 0, largest: undefined };
       clsValue = 0;
       clsLargest = undefined;
+      clsTime = undefined;
       clsDone = !clsPo;
     }
   };

--- a/packages/otel-web/src/instrumentations/runtime.test.ts
+++ b/packages/otel-web/src/instrumentations/runtime.test.ts
@@ -87,6 +87,22 @@ describe("instrumentation runtime", () => {
     expect(a["everr.visitor.id"]).toMatch(UNIQUE_ID);
   });
 
+  it("lets an instrumentation timestamp an event when it happened", async () => {
+    start({
+      instrumentations: [
+        (ctx) => {
+          ctx.emit(
+            "everr.test.delayed_event",
+            { "everr.test.delay_ms": 5_000 },
+            [1_725_000_000, 123_000_000],
+          );
+        },
+      ],
+    });
+    const [record] = await records();
+    expect(record.timeUnixNano).toBe("1725000000123000000");
+  });
+
   it("per-record attributes win over the envelope", async () => {
     start({
       instrumentations: [

--- a/packages/otel-web/src/instrumentations/runtime.test.ts
+++ b/packages/otel-web/src/instrumentations/runtime.test.ts
@@ -94,7 +94,7 @@ describe("instrumentation runtime", () => {
           ctx.emit(
             "everr.test.delayed_event",
             { "everr.test.delay_ms": 5_000 },
-            [1_725_000_000, 123_000_000],
+            1_725_000_000_123,
           );
         },
       ],

--- a/packages/otel-web/src/instrumentations/runtime.ts
+++ b/packages/otel-web/src/instrumentations/runtime.ts
@@ -14,7 +14,7 @@
 // instrumentation throws an error, that is an error of the caller. This code
 // does not hide it.
 
-import type { TimeInput, Tracer } from "@opentelemetry/api";
+import type { Tracer } from "@opentelemetry/api";
 import type { AttrValue } from "../pipeline/emitter.js";
 import type { PageContext } from "../state/session.js";
 
@@ -29,15 +29,14 @@ export interface InstrumentationContext {
    * the context from `setAttributes`. Then it puts the record in the batch with
    * the other records. The SDK ignores an attribute value of null and an
    * attribute value of undefined. Thus an optional attribute needs no
-   * additional code. The optional timestamp says when the event happened. It
-   * accepts the OpenTelemetry `TimeInput` forms: epoch milliseconds, a DOM
-   * high-resolution timestamp, a `Date`, or `HrTime`. Without it, the SDK uses
-   * the instant that `emit` is called.
+   * additional code. The optional timestamp is integer epoch milliseconds.
+   * Normalize a browser timestamp with `epoch()` at the capture site. Without
+   * it, the SDK uses the instant that `emit` is called.
    */
   emit(
     name: string,
     attributes?: Record<string, AttrValue | null | undefined>,
-    timestamp?: TimeInput,
+    timestamp?: number,
   ): void;
   /**
    * The OTel tracer of the SDK. The traces pipeline sends a completed span.

--- a/packages/otel-web/src/instrumentations/runtime.ts
+++ b/packages/otel-web/src/instrumentations/runtime.ts
@@ -14,7 +14,7 @@
 // instrumentation throws an error, that is an error of the caller. This code
 // does not hide it.
 
-import type { Tracer } from "@opentelemetry/api";
+import type { TimeInput, Tracer } from "@opentelemetry/api";
 import type { AttrValue } from "../pipeline/emitter.js";
 import type { PageContext } from "../state/session.js";
 
@@ -29,11 +29,15 @@ export interface InstrumentationContext {
    * the context from `setAttributes`. Then it puts the record in the batch with
    * the other records. The SDK ignores an attribute value of null and an
    * attribute value of undefined. Thus an optional attribute needs no
-   * additional code.
+   * additional code. The optional timestamp says when the event happened. It
+   * accepts the OpenTelemetry `TimeInput` forms: epoch milliseconds, a DOM
+   * high-resolution timestamp, a `Date`, or `HrTime`. Without it, the SDK uses
+   * the instant that `emit` is called.
    */
   emit(
     name: string,
     attributes?: Record<string, AttrValue | null | undefined>,
+    timestamp?: TimeInput,
   ): void;
   /**
    * The OTel tracer of the SDK. The traces pipeline sends a completed span.

--- a/packages/otel-web/src/logger.ts
+++ b/packages/otel-web/src/logger.ts
@@ -14,7 +14,7 @@ import { currentEmit } from "./state/emit.js";
 const level =
   (severityNumber: number) =>
   (body: string, attributes?: Record<string, AttrValue | null | undefined>) =>
-    currentEmit()?.("", attributes, severityNumber, body);
+    currentEmit()?.("", attributes, undefined, severityNumber, body);
 
 /** Sends a custom log on the SDK pipeline. The log carries the envelope, and
  * the SDK puts it in a batch. */

--- a/packages/otel-web/src/pipeline/emitter.test.ts
+++ b/packages/otel-web/src/pipeline/emitter.test.ts
@@ -152,6 +152,20 @@ describe("createEmitter", () => {
     });
   });
 
+  it("defaults the timestamp to the instant emit is called", async () => {
+    vi.setSystemTime(new Date("2024-08-30T00:00:00.123Z"));
+    [emit, flush, exitFlush] = makeEmitter(
+      () => ({}),
+      (item) => {
+        vi.setSystemTime(new Date("2024-08-30T00:00:05.123Z"));
+        return item;
+      },
+    );
+    emit("everr.browser.page_view");
+    await flush();
+    expect(sentRecords()[0].timeUnixNano).toBe("1724976000123000000");
+  });
+
   it("never drops a record on the normal flush path, whatever the burst size", async () => {
     // The queue has no limit until the sampling exists. Thus a large number of
     // records, much more than the batch size, must all go to the server. The
@@ -238,9 +252,14 @@ describe("span pipeline", () => {
     [emit, flush, exitFlush, emitSpan] = makeEmitter(() => ({
       "session.id": "s1",
     }));
-    emitSpan("a".repeat(32), "b".repeat(16), "GET /api", 1000, 1400, {
-      "http.request.method": "GET",
-    });
+    emitSpan(
+      "a".repeat(32),
+      "b".repeat(16),
+      "GET /api",
+      [1, 0],
+      [1, 400_000_000],
+      { "http.request.method": "GET" },
+    );
     await flush();
 
     expect(sent).toHaveLength(1);
@@ -379,7 +398,13 @@ describe("beforeSend on the log path", () => {
         };
       },
     );
-    emit("exception", { "exception.type": "Error" }, 17, "Error: tok_abc");
+    emit(
+      "exception",
+      { "exception.type": "Error" },
+      undefined,
+      17,
+      "Error: tok_abc",
+    );
     await flush();
 
     const record = sentRecords()[0];
@@ -399,7 +424,7 @@ describe("beforeSend on the log path", () => {
       (item) =>
         item.kind === "log" && item.eventName === "exception" ? null : item,
     );
-    emit("exception", {}, 17, "boom");
+    emit("exception", {}, undefined, 17, "boom");
     emit("everr.browser.page_view");
     await flush();
 
@@ -418,7 +443,7 @@ describe("beforeSend on the log path", () => {
       },
     );
     // This is the shape that logger.info() sends.
-    emit("", { feature: "billing" }, 9, "checkout started");
+    emit("", { feature: "billing" }, undefined, 9, "checkout started");
     await flush();
     expect(seen).toEqual([""]);
     expect(sentRecords()[0].body).toEqual({ stringValue: "checkout started" });

--- a/packages/otel-web/src/pipeline/emitter.test.ts
+++ b/packages/otel-web/src/pipeline/emitter.test.ts
@@ -166,6 +166,18 @@ describe("createEmitter", () => {
     expect(sentRecords()[0].timeUnixNano).toBe("1724976000123000000");
   });
 
+  it("sends each log batch in timestamp order, stable for equal times", async () => {
+    emit("later", {}, [10, 0]);
+    emit("earlier-a", {}, [2, 0]);
+    emit("earlier-b", {}, [2, 0]);
+    await flush();
+    expect(sentRecords().map((record) => record.eventName)).toEqual([
+      "earlier-a",
+      "earlier-b",
+      "later",
+    ]);
+  });
+
   it("never drops a record on the normal flush path, whatever the burst size", async () => {
     // The queue has no limit until the sampling exists. Thus a large number of
     // records, much more than the batch size, must all go to the server. The
@@ -300,6 +312,18 @@ describe("span pipeline", () => {
     const [root, child] = wireSpans();
     expect(root.parentSpanId).toBeUndefined();
     expect(child.parentSpanId).toBe("b".repeat(16));
+  });
+
+  it("sends each trace batch in start-time order, stable for equal times", async () => {
+    emitSpan("a".repeat(32), "b".repeat(16), "later", [10, 0], [11, 0], {});
+    emitSpan("a".repeat(32), "c".repeat(16), "earlier-a", [2, 0], [3, 0], {});
+    emitSpan("a".repeat(32), "d".repeat(16), "earlier-b", [2, 0], [4, 0], {});
+    await flush();
+    expect(wireSpans().map((span) => span.name)).toEqual([
+      "earlier-a",
+      "earlier-b",
+      "later",
+    ]);
   });
 
   it("marks error spans with OTLP status ERROR", async () => {

--- a/packages/otel-web/src/pipeline/emitter.test.ts
+++ b/packages/otel-web/src/pipeline/emitter.test.ts
@@ -167,9 +167,9 @@ describe("createEmitter", () => {
   });
 
   it("sends each log batch in timestamp order, stable for equal times", async () => {
-    emit("later", {}, [10, 0]);
-    emit("earlier-a", {}, [2, 0]);
-    emit("earlier-b", {}, [2, 0]);
+    emit("later", {}, 10);
+    emit("earlier-a", {}, 2);
+    emit("earlier-b", {}, 2);
     await flush();
     expect(sentRecords().map((record) => record.eventName)).toEqual([
       "earlier-a",
@@ -264,14 +264,9 @@ describe("span pipeline", () => {
     [emit, flush, exitFlush, emitSpan] = makeEmitter(() => ({
       "session.id": "s1",
     }));
-    emitSpan(
-      "a".repeat(32),
-      "b".repeat(16),
-      "GET /api",
-      [1, 0],
-      [1, 400_000_000],
-      { "http.request.method": "GET" },
-    );
+    emitSpan("a".repeat(32), "b".repeat(16), "GET /api", 1_000, 1_400, {
+      "http.request.method": "GET",
+    });
     await flush();
 
     expect(sent).toHaveLength(1);
@@ -315,9 +310,9 @@ describe("span pipeline", () => {
   });
 
   it("sends each trace batch in start-time order, stable for equal times", async () => {
-    emitSpan("a".repeat(32), "b".repeat(16), "later", [10, 0], [11, 0], {});
-    emitSpan("a".repeat(32), "c".repeat(16), "earlier-a", [2, 0], [3, 0], {});
-    emitSpan("a".repeat(32), "d".repeat(16), "earlier-b", [2, 0], [4, 0], {});
+    emitSpan("a".repeat(32), "b".repeat(16), "later", 10, 11, {});
+    emitSpan("a".repeat(32), "c".repeat(16), "earlier-a", 2, 3, {});
+    emitSpan("a".repeat(32), "d".repeat(16), "earlier-b", 2, 4, {});
     await flush();
     expect(wireSpans().map((span) => span.name)).toEqual([
       "earlier-a",

--- a/packages/otel-web/src/pipeline/emitter.ts
+++ b/packages/otel-web/src/pipeline/emitter.ts
@@ -9,6 +9,7 @@
 // an intValue is a decimal string. The other internal structures use tuples,
 // because minification keeps the property names but it does not keep the tuple
 // indexes.
+import type { TimeInput } from "@opentelemetry/api";
 import type { Send, Signal } from "./transport.js";
 
 export type AttrValue = string | number | boolean;
@@ -68,6 +69,7 @@ export type Emit = (
   // a cast, and an editor can still complete the EventName union.
   eventName: EventName | "" | (string & {}),
   attributes?: Record<string, AttrValue | null | undefined>,
+  timestamp?: TimeInput,
   severityNumber?: number,
   body?: string,
 ) => void;
@@ -82,8 +84,8 @@ export type EmitSpan = (
   traceId: string,
   spanId: string,
   name: string,
-  startEpochMs: number,
-  endEpochMs: number,
+  startTime: TimeInput,
+  endTime: TimeInput,
   attributes: Record<string, AttrValue | null | undefined>,
   error?: boolean,
   parentSpanId?: string,
@@ -211,6 +213,24 @@ function toKeyValues(
   // getter that returns null.
   return Object.entries(attributes).flatMap(([key, value]) =>
     value == null ? [] : [{ key, value: toAnyValue(value) }],
+  );
+}
+
+/** Converts the standard OTel time inputs to the decimal OTLP nanosecond form. */
+function toUnixNano(time: TimeInput): string {
+  if (Array.isArray(time)) {
+    return String(BigInt(time[0]) * 1_000_000_000n + BigInt(time[1]));
+  }
+  let milliseconds = typeof time === "number" ? time : time.getTime();
+  // A numeric OTel TimeInput before the document's time origin is a DOM
+  // high-resolution timestamp such as Event.timeStamp or an entry.startTime.
+  if (typeof time === "number" && time < performance.timeOrigin) {
+    milliseconds += performance.timeOrigin;
+  }
+  const whole = Math.trunc(milliseconds);
+  return String(
+    BigInt(whole) * 1_000_000n +
+      BigInt(Math.round((milliseconds - whole) * 1_000_000)),
   );
 }
 
@@ -388,11 +408,14 @@ export function createEmitter(
   const emit: Emit = (
     eventName,
     attributes,
+    time,
     severityNumber = 9, // INFO
-    // The default body is the event name. Thus a log viewer shows a line that
-    // the user can read.
     body = eventName,
   ) => {
+    // Read this before the hook. The default is the instant emit was called,
+    // even when a host hook does synchronous work before the item is queued.
+    const timestamp =
+      time === undefined ? `${Date.now()}000000` : toUnixNano(time);
     const item = applyBeforeSend({
       kind: "log",
       eventName,
@@ -405,7 +428,7 @@ export function createEmitter(
     // at run time.
     if (item?.kind !== "log") return;
     queue.push({
-      timeUnixNano: `${Date.now()}000000`,
+      timeUnixNano: timestamp,
       severityNumber: item.severityNumber,
       eventName: item.eventName,
       body: toAnyValue(item.body),
@@ -418,8 +441,8 @@ export function createEmitter(
     traceId,
     spanId,
     name,
-    startEpochMs,
-    endEpochMs,
+    startTime,
+    endTime,
     attributes,
     error,
     parentSpanId,
@@ -442,8 +465,8 @@ export function createEmitter(
       parentSpanId,
       name: item.name,
       kind: 3, // SPAN_KIND_CLIENT
-      startTimeUnixNano: `${startEpochMs}000000`,
-      endTimeUnixNano: `${endEpochMs}000000`,
+      startTimeUnixNano: toUnixNano(startTime),
+      endTimeUnixNano: toUnixNano(endTime),
       attributes: toKeyValues(item.attributes),
       // This is STATUS_CODE_ERROR. If not, the field is absent and thus Unset,
       // because JSON removes a value of undefined.

--- a/packages/otel-web/src/pipeline/emitter.ts
+++ b/packages/otel-web/src/pipeline/emitter.ts
@@ -325,9 +325,19 @@ export function createEmitter(
     }
   };
 
+  const sortBy = <T, K extends keyof T>(items: T[], key: K) =>
+    items.sort((a, b) =>
+      Number(BigInt(a[key] as string) - BigInt(b[key] as string)),
+    );
+
   const flush = (keepalive?: boolean): Promise<void> => {
     clearTimeout(timer);
     timer = undefined;
+    // Array.sort is stable, so records with the same timestamp keep their
+    // capture order. The exit path truncates before this sort, preserving its
+    // rule that records emitted by hide handlers stay in the constrained batch.
+    sortBy(queue, "timeUnixNano");
+    sortBy(spanQueue, "startTimeUnixNano");
     const posts: Promise<void>[] = [];
     if (queue.length) {
       posts.push(post("logs", buildLogs(), keepalive));

--- a/packages/otel-web/src/pipeline/emitter.ts
+++ b/packages/otel-web/src/pipeline/emitter.ts
@@ -9,7 +9,6 @@
 // an intValue is a decimal string. The other internal structures use tuples,
 // because minification keeps the property names but it does not keep the tuple
 // indexes.
-import type { TimeInput } from "@opentelemetry/api";
 import type { Send, Signal } from "./transport.js";
 
 export type AttrValue = string | number | boolean;
@@ -69,7 +68,7 @@ export type Emit = (
   // a cast, and an editor can still complete the EventName union.
   eventName: EventName | "" | (string & {}),
   attributes?: Record<string, AttrValue | null | undefined>,
-  timestamp?: TimeInput,
+  timestamp?: number,
   severityNumber?: number,
   body?: string,
 ) => void;
@@ -84,8 +83,8 @@ export type EmitSpan = (
   traceId: string,
   spanId: string,
   name: string,
-  startTime: TimeInput,
-  endTime: TimeInput,
+  startTime: number,
+  endTime: number,
   attributes: Record<string, AttrValue | null | undefined>,
   error?: boolean,
   parentSpanId?: string,
@@ -213,24 +212,6 @@ function toKeyValues(
   // getter that returns null.
   return Object.entries(attributes).flatMap(([key, value]) =>
     value == null ? [] : [{ key, value: toAnyValue(value) }],
-  );
-}
-
-/** Converts the standard OTel time inputs to the decimal OTLP nanosecond form. */
-function toUnixNano(time: TimeInput): string {
-  if (Array.isArray(time)) {
-    return String(BigInt(time[0]) * 1_000_000_000n + BigInt(time[1]));
-  }
-  let milliseconds = typeof time === "number" ? time : time.getTime();
-  // A numeric OTel TimeInput before the document's time origin is a DOM
-  // high-resolution timestamp such as Event.timeStamp or an entry.startTime.
-  if (typeof time === "number" && time < performance.timeOrigin) {
-    milliseconds += performance.timeOrigin;
-  }
-  const whole = Math.trunc(milliseconds);
-  return String(
-    BigInt(whole) * 1_000_000n +
-      BigInt(Math.round((milliseconds - whole) * 1_000_000)),
   );
 }
 
@@ -424,8 +405,7 @@ export function createEmitter(
   ) => {
     // Read this before the hook. The default is the instant emit was called,
     // even when a host hook does synchronous work before the item is queued.
-    const timestamp =
-      time === undefined ? `${Date.now()}000000` : toUnixNano(time);
+    const timestamp = `${time ?? Date.now()}000000`;
     const item = applyBeforeSend({
       kind: "log",
       eventName,
@@ -475,8 +455,8 @@ export function createEmitter(
       parentSpanId,
       name: item.name,
       kind: 3, // SPAN_KIND_CLIENT
-      startTimeUnixNano: toUnixNano(startTime),
-      endTimeUnixNano: toUnixNano(endTime),
+      startTimeUnixNano: `${startTime}000000`,
+      endTimeUnixNano: `${endTime}000000`,
       attributes: toKeyValues(item.attributes),
       // This is STATUS_CODE_ERROR. If not, the field is absent and thus Unset,
       // because JSON removes a value of undefined.

--- a/packages/otel-web/src/pipeline/tracer.test.ts
+++ b/packages/otel-web/src/pipeline/tracer.test.ts
@@ -48,7 +48,12 @@ describe("instrumentation tracer", () => {
     parent.end();
     const after = tracer.startSpan("later");
     after.end();
-    const [childWire, parentWire, afterWire] = await spans();
+    const wire = await spans();
+    const by = (name: string) =>
+      wire.find((span) => span.name === name) as OtlpSpan;
+    const childWire = by("work");
+    const parentWire = by("pageLoad");
+    const afterWire = by("later");
     expect(parentWire.name).toBe("pageLoad");
     expect(parentWire.parentSpanId).toBeUndefined();
     expect(childWire.traceId).toBe(parentWire.traceId);
@@ -205,12 +210,12 @@ describe("instrumentation tracer", () => {
     expect(attrs(wire[2])["exception.message"]).toBeUndefined();
   });
 
-  it("honors every OpenTelemetry time input", async () => {
+  it("honors normalized epoch-millisecond times", async () => {
     start();
     const explicit = tracer.startSpan("explicit", {
-      startTime: new Date("2024-08-30T00:00:00.123Z"),
+      startTime: 1_724_976_000_123,
     });
-    explicit.end([1_725_004_801, 456_000_000]);
+    explicit.end(1_725_004_801_456);
     const wire = await spans();
     expect(wire[0].startTimeUnixNano).toBe("1724976000123000000");
     expect(wire[0].endTimeUnixNano).toBe("1725004801456000000");

--- a/packages/otel-web/src/pipeline/tracer.test.ts
+++ b/packages/otel-web/src/pipeline/tracer.test.ts
@@ -205,21 +205,15 @@ describe("instrumentation tracer", () => {
     expect(attrs(wire[2])["exception.message"]).toBeUndefined();
   });
 
-  it("honors epoch-millis start/end times and falls back to now otherwise", async () => {
+  it("honors every OpenTelemetry time input", async () => {
     start();
-    const explicit = tracer.startSpan("explicit", { startTime: 1_000 });
-    explicit.end(2_000);
-    const fallback = tracer.startSpan("fallback", { startTime: new Date() });
-    fallback.end(new Date());
+    const explicit = tracer.startSpan("explicit", {
+      startTime: new Date("2024-08-30T00:00:00.123Z"),
+    });
+    explicit.end([1_725_004_801, 456_000_000]);
     const wire = await spans();
-    expect(wire[0].startTimeUnixNano).toBe("1000000000");
-    expect(wire[0].endTimeUnixNano).toBe("2000000000");
-    // For a Date input, the code uses the current time. That time is the same
-    // as the times in this test, or later.
-    expect(Number(wire[1].startTimeUnixNano)).toBeGreaterThan(2_000_000_000);
-    expect(Number(wire[1].endTimeUnixNano)).toBeGreaterThanOrEqual(
-      Number(wire[1].startTimeUnixNano),
-    );
+    expect(wire[0].startTimeUnixNano).toBe("1724976000123000000");
+    expect(wire[0].endTimeUnixNano).toBe("1725004801456000000");
   });
 
   it("startActiveSpan runs the callback with the span, options collapsed", async () => {

--- a/packages/otel-web/src/pipeline/tracer.ts
+++ b/packages/otel-web/src/pipeline/tracer.ts
@@ -23,14 +23,15 @@
 // span. The end() of a span removes it from the stack, in any sequence. The
 // tracer ignores the context argument of the two functions.
 
-import type { Exception, Span, SpanOptions, Tracer } from "@opentelemetry/api";
+import type {
+  Exception,
+  Span,
+  SpanOptions,
+  TimeInput,
+  Tracer,
+} from "@opentelemetry/api";
 import { randomHex } from "../state/session.js";
 import type { AttrValue, EmitSpan } from "./emitter.js";
-
-// Changes an OTel TimeInput to milliseconds from the epoch. For an hrtime value
-// and a Date value, the code uses the current time.
-const toMs = (time: unknown): number | undefined =>
-  typeof time === "number" ? time : undefined;
 
 export function createTracer(emitSpan: EmitSpan): Tracer {
   // The active spans, the most recent last.
@@ -50,7 +51,7 @@ export function createTracer(emitSpan: EmitSpan): Tracer {
       traceFlags: 1, // always sampled
     };
     const attributes: Record<string, AttrValue> = {};
-    const start = toMs(options?.startTime) ?? Date.now();
+    const start: TimeInput = options?.startTime ?? Date.now();
     let spanName = name;
     let ended = false;
     let errored = false;
@@ -104,7 +105,7 @@ export function createTracer(emitSpan: EmitSpan): Tracer {
           spanContext.spanId,
           spanName,
           start,
-          toMs(endTime) ?? Date.now(),
+          endTime ?? Date.now(),
           attributes,
           errored,
           parent?.spanId,

--- a/packages/otel-web/src/pipeline/tracer.ts
+++ b/packages/otel-web/src/pipeline/tracer.ts
@@ -23,13 +23,7 @@
 // span. The end() of a span removes it from the stack, in any sequence. The
 // tracer ignores the context argument of the two functions.
 
-import type {
-  Exception,
-  Span,
-  SpanOptions,
-  TimeInput,
-  Tracer,
-} from "@opentelemetry/api";
+import type { Exception, Span, SpanOptions, Tracer } from "@opentelemetry/api";
 import { randomHex } from "../state/session.js";
 import type { AttrValue, EmitSpan } from "./emitter.js";
 
@@ -51,7 +45,7 @@ export function createTracer(emitSpan: EmitSpan): Tracer {
       traceFlags: 1, // always sampled
     };
     const attributes: Record<string, AttrValue> = {};
-    const start: TimeInput = options?.startTime ?? Date.now();
+    const start = (options?.startTime as number | undefined) ?? Date.now();
     let spanName = name;
     let ended = false;
     let errored = false;
@@ -105,7 +99,7 @@ export function createTracer(emitSpan: EmitSpan): Tracer {
           spanContext.spanId,
           spanName,
           start,
-          endTime ?? Date.now(),
+          (endTime as number | undefined) ?? Date.now(),
           attributes,
           errored,
           parent?.spanId,

--- a/packages/otel-web/src/react.test.ts
+++ b/packages/otel-web/src/react.test.ts
@@ -64,6 +64,7 @@ describe("ErrorBoundary", () => {
         "everr.error.mechanism": "react",
         "everr.react.component_stack": expect.stringContaining("Bomb"),
       }),
+      undefined,
       17,
       "Error: render boom",
     );

--- a/packages/otel-web/src/server.ts
+++ b/packages/otel-web/src/server.ts
@@ -37,7 +37,6 @@
 // program of this package. That program has no Node types, and this is
 // correct.
 import { capture } from "@everr/otel-errors/core";
-import type { TimeInput } from "@opentelemetry/api";
 import { context } from "@opentelemetry/api";
 import {
   type LogAttributes,
@@ -83,6 +82,7 @@ export type {
   Instrumentation,
   InstrumentationContext,
 } from "./instrumentations/runtime.js";
+export { epoch } from "./time.js";
 export type { Persistence, UserTraits, WebSDKOptions } from "./types.js";
 export { logger };
 
@@ -204,7 +204,7 @@ const emitVia = (
     severityNumber: number,
     body: string,
     attributes: Record<string, AttrValue | null | undefined> | undefined,
-    timestamp?: TimeInput,
+    timestamp?: number,
   ): void =>
     otelLogger.emit({
       timestamp,

--- a/packages/otel-web/src/server.ts
+++ b/packages/otel-web/src/server.ts
@@ -37,6 +37,7 @@
 // program of this package. That program has no Node types, and this is
 // correct.
 import { capture } from "@everr/otel-errors/core";
+import type { TimeInput } from "@opentelemetry/api";
 import { context } from "@opentelemetry/api";
 import {
   type LogAttributes,
@@ -203,8 +204,10 @@ const emitVia = (
     severityNumber: number,
     body: string,
     attributes: Record<string, AttrValue | null | undefined> | undefined,
+    timestamp?: TimeInput,
   ): void =>
     otelLogger.emit({
+      timestamp,
       severityNumber,
       // The code reads the enum with this index. Each emit path in this
       // package sets the severity. If the number is not in the enum, the
@@ -215,12 +218,18 @@ const emitVia = (
       context: context.active(),
     });
 
-  return (eventName, attributes, severityNumber = 9, body = eventName) => {
+  return (
+    eventName,
+    attributes,
+    timestamp,
+    severityNumber = 9,
+    body = eventName,
+  ) => {
     // Without a hook the code sends the attributes of the caller directly. The
     // copy below exists only to keep a hook that changes the item away from
     // the object of the caller.
     if (!beforeSend) {
-      write(severityNumber, body, attributes);
+      write(severityNumber, body, attributes, timestamp);
       return;
     }
     const item = applyBeforeSend({
@@ -231,7 +240,7 @@ const emitVia = (
       body,
     });
     if (item?.kind !== "log") return;
-    write(item.severityNumber, item.body, item.attributes);
+    write(item.severityNumber, item.body, item.attributes, timestamp);
   };
 };
 

--- a/packages/otel-web/src/time.test.ts
+++ b/packages/otel-web/src/time.test.ts
@@ -1,0 +1,10 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { epoch } from "./time.js";
+
+afterEach(() => vi.unstubAllGlobals());
+
+it("converts a browser timestamp to integer epoch milliseconds", () => {
+  vi.stubGlobal("performance", { timeOrigin: 1_700_000_000_000 });
+
+  expect(epoch(120.5)).toBe(1_700_000_000_121);
+});

--- a/packages/otel-web/src/time.ts
+++ b/packages/otel-web/src/time.ts
@@ -1,0 +1,3 @@
+/** Converts a browser DOMHighResTimeStamp to integer epoch milliseconds. */
+export const epoch = (time: number): number =>
+  Math.round(performance.timeOrigin + time);


### PR DESCRIPTION
## Summary

- add optional epoch-millisecond timestamps to instrumentation event emission and spans
- normalize browser timestamps only where built-in instrumentations capture them
- expose a tiny `epoch()` helper for `DOMHighResTimeStamp` values
- timestamp Web Vitals and DOM interactions from their native browser events
- order each logs payload by event time and each traces payload by span start time
- preserve capture order when timestamps are equal
- keep the browser event catalog unchanged because this changes behavior, not the event schema

## Timestamp semantics

`Timestamp` is the time the event occurred, not the time a delayed observer reported it or a batch sent it. TTFB uses `responseStart`, LCP uses the chosen paint, CLS uses the last contributing shift in the selected session window, and INP uses the initial input. Click, change, and submit use the DOM event time. A rage click uses the first click in its burst.

Normalization happens at the event capture boundary. The built-in browser instrumentations convert their standard `DOMHighResTimeStamp` values with `epoch()`, which is just `Math.round(performance.timeOrigin + time)`. The emit and trace pipelines do not inspect values, guess their source, or infer their units.

Custom instrumentations own the same boundary: pass integer epoch milliseconds to `ctx.emit(name, attributes, timestamp)`, `startTime`, and `span.end(endTime)`. Use the exported `epoch()` helper when the source is a browser `Event.timeStamp` or `PerformanceEntry.startTime`. Omitting a timestamp defaults to the instant `emit`, `startSpan`, or `span.end` is called.

Records are ordered oldest to newest within each OTLP logs payload. Spans are ordered by start time within each traces payload. Equal timestamps preserve capture order.

## Verification

- 378 otel-web tests passed
- TypeScript and Biome checks passed
- production package build passed
- size-limit passed, all instrumentations are 9.87 kB gzip, down from 9.96 kB with generic normalization
- local Everr ingestion confirmed `delta_ms = 0` for a captured browser click and an explicitly timed span
