### PR TITLE
feat(clickhouse): bucket partitions by retention window

### DIFF
--- a/clickhouse/init/10-create-mvs.sql
+++ b/clickhouse/init/10-create-mvs.sql
@@ -2,13 +2,26 @@
 -- materialized view from the resource attribute the collector sets at
 -- authentication (everr.retention.days, one key holding the window for that
 -- pipeline's signal), and the view strips it before storage. The table
--- partitions by (day, retention_days) and the TTL is `day + retention_days`
--- with ttl_only_drop_parts = 1. Every row in a partition expires on the same
--- day, so ClickHouse drops whole parts and never rewrites one to expire a
--- single tenant. A retention change applies to rows ingested from that point
--- on. Every distinct retention value costs that many live partitions per
--- table; RETENTION_BY_TIER (packages/app/src/lib/retention.ts) is the only
--- source of values.
+-- partitions by (retention_days, bucket) and the TTL is `day + retention_days`
+-- with ttl_only_drop_parts = 1. Every row in a part shares one retention
+-- value, so ClickHouse drops the part whole once its newest row expires and
+-- never rewrites one to expire a single tenant. A retention change applies to
+-- rows ingested from that point on.
+--
+-- The bucket follows the window. A window of 90 days or less gets one part
+-- per day, so the data is gone the day after the window closes: a short
+-- window is a plan limit and must end on time. A longer window gets one part
+-- per month: a row can then outlive its window by up to 31 days, and a year
+-- of one series reads from 13 parts instead of 365. Measured on the metrics
+-- shape (160 series at 2-minute samples, one year), a query for one metric
+-- over the year ran 4x faster and the table used 17% less disk. Daily parts
+-- lose most of that to granule waste: each (tenant, service, metric) run is
+-- a fraction of one 8192-row granule, so the sparse index reads whole
+-- granules that mostly hold other series.
+--
+-- Partition budget: a window costs its days in live partitions when daily and
+-- its months when monthly. RETENTION_BY_TIER
+-- (packages/app/src/lib/retention.ts) is the only source of values.
 --
 -- Only the views write these tables. everrRetentionDays and
 -- everrStripRetention (05-create-retention-functions.sql) hold the stamp and
@@ -19,7 +32,7 @@
 -- Traces: tenant-enriched read table + MV
 CREATE TABLE IF NOT EXISTS app.traces
 ENGINE = MergeTree
-PARTITION BY (toDate(Timestamp), retention_days)
+PARTITION BY (retention_days, if(retention_days > 90, toStartOfMonth(Timestamp), toDate(Timestamp)))
 ORDER BY (tenant_id, ServiceName, SpanName, toDateTime(Timestamp))
 TTL toDate(Timestamp) + toIntervalDay(retention_days)
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
@@ -102,7 +115,7 @@ FROM
 -- Logs: tenant-enriched read table + MV
 CREATE TABLE IF NOT EXISTS app.logs
 ENGINE = MergeTree
-PARTITION BY (toDate(Timestamp), retention_days)
+PARTITION BY (retention_days, if(retention_days > 90, toStartOfMonth(Timestamp), toDate(Timestamp)))
 -- toStartOfFiveMinutes(Timestamp) is upstream's logs key. Timestamp is
 -- DateTime64(9), so it is unique per row and useless for granule pruning on
 -- its own; the truncation gives a run of equal values that a time filter can
@@ -204,7 +217,7 @@ FROM
 -- series over a long range; no built-in dashboard does that.
 CREATE TABLE IF NOT EXISTS app.metrics_gauge
 ENGINE = MergeTree
-PARTITION BY (toDate(TimeUnix), retention_days)
+PARTITION BY (retention_days, if(retention_days > 90, toStartOfMonth(TimeUnix), toDate(TimeUnix)))
 ORDER BY (tenant_id, ServiceName, MetricName, toStartOfHour(TimeUnix), cityHash64(Attributes), TimeUnix)
 TTL toDate(TimeUnix) + toIntervalDay(retention_days)
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
@@ -269,7 +282,7 @@ FROM
 -- Metrics (Sum): tenant-enriched read table + MV
 CREATE TABLE IF NOT EXISTS app.metrics_sum
 ENGINE = MergeTree
-PARTITION BY (toDate(TimeUnix), retention_days)
+PARTITION BY (retention_days, if(retention_days > 90, toStartOfMonth(TimeUnix), toDate(TimeUnix)))
 ORDER BY (tenant_id, ServiceName, MetricName, toStartOfHour(TimeUnix), cityHash64(Attributes), TimeUnix)
 TTL toDate(TimeUnix) + toIntervalDay(retention_days)
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
@@ -336,7 +349,7 @@ FROM
 -- Metrics (Histogram): tenant-enriched read table + MV
 CREATE TABLE IF NOT EXISTS app.metrics_histogram
 ENGINE = MergeTree
-PARTITION BY (toDate(TimeUnix), retention_days)
+PARTITION BY (retention_days, if(retention_days > 90, toStartOfMonth(TimeUnix), toDate(TimeUnix)))
 ORDER BY (tenant_id, ServiceName, MetricName, toStartOfHour(TimeUnix), cityHash64(Attributes), TimeUnix)
 TTL toDate(TimeUnix) + toIntervalDay(retention_days)
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
@@ -407,7 +420,7 @@ FROM
 -- Metrics (Exponential Histogram): tenant-enriched read table + MV
 CREATE TABLE IF NOT EXISTS app.metrics_exponential_histogram
 ENGINE = MergeTree
-PARTITION BY (toDate(TimeUnix), retention_days)
+PARTITION BY (retention_days, if(retention_days > 90, toStartOfMonth(TimeUnix), toDate(TimeUnix)))
 ORDER BY (tenant_id, ServiceName, MetricName, toStartOfHour(TimeUnix), cityHash64(Attributes), TimeUnix)
 TTL toDate(TimeUnix) + toIntervalDay(retention_days)
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
@@ -482,7 +495,7 @@ FROM
 -- Metrics (Summary): tenant-enriched read table + MV
 CREATE TABLE IF NOT EXISTS app.metrics_summary
 ENGINE = MergeTree
-PARTITION BY (toDate(TimeUnix), retention_days)
+PARTITION BY (retention_days, if(retention_days > 90, toStartOfMonth(TimeUnix), toDate(TimeUnix)))
 ORDER BY (tenant_id, ServiceName, MetricName, toStartOfHour(TimeUnix), cityHash64(Attributes), TimeUnix)
 TTL toDate(TimeUnix) + toIntervalDay(retention_days)
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1

--- a/clickhouse/migrations/2026-09-05-partition-buckets.sh
+++ b/clickhouse/migrations/2026-09-05-partition-buckets.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Move every app.* table to the partition key in init/10-create-mvs.sql:
+# (retention_days, bucket), where a window of 90 days or less gets a part per
+# day and a longer window a part per month.
+#
+# A partition key cannot be altered, so each table is rebuilt and its rows are
+# copied. Per table: rename the live table aside, recreate it from init/10
+# under the new key, copy the rows that are still inside their window, then
+# drop the old table. The views write to the table name, so after the rename
+# they fail until the recreate a moment later; the exporter retries those
+# inserts. Rows that arrive after the recreate land in the new table, and the
+# old table is frozen, so nothing is lost or copied twice. Rows already past
+# their window are not copied: the TTL would drop them on the next merge.
+#
+# The copy needs free disk for a second copy of the largest table and reads
+# every row once; budget the run for the biggest table's size.
+#
+# Usage (from the repo root, as an admin user):
+#   clickhouse/migrations/2026-09-05-partition-buckets.sh --host <h> --secure --user default --password '<pw>'
+# CLICKHOUSE_CLIENT overrides the client binary, e.g. for a container:
+#   CLICKHOUSE_CLIENT='docker exec -i everr-clickhouse-1 clickhouse-client' ...
+set -Eeuo pipefail
+
+cd "$(dirname "$0")/.."
+
+client() {
+  # shellcheck disable=SC2086
+  ${CLICKHOUSE_CLIENT:-clickhouse-client} "$@"
+}
+
+run_sql() {
+  client "${CLIENT_ARGS[@]}" --multiquery --query "$1"
+}
+
+run_file() {
+  client "${CLIENT_ARGS[@]}" --multiquery < "$1"
+}
+
+CLIENT_ARGS=("$@")
+
+# table:time column. The window predicate mirrors the TTL expression.
+TABLES=(
+  traces:Timestamp
+  logs:Timestamp
+  metrics_gauge:TimeUnix
+  metrics_sum:TimeUnix
+  metrics_histogram:TimeUnix
+  metrics_exponential_histogram:TimeUnix
+  metrics_summary:TimeUnix
+)
+
+NEW_KEY="if(retention_days > 90, toStartOfMonth"
+
+echo "0/2 guard: skip tables that already carry the new key, refuse a half-done run"
+for entry in "${TABLES[@]}"; do
+  t=${entry%%:*}
+  run_sql "SELECT throwIf(
+    (SELECT count() FROM system.tables WHERE database = 'app' AND name = '${t}_old') > 0,
+    'app.${t}_old exists: a previous run stopped before dropping it. Compare it with app.${t} and drop it by hand, then rerun') FORMAT Null"
+done
+
+for entry in "${TABLES[@]}"; do
+  t=${entry%%:*}
+  col=${entry##*:}
+  window="toDate(${col}) + toIntervalDay(retention_days) > today()"
+
+  if [[ "$(run_sql "SELECT partition_key FROM system.tables WHERE database = 'app' AND name = '${t}'")" == *"${NEW_KEY}"* ]]; then
+    echo "app.${t}: already on the new key, skipped"
+    continue
+  fi
+
+  echo "1/2 app.${t}: rename aside and recreate under the new key"
+  run_sql "RENAME TABLE app.${t} TO app.${t}_old"
+  # CREATE TABLE IF NOT EXISTS recreates only the table that is missing; the
+  # other statements in the file are no-ops on tables that already exist.
+  run_file init/10-create-mvs.sql
+  run_sql "SELECT throwIf(
+    position((SELECT partition_key FROM system.tables WHERE database = 'app' AND name = '${t}'), '${NEW_KEY}') = 0,
+    'app.${t} was recreated without the new partition key') FORMAT Null"
+
+  echo "2/2 app.${t}: copy the rows inside their window, then drop the old table"
+  # Copy by column name, not by position, so a column the old table lacks
+  # fails the insert instead of shifting values into the wrong column.
+  cols=$(run_sql "SELECT arrayStringConcat(groupArray(concat('\`', name, '\`')), ', ')
+    FROM system.columns
+    WHERE database = 'app' AND table = '${t}' AND default_kind NOT IN ('ALIAS', 'MATERIALIZED')")
+  run_sql "INSERT INTO app.${t} (${cols}) SELECT ${cols} FROM app.${t}_old WHERE ${window}"
+  run_sql "SELECT throwIf(
+    (SELECT count() FROM app.${t} WHERE ${window}) < (SELECT count() FROM app.${t}_old WHERE ${window}),
+    'app.${t}: the copy holds fewer rows than app.${t}_old; both tables are kept') FORMAT Null"
+  run_sql "DROP TABLE app.${t}_old"
+done
+
+echo "done"
+run_sql "SELECT name, partition_key FROM system.tables WHERE database = 'app' AND engine = 'MergeTree' ORDER BY name FORMAT PrettyCompact"
+run_sql "SELECT table, count() AS partitions, sum(rows) AS rows FROM system.parts WHERE database = 'app' AND active GROUP BY table ORDER BY table FORMAT PrettyCompact"

