### PR TITLE
fix: drop step spans without timestamps and bound run lookups by the run's window

### DIFF
--- a/collector/receiver/githubactionsreceiver/log_event_handling.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling.go
@@ -297,6 +297,10 @@ func scanLogFile(f *zip.File, logger *zap.Logger, emit func(parsedLine)) {
 	reader := bufio.NewReader(ff)
 	firstLine := true
 	var lastTime time.Time
+	// Lines that come before the first timestamped line. They take that
+	// line's time once it appears. A zero time is exported as the year 1754
+	// and stored as 1900-01-01, which falls outside every run window.
+	var leading []string
 	for {
 		lineText, err := readLogLine(reader)
 		if err != nil {
@@ -316,15 +320,33 @@ func scanLogFile(f *zip.File, logger *zap.Logger, emit func(parsedLine)) {
 		if ts, line, ok := strings.Cut(lineText, " "); ok {
 			if parsedTime, err := time.Parse(time.RFC3339, ts); err == nil {
 				lastTime = parsedTime
+				for _, body := range leading {
+					emit(parsedLine{time: parsedTime, body: body})
+				}
+				leading = nil
 				emit(parsedLine{time: parsedTime, body: line})
 				continue
 			}
 		}
 
-		// No leading timestamp — this is a continuation of multi-line step
-		// output, not an error. Keep the full text and attribute it to the
-		// previous line's timestamp (zero if it's the very first line).
+		if lastTime.IsZero() {
+			leading = append(leading, lineText)
+			continue
+		}
+		// No leading timestamp: a continuation of multi-line step output,
+		// not an error. Keep the full text and give it the previous line's
+		// time.
 		emit(parsedLine{time: lastTime, body: lineText})
+	}
+
+	// No line in the file carried a timestamp. The time the archive was read
+	// is the only time there is; the OTel log model falls back to the
+	// observed time in the same way.
+	if len(leading) > 0 {
+		now := time.Now().UTC()
+		for _, body := range leading {
+			emit(parsedLine{time: now, body: body})
+		}
 	}
 }
 

--- a/collector/receiver/githubactionsreceiver/log_event_handling.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling.go
@@ -202,6 +202,7 @@ func eventToLogs(ctx context.Context, event interface{}, config *Config, ghClien
 	// GitHub sanitizes "/" to "_" in ZIP paths, causing span ID mismatches
 	// for matrix/sharded jobs like "test (1/2)" → "test (1_2)".
 	resolvedNames := resolveJobNames(ctx, jobs, jobNamesCache, ghClient, e, logger)
+	runStart := e.GetWorkflowRun().GetRunStartedAt().Time
 
 	for _, zipJobName := range jobs {
 		// Use the original (unsanitized) name for scope attributes and span IDs.
@@ -213,9 +214,11 @@ func eventToLogs(ctx context.Context, event interface{}, config *Config, ghClien
 			}
 		}
 		jobID := int64(0)
+		var steps []stepTiming
 		if metadata, ok := jobMetadataByZipName[zipJobName]; ok {
 			jobName = metadata.jobName
 			jobID = metadata.jobID
+			steps = metadata.steps
 		}
 
 		jobLogsScope := allLogs.ScopeLogs().AppendEmpty()
@@ -242,7 +245,8 @@ func eventToLogs(ctx context.Context, event interface{}, config *Config, ghClien
 				continue
 			}
 
-			emitLogRecords(logFile, jobLogsScope, traceID, spanID, stepNumber, withTraceInfo, logger)
+			fallback := logFallbackTime(steps, int64(stepNumber), runStart)
+			emitLogRecords(logFile, jobLogsScope, traceID, spanID, stepNumber, fallback, withTraceInfo, logger)
 		}
 	}
 
@@ -285,8 +289,10 @@ func readLogLine(r *bufio.Reader) (string, error) {
 	}
 }
 
