### PR TITLE
fix(collector): derive SRC_ROOT from this file, not from git

### DIFF
--- a/collector/Makefile.Common
+++ b/collector/Makefile.Common
@@ -9,8 +9,15 @@ else
 	.SHELLFLAGS = -o pipefail -c
 endif
 
-# SRC_ROOT is the top of the source tree.
-SRC_ROOT := $(shell git rev-parse --show-toplevel)
+# SRC_ROOT is the top of the source tree, derived from this file's own
+# location rather than from git. `git rev-parse --show-toplevel` answers with
+# the current directory whenever GIT_DIR is set and GIT_WORK_TREE is not, which
+# is exactly how lefthook runs these targets: it exports GIT_DIR and the hook
+# does `cd collector` first, so SRC_ROOT came back as <repo>/collector and every
+# path built from it doubled up. TOOLS_PKG_NAMES then read an empty list, so
+# install-tools built nothing and $(LINT) pointed at a binary that could not
+# exist. This also lets the targets run with no .git at all.
+SRC_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/..)
 
 # A lot of the following install tools commands were leveraged from the
 # Open Telemetry Contributor Makefile following the Go Paradigm for Third Party Tools


### PR DESCRIPTION
## Why

`collector/Makefile.Common` computed the source root with `git rev-parse --show-toplevel`. That answers with the **current directory** whenever `GIT_DIR` is set and `GIT_WORK_TREE` is not, which is exactly how lefthook runs the collector jobs: it exports `GIT_DIR`, and the jobs `cd collector` first. So `SRC_ROOT` came back as `<repo>/collector`, and every path built from it doubled:

```
/…/everr/collector/collector/internal/tools/tools.go: No such file or directory
```

Reproduced in a plain checkout as well as a worktree, so the trigger is `GIT_DIR` plus the `cd`, not worktrees:

| | `git rev-parse --show-toplevel` from `collector/` |
|---|---|
| plain | `/…/everr` |
| with `GIT_DIR` set | `/…/everr/collector` |

## What it cost

The one-line-per-module noise was the visible part. The real cost: `TOOLS_PKG_NAMES` greps `$(TOOLS_MOD_DIR)/tools.go`, that grep failed, so the list was empty, `install-tools` built nothing, and `$(LINT)` pointed at `<repo>/collector/collector/.tools/golangci-lint`, which cannot exist.

**The pre-commit lint gate on all collector code has never run.** `collector-lint` was not flaky; it could not pass, and committing collector changes needed `LEFTHOOK_EXCLUDE=collector-lint`.

## The fix

`Makefile.Common` always sits one level under the repository root, and all twelve module Makefiles include that one file. Deriving `SRC_ROOT` from its own path is correct from any module directory and any working directory, and it drops the git dependency, so the targets also run in a tree with no `.git`.

## Verified

- Under real hook conditions (`GIT_DIR` set, `cd collector`, no override): no path errors from `fmt-all`, `tidy-all` or `lint-all`.
- All seven tools build into `collector/.tools`.
- `make lint-all` is clean across the eleven modules, so turning the gate on adds no backlog.

The remaining `rm: go.sum: No such file or directory` from `tidy` is the target's own `-rm go.sum` in the two modules that have no `go.sum`. The `-` prefix ignores it by design; unrelated to this change.

## After this merges

`LEFTHOOK_EXCLUDE=collector-lint` is no longer needed for collector commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed development and validation commands that could fail when run from the collector directory.
  * Improved command reliability in environments without Git metadata.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->