--- a/packages/app/src/lib/retention.ts
+++ b/packages/app/src/lib/retention.ts
@@ -8,15 +8,18 @@ export type TenantRetention = {
 
 // The only retention values that exist. retentionForOrg (retention.server.ts)
 // hands them to the collector, which stamps them on every resource, and the
-// app.* tables partition by (day, retention_days). A table holds one live
-// partition per day per distinct value in its column below: 14 + 365 = 379 for
-// every table. A new tier or a new value adds its days to that budget; keep it
-// under about 1,000 per table.
+// app.* tables partition by (retention_days, bucket). The bucket follows the
+// value (clickhouse/init/10-create-mvs.sql): 90 days or less is one partition
+// per day, so the window ends on time; more is one partition per month, so a
+// row can outlive its window by up to 31 days and a year reads from 13 parts.
+// Live partitions per table: 14 daily + 13 monthly, about 27. A new value adds
+// its days when 90 or less and its months when more; keep the total under
+// about 1,000 per table.
 const RETENTION_BY_TIER: Record<Tier, TenantRetention> = {
   free: { tracesDays: 14, logsDays: 14, metricsDays: 14 },
   // One window per tier across all three signals. A single value per tier is
   // what keeps the partition budget flat: a signal with its own number adds
-  // that many more daily partitions to its table.
+  // its own partitions to its table.
   pro: { tracesDays: 365, logsDays: 365, metricsDays: 365 },
 };
 

--- a/packages/docs/content/docs/reference/retention.mdx
+++ b/packages/docs/content/docs/reference/retention.mdx
@@ -15,6 +15,8 @@ Everr keeps your telemetry for a fixed window based on your plan. Once data fall
 
 One window per plan, the same for traces, logs and metrics. No signal rolls off before the others.
 
+On the Pro plan, data can stay available for up to a month after its year ends before it is removed.
+
 ## When your plan changes
 
 Each event is kept for the window of your plan **at the time we receive it**. Retention is not retroactive, so a plan change only affects data that arrives after it. A new window takes effect within about a minute.


### PR DESCRIPTION
Stacked on #426. Changes the partition key of every `app.*` signal table from `(day, retention_days)` to `(retention_days, bucket)`, where the bucket follows the window:

- 90 days or less: one part per day. Free-tier data is gone the day after its window closes.
- Longer: one part per month. A year of one series reads from 13 parts instead of 365. A row can outlive its window by up to 31 days.

Live partitions per table drop from 379 to about 27.

## Why

Benchmark on ClickHouse 26.5 with the exact gauge schema (columns, ORDER BY, codecs, skip indexes), 49.5M rows: one pro tenant with 160 series at 2-minute samples for a year, one pro tenant with 10 series, three free tenants with 14 days. One merged wide part per partition. Warm medians in ms:

| Query | daily | monthly | this key |
|---|---|---|---|
| Year, one metric, big tenant | 429 | 112 | 105 |
| Year, one metric, small tenant | 67 | 42 | 40 |
| Year, count rows of big tenant | 36 | 3 | 2 |
| Year, full scan top series | 3135 | 2868 | 2742 |
| Last 7 days, one metric | 18 | 9 | 8 |
| Free tenant, 14 days | 27 | 16 | 18 |
| Disk | 613 MiB | 525 MiB | 528 MiB |

The gain is not per-part overhead, which measured at about 0.1 ms per part. It is granule waste: with daily parts each (tenant, service, metric) run is a fraction of one 8192-row granule, so the year query read 35.7M rows for a 6.3M-row answer. Time-range pruning works through the `if()`, because ClickHouse keeps a minmax index per part for each source column of the key: the 7-day query selects 2 parts.

## Migration

`clickhouse/migrations/2026-09-05-partition-buckets.sh`. A partition key cannot be altered, so per table it renames the live table aside, recreates it from `init/10` under the new key, copies the rows still inside their window by column name, checks the count, and drops the old table. Views write to the table name, so inserts fail for the moment between rename and recreate and the exporter retries them. Needs free disk for a second copy of the largest table. Rerunnable: tables already on the new key are skipped, and a leftover `_old` table stops the run.

## Review notes

- Only the metrics tables were benchmarked. Logs and traces get the same key because the retention stamping and the partition budget are one policy across signals. Their ORDER BY leads with time after the tenant, so the granule effect should be smaller there.
- `packages/docs/content/docs/reference/retention.mdx` gains one sentence saying Pro data can stay up to a month past its year. Drop it if you would rather not say that.
- Follow-up, not in this PR: `max_partitions_to_read = 64 READONLY` in the SQL API profile. A full-year query touches 13 partitions, so it guards only against a future tier value.

## Verification

- Fresh init from the new scripts in a 26.5 container: all seven tables carry the new key, a free row lands in `(14, day)` and a pro row in `(365, month)`, the retention stamp is stripped.
- Migration against a container built from the old init on this branch's base, loaded with rows of several ages per tier: rows kept, partitions as expected, row policies still attached to every table, all views still target the rebuilt tables, ingest after the migration lands in the new parts, second run skips every table.