-// scanLogFile reads a zip log file and calls emit for each parsed line.
-func scanLogFile(f *zip.File, logger *zap.Logger, emit func(parsedLine)) {
+// scanLogFile reads a zip log file and calls emit for each parsed line. A
+// line with no timestamp takes the previous line's time. A file with no
+// timestamp at all takes fallback.
+func scanLogFile(f *zip.File, fallback time.Time, logger *zap.Logger, emit func(parsedLine)) {
 	ff, err := f.Open()
 	if err != nil {
 		logger.Error("Failed to open file", zap.Error(err))
@@ -339,20 +345,34 @@ func scanLogFile(f *zip.File, logger *zap.Logger, emit func(parsedLine)) {
 		emit(parsedLine{time: lastTime, body: lineText})
 	}
 
-	// No line in the file carried a timestamp. The time the archive was read
-	// is the only time there is; the OTel log model falls back to the
-	// observed time in the same way.
-	if len(leading) > 0 {
-		now := time.Now().UTC()
-		for _, body := range leading {
-			emit(parsedLine{time: now, body: body})
-		}
+	// No line in the file carried a timestamp. The caller passes a time that
+	// belongs to the run, so the lines stay inside the run's window however
+	// late the archive is processed. The observed time records when the
+	// archive was read.
+	for _, body := range leading {
+		emit(parsedLine{time: fallback, body: body})
 	}
 }
 
+// logFallbackTime is the event time for a log file that has no timestamp of
+// its own: the start of its step, else the start of the run. A run with no
+// start time at all leaves only the current time, which is still not the
+// zero time.
+func logFallbackTime(steps []stepTiming, stepNumber int64, runStart time.Time) time.Time {
+	for _, s := range steps {
+		if s.Number == stepNumber && !s.StartedAt.IsZero() {
+			return s.StartedAt
+		}
+	}
+	if !runStart.IsZero() {
+		return runStart
+	}
+	return time.Now().UTC()
+}
+
 // emitLogRecords reads a zip log file and emits one log record per line.
-func emitLogRecords(logFile *zip.File, scope plog.ScopeLogs, traceID pcommon.TraceID, spanID pcommon.SpanID, stepNumber int, withTraceInfo bool, logger *zap.Logger) {
-	scanLogFile(logFile, logger, func(pl parsedLine) {
+func emitLogRecords(logFile *zip.File, scope plog.ScopeLogs, traceID pcommon.TraceID, spanID pcommon.SpanID, stepNumber int, fallback time.Time, withTraceInfo bool, logger *zap.Logger) {
+	scanLogFile(logFile, fallback, logger, func(pl parsedLine) {
 		record := scope.LogRecords().AppendEmpty()
 		if withTraceInfo {
 			record.SetSpanID(spanID)
@@ -380,6 +400,7 @@ func processCombinedLogs(
 ) {
 	runID := e.GetWorkflowRun().GetID()
 	runAttempt := e.GetWorkflowRun().GetRunAttempt()
+	runStart := e.GetWorkflowRun().GetRunStartedAt().Time
 
 	// Build a lookup from sanitized job name → jobStepTimings.
 	// Combined file names are "0_<jobName>.txt" where jobName matches the
@@ -428,7 +449,14 @@ func processCombinedLogs(
 			})
 		}
 
-		scanLogFile(cf, logger, func(pl parsedLine) {
+		// A file with no timestamp at all goes to the first step.
+		var firstStep int64
+		if len(jst.steps) > 0 {
+			firstStep = jst.steps[0].Number
+		}
+		fallback := logFallbackTime(jst.steps, firstStep, runStart)
+
+		scanLogFile(cf, fallback, logger, func(pl parsedLine) {
 			// Find which step this line belongs to based on timestamp
 			step := assignLineToStep(pl.time, steps)
 			if step == nil {
@@ -533,11 +561,6 @@ func minDuration(a, b time.Duration) time.Duration {
 	return b
 }
 
-type logJobMetadata struct {
-	jobID   int64
-	jobName string
-}
-
 func setJobScopeAttributes(scopeLogs plog.ScopeLogs, jobName string, jobID int64) {
 	attrs := scopeLogs.Scope().Attributes()
 	attrs.PutStr(string(conventions.CICDPipelineTaskNameKey), jobName)
@@ -546,8 +569,8 @@ func setJobScopeAttributes(scopeLogs plog.ScopeLogs, jobName string, jobID int64
 	}
 }
 
-func resolveLogJobMetadata(ctx context.Context, zipJobNames []string, stepTimingsCache *stepTimingCache, ghClient *github.Client, e *github.WorkflowRunEvent, logger *zap.Logger) map[string]logJobMetadata {
-	result := make(map[string]logJobMetadata)
+func resolveLogJobMetadata(ctx context.Context, zipJobNames []string, stepTimingsCache *stepTimingCache, ghClient *github.Client, e *github.WorkflowRunEvent, logger *zap.Logger) map[string]jobStepTimings {
+	result := make(map[string]jobStepTimings)
 	key := runKey{
 		repoID:     e.GetRepo().GetID(),
 		runID:      e.GetWorkflowRun().GetID(),
@@ -560,7 +583,7 @@ func resolveLogJobMetadata(ctx context.Context, zipJobNames []string, stepTiming
 	// ListWorkflowJobs provides the same ID/name mapping before we emit logs.
 	if stepTimingsCache != nil {
 		if cachedJobs := stepTimingsCache.GetSteps(key); cachedJobs != nil {
-			addJobTimingsMetadata(result, cachedJobs)
+			addJobMetadata(result, cachedJobs)
 			stepTimingsCache.Delete(key)
 		}
 	}
@@ -573,7 +596,7 @@ func resolveLogJobMetadata(ctx context.Context, zipJobNames []string, stepTiming
 	return result
 }
 
-func hasMetadataForAllJobs(metadata map[string]logJobMetadata, zipJobNames []string) bool {
+func hasMetadataForAllJobs(metadata map[string]jobStepTimings, zipJobNames []string) bool {
 	for _, jobName := range zipJobNames {
 		if _, ok := metadata[jobName]; !ok {
 			return false
@@ -582,18 +605,7 @@ func hasMetadataForAllJobs(metadata map[string]logJobMetadata, zipJobNames []str
 	return true
 }
 
-func addJobTimingsMetadata(dst map[string]logJobMetadata, jobs []jobStepTimings) {
-	metadata := make([]logJobMetadata, 0, len(jobs))
-	for _, job := range jobs {
-		metadata = append(metadata, logJobMetadata{
-			jobID:   job.jobID,
-			jobName: job.jobName,
-		})
-	}
-	addJobMetadata(dst, metadata)
-}
-
-func addJobMetadata(dst map[string]logJobMetadata, jobs []logJobMetadata) {
+func addJobMetadata(dst map[string]jobStepTimings, jobs []jobStepTimings) {
 	for _, job := range jobs {
 		if job.jobName == "" {
 			continue
@@ -628,18 +640,7 @@ func fetchStepTimingsFromAPI(ctx context.Context, ghClient *github.Client, e *gi
 			if job.GetStatus() != "completed" {
 				continue
 			}
-			var timings []stepTiming
-			for _, s := range job.Steps {
-				if s.StartedAt == nil || s.CompletedAt == nil {
-					continue
-				}
-				timings = append(timings, stepTiming{
-					Number:      s.GetNumber(),
-					Name:        s.GetName(),
-					StartedAt:   s.GetStartedAt().Time,
-					CompletedAt: s.GetCompletedAt().Time,
-				})
-			}
+			timings := stepTimingsOf(job)
 			if len(timings) > 0 {
 				result = append(result, jobStepTimings{
 					jobID:   job.GetID(),
@@ -658,7 +659,24 @@ func fetchStepTimingsFromAPI(ctx context.Context, ghClient *github.Client, e *gi
 	return result
 }
 
-func listWorkflowJobMetadata(ctx context.Context, ghClient *github.Client, e *github.WorkflowRunEvent, logger *zap.Logger) []logJobMetadata {
+// stepTimingsOf keeps the steps of a job that have both of their times.
+func stepTimingsOf(job *github.WorkflowJob) []stepTiming {
+	var timings []stepTiming
+	for _, s := range job.Steps {
+		if s.StartedAt == nil || s.CompletedAt == nil {
+			continue
+		}
+		timings = append(timings, stepTiming{
+			Number:      s.GetNumber(),
+			Name:        s.GetName(),
+			StartedAt:   s.GetStartedAt().Time,
+			CompletedAt: s.GetCompletedAt().Time,
+		})
+	}
+	return timings
+}
+
+func listWorkflowJobMetadata(ctx context.Context, ghClient *github.Client, e *github.WorkflowRunEvent, logger *zap.Logger) []jobStepTimings {
 	owner := e.GetRepo().GetOwner().GetLogin()
 	repo := e.GetRepo().GetName()
 	runID := e.GetWorkflowRun().GetID()
@@ -666,7 +684,7 @@ func listWorkflowJobMetadata(ctx context.Context, ghClient *github.Client, e *gi
 
 	opts := &github.ListOptions{PerPage: 100}
 
-	var result []logJobMetadata
+	var result []jobStepTimings
 	for {
 		jobsResp, resp, err := ghClient.Actions.ListWorkflowJobsAttempt(ctx, owner, repo, runID, runAttempt, opts)
 		if err != nil {
@@ -678,9 +696,10 @@ func listWorkflowJobMetadata(ctx context.Context, ghClient *github.Client, e *gi
 			if job.GetStatus() != "completed" {
 				continue
 			}
-			result = append(result, logJobMetadata{
+			result = append(result, jobStepTimings{
 				jobID:   job.GetID(),
 				jobName: job.GetName(),
+				steps:   stepTimingsOf(job),
 			})
 		}
 

--- a/collector/receiver/githubactionsreceiver/log_event_handling_test.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling_test.go
@@ -607,15 +607,26 @@ func TestScanLogFileContinuationLines(t *testing.T) {
 		require.Equal(t, 0, observed.Len(), "continuation lines must not log at error level")
 	})
 
-	t.Run("leading line without timestamp", func(t *testing.T) {
+	t.Run("leading line takes the first timestamp", func(t *testing.T) {
 		lines, observed := scan(t, ""+
-			"no timestamp at all\n"+
+			"before any timestamp\n"+
 			"2023-10-13T10:11:33Z line one\n")
 
 		require.Len(t, lines, 2)
-		require.Equal(t, "no timestamp at all", lines[0].body)
-		require.True(t, lines[0].time.IsZero(), "line before any timestamp should have zero time")
+		require.Equal(t, "before any timestamp", lines[0].body)
+		require.Equal(t, lines[1].time, lines[0].time, "a leading line takes the time of the first timestamped line")
 		require.Equal(t, "line one", lines[1].body)
+
+		require.Equal(t, 0, observed.Len(), "lines without timestamps must not log at error level")
+	})
+
+	t.Run("file without any timestamp", func(t *testing.T) {
+		lines, observed := scan(t, "first\nsecond\n")
+
+		require.Len(t, lines, 2)
+		require.False(t, lines[0].time.IsZero(), "a line never carries the zero time")
+		require.Equal(t, lines[0].time, lines[1].time)
+		require.Equal(t, []string{"first", "second"}, []string{lines[0].body, lines[1].body})
 
 		require.Equal(t, 0, observed.Len(), "lines without timestamps must not log at error level")
 	})

--- a/collector/receiver/githubactionsreceiver/log_event_handling_test.go
+++ b/collector/receiver/githubactionsreceiver/log_event_handling_test.go
@@ -568,6 +568,22 @@ func TestEventToLogsNoLogArchive(t *testing.T) {
 	})
 }
 
+func TestLogFallbackTime(t *testing.T) {
+	runStart := time.Date(2023, 10, 13, 10, 0, 0, 0, time.UTC)
+	steps := []stepTiming{
+		{Number: 1, StartedAt: runStart.Add(10 * time.Second)},
+		{Number: 2, StartedAt: runStart.Add(40 * time.Second)},
+	}
+
+	require.Equal(t, runStart.Add(40*time.Second), logFallbackTime(steps, 2, runStart), "a known step gives its start")
+	require.Equal(t, runStart, logFallbackTime(steps, 7, runStart), "an unknown step gives the run's start")
+	require.Equal(t, runStart, logFallbackTime(nil, 1, runStart), "no step timings give the run's start")
+
+	got := logFallbackTime(nil, 1, time.Time{})
+	require.False(t, got.IsZero(), "a run with no start time still never gives the zero time")
+	require.WithinDuration(t, time.Now(), got, time.Minute)
+}
+
 // TestScanLogFileContinuationLines verifies that multi-line step output —
 // where continuation lines have no leading timestamp — is preserved with the
 // previous line's timestamp and doesn't produce error-level logs.
@@ -581,11 +597,12 @@ func TestScanLogFileContinuationLines(t *testing.T) {
 		return reader.File[0]
 	}
 
+	fallback := time.Date(2023, 10, 13, 10, 11, 30, 0, time.UTC)
 	scan := func(t *testing.T, content string) ([]parsedLine, *observer.ObservedLogs) {
 		t.Helper()
 		core, observed := observer.New(zap.ErrorLevel)
 		var lines []parsedLine
-		scanLogFile(newZipFile(t, content), zap.New(core), func(pl parsedLine) {
+		scanLogFile(newZipFile(t, content), fallback, zap.New(core), func(pl parsedLine) {
 			lines = append(lines, pl)
 		})
 		return lines, observed
@@ -624,8 +641,8 @@ func TestScanLogFileContinuationLines(t *testing.T) {
 		lines, observed := scan(t, "first\nsecond\n")
 
 		require.Len(t, lines, 2)
-		require.False(t, lines[0].time.IsZero(), "a line never carries the zero time")
-		require.Equal(t, lines[0].time, lines[1].time)
+		require.Equal(t, fallback, lines[0].time, "a file with no timestamp takes the caller's time, not the time of the scan")
+		require.Equal(t, fallback, lines[1].time)
 		require.Equal(t, []string{"first", "second"}, []string{lines[0].body, lines[1].body})
 
 		require.Equal(t, 0, observed.Len(), "lines without timestamps must not log at error level")

--- a/collector/receiver/githubactionsreceiver/receiver_test.go
+++ b/collector/receiver/githubactionsreceiver/receiver_test.go
@@ -152,6 +152,9 @@ func TestEventToTracesTraces(t *testing.T) {
 }
 
 func TestProcessSteps(t *testing.T) {
+	at := func(hour int) *github.Timestamp {
+		return &github.Timestamp{Time: time.Date(2024, 1, 1, hour, 0, 0, 0, time.UTC)}
+	}
 	tests := []struct {
 		desc             string
 		givenSteps       []*github.TaskStep
@@ -162,9 +165,9 @@ func TestProcessSteps(t *testing.T) {
 			desc: "Multiple steps with mixed status",
 
 			givenSteps: []*github.TaskStep{
-				{Name: getPtr("Checkout"), Status: getPtr("completed"), Conclusion: getPtr("success")},
-				{Name: getPtr("Build"), Status: getPtr("completed"), Conclusion: getPtr("failure")},
-				{Name: getPtr("Test"), Status: getPtr("completed"), Conclusion: getPtr("success")},
+				{Name: getPtr("Checkout"), Status: getPtr("completed"), Conclusion: getPtr("success"), StartedAt: at(12), CompletedAt: at(13)},
+				{Name: getPtr("Build"), Status: getPtr("completed"), Conclusion: getPtr("failure"), StartedAt: at(13), CompletedAt: at(14)},
+				{Name: getPtr("Test"), Status: getPtr("completed"), Conclusion: getPtr("success"), StartedAt: at(14), CompletedAt: at(15)},
 			},
 			expectedSpans: 4, // Includes parent span
 			expectedStatuses: []ptrace.StatusCode{
@@ -178,6 +181,15 @@ func TestProcessSteps(t *testing.T) {
 			givenSteps:       []*github.TaskStep{},
 			expectedSpans:    1, // Only the parent span should be created
 			expectedStatuses: nil,
+		},
+		{
+			desc: "A step the webhook lists as pending, with no timestamps, gets no span",
+			givenSteps: []*github.TaskStep{
+				{Name: getPtr("Checkout"), Status: getPtr("completed"), Conclusion: getPtr("success"), StartedAt: at(12), CompletedAt: at(13)},
+				{Name: getPtr("Complete runner"), Status: getPtr("pending")},
+			},
+			expectedSpans:    2, // Parent span and the completed step
+			expectedStatuses: []ptrace.StatusCode{ptrace.StatusCodeOk},
 		},
 	}
 

--- a/collector/receiver/githubactionsreceiver/trace_event_handling.go
+++ b/collector/receiver/githubactionsreceiver/trace_event_handling.go
@@ -307,6 +307,16 @@ func generateStepSpanID(runID int64, runAttempt int, jobName string, stepNumber 
 
 func processSteps(scopeSpans ptrace.ScopeSpans, steps []*github.TaskStep, job *github.WorkflowJob, traceID pcommon.TraceID, parentSpanID pcommon.SpanID, logger *zap.Logger) {
 	for _, step := range steps {
+		// A completed job's webhook can still list a trailing step as
+		// "pending" with null started_at and completed_at. A span built from
+		// those carries the zero time, which the exporter serialises as the
+		// year 1754 and ClickHouse stores as 1900-01-01, where it never
+		// expires and sorts first in every run view. A step that never
+		// started has no span.
+		if step.GetStartedAt().Time.IsZero() && step.GetCompletedAt().Time.IsZero() {
+			logger.Debug("Skipping step without timestamps", zap.String("step_name", step.GetName()), zap.String("step_status", step.GetStatus()))
+			continue
+		}
 		if _, err := createSpan(scopeSpans, step, job, traceID, parentSpanID, logger); err != nil {
 			logger.Error("Failed to create span for step", zap.String("step_name", step.GetName()), zap.Error(err))
 		}

--- a/packages/app/src/data/resource-usage.ts
+++ b/packages/app/src/data/resource-usage.ts
@@ -44,11 +44,22 @@ interface RawMetricRow {
   networkInterface: string;
 }
 
+// Runner metrics sit inside the job's span. The hour of slack covers the
+// runner's clock and the scrape interval; the metrics tables sort by hour and
+// carry a minmax index on TimeUnix, and without a time predicate neither one
+// prunes anything.
+const METRICS_WINDOW_SLACK_SECONDS = 60 * 60;
+
 function resolveJobIdentifiers(
-  rows: { runId: string; jobName: string }[],
-): { runId: string; jobName: string } | null {
+  rows: { runId: string; jobName: string; jobStart: string; jobEnd: string }[],
+): { runId: string; jobName: string; jobStart: number; jobEnd: number } | null {
   if (rows.length === 0) return null;
-  return { runId: rows[0].runId, jobName: rows[0].jobName };
+  return {
+    runId: rows[0].runId,
+    jobName: rows[0].jobName,
+    jobStart: Number(rows[0].jobStart),
+    jobEnd: Number(rows[0].jobEnd),
+  };
 }
 
 function aggregatePoints(rows: RawMetricRow[]): ResourceUsagePoint[] {
@@ -219,18 +230,28 @@ const getJobResourceUsage = createAuthenticatedServerFn({
       data: { traceId, jobId },
       context: { clickhouse },
     }): Promise<JobResourceUsage | null> => {
+      // The window comes from traces_trace_id_ts, as in runs/server.ts:
+      // traces sorts by tenant, service and time, so a bare TraceId predicate
+      // reads the bloom filter of every granule the tenant has.
       const identifierSql = `
+      WITH
+        (SELECT (min(Start), max(End) + 1) FROM traces_trace_id_ts WHERE TraceId = {traceId:String}) AS traceWindow
       SELECT
         anyLast(ResourceAttributes['cicd.pipeline.run.id']) as runId,
-        anyLast(ResourceAttributes['cicd.pipeline.task.name']) as jobName
+        anyLast(ResourceAttributes['cicd.pipeline.task.name']) as jobName,
+        toUnixTimestamp(min(Timestamp)) as jobStart,
+        toUnixTimestamp(max(Timestamp + toIntervalNanosecond(Duration))) as jobEnd
       FROM traces
       WHERE TraceId = {traceId:String}
+        AND Timestamp BETWEEN traceWindow.1 AND traceWindow.2
         AND ResourceAttributes['cicd.pipeline.task.run.id'] = {jobId:String}
     `;
 
       const identifierRows = await clickhouse.query<{
         runId: string;
         jobName: string;
+        jobStart: string;
+        jobEnd: string;
       }>(identifierSql, { traceId, jobId });
 
       const ids = resolveJobIdentifiers(identifierRows);
@@ -252,6 +273,7 @@ const getJobResourceUsage = createAuthenticatedServerFn({
       WHERE ResourceAttributes['cicd.pipeline.run.id'] = {runId:String}
         AND Attributes['cicd.pipeline.task.name'] = {jobName:String}
         AND MetricName IN ('system.cpu.utilization', 'system.memory.utilization', 'system.filesystem.utilization')
+        AND TimeUnix BETWEEN toDateTime({metricsFrom:UInt32}) AND toDateTime({metricsTo:UInt32})
 
       UNION ALL
 
@@ -268,6 +290,7 @@ const getJobResourceUsage = createAuthenticatedServerFn({
       WHERE ResourceAttributes['cicd.pipeline.run.id'] = {runId:String}
         AND Attributes['cicd.pipeline.task.name'] = {jobName:String}
         AND MetricName IN ('system.memory.limit', 'system.memory.usage', 'system.filesystem.limit', 'system.filesystem.usage', 'system.network.io')
+        AND TimeUnix BETWEEN toDateTime({metricsFrom:UInt32}) AND toDateTime({metricsTo:UInt32})
 
       ORDER BY timestamp
     `;
@@ -275,6 +298,8 @@ const getJobResourceUsage = createAuthenticatedServerFn({
       const metricRows = await clickhouse.query<RawMetricRow>(metricsSql, {
         runId: ids.runId,
         jobName: ids.jobName,
+        metricsFrom: ids.jobStart - METRICS_WINDOW_SLACK_SECONDS,
+        metricsTo: ids.jobEnd + METRICS_WINDOW_SLACK_SECONDS,
       });
 
       if (metricRows.length === 0) return null;

--- a/packages/app/src/data/runs.test.ts
+++ b/packages/app/src/data/runs.test.ts
@@ -10,6 +10,7 @@ vi.mock("@/lib/clickhouse", () => ({
   query: vi.fn(),
 }));
 
+import { pool } from "@/db/client";
 import { query } from "@/lib/clickhouse";
 import { getRunJobs, getRunSpans, getStepLogs } from "./runs/server";
 
@@ -51,6 +52,20 @@ describe("getRunJobs", () => {
 });
 
 describe("getRunSpans", () => {
+  it("takes the run's window from the trace id lookup table", async () => {
+    mockedQuery.mockResolvedValue([]);
+
+    await getRunSpans({ data: "trace-1" });
+
+    const [sql, , params] = mockedQuery.mock.calls[0] ?? [];
+    expect(sql).toContain(
+      "FROM traces_trace_id_ts WHERE TraceId = {traceId:String}",
+    );
+    expect(sql).toContain("Timestamp BETWEEN traceWindow.1 AND traceWindow.2");
+    expect(params).toEqual({ traceId: "trace-1" });
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+
   it("maps a step span from the query result", async () => {
     mockedQuery.mockResolvedValue([
       {
@@ -105,6 +120,23 @@ describe("getRunSpans", () => {
 });
 
 describe("getStepLogs", () => {
+  it("bounds the log reads by the run's end, taken from its spans", async () => {
+    mockedQuery.mockResolvedValueOnce([{ cnt: "0" }]).mockResolvedValueOnce([]);
+
+    await getStepLogs({
+      data: { traceId: "trace-1", jobName: "build", stepNumber: "2" },
+    });
+
+    expect(mockedQuery).toHaveBeenCalledTimes(2);
+    for (const [sql] of mockedQuery.mock.calls) {
+      expect(sql).toContain(
+        "FROM traces_trace_id_ts WHERE TraceId = {traceId:String}",
+      );
+      expect(sql).toContain("runEnd + INTERVAL 1 HOUR");
+    }
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+
   it("normalizes full log timestamps to timezone-aware UTC ISO strings", async () => {
     mockedQuery.mockResolvedValueOnce([{ cnt: "2" }]).mockResolvedValueOnce([
       {

--- a/packages/app/src/data/runs/server.ts
+++ b/packages/app/src/data/runs/server.ts
@@ -14,6 +14,31 @@ function normalizeConclusion(conclusion: string | null): string {
 }
 const MAX_LOG_PAGE_SIZE = 5000;
 
+// Every ClickHouse query in this file looks a run up by TraceId. traces and
+// logs sort by tenant, service and time, not by TraceId, so a bare TraceId
+// predicate reads the TraceId bloom filter of every granule the tenant has,
+// which grows with the tenant's data. traces_trace_id_ts sorts by TraceId and
+// holds min(Timestamp) and max(Timestamp) per trace per inserted block, so
+// the window is one primary-key read there, and the traces and logs reads
+// prune to the run's own partition and granules. ClickHouse folds the scalar
+// subqueries to constants before it plans the outer read, which is what lets
+// them drive the primary key; a later subquery may use an earlier alias.
+//
+// The window is exact for spans: every span's Timestamp sits between
+// min(Start) and max(End) + 1, the + 1 covering End's truncation to whole
+// seconds. Logs need the run's end, which the lookup table does not hold
+// because End is the start of the latest span, so the log queries take
+// max(Timestamp + Duration) from the run's spans and allow an hour on each
+// side for the second rounding of GitHub's step times. A trace with no spans
+// yet has an empty window and no rows.
+const TRACE_WINDOW = `WITH
+      (SELECT (min(Start), max(End) + 1) FROM traces_trace_id_ts WHERE TraceId = {traceId:String}) AS traceWindow`;
+const SPAN_IN_WINDOW = "Timestamp BETWEEN traceWindow.1 AND traceWindow.2";
+const RUN_WINDOW = `${TRACE_WINDOW},
+      (SELECT max(Timestamp + toIntervalNanosecond(Duration)) FROM traces WHERE TraceId = {traceId:String} AND ${SPAN_IN_WINDOW}) AS runEnd`;
+const LOG_IN_WINDOW =
+  "Timestamp BETWEEN traceWindow.1 - INTERVAL 1 HOUR AND runEnd + INTERVAL 1 HOUR";
+
 function mapLogRow(row: { timestamp: string; body: string | null }): LogEntry {
   return {
     timestamp: normalizeTimestampToUtc(row.timestamp),
@@ -60,9 +85,11 @@ async function countStepLogs(
     ? "\n      AND match(Body, {egrep:String})"
     : "";
   const sql = `
+    ${RUN_WINDOW}
     SELECT count() as cnt
     FROM logs
     WHERE TraceId = {traceId:String}
+      AND ${LOG_IN_WINDOW}
       ${jobClause}
       AND LogAttributes['everr.github.workflow_job_step.number'] = {stepNumber:String}${egrepClause}
   `;
@@ -99,11 +126,13 @@ async function getRawStepLogs(
     ? "\n\t\t\tAND match(Body, {egrep:String})"
     : "";
   const sql = `
+		${RUN_WINDOW}
 		SELECT
 			Timestamp as timestamp,
 			Body as body
 		FROM logs
 		WHERE TraceId = {traceId:String}
+			AND ${LOG_IN_WINDOW}
 			${jobClause}
 			AND LogAttributes['everr.github.workflow_job_step.number'] = {stepNumber:String}${egrepClause}
 		ORDER BY Timestamp ${order}
@@ -204,7 +233,8 @@ export const getRunJobs = createAuthenticatedServerFn({
         duration: string;
         firstFailingStep: string;
       }>(
-        `SELECT
+        `${TRACE_WINDOW}
+          SELECT
             ResourceAttributes['cicd.pipeline.task.run.id'] as jobId,
             anyLast(ResourceAttributes['cicd.pipeline.task.name']) as name,
             anyLast(ResourceAttributes['cicd.pipeline.task.run.result']) as conclusion,
@@ -216,6 +246,7 @@ export const getRunJobs = createAuthenticatedServerFn({
             ) as firstFailingStep
           FROM traces
           WHERE TraceId = {traceId:String}
+            AND ${SPAN_IN_WINDOW}
             AND ResourceAttributes['cicd.pipeline.task.run.id'] != ''
           GROUP BY jobId
           ORDER BY min(Timestamp)`,
@@ -277,6 +308,7 @@ export const getAllJobsSteps = createAuthenticatedServerFn({
 
     const result: Record<string, Step[]> = {};
     const sql = `
+      ${TRACE_WINDOW}
       SELECT
         ResourceAttributes['cicd.pipeline.task.run.id'] as jobId,
         SpanName as name,
@@ -287,6 +319,7 @@ export const getAllJobsSteps = createAuthenticatedServerFn({
         toUnixTimestamp64Milli(Timestamp) + intDiv(Duration, 1000000) as endTime
       FROM traces
       WHERE TraceId = {traceId:String}
+        AND ${SPAN_IN_WINDOW}
         AND ResourceAttributes['cicd.pipeline.task.run.id'] IN {jobIds:Array(String)}
         AND SpanAttributes['everr.github.workflow_job_step.number'] != ''
       ORDER BY jobId, toUInt32OrZero(stepNumber)
@@ -386,6 +419,7 @@ export const getRunSpans = createAuthenticatedServerFn({
   .inputValidator(z.string())
   .handler(async ({ data: traceId, context: { clickhouse } }) => {
     const sql = `
+			${TRACE_WINDOW}
 			SELECT
 				SpanId as spanId,
 				ParentSpanId as parentSpanId,
@@ -408,6 +442,7 @@ export const getRunSpans = createAuthenticatedServerFn({
 				ResourceAttributes['cicd.pipeline.task.run.url.full'] as htmlUrl
 			FROM traces
 			WHERE TraceId = {traceId:String}
+			AND ${SPAN_IN_WINDOW}
 			ORDER BY startTime ASC
 		`;
 


### PR DESCRIPTION
Stacked on #426. The run page reads the `traces_trace_id_ts` lookup table and the `(tenant_id, ServiceName, Timestamp)` keys that branch adds, so this PR merges after it.

## Why

The run page for https://app.everr.dev/runs/80b71f11ce704bf482eebf4f7210cded shows a `Complete runner` step with a start time in the year 1900. The `workflow_job` webhook for that job listed the step as `pending` with null `started_at` and `completed_at`. The receiver built a span from those and stamped it with the zero Go time. The exporter serialises that as 1754-08-30 and ClickHouse stores it as 1900-01-01, the DateTime64 minimum. Production holds 3 such spans among 13.7M, all `Complete runner` or `Post Checkout` steps of jobs that had already succeeded. They sit in partition `20790607`, which no TTL will ever drop.

Separately, every ClickHouse query behind the run and job views filtered on `TraceId` alone. Neither `traces` nor `logs` sorts by `TraceId`, so ClickHouse checks the `TraceId` bloom filter of every granule the tenant has and reads a granule for every false positive. On a 31M-span table in 360 parts that is 18 ms warm and 40 ms cold per query, and it grows with the tenant's data.

## What

- **The receiver skips a step that never started.** `processSteps` drops a step whose `started_at` and `completed_at` are both zero. Skipped steps and skipped jobs keep their spans: GitHub stamps those with equal start and end times, and none of the 1,667 skipped steps or 376 skipped jobs of the last 90 days in production match the guard.
- **The receiver never stamps a log line with the zero time.** `scanLogFile` gave a line with no leading timestamp the previous line's time, and the zero time when it was the first line, the same value that made the 1900 spans. A leading line now takes the time of the first timestamped line. A file with no timestamp on any line takes the start of its step, else the start of the run, both known to the receiver from the job's step timings and the webhook event. The time the archive was read stays in `ObservedTimestamp` only, so an archive processed late, a webhook redelivery or a backfill, still lands inside the run's window on the run page. Production holds no log row before 2000, so this one is preventive.
- **Every run page query takes its window from the trace id lookup table**, in the same statement:

  ```sql
  WITH (SELECT (min(Start), max(End) + 1) FROM traces_trace_id_ts WHERE TraceId = {traceId:String}) AS traceWindow
  SELECT ... FROM traces WHERE TraceId = {traceId:String} AND Timestamp BETWEEN traceWindow.1 AND traceWindow.2
  ```

  ClickHouse folds the scalar subquery to a constant before it plans the outer read, so the window drives the partition key and the primary key. The window is exact for spans. The log queries add the run's end as a second scalar, `max(Timestamp + Duration)` over the run's spans, with an hour of slack, because the lookup table's `End` is the start of the latest span. `getRunJobs`, `getAllJobsSteps`, `getRunSpans`, `countStepLogs`, `getRawStepLogs` and `getJobResourceUsage` all use it, and the resource usage metrics query is bounded by the job's own span, so the hourly key and `idx_time_minmax` on the metrics tables apply there too. No Postgres round trip, no client-supplied window, one mechanism for every query on the page.

## Review findings, in order

1. **Zero time on the log path.** Fixed in the receiver, see above. The count on production is 0.
2. **`TimestampTime` for logs.** Moot on #426: the column is gone and `app.logs` sorts by `(tenant_id, ServiceName, Timestamp)`, so the same predicate prunes logs and traces alike.
3. **The three 1900 rows are hidden, not removed.** The #426 cut-over rebuilds `app.traces` empty, so they go with it. To remove them before that: `ALTER TABLE app.traces DROP PARTITION '20790607'`. The window is a performance change on its own now; it does not exist to hide rows.
- `getRunJobs` parallelism: back, the window is inside the ClickHouse statement and the Postgres jobs query runs beside it.
- Five `workflow_runs` lookups per page: gone.
- `getJobResourceUsage` unbounded: bounded, and its metrics query with it.
- `run_started_at ?? last_event_at` and `parseDateTime64BestEffort`: gone with the Postgres window.

## Measured

Container built from `clickhouse/Dockerfile` at #426's schema. One tenant, 90 daily partitions, 31M spans in 360 parts, 6.5M log lines in 90 parts, random hex trace ids, caches dropped before the cold run, `use_query_condition_cache = 0`, `SELECT 1` at 0 ms.

| Query | Cold | Warm | Rows read | Parts touched |
| --- | ---: | ---: | ---: | ---: |
| Spans by `TraceId` alone (main) | 40 ms | 18 ms | 42,656 | 360 |
| Spans with the window, lookup table partitioned by day, 552 parts | 99 ms | 94 ms | 2,808,792 | 555 |
| Spans with the window, lookup table partitioned by month, 13 parts | 8 ms | 7 ms | 117,856 | 16 |
| Step logs by `TraceId` alone (main) | 18 ms | 9 ms | 8,192 | 90 |
| Step logs with the window and the run end | 11 ms | 10 ms | 126,048 | 17 |

The second row is why #426 now partitions `traces_trace_id_ts` by month with `index_granularity = 256`: a point lookup reads one granule from every part whose id range covers the id, and with random ids that is every part, so the lookup's cost is the part count. The bare bloom scan's cost is the tenant's granule count instead, so the two cross as the tenant grows.

## Verified

- Receiver: `TestProcessSteps` gains a `pending` step with no timestamps, 3 spans before the fix and 2 after; `TestScanLogFileContinuationLines` covers the leading line and a file with no timestamp at all, which takes the caller's time; `TestLogFallbackTime` covers the step start, the run start and the last resort. `go vet`, `gofmt` and `golangci-lint` are clean.
- App: `runs.test.ts` asserts that `getRunSpans` and `getStepLogs` take their window from `traces_trace_id_ts` and never call Postgres. The 23 tests across the run routes pass; `tsc --noEmit` and biome are clean.
- The exact SQL the six server functions emit, captured from the mocked client and run verbatim with `clickhouse-client --param_*` as `app_ro` against the container: spans, jobs, steps, log count, log lines, job identifiers and runner metrics all return the expected rows. `EXPLAIN indexes = 1` shows the window pruning to 3 of 360 parts and 3 of 44 granules before the bloom filter runs.
- The value chain for a zero time was run, not inferred: `time.Time{}.UnixNano()` is -6795364578871345152, `AsTime()` on export gives 1754-08-30T22:43:41Z, and ClickHouse stores that as 1900-01-01 00:00:00.128654848 in partition `20790607`.

