### PR TITLE
feat(clickhouse): store log and span attributes as JSON columns

### DIFF
--- a/clickhouse/init/03-create-otel-tables.sql
+++ b/clickhouse/init/03-create-otel-tables.sql
@@ -7,6 +7,13 @@
 -- so keep them in step when that pin moves. The exporter's DDL is the
 -- reference: internal/sqltemplates/*.sql in that module.
 --
+-- Logs and traces carry the JSON column set the exporter writes with
+-- `json: true`, typed values and one keys array per attribute column; the
+-- metrics tables keep their maps because the attribute map is the series key
+-- there. `max_dynamic_paths = 256` is the guard against a tenant with
+-- thousands of distinct keys, the same value on every JSON column here, in
+-- 10-create-mvs.sql and in the local store's templates.
+--
 -- Types only, no codecs. A Null table compresses nothing, and app.* is built
 -- with CREATE TABLE ... AS SELECT, which copies types but not codecs, so the
 -- codecs that matter are the MODIFY COLUMN blocks in 10-create-mvs.sql.
@@ -21,23 +28,25 @@ CREATE TABLE IF NOT EXISTS otel.otel_traces (
     SpanName LowCardinality(String),
     SpanKind LowCardinality(String),
     ServiceName LowCardinality(String),
-    ResourceAttributes Map(LowCardinality(String), String),
+    ResourceAttributes JSON(max_dynamic_paths = 256),
+    ResourceAttributesKeys Array(LowCardinality(String)),
     ScopeName String,
     ScopeVersion String,
-    SpanAttributes Map(LowCardinality(String), String),
+    SpanAttributes JSON(max_dynamic_paths = 256),
+    SpanAttributesKeys Array(LowCardinality(String)),
     Duration UInt64,
     StatusCode LowCardinality(String),
     StatusMessage String,
     Events Nested (
         Timestamp DateTime64(9),
         Name LowCardinality(String),
-        Attributes Map(LowCardinality(String), String)
+        Attributes JSON(max_dynamic_paths = 256)
     ),
     Links Nested (
         TraceId String,
         SpanId String,
         TraceState String,
-        Attributes Map(LowCardinality(String), String)
+        Attributes JSON(max_dynamic_paths = 256)
     )
 ) ENGINE = Null;
 
@@ -51,12 +60,15 @@ CREATE TABLE IF NOT EXISTS otel.otel_logs (
     ServiceName LowCardinality(String),
     Body String,
     ResourceSchemaUrl LowCardinality(String),
-    ResourceAttributes Map(LowCardinality(String), String),
+    ResourceAttributes JSON(max_dynamic_paths = 256),
+    ResourceAttributesKeys Array(LowCardinality(String)),
     ScopeSchemaUrl LowCardinality(String),
     ScopeName String,
     ScopeVersion LowCardinality(String),
-    ScopeAttributes Map(LowCardinality(String), String),
-    LogAttributes Map(LowCardinality(String), String),
+    ScopeAttributes JSON(max_dynamic_paths = 256),
+    ScopeAttributesKeys Array(LowCardinality(String)),
+    LogAttributes JSON(max_dynamic_paths = 256),
+    LogAttributesKeys Array(LowCardinality(String)),
     EventName String
 ) ENGINE = Null;
 

--- a/clickhouse/init/04-create-error-fingerprint-function.sql
+++ b/clickhouse/init/04-create-error-fingerprint-function.sql
@@ -7,24 +7,29 @@
 -- service, exception type, and a normalized exception message (UUIDs, long
 -- ids/hex, and long quoted literals collapsed so noisy variants group together).
 --
+-- Callers pass the three attributes as text: `` toString(LogAttributes.`error.fingerprint`) ``
+-- and the two exception paths. A query built this way reads three
+-- subcolumns of the JSON document and never the whole column. `toString` of
+-- a missing path gives '', the same empty value the map form gave.
+--
 -- Keep in step with the collector's copy at
 -- collector/exporter/chdbexporter/internal/sqltemplates/create_error_fingerprint_function.sql
 --
 -- init/ runs only on a fresh server. Apply to an existing cluster with:
 --   clickhouse-client --user default --password '<ADMIN_PASSWORD>' --multiquery \
 --     < clickhouse/init/04-create-error-fingerprint-function.sql
-CREATE OR REPLACE FUNCTION errorFingerprint AS (serviceName, logAttributes) ->
+CREATE OR REPLACE FUNCTION errorFingerprint AS (serviceName, fingerprint, exceptionType, exceptionMessage) ->
   if(
-    logAttributes['error.fingerprint'] != '',
-    logAttributes['error.fingerprint'],
+    fingerprint != '',
+    fingerprint,
     toString(cityHash64(
       serviceName,
-      logAttributes['exception.type'],
+      exceptionType,
       substring(
         replaceRegexpAll(
           replaceRegexpAll(
             replaceRegexpAll(
-              trim(BOTH ' ' FROM logAttributes['exception.message']),
+              trim(BOTH ' ' FROM exceptionMessage),
               '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}',
               '<uuid>'
             ),

--- a/clickhouse/init/05-create-retention-functions.sql
+++ b/clickhouse/init/05-create-retention-functions.sql
@@ -24,3 +24,20 @@ CREATE OR REPLACE FUNCTION everrRetentionDays AS (resourceAttributes) ->
 
 CREATE OR REPLACE FUNCTION everrStripRetention AS (resourceAttributes) ->
   mapFilter((k, v) -> k != 'everr.retention.days', resourceAttributes);
+
+-- The JSON forms for app.logs and app.traces. getSubcolumn on a block that
+-- is already in memory costs nothing on disk, and it avoids the question of
+-- how `x.`path`` resolves against a lambda parameter. toString accepts the
+-- stamp as a string or as a number and gives '' for a missing path, so the
+-- guard below is the same test as in everrRetentionDays. The strip of the
+-- document itself is the SKIP on the app table's column type; only the keys
+-- array needs a filter.
+CREATE OR REPLACE FUNCTION everrRetentionDaysJson AS (resourceAttributes) ->
+  toUInt16OrZero(toString(getSubcolumn(resourceAttributes, 'everr.retention.days')))
+    + throwIf(
+        toUInt16OrZero(toString(getSubcolumn(resourceAttributes, 'everr.retention.days'))) = 0,
+        'everr.retention.days resource attribute missing or not a positive number of days'
+      );
+
+CREATE OR REPLACE FUNCTION everrStripRetentionKeys AS (keys) ->
+  arrayFilter(k -> k != 'everr.retention.days', keys);

--- a/clickhouse/init/10-create-mvs.sql
+++ b/clickhouse/init/10-create-mvs.sql
@@ -15,6 +15,13 @@
 -- the strip. The stamp is computed in an inner query because the
 -- `everrStripRetention(...) AS ResourceAttributes` alias in the outer query
 -- shadows the source column.
+--
+-- On app.logs and app.traces the attributes are JSON columns. The strip of
+-- `everr.retention.days` from the document is the SKIP on the column type,
+-- applied when the view's rows land in the table, so the view only filters
+-- the keys array, and the stamp reads the path with getSubcolumn.
+-- `everr.tenant.id` stays in the document and in the keys, as it does with
+-- the maps.
 
 -- Traces: tenant-enriched read table + MV
 CREATE TABLE IF NOT EXISTS app.traces
@@ -36,7 +43,7 @@ SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
 AS
 SELECT
   *,
-  CAST(ResourceAttributes['everr.tenant.id'] AS String) AS tenant_id,
+  toString(getSubcolumn(ResourceAttributes, 'everr.tenant.id')) AS tenant_id,
   toUInt16(0) AS retention_days
 FROM otel.otel_traces
 WHERE 1 = 0;
@@ -45,30 +52,27 @@ WHERE 1 = 0;
 -- columns but not indexes, so app.traces starts bare; add the same set the raw
 -- table carries so app-side queries prune the same way.
 --
--- The map indexes stay bloom_filter on purpose, here and in every app.* table
--- below. Upstream's exporter switches them to TYPE text(tokenizer = 'array')
--- on ClickHouse 26.2 and later, so a diff against upstream shows a difference.
--- Do not "fix" it. Measured on 1M rows with one match, both types read the
--- same 8,192 rows for the two predicates the app emits, mapContains(map, key)
--- and map[key] IN (...), but the text indexes cost 5.94 MiB against 11.71 KiB
--- for bloom_filter on 7.81 MiB of data. That is 500 times the index storage
--- for identical pruning, paid on every partition for the full retention
--- window. Revisit only if we add substring or token search inside attribute
--- values, which bloom_filter cannot serve and text() can.
+-- The keys arrays carry the only skip indexes on attributes. A filter on one
+-- key reads that key's own subcolumn, so a value index has nothing to add;
+-- the keys index serves the exists filter and the key list of the filter UI.
+-- The metrics tables below keep their map indexes, measured in PR #426:
+-- bloom_filter reads the same rows as upstream's text() for the two
+-- predicates the app emits at 500 times less storage.
 ALTER TABLE app.traces
   ADD INDEX IF NOT EXISTS idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
-  ADD INDEX IF NOT EXISTS idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-  ADD INDEX IF NOT EXISTS idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-  ADD INDEX IF NOT EXISTS idx_span_attr_key mapKeys(SpanAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-  ADD INDEX IF NOT EXISTS idx_span_attr_value mapValues(SpanAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_res_attr_keys ResourceAttributesKeys TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_span_attr_keys SpanAttributesKeys TYPE bloom_filter(0.01) GRANULARITY 1,
   ADD INDEX IF NOT EXISTS idx_duration Duration TYPE minmax GRANULARITY 1;
 
 -- Codecs for app.traces. CREATE TABLE ... AS SELECT copies types but not
 -- codecs, so without this every column falls back to LZ4 and the table is
 -- about twice the size of the raw copy. MODIFY COLUMN without a type keeps
 -- the type the CTAS copied, so 03-create-otel-tables.sql stays the only place
--- a column type is written. Every app.* table below repeats this for its own
--- source.
+-- a column type is written, with one exception: the attribute columns of
+-- app.traces and app.logs, because the SKIP of everr.retention.days is part
+-- of the column type and belongs to the app table only, so it is written
+-- here instead. The landing table keeps the path so the view can read it.
+-- Every app.* table below repeats this for its own source.
 ALTER TABLE app.traces
   MODIFY COLUMN `Timestamp` CODEC(Delta(8), ZSTD(1)),
   MODIFY COLUMN `TraceId` CODEC(ZSTD(1)),
@@ -78,10 +82,12 @@ ALTER TABLE app.traces
   MODIFY COLUMN `SpanName` CODEC(ZSTD(1)),
   MODIFY COLUMN `SpanKind` CODEC(ZSTD(1)),
   MODIFY COLUMN `ServiceName` CODEC(ZSTD(1)),
-  MODIFY COLUMN `ResourceAttributes` CODEC(ZSTD(1)),
+  MODIFY COLUMN `ResourceAttributes` JSON(max_dynamic_paths = 256, SKIP `everr.retention.days`) CODEC(ZSTD(1)),
+  MODIFY COLUMN `ResourceAttributesKeys` CODEC(ZSTD(1)),
   MODIFY COLUMN `ScopeName` CODEC(ZSTD(1)),
   MODIFY COLUMN `ScopeVersion` CODEC(ZSTD(1)),
-  MODIFY COLUMN `SpanAttributes` CODEC(ZSTD(1)),
+  MODIFY COLUMN `SpanAttributes` JSON(max_dynamic_paths = 256) CODEC(ZSTD(1)),
+  MODIFY COLUMN `SpanAttributesKeys` CODEC(ZSTD(1)),
   MODIFY COLUMN `Duration` CODEC(ZSTD(1)),
   MODIFY COLUMN `StatusCode` CODEC(ZSTD(1)),
   MODIFY COLUMN `StatusMessage` CODEC(ZSTD(1)),
@@ -98,14 +104,14 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS app.traces_mv
 TO app.traces
 AS
 SELECT
-  * EXCEPT (ResourceAttributes),
-  everrStripRetention(ResourceAttributes) AS ResourceAttributes
+  * EXCEPT (ResourceAttributesKeys),
+  everrStripRetentionKeys(ResourceAttributesKeys) AS ResourceAttributesKeys
 FROM
 (
   SELECT
     *,
-    ResourceAttributes['everr.tenant.id'] AS tenant_id,
-    everrRetentionDays(ResourceAttributes) AS retention_days
+    toString(getSubcolumn(ResourceAttributes, 'everr.tenant.id')) AS tenant_id,
+    everrRetentionDaysJson(ResourceAttributes) AS retention_days
   FROM otel.otel_traces
 );
 
@@ -150,16 +156,16 @@ SETTINGS index_granularity = 256, ttl_only_drop_parts = 1;
 -- chained off app.traces would need the inserting user to hold SELECT on
 -- app.traces, because ClickHouse checks that user against every view in the
 -- chain, and the collector user stays on otel.* only. The guard in
--- everrRetentionDays fires here too, which refuses the same rows.
+-- everrRetentionDaysJson fires here too, which refuses the same rows.
 CREATE MATERIALIZED VIEW IF NOT EXISTS app.traces_trace_id_ts_mv
 TO app.traces_trace_id_ts
 AS
 SELECT
-  ResourceAttributes['everr.tenant.id'] AS tenant_id,
+  toString(getSubcolumn(ResourceAttributes, 'everr.tenant.id')) AS tenant_id,
   TraceId,
   min(Timestamp) AS Start,
   max(Timestamp) AS End,
-  everrRetentionDays(ResourceAttributes) AS retention_days
+  everrRetentionDaysJson(ResourceAttributes) AS retention_days
 FROM otel.otel_traces
 WHERE TraceId != ''
 GROUP BY tenant_id, retention_days, TraceId;
@@ -188,7 +194,7 @@ SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
 AS
 SELECT
   *,
-  CAST(ResourceAttributes['everr.tenant.id'] AS String) AS tenant_id,
+  toString(getSubcolumn(ResourceAttributes, 'everr.tenant.id')) AS tenant_id,
   toUInt16(0) AS retention_days
 FROM otel.otel_logs
 WHERE 1 = 0;
@@ -212,12 +218,9 @@ WHERE 1 = 0;
 -- table rebuild, so make the trade if body search becomes a hot path.
 ALTER TABLE app.logs
   ADD INDEX IF NOT EXISTS idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
-  ADD INDEX IF NOT EXISTS idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-  ADD INDEX IF NOT EXISTS idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-  ADD INDEX IF NOT EXISTS idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-  ADD INDEX IF NOT EXISTS idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-  ADD INDEX IF NOT EXISTS idx_log_attr_key mapKeys(LogAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-  ADD INDEX IF NOT EXISTS idx_log_attr_value mapValues(LogAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_res_attr_keys ResourceAttributesKeys TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_scope_attr_keys ScopeAttributesKeys TYPE bloom_filter(0.01) GRANULARITY 1,
+  ADD INDEX IF NOT EXISTS idx_log_attr_keys LogAttributesKeys TYPE bloom_filter(0.01) GRANULARITY 1,
   ADD INDEX IF NOT EXISTS idx_lower_body lower(Body) TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 8;
 
 -- Codecs mirrored from otel.otel_logs (see the app.traces note above).
@@ -229,12 +232,15 @@ ALTER TABLE app.logs
   MODIFY COLUMN `ServiceName` CODEC(ZSTD(1)),
   MODIFY COLUMN `Body` CODEC(ZSTD(1)),
   MODIFY COLUMN `ResourceSchemaUrl` CODEC(ZSTD(1)),
-  MODIFY COLUMN `ResourceAttributes` CODEC(ZSTD(1)),
+  MODIFY COLUMN `ResourceAttributes` JSON(max_dynamic_paths = 256, SKIP `everr.retention.days`) CODEC(ZSTD(1)),
+  MODIFY COLUMN `ResourceAttributesKeys` CODEC(ZSTD(1)),
   MODIFY COLUMN `ScopeSchemaUrl` CODEC(ZSTD(1)),
   MODIFY COLUMN `ScopeName` CODEC(ZSTD(1)),
   MODIFY COLUMN `ScopeVersion` CODEC(ZSTD(1)),
-  MODIFY COLUMN `ScopeAttributes` CODEC(ZSTD(1)),
-  MODIFY COLUMN `LogAttributes` CODEC(ZSTD(1)),
+  MODIFY COLUMN `ScopeAttributes` JSON(max_dynamic_paths = 256) CODEC(ZSTD(1)),
+  MODIFY COLUMN `ScopeAttributesKeys` CODEC(ZSTD(1)),
+  MODIFY COLUMN `LogAttributes` JSON(max_dynamic_paths = 256) CODEC(ZSTD(1)),
+  MODIFY COLUMN `LogAttributesKeys` CODEC(ZSTD(1)),
   MODIFY COLUMN `EventName` CODEC(ZSTD(1)),
   MODIFY COLUMN `tenant_id` CODEC(ZSTD(1));
 
@@ -242,14 +248,14 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS app.logs_mv
 TO app.logs
 AS
 SELECT
-  * EXCEPT (ResourceAttributes),
-  everrStripRetention(ResourceAttributes) AS ResourceAttributes
+  * EXCEPT (ResourceAttributesKeys),
+  everrStripRetentionKeys(ResourceAttributesKeys) AS ResourceAttributesKeys
 FROM
 (
   SELECT
     *,
-    ResourceAttributes['everr.tenant.id'] AS tenant_id,
-    everrRetentionDays(ResourceAttributes) AS retention_days
+    toString(getSubcolumn(ResourceAttributes, 'everr.tenant.id')) AS tenant_id,
+    everrRetentionDaysJson(ResourceAttributes) AS retention_days
   FROM otel.otel_logs
 );
 

--- a/clickhouse/init/10-create-mvs.sql
+++ b/clickhouse/init/10-create-mvs.sql
@@ -12,9 +12,10 @@
 --
 -- Only the views write these tables. everrRetentionDays and
 -- everrStripRetention (05-create-retention-functions.sql) hold the stamp and
--- the strip. The stamp is computed in an inner query because the
--- `everrStripRetention(...) AS ResourceAttributes` alias in the outer query
--- shadows the source column.
+-- the strip. On the metrics views the stamp is computed in an inner query
+-- because the `everrStripRetention(...) AS ResourceAttributes` alias in the
+-- outer query shadows the source column. The logs and traces views keep the
+-- same inner query, so all five views read alike.
 --
 -- On app.logs and app.traces the attributes are JSON columns. The strip of
 -- `everr.retention.days` from the document is the SKIP on the column type,

--- a/clickhouse/init/12-create-alert-events.sql
+++ b/clickhouse/init/12-create-alert-events.sql
@@ -75,13 +75,12 @@ SELECT
   '' AS ResourceSchemaUrl,
   -- Env facet ('deployment.environment' resource attr): the preview name for
   -- preview alerts, 'production' for live.
-  --
-  -- The keys arrays list the same keys as the documents above them, because
-  -- the filter UI and the exists index read them.
   CAST(map(
     'everr.tenant.id', tenant_id,
     'deployment.environment', if(preview = '', 'production', preview)
   ), 'JSON(max_dynamic_paths = 256)') AS ResourceAttributes,
+  -- Each keys array lists the same keys as the document it follows: the
+  -- filter UI and the exists index read the array.
   CAST(['everr.tenant.id', 'deployment.environment'], 'Array(LowCardinality(String))') AS ResourceAttributesKeys,
   '' AS ScopeSchemaUrl,
   'everr.alerting' AS ScopeName,

--- a/clickhouse/init/12-create-alert-events.sql
+++ b/clickhouse/init/12-create-alert-events.sql
@@ -75,15 +75,20 @@ SELECT
   '' AS ResourceSchemaUrl,
   -- Env facet ('deployment.environment' resource attr): the preview name for
   -- preview alerts, 'production' for live.
-  map(
+  --
+  -- The keys arrays list the same keys as the documents above them, because
+  -- the filter UI and the exists index read them.
+  CAST(map(
     'everr.tenant.id', tenant_id,
     'deployment.environment', if(preview = '', 'production', preview)
-  ) AS ResourceAttributes,
+  ), 'JSON(max_dynamic_paths = 256)') AS ResourceAttributes,
+  CAST(['everr.tenant.id', 'deployment.environment'], 'Array(LowCardinality(String))') AS ResourceAttributesKeys,
   '' AS ScopeSchemaUrl,
   'everr.alerting' AS ScopeName,
   '' AS ScopeVersion,
-  map() AS ScopeAttributes,
-  map(
+  CAST(map(), 'JSON(max_dynamic_paths = 256)') AS ScopeAttributes,
+  CAST([], 'Array(LowCardinality(String))') AS ScopeAttributesKeys,
+  CAST(map(
     'alert.slug', slug,
     'alert.preview', preview,
     'alert.event_type', event_type,
@@ -94,7 +99,8 @@ SELECT
     'alert.evidence_json', evidence_json,
     'alert.instance_fingerprint', instance_fingerprint,
     'alert.instance_labels', instance_labels_json
-  ) AS LogAttributes,
+  ), 'JSON(max_dynamic_paths = 256)') AS LogAttributes,
+  CAST(['alert.slug', 'alert.preview', 'alert.event_type', 'alert.delivery_targets', 'alert.silenced', 'alert.row_count', 'alert.evidence_truncated', 'alert.evidence_json', 'alert.instance_fingerprint', 'alert.instance_labels'], 'Array(LowCardinality(String))') AS LogAttributesKeys,
   concat('alert.', slug, '.', event_type) AS EventName,
   -- Required for app.logs RLS and partitioning; ResourceAttributes alone is
   -- not enough.

--- a/clickhouse/migrations/2026-09-03-direct-ingest.sh
+++ b/clickhouse/migrations/2026-09-03-direct-ingest.sh
@@ -10,6 +10,12 @@
 # view and creating the new one in which exporter inserts fail; the exporter
 # retries them.
 #
+# The collector that runs `json: true` deploys right after this script, not
+# before: its JSON inserts fail against the Map landing tables, and the old
+# collector's Map inserts fail against the JSON ones. The exporter's queue
+# retries what falls in between. The guard below reads the Map form on purpose:
+# it runs against the old tables.
+#
 # Usage (from the repo root, as an admin user):
 #   clickhouse/migrations/2026-09-03-direct-ingest.sh --host <h> --secure --user default --password '<pw>'
 # CLICKHOUSE_CLIENT overrides the client binary, e.g. for a container:

--- a/clickhouse/migrations/2026-09-03-direct-ingest.sh
+++ b/clickhouse/migrations/2026-09-03-direct-ingest.sh
@@ -16,6 +16,12 @@
 # retries what falls in between. The guard below reads the Map form on purpose:
 # it runs against the old tables.
 #
+# Between the app deploy and the end of this script the app's reads fail,
+# because its queries use the JSON form against the Map columns: the runs list
+# and detail, workflows, repo detail, cost analysis, the home CI panel, the
+# explorers and the built-in dashboards. Run the three steps, app, this script,
+# collector, back to back in one window.
+#
 # Usage (from the repo root, as an admin user):
 #   clickhouse/migrations/2026-09-03-direct-ingest.sh --host <h> --secure --user default --password '<pw>'
 # CLICKHOUSE_CLIENT overrides the client binary, e.g. for a container:

--- a/collector/config.example.yml
+++ b/collector/config.example.yml
@@ -117,6 +117,12 @@ exporters:
     password: collector-dev
     database: otel
     create_schema: false
+    # Logs and traces write JSON attribute columns with typed values and one
+    # keys array per attribute column; the landing tables in
+    # clickhouse/init/03 declare that column set. A Map exporter against those
+    # tables fails every insert, and the reverse too, so this flag and the
+    # schema move together.
+    json: true
     # Batching belongs here, not in a `batch` processor: the processor
     # acknowledges data to the receiver before the insert happens, so a crash
     # loses the batch and a failed insert cannot apply backpressure. The

--- a/collector/exporter/chdbexporter/EVERR_CHANGES.md
+++ b/collector/exporter/chdbexporter/EVERR_CHANGES.md
@@ -136,3 +136,18 @@ This file records the meaningful differences from upstream `open-telemetry/opent
   same table as `app.traces_trace_id_ts`, with `tenant_id` in front of the
   key, and the `everr-use-telemetry` skill teaches the two-step trace lookup
   against both.
+
+## JSON attribute columns
+
+- The local store runs the exporter's `json` mode, the cloud's choice: typed
+  values, one `*Keys Array(LowCardinality(String))` per attribute column, and
+  a `bloom_filter` index on each keys array. The Map templates stay in the
+  tree for a `json: false` config but nothing in Everr uses them.
+- Every JSON column is `JSON(max_dynamic_paths = 256)`, the same guard as the
+  cloud tables in `clickhouse/init`. Upstream's default of 1024 let every
+  mixed-tenant part carry a thousand path columns and made merges fail.
+- `logs_json` and `traces_json` carry `idx_trace_id` and `logs_json` carries
+  `idx_lower_body`, as the Map templates do; upstream's JSON templates have
+  neither.
+- `errorFingerprint` takes the three attributes as text arguments instead of
+  the map, so a query reads three subcolumns and not the whole column.

--- a/collector/exporter/chdbexporter/EVERR_CHANGES.md
+++ b/collector/exporter/chdbexporter/EVERR_CHANGES.md
@@ -151,3 +151,5 @@ This file records the meaningful differences from upstream `open-telemetry/opent
   neither.
 - `errorFingerprint` takes the three attributes as text arguments instead of
   the map, so a query reads three subcolumns and not the whole column.
+- `localSchemaVersion` is 2. A store built at version 1 holds Map `logs` and
+  `traces` tables under the same names, and the rebuild replaces them.

--- a/collector/exporter/chdbexporter/exporter_chdb_roundtrip_test.go
+++ b/collector/exporter/chdbexporter/exporter_chdb_roundtrip_test.go
@@ -132,6 +132,34 @@ func TestChDBRoundTripKeepsLogTimestampNanoseconds(t *testing.T) {
 	require.Equal(t, strconv.FormatInt(roundTripTime.UnixNano(), 10), rows[0]["nanos"])
 }
 
+func TestChDBRoundTripStoresTypedJSONAttributes(t *testing.T) {
+	handle := openRealChDB(t)
+	cfg := withDefaultConfig(func(c *Config) { c.JSON = true })
+	exp := newLogsJSONExporter(zaptest.NewLogger(t), cfg, handle)
+	require.NoError(t, exp.start(t.Context(), nil))
+	t.Cleanup(func() { _ = exp.shutdown(context.Background()) })
+
+	ld := plog.NewLogs()
+	record := ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	record.SetTimestamp(pcommon.NewTimestampFromTime(roundTripTime))
+	record.Body().SetStr("typed attributes")
+	record.Attributes().PutInt("everr.github.workflow_job_step.number", 3)
+	record.Attributes().PutStr("http.route", "/x")
+	require.NoError(t, exp.pushLogsData(t.Context(), ld))
+
+	rows := queryJSONRows(t, handle,
+		"SELECT toString(LogAttributes.`everr.github.workflow_job_step.number`) AS step,"+
+			" dynamicType(LogAttributes.`everr.github.workflow_job_step.number`) AS stepType,"+
+			" toString(LogAttributes.`http.route`) AS route,"+
+			" has(LogAttributesKeys, 'http.route') AS hasRoute"+
+			` FROM "`+cfg.database()+`"."`+cfg.LogsTableName+`"`)
+	require.Len(t, rows, 1)
+	require.Equal(t, "3", rows[0]["step"])
+	require.Equal(t, "Int64", rows[0]["stepType"], "an integer attribute is stored as a number, not as text")
+	require.Equal(t, "/x", rows[0]["route"])
+	require.Equal(t, float64(1), rows[0]["hasRoute"])
+}
+
 func TestChDBRoundTripKeepsSpanTimestampNanoseconds(t *testing.T) {
 	handle := openRealChDB(t)
 	cfg := withDefaultConfig()

--- a/collector/exporter/chdbexporter/factory_chdb_test.go
+++ b/collector/exporter/chdbexporter/factory_chdb_test.go
@@ -141,7 +141,7 @@ func TestStartRebuildsAStoreThatWasNeverStamped(t *testing.T) {
 		strings.Index(queries, `DROP TABLE IF EXISTS "default"."traces_trace_id_ts_mv"`),
 		strings.Index(queries, `DROP TABLE IF EXISTS "default"."traces_trace_id_ts"`),
 	)
-	require.Contains(t, queries, `INSERT INTO "default"."_everr_schema" (version) VALUES (1)`)
+	require.Contains(t, queries, `INSERT INTO "default"."_everr_schema" (version) VALUES (`+strconv.Itoa(localSchemaVersion)+`)`)
 }
 
 func TestStartRebuildsOnceForEverySignal(t *testing.T) {
@@ -153,7 +153,7 @@ func TestStartRebuildsOnceForEverySignal(t *testing.T) {
 	queries := startAllExporters(t, session, handle, withCloudTableNamesConfig())
 
 	require.Equal(t, 1, strings.Count(queries, `DROP TABLE IF EXISTS "default"."logs"`))
-	require.Equal(t, 1, strings.Count(queries, `INSERT INTO "default"."_everr_schema" (version) VALUES (1)`))
+	require.Equal(t, 1, strings.Count(queries, `INSERT INTO "default"."_everr_schema" (version) VALUES (`+strconv.Itoa(localSchemaVersion)+`)`))
 }
 
 func TestStartLeavesAStoreOnTheCurrentVersionAlone(t *testing.T) {

--- a/collector/exporter/chdbexporter/internal/sqltemplates/create_error_fingerprint_function.sql
+++ b/collector/exporter/chdbexporter/internal/sqltemplates/create_error_fingerprint_function.sql
@@ -4,18 +4,23 @@
 --
 -- Keep in step with clickhouse/init/04-create-error-fingerprint-function.sql
 -- (the body below must stay identical, or local and cloud fingerprints diverge).
-CREATE OR REPLACE FUNCTION errorFingerprint AS (serviceName, logAttributes) ->
+--
+-- Callers pass the three attributes as text: `` toString(LogAttributes.`error.fingerprint`) ``
+-- and the two exception paths. A query built this way reads three
+-- subcolumns of the JSON document and never the whole column. `toString` of
+-- a missing path gives '', the same empty value the map form gave.
+CREATE OR REPLACE FUNCTION errorFingerprint AS (serviceName, fingerprint, exceptionType, exceptionMessage) ->
   if(
-    logAttributes['error.fingerprint'] != '',
-    logAttributes['error.fingerprint'],
+    fingerprint != '',
+    fingerprint,
     toString(cityHash64(
       serviceName,
-      logAttributes['exception.type'],
+      exceptionType,
       substring(
         replaceRegexpAll(
           replaceRegexpAll(
             replaceRegexpAll(
-              trim(BOTH ' ' FROM logAttributes['exception.message']),
+              trim(BOTH ' ' FROM exceptionMessage),
               '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}',
               '<uuid>'
             ),

--- a/collector/exporter/chdbexporter/internal/sqltemplates/logs_json_table.sql
+++ b/collector/exporter/chdbexporter/internal/sqltemplates/logs_json_table.sql
@@ -8,21 +8,22 @@ CREATE TABLE IF NOT EXISTS {{ident .Database}}.{{ident .TableName}} {{.ClusterSt
     `ServiceName` LowCardinality(String) CODEC(ZSTD(1)),
     `Body` String CODEC(ZSTD(1)),
     `ResourceSchemaUrl` LowCardinality(String) CODEC(ZSTD(1)),
-    `ResourceAttributes` JSON CODEC(ZSTD(1)),
+    `ResourceAttributes` JSON(max_dynamic_paths = 256) CODEC(ZSTD(1)),
     `ResourceAttributesKeys` Array(LowCardinality(String)) CODEC(ZSTD(1)),
     `ScopeSchemaUrl` LowCardinality(String) CODEC(ZSTD(1)),
     `ScopeName` String CODEC(ZSTD(1)),
     `ScopeVersion` LowCardinality(String) CODEC(ZSTD(1)),
-    `ScopeAttributes` JSON CODEC(ZSTD(1)),
+    `ScopeAttributes` JSON(max_dynamic_paths = 256) CODEC(ZSTD(1)),
     `ScopeAttributesKeys` Array(LowCardinality(String)) CODEC(ZSTD(1)),
-    `LogAttributes` JSON CODEC(ZSTD(1)),
+    `LogAttributes` JSON(max_dynamic_paths = 256) CODEC(ZSTD(1)),
     `LogAttributesKeys` Array(LowCardinality(String)) CODEC(ZSTD(1)),
     `EventName` String CODEC(ZSTD(1)),
 
     INDEX idx_res_attr_keys ResourceAttributesKeys TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_scope_attr_keys ScopeAttributesKeys TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_log_attr_keys LogAttributesKeys TYPE bloom_filter(0.01) GRANULARITY 1,
-    INDEX idx_body Body TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 8
+    INDEX idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
+    INDEX idx_lower_body lower(Body) TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 8
 ) ENGINE = {{.Engine}}
 PARTITION BY toDate(Timestamp)
 ORDER BY (ServiceName, Timestamp)

--- a/collector/exporter/chdbexporter/internal/sqltemplates/traces_json_table.sql
+++ b/collector/exporter/chdbexporter/internal/sqltemplates/traces_json_table.sql
@@ -7,11 +7,11 @@ CREATE TABLE IF NOT EXISTS %q.%q %s (
     SpanName LowCardinality(String) CODEC(ZSTD(1)),
     SpanKind LowCardinality(String) CODEC(ZSTD(1)),
     ServiceName LowCardinality(String) CODEC(ZSTD(1)),
-    ResourceAttributes JSON CODEC(ZSTD(1)),
+    ResourceAttributes JSON(max_dynamic_paths = 256) CODEC(ZSTD(1)),
     ResourceAttributesKeys Array(LowCardinality(String)) CODEC(ZSTD(1)),
     ScopeName String CODEC(ZSTD(1)),
     ScopeVersion String CODEC(ZSTD(1)),
-    SpanAttributes JSON CODEC(ZSTD(1)),
+    SpanAttributes JSON(max_dynamic_paths = 256) CODEC(ZSTD(1)),
     SpanAttributesKeys Array(LowCardinality(String)) CODEC(ZSTD(1)),
     Duration UInt64 CODEC(ZSTD(1)),
     StatusCode LowCardinality(String) CODEC(ZSTD(1)),
@@ -19,15 +19,16 @@ CREATE TABLE IF NOT EXISTS %q.%q %s (
     Events Nested (
         Timestamp DateTime64(9),
         Name LowCardinality(String),
-        Attributes JSON
+        Attributes JSON(max_dynamic_paths = 256)
     ) CODEC(ZSTD(1)),
     Links Nested (
         TraceId String,
         SpanId String,
         TraceState String,
-        Attributes JSON
+        Attributes JSON(max_dynamic_paths = 256)
     ) CODEC(ZSTD(1)),
 
+    INDEX idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
     INDEX idx_res_attr_keys ResourceAttributesKeys TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_span_attr_keys SpanAttributesKeys TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_duration Duration TYPE minmax GRANULARITY 1

--- a/collector/exporter/chdbexporter/schema_version.go
+++ b/collector/exporter/chdbexporter/schema_version.go
@@ -23,9 +23,12 @@ import (
 // touching. Local telemetry is a rolling cache bounded by `ttl` and never a
 // system of record, so a rebuild costs at most one ttl window of local data.
 //
-// Version 1 is the first stamped shape. Every store built before it reads as 0
-// and rebuilds once.
-const localSchemaVersion = 1
+// Version 2 is the JSON attribute columns. A store built at version 1 holds
+// Map `logs` and `traces` tables under the same names the JSON templates use.
+// `CREATE TABLE IF NOT EXISTS` would keep them, so without this bump the
+// rebuild would not fire. The rebuild replaces them at the cost of one 7-day
+// cache.
+const localSchemaVersion = 2
 
 // schemaVersionTable holds exactly one row: the version the store was built
 // at. It lives inside the store rather than in a file beside it so that it

--- a/collector/exporter/chdbexporter/schema_version_test.go
+++ b/collector/exporter/chdbexporter/schema_version_test.go
@@ -23,7 +23,7 @@ import (
 // shapedTemplatesDigest pins the DDL that decides the shape of the local
 // store. localSchemaVersion has to change with it, because a store built by an
 // older binary is only dropped and rebuilt when the version differs.
-const shapedTemplatesDigest = "df67a46ca57e2ce548c98f71809e38a226d33682c82b3d1d0f3ebc522ea525fc"
+const shapedTemplatesDigest = "2414fb829f1db0f493f12bbc6ca8ead5d7606da2c51eaf5e2172813f589f2acf"
 
 func TestSchemaTemplatesMatchVersion(t *testing.T) {
 	digest := sha256.New()

--- a/collector/internal/localgateway/config/config.go
+++ b/collector/internal/localgateway/config/config.go
@@ -75,7 +75,10 @@ func BuildCollectorConfigMap(cfg CollectorConfig) map[string]any {
 		},
 		"exporters": map[string]any{
 			"chdb": map[string]any{
-				"ttl": cfg.TTL.String(),
+				// The same JSON attribute columns as the cloud tables, so the
+				// shared explorer queries run unchanged.
+				"json": true,
+				"ttl":  cfg.TTL.String(),
 				// Local tables carry the same names as the cloud's query-facing
 				// tables so the shared explorer queries run unchanged.
 				"logs_table_name":   "logs",

--- a/collector/internal/localgateway/config/config_test.go
+++ b/collector/internal/localgateway/config/config_test.go
@@ -43,6 +43,7 @@ func TestBuildCollectorConfigUsesLocalDefaults(t *testing.T) {
 	// explorer queries run unchanged.
 	require.Equal(t, "logs", chdb["logs_table_name"])
 	require.Equal(t, "traces", chdb["traces_table_name"])
+	require.Equal(t, true, chdb["json"], "the local store writes JSON attribute columns like the cloud")
 	metricsTables := chdb["metrics_tables"].(map[string]any)
 	require.Equal(t, map[string]any{"name": "metrics_gauge"}, metricsTables["gauge"])
 	require.Equal(t, map[string]any{"name": "metrics_sum"}, metricsTables["sum"])

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/alerts.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/alerts.md
@@ -62,23 +62,23 @@ The link appears on the alert's detail page and list row, and in the Telegram an
 
 Runbooks can also show the alert's own status by querying the alert service
 events projected into `logs`. Add a small Table panel that filters
-`ServiceName = 'alert'`, `LogAttributes['alert.slug'] = '<alert-slug>'`, and
+`ServiceName = 'alert'`, `` toString(LogAttributes.`alert.slug`) = '<alert-slug>' ``, and
 the selected time range. Useful columns are
-`LogAttributes['alert.event_type']`, `alert.row_count`, `alert.silenced`,
+`` toString(LogAttributes.`alert.event_type`) ``, `alert.row_count`, `alert.silenced`,
 `alert.delivery_targets`, and `alert.instance_labels`.
 
 ```sql
 SELECT
   Timestamp AS event_time,
-  LogAttributes['alert.event_type'] AS event_type,
-  LogAttributes['alert.row_count'] AS row_count,
-  LogAttributes['alert.silenced'] AS silenced,
-  LogAttributes['alert.delivery_targets'] AS delivery_targets,
-  LogAttributes['alert.instance_labels'] AS instance_labels
+  toString(LogAttributes.`alert.event_type`) AS event_type,
+  toString(LogAttributes.`alert.row_count`) AS row_count,
+  toString(LogAttributes.`alert.silenced`) AS silenced,
+  toString(LogAttributes.`alert.delivery_targets`) AS delivery_targets,
+  toString(LogAttributes.`alert.instance_labels`) AS instance_labels
 FROM logs
 WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
   AND ServiceName = 'alert'
-  AND LogAttributes['alert.slug'] = '<alert-slug>'
+  AND toString(LogAttributes.`alert.slug`) = '<alert-slug>'
 ORDER BY event_time DESC
 LIMIT 50
 ```

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/dashboards.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/dashboards.md
@@ -139,7 +139,7 @@ spec:
           - { x: 0,  y: 8, width: 24, height: 10, content: { $ref: "#/spec/panels/slowest-endpoints" } }
 ```
 
-> The column names above (`ServiceName`, `SpanName`, `Duration`, `StatusCode`) are the standard `traces` columns. If you query attributes (`SpanAttributes['http.route']`, etc.) or other tables, discover the real columns first — see Startup Access in the skill root.
+> The column names above (`ServiceName`, `SpanName`, `Duration`, `StatusCode`) are the standard `traces` columns. If you query attributes (`` toString(SpanAttributes.`http.route`) ``, etc.) or other tables, discover the real columns first: see Startup Access in the skill root.
 
 ## Common mistakes
 

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/geomap.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/geomap.md
@@ -40,11 +40,11 @@ Skipped rows in either mode surface as an "N rows not mapped" badge on the panel
 
 ```sql
 -- choropleth: requests per country (alpha-2 codes)
-SELECT SpanAttributes['geo.country_code'] AS region,
+SELECT toString(SpanAttributes.`geo.country_code`) AS region,
        count() AS value
 FROM traces
 WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
-  AND SpanAttributes['geo.country_code'] != ''
+  AND toString(SpanAttributes.`geo.country_code`) != ''
 GROUP BY region
 ```
 

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/treemap.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/treemap.md
@@ -29,11 +29,11 @@ One row per tile: a label column + a **positive** numeric column, optionally a g
 ```sql
 -- requests per route, grouped (colored) by service
 SELECT ServiceName AS service,
-       SpanAttributes['http.route'] AS route,
+       toString(SpanAttributes.`http.route`) AS route,
        count() AS value
 FROM traces
 WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
-  AND SpanAttributes['http.route'] != ''
+  AND toString(SpanAttributes.`http.route`) != ''
 GROUP BY service, route
 ORDER BY value DESC
 LIMIT 50

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/electron.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/electron.md
@@ -192,8 +192,8 @@ Renderer records carry the mark you chose above: `everr.process.type = renderer`
 
 ```sql
 SELECT Timestamp, ServiceName, SeverityText, Body,
-       LogAttributes['everr.process.type'] AS process_type,
-       LogAttributes['exception.mechanism'] AS mechanism,
+       toString(LogAttributes.`everr.process.type`) AS process_type,
+       toString(LogAttributes.`exception.mechanism`) AS mechanism,
        TraceId
 FROM logs
 WHERE Timestamp > now() - INTERVAL 10 MINUTE

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/tauri.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/tauri.md
@@ -367,9 +367,9 @@ Confirm all rows include the required resource attributes:
 ```sql
 SELECT
   ServiceName,
-  ResourceAttributes['service.version'] AS service_version,
-  ResourceAttributes['service.instance.id'] AS service_instance_id,
-  ResourceAttributes['deployment.environment.name'] AS environment
+  toString(ResourceAttributes.`service.version`) AS service_version,
+  toString(ResourceAttributes.`service.instance.id`) AS service_instance_id,
+  toString(ResourceAttributes.`deployment.environment.name`) AS environment
 FROM logs
 WHERE Timestamp > now() - INTERVAL 10 MINUTE
   AND ServiceName IN ('<rust-service-name>', '<browser-service-name>')

--- a/crates/everr-core/assets/skills/everr-setup-telemetry/rules/validation.md
+++ b/crates/everr-core/assets/skills/everr-setup-telemetry/rules/validation.md
@@ -41,8 +41,8 @@ WHERE Timestamp > now() - INTERVAL 10 MINUTE
   AND ServiceName = '<service-name>'
   AND SeverityNumber >= 17
   AND (
-    mapContains(LogAttributes, 'exception.type')
-    OR mapContains(LogAttributes, 'exception.message')
+    has(LogAttributesKeys, 'exception.type')
+    OR has(LogAttributesKeys, 'exception.message')
   )
 ORDER BY Timestamp DESC
 LIMIT 20
@@ -91,8 +91,8 @@ FROM traces
 WHERE Timestamp > now() - INTERVAL 10 MINUTE
   AND ServiceName = '<service-name>'
   AND (
-    ResourceAttributes['request.id'] = '<request-id>'
-    OR SpanAttributes['request.id'] = '<request-id>'
+    toString(ResourceAttributes.`request.id`) = '<request-id>'
+    OR toString(SpanAttributes.`request.id`) = '<request-id>'
   )
 ORDER BY Timestamp DESC
 LIMIT 20
@@ -106,8 +106,8 @@ FROM logs
 WHERE Timestamp > now() - INTERVAL 10 MINUTE
   AND ServiceName = '<service-name>'
   AND (
-    ResourceAttributes['request.id'] = '<request-id>'
-    OR LogAttributes['request.id'] = '<request-id>'
+    toString(ResourceAttributes.`request.id`) = '<request-id>'
+    OR toString(LogAttributes.`request.id`) = '<request-id>'
   )
 ORDER BY Timestamp DESC
 LIMIT 20

--- a/crates/everr-core/assets/skills/everr-use-telemetry/SKILL.md
+++ b/crates/everr-core/assets/skills/everr-use-telemetry/SKILL.md
@@ -71,7 +71,7 @@ Useful log columns: `Timestamp`, `TraceId`, `SpanId`, `ServiceName`, `ScopeName`
 
 `Duration` is nanoseconds (`UInt64`): divide by `1e9` for seconds, `1e6` for milliseconds.
 
-`SpanAttributes`, `LogAttributes`, and `ResourceAttributes` are key/value maps; read a key with `Column['key']`. **Before assuming attribute names** (like `SpanAttributes['http.route']` or `SpanAttributes['db.statement']`), discover what exists with `DESCRIBE TABLE <table>` or by sampling a few rows. OTel attribute naming conventions vary across languages and frameworks.
+`SpanAttributes`, `LogAttributes`, and `ResourceAttributes` are JSON columns with typed values. Read a key as text with `` toString(Column.`key`) `` (backticks around the key, dots included): a missing key gives `''`. Read a number with `` toFloat64OrZero(toString(Column.`key`)) ``. Test presence with `has(ColumnKeys, 'key')`, which is indexed. Never compare the raw `` Column.`key` `` without a conversion: it is a `Dynamic` value, refused in `GROUP BY` and in a comparison across mixed types. The `metrics_*` tables keep maps: `Attributes['key']`. **Before assuming attribute names** (like `` SpanAttributes.`http.route` `` or `` SpanAttributes.`db.statement` ``), discover what exists with `SELECT DISTINCT arrayJoin(SpanAttributesKeys)` over a short window, or by sampling a few rows. OTel attribute naming conventions vary across languages and frameworks.
 
 ## Useful Queries
 
@@ -158,27 +158,27 @@ LIMIT 20
 
 ## Group Errors By Fingerprint
 
-Everr groups error logs into Errors by a *fingerprint*: the `error.fingerprint` log attribute when present, else a hash of the service, exception type, and a normalized exception message. The fingerprint is a ClickHouse UDF, `errorFingerprint(ServiceName, LogAttributes)`, available on both cloud and local telemetry, so you get the same identity the app groups by. The "Copy agent prompt" button in the web UI hands you a Fingerprint.
+Everr groups error logs into Errors by a *fingerprint*: the `error.fingerprint` log attribute when present, else a hash of the service, exception type, and a normalized exception message. The fingerprint is a ClickHouse UDF, `` errorFingerprint(ServiceName, toString(LogAttributes.`error.fingerprint`), toString(LogAttributes.`exception.type`), toString(LogAttributes.`exception.message`)) ``, available on both cloud and local telemetry, so you get the same identity the app groups by. The "Copy agent prompt" button in the web UI hands you a Fingerprint.
 
 An error log has a `service.name` resource attribute, `SeverityNumber >= 17`, and an exception type or message:
 ```sql
-mapContains(ResourceAttributes, 'service.name')
+has(ResourceAttributesKeys, 'service.name')
 AND SeverityNumber >= 17
 AND (
-  mapContains(LogAttributes, 'exception.type')
-  OR mapContains(LogAttributes, 'exception.message')
+  has(LogAttributesKeys, 'exception.type')
+  OR has(LogAttributesKeys, 'exception.message')
 )
 ```
 
 Occurrences of one Fingerprint (widen the window if the Error is older):
 ```sql
 SELECT toString(Timestamp) AS timestamp, ServiceName, TraceId,
-  LogAttributes['exception.stacktrace'] AS stacktrace
+  toString(LogAttributes.`exception.stacktrace`) AS stacktrace
 FROM logs
 WHERE Timestamp > now() - INTERVAL 7 DAY
-  AND mapContains(ResourceAttributes, 'service.name')
+  AND has(ResourceAttributesKeys, 'service.name')
   AND SeverityNumber >= 17
-  AND errorFingerprint(ServiceName, LogAttributes) = '<fingerprint>'
+  AND errorFingerprint(ServiceName, toString(LogAttributes.`error.fingerprint`), toString(LogAttributes.`exception.type`), toString(LogAttributes.`exception.message`)) = '<fingerprint>'
 ORDER BY Timestamp DESC
 LIMIT 50
 ```

--- a/crates/everr-core/assets/skills/everr-use-telemetry/rules/browser-events.md
+++ b/crates/everr-core/assets/skills/everr-use-telemetry/rules/browser-events.md
@@ -73,9 +73,9 @@ The INP vital does not use that prefix. It carries the same attribution as the `
 Web-vital p75 by route (one row per metric per route):
 
 ```sql
-SELECT LogAttributes['everr.route.pattern'] AS route,
-  LogAttributes['browser.web_vital.name'] AS vital,
-  quantile(0.75)(toFloat64(LogAttributes['browser.web_vital.value'])) AS p75,
+SELECT toString(LogAttributes.`everr.route.pattern`) AS route,
+  toString(LogAttributes.`browser.web_vital.name`) AS vital,
+  quantile(0.75)(toFloat64OrZero(toString(LogAttributes.`browser.web_vital.value`))) AS p75,
   count() AS samples
 FROM logs
 WHERE Timestamp > now() - INTERVAL 24 HOUR
@@ -88,8 +88,8 @@ LIMIT 50
 Rage clicks by element, to find broken UI:
 
 ```sql
-SELECT LogAttributes['everr.route.pattern'] AS route,
-  LogAttributes['everr.element.selector'] AS selector,
+SELECT toString(LogAttributes.`everr.route.pattern`) AS route,
+  toString(LogAttributes.`everr.element.selector`) AS selector,
   count() AS rage_clicks
 FROM logs
 WHERE Timestamp > now() - INTERVAL 24 HOUR
@@ -102,7 +102,7 @@ LIMIT 20
 Frontend error rate by page:
 
 ```sql
-SELECT LogAttributes['everr.route.pattern'] AS route,
+SELECT toString(LogAttributes.`everr.route.pattern`) AS route,
   countIf(EventName = 'exception') AS errors,
   countIf(EventName = 'everr.browser.page_view') AS views
 FROM logs
@@ -117,15 +117,15 @@ What one user session did, in order (events and requests interleaved):
 
 ```sql
 SELECT * FROM (
-  SELECT Timestamp, EventName AS what, LogAttributes['url.path'] AS path
+  SELECT Timestamp, EventName AS what, toString(LogAttributes.`url.path`) AS path
   FROM logs
   WHERE Timestamp > now() - INTERVAL 24 HOUR
-    AND LogAttributes['session.id'] = '<session-id>'
+    AND toString(LogAttributes.`session.id`) = '<session-id>'
   UNION ALL
-  SELECT Timestamp, SpanName, SpanAttributes['url.full']
+  SELECT Timestamp, SpanName, toString(SpanAttributes.`url.full`)
   FROM traces
   WHERE Timestamp > now() - INTERVAL 24 HOUR
-    AND SpanAttributes['session.id'] = '<session-id>'
+    AND toString(SpanAttributes.`session.id`) = '<session-id>'
 )
 ORDER BY Timestamp ASC
 LIMIT 200

--- a/crates/everr-core/assets/skills/everr-working-with-ci/SKILL.md
+++ b/crates/everr-core/assets/skills/everr-working-with-ci/SKILL.md
@@ -73,17 +73,17 @@ Recent run history:
 SELECT
   max(Timestamp) AS last_seen,
   TraceId,
-  anyLast(ResourceAttributes['cicd.pipeline.run.id']) AS run_id,
-  anyLast(ResourceAttributes['cicd.pipeline.name']) AS workflow,
-  anyLast(ResourceAttributes['vcs.ref.head.name']) AS branch,
-  anyLast(ResourceAttributes['vcs.ref.head.revision']) AS sha,
-  anyLast(ResourceAttributes['cicd.pipeline.task.run.result']) AS result
+  anyLast(toString(ResourceAttributes.`cicd.pipeline.run.id`)) AS run_id,
+  anyLast(toString(ResourceAttributes.`cicd.pipeline.name`)) AS workflow,
+  anyLast(toString(ResourceAttributes.`vcs.ref.head.name`)) AS branch,
+  anyLast(toString(ResourceAttributes.`vcs.ref.head.revision`)) AS sha,
+  anyLast(toString(ResourceAttributes.`cicd.pipeline.task.run.result`)) AS result
 FROM traces
 WHERE Timestamp > now() - INTERVAL 7 DAY
   AND ServiceName = 'github-actions'
-  AND ResourceAttributes['vcs.repository.name'] = '<owner/repo>'
-  AND ResourceAttributes['cicd.pipeline.run.id'] != ''
-  AND SpanAttributes['everr.github.workflow_job_step.number'] = ''
+  AND toString(ResourceAttributes.`vcs.repository.name`) = '<owner/repo>'
+  AND toString(ResourceAttributes.`cicd.pipeline.run.id`) != ''
+  AND toString(SpanAttributes.`everr.github.workflow_job_step.number`) = ''
 GROUP BY TraceId
 ORDER BY last_seen DESC
 LIMIT 20
@@ -93,16 +93,16 @@ Repeated failure log lines:
 
 ```sql
 SELECT
-  anyLast(ResourceAttributes['cicd.pipeline.name']) AS workflow,
-  anyLast(ScopeAttributes['cicd.pipeline.task.name']) AS job,
-  anyLast(LogAttributes['everr.github.workflow_job_step.number']) AS step,
+  anyLast(toString(ResourceAttributes.`cicd.pipeline.name`)) AS workflow,
+  anyLast(toString(ScopeAttributes.`cicd.pipeline.task.name`)) AS job,
+  anyLast(toString(LogAttributes.`everr.github.workflow_job_step.number`)) AS step,
   uniqExact(TraceId) AS runs,
   count() AS lines,
   max(Timestamp) AS last_seen,
   anyLast(Body) AS sample
 FROM logs
 WHERE Timestamp > now() - INTERVAL 14 DAY
-  AND ResourceAttributes['vcs.repository.name'] = '<owner/repo>'
+  AND toString(ResourceAttributes.`vcs.repository.name`) = '<owner/repo>'
   AND startsWith(Body, '##[error]')
 GROUP BY cityHash64(Body)
 ORDER BY runs DESC, lines DESC, last_seen DESC

--- a/everr/cloud-query.alert.yaml
+++ b/everr/cloud-query.alert.yaml
@@ -16,9 +16,9 @@ spec:
   query: |
     SELECT
       count() AS system_errors,
-      arrayStringConcat(groupUniqArray(SpanAttributes['everr.cloud_query.kind']), ', ') AS kinds
+      arrayStringConcat(groupUniqArray(toString(SpanAttributes.`everr.cloud_query.kind`)), ', ') AS kinds
     FROM traces
     WHERE SpanName = 'POST /api/cli/sql' AND SpanKind = 'Server'
-      AND SpanAttributes['everr.cloud_query.outcome'] = 'system_error'
+      AND toString(SpanAttributes.`everr.cloud_query.outcome`) = 'system_error'
       AND Timestamp >= now() - INTERVAL 5 MINUTE
     HAVING system_errors >= 2

--- a/everr/cloud-query.dashboard.yaml
+++ b/everr/cloud-query.dashboard.yaml
@@ -56,7 +56,7 @@ spec:
                 kind: ClickHouseSQL
                 spec:
                   query: |
-                    SELECT countIf(SpanAttributes['everr.cloud_query.outcome'] = 'system_error') AS system_errors
+                    SELECT countIf(toString(SpanAttributes.`everr.cloud_query.outcome`) = 'system_error') AS system_errors
                     FROM traces
                     WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
                       AND SpanName = 'POST /api/cli/sql' AND SpanKind = 'Server'
@@ -75,7 +75,7 @@ spec:
                 kind: ClickHouseSQL
                 spec:
                   query: |
-                    SELECT countIf(SpanAttributes['everr.cloud_query.outcome'] = 'user_error') AS user_errors
+                    SELECT countIf(toString(SpanAttributes.`everr.cloud_query.outcome`) = 'user_error') AS user_errors
                     FROM traces
                     WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
                       AND SpanName = 'POST /api/cli/sql' AND SpanKind = 'Server'
@@ -115,8 +115,8 @@ spec:
                 spec:
                   query: |
                     SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} SECOND) AS ts,
-                           if(SpanAttributes['everr.cloud_query.outcome'] = '', 'unknown',
-                              SpanAttributes['everr.cloud_query.outcome']) AS outcome,
+                           if(toString(SpanAttributes.`everr.cloud_query.outcome`) = '', 'unknown',
+                              toString(SpanAttributes.`everr.cloud_query.outcome`)) AS outcome,
                            count() AS requests
                     FROM traces
                     WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
@@ -170,10 +170,10 @@ spec:
                 spec:
                   query: |
                     SELECT formatDateTime(Timestamp, '%m-%d %H:%i:%S') AS time,
-                           SpanAttributes['everr.org_id'] AS org,
+                           toString(SpanAttributes.`everr.org_id`) AS org,
                            round(Duration / 1e6, 0) AS duration_ms,
-                           if(SpanAttributes['everr.cloud_query.outcome'] = '', 'unknown',
-                              SpanAttributes['everr.cloud_query.outcome']) AS outcome,
+                           if(toString(SpanAttributes.`everr.cloud_query.outcome`) = '', 'unknown',
+                              toString(SpanAttributes.`everr.cloud_query.outcome`)) AS outcome,
                            TraceId AS trace_id
                     FROM traces
                     WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
@@ -196,14 +196,14 @@ spec:
                 kind: ClickHouseSQL
                 spec:
                   query: |
-                    SELECT SpanAttributes['everr.cloud_query.outcome'] AS outcome,
-                           SpanAttributes['everr.cloud_query.kind'] AS kind,
+                    SELECT toString(SpanAttributes.`everr.cloud_query.outcome`) AS outcome,
+                           toString(SpanAttributes.`everr.cloud_query.kind`) AS kind,
                            count() AS count,
                            formatDateTime(max(Timestamp), '%m-%d %H:%i') AS last_seen
                     FROM traces
                     WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
                       AND SpanName = 'POST /api/cli/sql' AND SpanKind = 'Server'
-                      AND SpanAttributes['everr.cloud_query.outcome'] IN ('user_error', 'system_error')
+                      AND toString(SpanAttributes.`everr.cloud_query.outcome`) IN ('user_error', 'system_error')
                     GROUP BY outcome, kind
                     ORDER BY count DESC
                     LIMIT 20
@@ -223,10 +223,10 @@ spec:
                 kind: ClickHouseSQL
                 spec:
                   query: |
-                    SELECT SpanAttributes['everr.org_id'] AS org,
+                    SELECT toString(SpanAttributes.`everr.org_id`) AS org,
                            count() AS requests,
-                           countIf(SpanAttributes['everr.cloud_query.outcome'] = 'user_error') AS user_errors,
-                           countIf(SpanAttributes['everr.cloud_query.outcome'] = 'system_error') AS system_errors
+                           countIf(toString(SpanAttributes.`everr.cloud_query.outcome`) = 'user_error') AS user_errors,
+                           countIf(toString(SpanAttributes.`everr.cloud_query.outcome`) = 'system_error') AS system_errors
                     FROM traces
                     WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
                       AND SpanName = 'POST /api/cli/sql' AND SpanKind = 'Server'

--- a/everr/cloud-query.runbook.yaml
+++ b/everr/cloud-query.runbook.yaml
@@ -27,14 +27,14 @@ spec:
                 spec:
                   query: |
                     SELECT formatDateTime(Timestamp, '%m-%d %H:%i:%S') AS time,
-                           SpanAttributes['everr.cloud_query.kind'] AS kind,
-                           SpanAttributes['everr.org_id'] AS org,
+                           toString(SpanAttributes.`everr.cloud_query.kind`) AS kind,
+                           toString(SpanAttributes.`everr.org_id`) AS org,
                            round(Duration / 1e6, 0) AS duration_ms,
                            TraceId AS trace_id
                     FROM traces
                     WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
                       AND SpanName = 'POST /api/cli/sql' AND SpanKind = 'Server'
-                      AND SpanAttributes['everr.cloud_query.outcome'] = 'system_error'
+                      AND toString(SpanAttributes.`everr.cloud_query.outcome`) = 'system_error'
                     ORDER BY Timestamp DESC
                     LIMIT 50
     error-kind-breakdown:
@@ -54,12 +54,12 @@ spec:
                 spec:
                   query: |
                     SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} SECOND) AS ts,
-                           SpanAttributes['everr.cloud_query.kind'] AS kind,
+                           toString(SpanAttributes.`everr.cloud_query.kind`) AS kind,
                            count() AS errors
                     FROM traces
                     WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
                       AND SpanName = 'POST /api/cli/sql' AND SpanKind = 'Server'
-                      AND SpanAttributes['everr.cloud_query.outcome'] = 'system_error'
+                      AND toString(SpanAttributes.`everr.cloud_query.outcome`) = 'system_error'
                     GROUP BY ts, kind
                     ORDER BY ts
     latency:
@@ -118,7 +118,7 @@ spec:
                     WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
                       AND (
                         (SpanName = 'POST /api/cli/sql' AND SpanKind = 'Server')
-                        OR (SpanName = 'ClickHouse QUERY' AND SpanAttributes['clickhouse.client'] = 'sql_api')
+                        OR (SpanName = 'ClickHouse QUERY' AND toString(SpanAttributes.`clickhouse.client`) = 'sql_api')
                       )
                     GROUP BY ts, span
                     ORDER BY ts

--- a/everr/collector-oom.runbook.yaml
+++ b/everr/collector-oom.runbook.yaml
@@ -58,7 +58,7 @@ spec:
                   query: |
                     SELECT
                       formatDateTime(Timestamp, '%m-%d %H:%i:%S') AS started,
-                      SpanAttributes['github.event.type'] AS event_type,
+                      toString(SpanAttributes.`github.event.type`) AS event_type,
                       round(Duration / 1e6, 1) AS duration_ms,
                       TraceId AS trace_id
                     FROM traces
@@ -113,7 +113,7 @@ spec:
                 spec:
                   query: |
                     SELECT
-                      SpanAttributes['github.event.type'] AS event_type,
+                      toString(SpanAttributes.`github.event.type`) AS event_type,
                       count() AS replays,
                       round(quantile(0.5)(Duration) / 1e6, 1) AS p50_ms,
                       round(quantile(0.95)(Duration) / 1e6, 1) AS p95_ms,
@@ -223,7 +223,7 @@ spec:
                   query: |
                     SELECT
                       formatDateTime(Timestamp, '%m-%d %H:%i:%S') AS started,
-                      SpanAttributes['github.event.type'] AS event_type,
+                      toString(SpanAttributes.`github.event.type`) AS event_type,
                       round(Duration / 1e6, 1) AS duration_ms,
                       TraceId AS trace_id
                     FROM traces
@@ -305,7 +305,7 @@ spec:
                   query: |
                     SELECT
                       formatDateTime(Timestamp, '%m-%d %H:%i:%S') AS started,
-                      SpanAttributes['github.event.type'] AS event_type,
+                      toString(SpanAttributes.`github.event.type`) AS event_type,
                       round(Duration / 1e6, 1) AS duration_ms,
                       StatusCode AS status,
                       TraceId AS trace_id

--- a/everr/eventloop-delay.runbook.yaml
+++ b/everr/eventloop-delay.runbook.yaml
@@ -123,7 +123,7 @@ spec:
                       formatDateTime(min(Timestamp), '%m-%d %H:%i:%S') AS started,
                       any(ServiceName) AS service,
                       anyIf(SpanName, SpanKind = 'Server' OR ParentSpanId = '') AS entry,
-                      anyIf(SpanAttributes['rpc.method'], SpanAttributes['rpc.method'] != '') AS server_fn,
+                      anyIf(toString(SpanAttributes.`rpc.method`), toString(SpanAttributes.`rpc.method`) != '') AS server_fn,
                       round(max(Duration) / 1e6, 1) AS duration_ms,
                       TraceId AS trace_id
                     FROM traces
@@ -157,8 +157,8 @@ spec:
                 spec:
                   query: |
                     SELECT
-                      if(SpanAttributes['rpc.method'] != '',
-                         concat('fn ', SpanAttributes['rpc.method']),
+                      if(toString(SpanAttributes.`rpc.method`) != '',
+                         concat('fn ', toString(SpanAttributes.`rpc.method`)),
                          SpanName) AS operation,
                       count() AS calls,
                       round(quantile(0.95)(Duration) / 1e6, 1) AS p95_ms,
@@ -172,7 +172,7 @@ spec:
                         WHERE TimeUnix >= {from:String} AND TimeUnix <= {to:String}
                           AND MetricName = 'nodejs.eventloop.delay.p99'
                       )
-                      AND (SpanKind = 'Server' OR ParentSpanId = '' OR SpanAttributes['rpc.method'] != '')
+                      AND (SpanKind = 'Server' OR ParentSpanId = '' OR toString(SpanAttributes.`rpc.method`) != '')
                     GROUP BY operation
                     ORDER BY total_ms DESC
                     LIMIT 20
@@ -267,7 +267,7 @@ spec:
                 spec:
                   query: |
                     SELECT
-                      SpanAttributes['rpc.method'] AS server_fn,
+                      toString(SpanAttributes.`rpc.method`) AS server_fn,
                       count() AS calls,
                       round(quantile(0.5)(Duration) / 1e6, 1) AS p50_ms,
                       round(quantile(0.95)(Duration) / 1e6, 1) AS p95_ms,
@@ -275,7 +275,7 @@ spec:
                       countIf(StatusCode = 'Error') AS errors
                     FROM traces
                     WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}
-                      AND SpanAttributes['rpc.method'] != ''
+                      AND toString(SpanAttributes.`rpc.method`) != ''
                     GROUP BY server_fn
                     ORDER BY p95_ms DESC
                     LIMIT 30

--- a/packages/app/src/data/cost-analysis/server.test.ts
+++ b/packages/app/src/data/cost-analysis/server.test.ts
@@ -28,10 +28,10 @@ describe("cost analysis queries", () => {
 
     const sql = mockedQuery.mock.calls[0]?.[0] ?? "";
     expect(sql).toContain(
-      "mapContains(ResourceAttributes, 'cicd.pipeline.worker.labels')",
+      "has(ResourceAttributesKeys, 'cicd.pipeline.worker.labels')",
     );
     expect(sql).toContain(
-      "mapContains(ResourceAttributes, 'cicd.pipeline.task.run.id')",
+      "has(ResourceAttributesKeys, 'cicd.pipeline.task.run.id')",
     );
     expect(sql).not.toContain("PREWHERE");
     expect(sql).not.toContain("SQL_everr_tenant_id");
@@ -42,17 +42,13 @@ describe("cost analysis queries", () => {
 
     const sql = mockedQuery.mock.calls[0]?.[0] ?? "";
     expect(sql).toContain(
-      "mapContains(ResourceAttributes, 'cicd.pipeline.worker.labels')",
+      "has(ResourceAttributesKeys, 'cicd.pipeline.worker.labels')",
     );
     expect(sql).toContain(
-      "mapContains(ResourceAttributes, 'cicd.pipeline.task.run.id')",
+      "has(ResourceAttributesKeys, 'cicd.pipeline.task.run.id')",
     );
-    expect(sql).toContain(
-      "mapContains(ResourceAttributes, 'vcs.repository.name')",
-    );
-    expect(sql).toContain(
-      "mapContains(ResourceAttributes, 'cicd.pipeline.name')",
-    );
+    expect(sql).toContain("has(ResourceAttributesKeys, 'vcs.repository.name')");
+    expect(sql).toContain("has(ResourceAttributesKeys, 'cicd.pipeline.name')");
   });
 
   it("exposes ResourceAttributes key checks for over-time breakdown", async () => {
@@ -62,13 +58,11 @@ describe("cost analysis queries", () => {
 
     const sql = mockedQuery.mock.calls[0]?.[0] ?? "";
     expect(sql).toContain(
-      "mapContains(ResourceAttributes, 'cicd.pipeline.worker.labels')",
+      "has(ResourceAttributesKeys, 'cicd.pipeline.worker.labels')",
     );
     expect(sql).toContain(
-      "mapContains(ResourceAttributes, 'cicd.pipeline.task.run.id')",
+      "has(ResourceAttributesKeys, 'cicd.pipeline.task.run.id')",
     );
-    expect(sql).toContain(
-      "mapContains(ResourceAttributes, 'vcs.repository.name')",
-    );
+    expect(sql).toContain("has(ResourceAttributesKeys, 'vcs.repository.name')");
   });
 });

--- a/packages/app/src/data/cost-analysis/server.ts
+++ b/packages/app/src/data/cost-analysis/server.ts
@@ -66,7 +66,7 @@ export const getCostOverview = createAuthenticatedServerFn({
         AND ${nonEmptyResourceAttribute(RESOURCE_ATTRIBUTE_KEYS.runnerLabels)}
         AND ${nonEmptyResourceAttribute(RESOURCE_ATTRIBUTE_KEYS.jobId)}
         AND lowerUTF8(${resourceAttribute("cicd.pipeline.task.run.result")}) != 'skip'
-        AND SpanAttributes['everr.github.workflow_job_step.number'] = ''
+        AND toString(SpanAttributes.\`everr.github.workflow_job_step.number\`) = ''
       GROUP BY labels
     `;
 
@@ -136,13 +136,13 @@ export const getCostByWorkflow = createAuthenticatedServerFn({
         count(*) as totalJobs,
         sum(Duration) / 1000000 as totalDurationMs,
         sum(ceil(Duration / 60000000000.0)) as roundedMinutes,
-        uniqExact(ResourceAttributes['cicd.pipeline.run.id']) as uniqueRuns
+        uniqExact(toString(ResourceAttributes.\`cicd.pipeline.run.id\`)) as uniqueRuns
       FROM traces
       WHERE Timestamp >= {fromTime:String} AND Timestamp <= {toTime:String}
         AND ${nonEmptyResourceAttribute(RESOURCE_ATTRIBUTE_KEYS.runnerLabels)}
         AND ${nonEmptyResourceAttribute(RESOURCE_ATTRIBUTE_KEYS.jobId)}
         AND lowerUTF8(${resourceAttribute("cicd.pipeline.task.run.result")}) != 'skip'
-        AND SpanAttributes['everr.github.workflow_job_step.number'] = ''
+        AND toString(SpanAttributes.\`everr.github.workflow_job_step.number\`) = ''
         AND ${nonEmptyResourceAttribute(RESOURCE_ATTRIBUTE_KEYS.repo)}
         AND ${nonEmptyResourceAttribute(RESOURCE_ATTRIBUTE_KEYS.workflow)}
       GROUP BY repo, workflow, labels
@@ -239,7 +239,7 @@ export const getCostOverTimeBreakdown = createAuthenticatedServerFn({
         AND ${nonEmptyResourceAttribute(RESOURCE_ATTRIBUTE_KEYS.runnerLabels)}
         AND ${nonEmptyResourceAttribute(RESOURCE_ATTRIBUTE_KEYS.jobId)}
         AND lowerUTF8(${resourceAttribute("cicd.pipeline.task.run.result")}) != 'skip'
-        AND SpanAttributes['everr.github.workflow_job_step.number'] = ''
+        AND toString(SpanAttributes.\`everr.github.workflow_job_step.number\`) = ''
         ${dimensionFilter}
       GROUP BY date, series, labels
       ORDER BY date ASC

--- a/packages/app/src/data/dashboards/built-in/capabilities.test.ts
+++ b/packages/app/src/data/dashboards/built-in/capabilities.test.ts
@@ -41,9 +41,10 @@ describe("CATALOG_PROBES", () => {
 });
 
 describe("buildCapabilitiesQuery", () => {
-  // `mapContains` is the shape the tables' bloom_filter key indexes can
-  // prune, so an absent attribute reads zero granules instead of the window.
-  it("probes a trace attribute with the index-prunable mapContains", () => {
+  // `has(...Keys, ...)` is the shape the tables' bloom_filter indexes on the
+  // keys arrays can prune, so an absent attribute reads zero granules instead
+  // of the window.
+  it("probes a trace attribute with the index-prunable keys array", () => {
     expect(
       buildCapabilitiesQuery([{ signal: "traces", match: "faas.trigger" }]),
     ).toBe(

--- a/packages/app/src/data/dashboards/built-in/capabilities.test.ts
+++ b/packages/app/src/data/dashboards/built-in/capabilities.test.ts
@@ -51,7 +51,7 @@ describe("buildCapabilitiesQuery", () => {
         "SELECT 'traces:faas.trigger' AS key FROM traces WHERE " +
         "Timestamp >= parseDateTime64BestEffort({from:String}, 9) AND " +
         "Timestamp <= parseDateTime64BestEffort({to:String}, 9) AND " +
-        "mapContains(SpanAttributes, 'faas.trigger') LIMIT 1\n)",
+        "has(SpanAttributesKeys, 'faas.trigger') LIMIT 1\n)",
     );
   });
 
@@ -65,7 +65,7 @@ describe("buildCapabilitiesQuery", () => {
         "SELECT 'logs:browser.web_vital.value' AS key FROM logs WHERE " +
         "Timestamp >= parseDateTime64BestEffort({from:String}, 9) AND " +
         "Timestamp <= parseDateTime64BestEffort({to:String}, 9) AND " +
-        "mapContains(LogAttributes, 'browser.web_vital.value') LIMIT 1\n)",
+        "has(LogAttributesKeys, 'browser.web_vital.value') LIMIT 1\n)",
     );
   });
 

--- a/packages/app/src/data/dashboards/built-in/capabilities.ts
+++ b/packages/app/src/data/dashboards/built-in/capabilities.ts
@@ -127,13 +127,13 @@ function prefixTest(column: string, match: string): string {
  *   SELECT DISTINCT key FROM (
  *     SELECT 'traces' AS key FROM traces WHERE <time range> LIMIT 1
  *     UNION ALL
- *     SELECT 'traces:http.request.method' AS key FROM traces WHERE <time range> AND mapContains(SpanAttributes, 'http.request.method') LIMIT 1
+ *     SELECT 'traces:http.request.method' AS key FROM traces WHERE <time range> AND has(SpanAttributesKeys, 'http.request.method') LIMIT 1
  *     UNION ALL
- *     SELECT 'traces:rpc.system.name' AS key FROM traces WHERE <time range> AND mapContains(SpanAttributes, 'rpc.system.name') LIMIT 1
+ *     SELECT 'traces:rpc.system.name' AS key FROM traces WHERE <time range> AND has(SpanAttributesKeys, 'rpc.system.name') LIMIT 1
  *     UNION ALL
- *     SELECT 'traces:everr.server_function.name' AS key FROM traces WHERE <time range> AND mapContains(SpanAttributes, 'everr.server_function.name') LIMIT 1
+ *     SELECT 'traces:everr.server_function.name' AS key FROM traces WHERE <time range> AND has(SpanAttributesKeys, 'everr.server_function.name') LIMIT 1
  *     UNION ALL
- *     SELECT 'traces:faas.trigger' AS key FROM traces WHERE <time range> AND mapContains(SpanAttributes, 'faas.trigger') LIMIT 1
+ *     SELECT 'traces:faas.trigger' AS key FROM traces WHERE <time range> AND has(SpanAttributesKeys, 'faas.trigger') LIMIT 1
  *     UNION ALL
  *     SELECT 'logs' AS key FROM logs WHERE <time range> LIMIT 1
  *     UNION ALL
@@ -217,9 +217,9 @@ function prefixTest(column: string, match: string): string {
  *     UNION ALL
  *     SELECT 'metrics:k8s.' AS key FROM metrics_summary WHERE <time range> AND startsWith(MetricName, 'k8s.') LIMIT 1
  *     UNION ALL
- *     SELECT 'logs:browser.web_vital.value' AS key FROM logs WHERE <time range> AND mapContains(LogAttributes, 'browser.web_vital.value') LIMIT 1
+ *     SELECT 'logs:browser.web_vital.value' AS key FROM logs WHERE <time range> AND has(LogAttributesKeys, 'browser.web_vital.value') LIMIT 1
  *     UNION ALL
- *     SELECT 'logs:everr.page_view.id' AS key FROM logs WHERE <time range> AND mapContains(LogAttributes, 'everr.page_view.id') LIMIT 1
+ *     SELECT 'logs:everr.page_view.id' AS key FROM logs WHERE <time range> AND has(LogAttributesKeys, 'everr.page_view.id') LIMIT 1
  *   )
  */
 export function buildCapabilitiesQuery(
@@ -268,7 +268,7 @@ export function buildCapabilitiesQuery(
 
     if (match) {
       branches.push(
-        `SELECT ${key} AS key FROM ${signal} WHERE ${window} AND mapContains(${attributes}, '${match}') LIMIT 1`,
+        `SELECT ${key} AS key FROM ${signal} WHERE ${window} AND has(${attributes}Keys, '${match}') LIMIT 1`,
       );
     } else {
       branches.push(

--- a/packages/app/src/data/dashboards/built-in/capabilities.ts
+++ b/packages/app/src/data/dashboards/built-in/capabilities.ts
@@ -1,3 +1,4 @@
+import { attributeExists } from "@everr/telemetry-explorer/sql";
 import { z } from "zod";
 import { BUILTIN_DASHBOARDS } from "./catalog";
 import { type BuiltinDashboard, SIGNALS, type Signal } from "./types";
@@ -268,7 +269,7 @@ export function buildCapabilitiesQuery(
 
     if (match) {
       branches.push(
-        `SELECT ${key} AS key FROM ${signal} WHERE ${window} AND has(${attributes}Keys, '${match}') LIMIT 1`,
+        `SELECT ${key} AS key FROM ${signal} WHERE ${window} AND ${attributeExists(attributes, match)} LIMIT 1`,
       );
     } else {
       branches.push(

--- a/packages/app/src/data/dashboards/built-in/catalog/application/http-endpoints.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/application/http-endpoints.yaml
@@ -51,7 +51,7 @@ document:
                     query: |-
                       SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} SECOND) AS ts, count() AS requests
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Server' AND SpanAttributes['http.request.method'] != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Server' AND toString(SpanAttributes.`http.request.method`) != ''
                       GROUP BY ts
                       ORDER BY ts
       server-errors:
@@ -80,9 +80,9 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT countIf(toUInt16OrZero(SpanAttributes['http.response.status_code']) >= 500) / count() * 100 AS pct
+                      SELECT countIf(toUInt16OrZero(toString(SpanAttributes.`http.response.status_code`)) >= 500) / count() * 100 AS pct
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Server' AND SpanAttributes['http.request.method'] != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Server' AND toString(SpanAttributes.`http.request.method`) != ''
       client-errors:
         kind: Panel
         spec:
@@ -109,9 +109,9 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT countIf(toUInt16OrZero(SpanAttributes['http.response.status_code']) BETWEEN 400 AND 499) / count() * 100 AS pct
+                      SELECT countIf(toUInt16OrZero(toString(SpanAttributes.`http.response.status_code`)) BETWEEN 400 AND 499) / count() * 100 AS pct
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Server' AND SpanAttributes['http.request.method'] != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Server' AND toString(SpanAttributes.`http.request.method`) != ''
       p95-latency:
         kind: Panel
         spec:
@@ -132,7 +132,7 @@ document:
                     query: |-
                       SELECT round(quantile(0.95)(Duration) / 1000000, 1) AS p95
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Server' AND SpanAttributes['http.request.method'] != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Server' AND toString(SpanAttributes.`http.request.method`) != ''
       by-status:
         kind: Panel
         spec:
@@ -151,10 +151,10 @@ document:
                   spec:
                     query: |-
                       SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts,
-                             concat(toString(intDiv(toUInt16OrZero(SpanAttributes['http.response.status_code']), 100)), 'xx') AS status_class,
+                             concat(toString(intDiv(toUInt16OrZero(toString(SpanAttributes.`http.response.status_code`)), 100)), 'xx') AS status_class,
                              count() AS requests
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Server' AND SpanAttributes['http.request.method'] != '' AND SpanAttributes['http.response.status_code'] != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Server' AND toString(SpanAttributes.`http.request.method`) != '' AND toString(SpanAttributes.`http.response.status_code`) != ''
                       GROUP BY ts, status_class
                       ORDER BY ts
       by-route:
@@ -176,13 +176,13 @@ document:
                   spec:
                     query: |-
                       SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts,
-                             coalesce(nullIf(SpanAttributes['http.route'], ''), nullIf(SpanAttributes['url.path'], ''), SpanName) AS route,
+                             coalesce(nullIf(toString(SpanAttributes.`http.route`), ''), nullIf(toString(SpanAttributes.`url.path`), ''), SpanName) AS route,
                              count() AS requests
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Server' AND SpanAttributes['http.request.method'] != ''
-                        AND coalesce(nullIf(SpanAttributes['http.route'], ''), nullIf(SpanAttributes['url.path'], ''), SpanName) IN (
-                        SELECT coalesce(nullIf(SpanAttributes['http.route'], ''), nullIf(SpanAttributes['url.path'], ''), SpanName) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Server' AND SpanAttributes['http.request.method'] != ''
-                        GROUP BY coalesce(nullIf(SpanAttributes['http.route'], ''), nullIf(SpanAttributes['url.path'], ''), SpanName) ORDER BY count() DESC LIMIT 8
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Server' AND toString(SpanAttributes.`http.request.method`) != ''
+                        AND coalesce(nullIf(toString(SpanAttributes.`http.route`), ''), nullIf(toString(SpanAttributes.`url.path`), ''), SpanName) IN (
+                        SELECT coalesce(nullIf(toString(SpanAttributes.`http.route`), ''), nullIf(toString(SpanAttributes.`url.path`), ''), SpanName) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Server' AND toString(SpanAttributes.`http.request.method`) != ''
+                        GROUP BY coalesce(nullIf(toString(SpanAttributes.`http.route`), ''), nullIf(toString(SpanAttributes.`url.path`), ''), SpanName) ORDER BY count() DESC LIMIT 8
                       )
                       GROUP BY ts, route
                       ORDER BY ts
@@ -204,13 +204,13 @@ document:
                   spec:
                     query: |-
                       SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts,
-                             coalesce(nullIf(SpanAttributes['http.route'], ''), nullIf(SpanAttributes['url.path'], ''), SpanName) AS route,
+                             coalesce(nullIf(toString(SpanAttributes.`http.route`), ''), nullIf(toString(SpanAttributes.`url.path`), ''), SpanName) AS route,
                              round(quantile(0.95)(Duration) / 1000000, 1) AS p95_ms
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Server' AND SpanAttributes['http.request.method'] != ''
-                        AND coalesce(nullIf(SpanAttributes['http.route'], ''), nullIf(SpanAttributes['url.path'], ''), SpanName) IN (
-                        SELECT coalesce(nullIf(SpanAttributes['http.route'], ''), nullIf(SpanAttributes['url.path'], ''), SpanName) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Server' AND SpanAttributes['http.request.method'] != ''
-                        GROUP BY coalesce(nullIf(SpanAttributes['http.route'], ''), nullIf(SpanAttributes['url.path'], ''), SpanName) ORDER BY count() DESC LIMIT 8
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Server' AND toString(SpanAttributes.`http.request.method`) != ''
+                        AND coalesce(nullIf(toString(SpanAttributes.`http.route`), ''), nullIf(toString(SpanAttributes.`url.path`), ''), SpanName) IN (
+                        SELECT coalesce(nullIf(toString(SpanAttributes.`http.route`), ''), nullIf(toString(SpanAttributes.`url.path`), ''), SpanName) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Server' AND toString(SpanAttributes.`http.request.method`) != ''
+                        GROUP BY coalesce(nullIf(toString(SpanAttributes.`http.route`), ''), nullIf(toString(SpanAttributes.`url.path`), ''), SpanName) ORDER BY count() DESC LIMIT 8
                       )
                       GROUP BY ts, route
                       ORDER BY ts
@@ -231,14 +231,14 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT coalesce(nullIf(SpanAttributes['http.route'], ''), nullIf(SpanAttributes['url.path'], ''), SpanName) AS route,
-                             SpanAttributes['http.request.method'] AS method,
+                      SELECT coalesce(nullIf(toString(SpanAttributes.`http.route`), ''), nullIf(toString(SpanAttributes.`url.path`), ''), SpanName) AS route,
+                             toString(SpanAttributes.`http.request.method`) AS method,
                              count() AS requests,
                              round(avg(Duration) / 1000000, 1) AS avg_ms,
                              round(quantile(0.95)(Duration) / 1000000, 1) AS p95_ms,
                              round(quantile(0.99)(Duration) / 1000000, 1) AS p99_ms
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Server' AND SpanAttributes['http.request.method'] != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Server' AND toString(SpanAttributes.`http.request.method`) != ''
                       GROUP BY route, method
                       ORDER BY p95_ms DESC
                       LIMIT 30
@@ -259,13 +259,13 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT coalesce(nullIf(SpanAttributes['http.route'], ''), nullIf(SpanAttributes['url.path'], ''), SpanName) AS route,
-                             SpanAttributes['http.request.method'] AS method,
+                      SELECT coalesce(nullIf(toString(SpanAttributes.`http.route`), ''), nullIf(toString(SpanAttributes.`url.path`), ''), SpanName) AS route,
+                             toString(SpanAttributes.`http.request.method`) AS method,
                              count() AS requests,
                              round(sum(Duration) / 1000000000, 2) AS total_seconds,
-                             round(sum(Duration) / (SELECT sum(Duration) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Server' AND SpanAttributes['http.request.method'] != '') * 100, 1) AS share_pct
+                             round(sum(Duration) / (SELECT sum(Duration) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Server' AND toString(SpanAttributes.`http.request.method`) != '') * 100, 1) AS share_pct
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Server' AND SpanAttributes['http.request.method'] != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Server' AND toString(SpanAttributes.`http.request.method`) != ''
                       GROUP BY route, method
                       ORDER BY total_seconds DESC
                       LIMIT 30
@@ -285,14 +285,14 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT coalesce(nullIf(SpanAttributes['http.route'], ''), nullIf(SpanAttributes['url.path'], ''), SpanName) AS route,
-                             SpanAttributes['http.request.method'] AS method,
-                             countIf(toUInt16OrZero(SpanAttributes['http.response.status_code']) >= 500) AS server_errors,
-                             countIf(toUInt16OrZero(SpanAttributes['http.response.status_code']) BETWEEN 400 AND 499) AS client_errors,
+                      SELECT coalesce(nullIf(toString(SpanAttributes.`http.route`), ''), nullIf(toString(SpanAttributes.`url.path`), ''), SpanName) AS route,
+                             toString(SpanAttributes.`http.request.method`) AS method,
+                             countIf(toUInt16OrZero(toString(SpanAttributes.`http.response.status_code`)) >= 500) AS server_errors,
+                             countIf(toUInt16OrZero(toString(SpanAttributes.`http.response.status_code`)) BETWEEN 400 AND 499) AS client_errors,
                              count() AS requests,
-                             anyIf(SpanAttributes['http.response.status_code'], toUInt16OrZero(SpanAttributes['http.response.status_code']) >= 400) AS sample_status
+                             anyIf(toString(SpanAttributes.`http.response.status_code`), toUInt16OrZero(toString(SpanAttributes.`http.response.status_code`)) >= 400) AS sample_status
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Server' AND SpanAttributes['http.request.method'] != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Server' AND toString(SpanAttributes.`http.request.method`) != ''
                       GROUP BY route, method
                       HAVING server_errors + client_errors > 0
                       ORDER BY server_errors DESC, client_errors DESC
@@ -316,7 +316,7 @@ document:
                     query: |-
                       SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} SECOND) AS ts, count() AS calls
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Client' AND SpanAttributes['http.request.method'] != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Client' AND toString(SpanAttributes.`http.request.method`) != ''
                       GROUP BY ts
                       ORDER BY ts
       outbound-errors:
@@ -345,9 +345,9 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT countIf(toUInt16OrZero(SpanAttributes['http.response.status_code']) >= 500) / count() * 100 AS pct
+                      SELECT countIf(toUInt16OrZero(toString(SpanAttributes.`http.response.status_code`)) >= 500) / count() * 100 AS pct
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Client' AND SpanAttributes['http.request.method'] != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Client' AND toString(SpanAttributes.`http.request.method`) != ''
       outbound-p95:
         kind: Panel
         spec:
@@ -368,7 +368,7 @@ document:
                     query: |-
                       SELECT round(quantile(0.95)(Duration) / 1000000, 1) AS p95
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Client' AND SpanAttributes['http.request.method'] != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Client' AND toString(SpanAttributes.`http.request.method`) != ''
       outbound-by-host:
         kind: Panel
         spec:
@@ -387,13 +387,13 @@ document:
                   spec:
                     query: |-
                       SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts,
-                             coalesce(nullIf(SpanAttributes['server.address'], ''), SpanName) AS host,
+                             coalesce(nullIf(toString(SpanAttributes.`server.address`), ''), SpanName) AS host,
                              count() AS calls
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Client' AND SpanAttributes['http.request.method'] != ''
-                        AND coalesce(nullIf(SpanAttributes['server.address'], ''), SpanName) IN (
-                        SELECT coalesce(nullIf(SpanAttributes['server.address'], ''), SpanName) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Client' AND SpanAttributes['http.request.method'] != ''
-                        GROUP BY coalesce(nullIf(SpanAttributes['server.address'], ''), SpanName) ORDER BY count() DESC LIMIT 8
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Client' AND toString(SpanAttributes.`http.request.method`) != ''
+                        AND coalesce(nullIf(toString(SpanAttributes.`server.address`), ''), SpanName) IN (
+                        SELECT coalesce(nullIf(toString(SpanAttributes.`server.address`), ''), SpanName) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Client' AND toString(SpanAttributes.`http.request.method`) != ''
+                        GROUP BY coalesce(nullIf(toString(SpanAttributes.`server.address`), ''), SpanName) ORDER BY count() DESC LIMIT 8
                       )
                       GROUP BY ts, host
                       ORDER BY ts
@@ -415,10 +415,10 @@ document:
                   spec:
                     query: |-
                       SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts,
-                             concat(toString(intDiv(toUInt16OrZero(SpanAttributes['http.response.status_code']), 100)), 'xx') AS status_class,
+                             concat(toString(intDiv(toUInt16OrZero(toString(SpanAttributes.`http.response.status_code`)), 100)), 'xx') AS status_class,
                              count() AS calls
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Client' AND SpanAttributes['http.request.method'] != '' AND SpanAttributes['http.response.status_code'] != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Client' AND toString(SpanAttributes.`http.request.method`) != '' AND toString(SpanAttributes.`http.response.status_code`) != ''
                       GROUP BY ts, status_class
                       ORDER BY ts
       dependencies:
@@ -438,14 +438,14 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT coalesce(nullIf(SpanAttributes['server.address'], ''), SpanName) AS host,
-                             SpanAttributes['http.request.method'] AS method,
+                      SELECT coalesce(nullIf(toString(SpanAttributes.`server.address`), ''), SpanName) AS host,
+                             toString(SpanAttributes.`http.request.method`) AS method,
                              count() AS calls,
-                             countIf(toUInt16OrZero(SpanAttributes['http.response.status_code']) >= 400) AS errors,
+                             countIf(toUInt16OrZero(toString(SpanAttributes.`http.response.status_code`)) >= 400) AS errors,
                              round(avg(Duration) / 1000000, 1) AS avg_ms,
                              round(quantile(0.95)(Duration) / 1000000, 1) AS p95_ms
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Client' AND SpanAttributes['http.request.method'] != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanKind = 'Client' AND toString(SpanAttributes.`http.request.method`) != ''
                       GROUP BY host, method
                       ORDER BY calls DESC
                       LIMIT 30

--- a/packages/app/src/data/dashboards/built-in/catalog/application/rpc-services.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/application/rpc-services.yaml
@@ -51,7 +51,7 @@ document:
                     query: |-
                       SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} SECOND) AS ts, count() AS calls
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['rpc.system.name'] != '' AND SpanKind = 'Server'
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`rpc.system.name`) != '' AND SpanKind = 'Server'
                       GROUP BY ts
                       ORDER BY ts
       error-rate:
@@ -82,7 +82,7 @@ document:
                     query: |-
                       SELECT countIf(StatusCode = 'Error') / count() * 100 AS error_pct
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['rpc.system.name'] != '' AND SpanKind = 'Server'
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`rpc.system.name`) != '' AND SpanKind = 'Server'
       p95-latency:
         kind: Panel
         spec:
@@ -103,7 +103,7 @@ document:
                     query: |-
                       SELECT round(quantile(0.95)(Duration) / 1000000, 1) AS p95
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['rpc.system.name'] != '' AND SpanKind = 'Server'
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`rpc.system.name`) != '' AND SpanKind = 'Server'
       p99-latency:
         kind: Panel
         spec:
@@ -124,7 +124,7 @@ document:
                     query: |-
                       SELECT round(quantile(0.99)(Duration) / 1000000, 1) AS p99
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['rpc.system.name'] != '' AND SpanKind = 'Server'
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`rpc.system.name`) != '' AND SpanKind = 'Server'
       by-status:
         kind: Panel
         spec:
@@ -144,13 +144,13 @@ document:
                   spec:
                     query: |-
                       SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts,
-                             SpanAttributes['rpc.response.status_code'] AS status_code,
+                             toString(SpanAttributes.`rpc.response.status_code`) AS status_code,
                              count() AS calls
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['rpc.system.name'] != '' AND SpanKind = 'Server' AND SpanAttributes['rpc.response.status_code'] != ''
-                        AND SpanAttributes['rpc.response.status_code'] IN (
-                        SELECT SpanAttributes['rpc.response.status_code'] FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['rpc.system.name'] != '' AND SpanKind = 'Server' AND SpanAttributes['rpc.response.status_code'] != ''
-                        GROUP BY SpanAttributes['rpc.response.status_code'] ORDER BY count() DESC LIMIT 8
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`rpc.system.name`) != '' AND SpanKind = 'Server' AND toString(SpanAttributes.`rpc.response.status_code`) != ''
+                        AND toString(SpanAttributes.`rpc.response.status_code`) IN (
+                        SELECT toString(SpanAttributes.`rpc.response.status_code`) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`rpc.system.name`) != '' AND SpanKind = 'Server' AND toString(SpanAttributes.`rpc.response.status_code`) != ''
+                        GROUP BY toString(SpanAttributes.`rpc.response.status_code`) ORDER BY count() DESC LIMIT 8
                       )
                       GROUP BY ts, status_code
                       ORDER BY ts
@@ -173,13 +173,13 @@ document:
                   spec:
                     query: |-
                       SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts,
-                             coalesce(nullIf(SpanAttributes['rpc.method'], ''), SpanName) AS method,
+                             coalesce(nullIf(toString(SpanAttributes.`rpc.method`), ''), SpanName) AS method,
                              count() AS calls
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['rpc.system.name'] != '' AND SpanKind = 'Server'
-                        AND coalesce(nullIf(SpanAttributes['rpc.method'], ''), SpanName) IN (
-                        SELECT coalesce(nullIf(SpanAttributes['rpc.method'], ''), SpanName) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['rpc.system.name'] != '' AND SpanKind = 'Server'
-                        GROUP BY coalesce(nullIf(SpanAttributes['rpc.method'], ''), SpanName) ORDER BY count() DESC LIMIT 8
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`rpc.system.name`) != '' AND SpanKind = 'Server'
+                        AND coalesce(nullIf(toString(SpanAttributes.`rpc.method`), ''), SpanName) IN (
+                        SELECT coalesce(nullIf(toString(SpanAttributes.`rpc.method`), ''), SpanName) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`rpc.system.name`) != '' AND SpanKind = 'Server'
+                        GROUP BY coalesce(nullIf(toString(SpanAttributes.`rpc.method`), ''), SpanName) ORDER BY count() DESC LIMIT 8
                       )
                       GROUP BY ts, method
                       ORDER BY ts
@@ -201,13 +201,13 @@ document:
                   spec:
                     query: |-
                       SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts,
-                             coalesce(nullIf(SpanAttributes['rpc.method'], ''), SpanName) AS method,
+                             coalesce(nullIf(toString(SpanAttributes.`rpc.method`), ''), SpanName) AS method,
                              round(quantile(0.95)(Duration) / 1000000, 1) AS p95_ms
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['rpc.system.name'] != '' AND SpanKind = 'Server'
-                        AND coalesce(nullIf(SpanAttributes['rpc.method'], ''), SpanName) IN (
-                        SELECT coalesce(nullIf(SpanAttributes['rpc.method'], ''), SpanName) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['rpc.system.name'] != '' AND SpanKind = 'Server'
-                        GROUP BY coalesce(nullIf(SpanAttributes['rpc.method'], ''), SpanName) ORDER BY count() DESC LIMIT 8
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`rpc.system.name`) != '' AND SpanKind = 'Server'
+                        AND coalesce(nullIf(toString(SpanAttributes.`rpc.method`), ''), SpanName) IN (
+                        SELECT coalesce(nullIf(toString(SpanAttributes.`rpc.method`), ''), SpanName) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`rpc.system.name`) != '' AND SpanKind = 'Server'
+                        GROUP BY coalesce(nullIf(toString(SpanAttributes.`rpc.method`), ''), SpanName) ORDER BY count() DESC LIMIT 8
                       )
                       GROUP BY ts, method
                       ORDER BY ts
@@ -230,13 +230,13 @@ document:
                   spec:
                     query: |-
                       SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts,
-                             SpanAttributes['rpc.system.name'] AS rpc_system,
+                             toString(SpanAttributes.`rpc.system.name`) AS rpc_system,
                              count() AS calls
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['rpc.system.name'] != '' AND SpanKind = 'Server'
-                        AND SpanAttributes['rpc.system.name'] IN (
-                        SELECT SpanAttributes['rpc.system.name'] FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['rpc.system.name'] != '' AND SpanKind = 'Server'
-                        GROUP BY SpanAttributes['rpc.system.name'] ORDER BY count() DESC LIMIT 8
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`rpc.system.name`) != '' AND SpanKind = 'Server'
+                        AND toString(SpanAttributes.`rpc.system.name`) IN (
+                        SELECT toString(SpanAttributes.`rpc.system.name`) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`rpc.system.name`) != '' AND SpanKind = 'Server'
+                        GROUP BY toString(SpanAttributes.`rpc.system.name`) ORDER BY count() DESC LIMIT 8
                       )
                       GROUP BY ts, rpc_system
                       ORDER BY ts
@@ -257,14 +257,14 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT coalesce(nullIf(SpanAttributes['rpc.method'], ''), SpanName) AS method,
-                             SpanAttributes['rpc.system.name'] AS rpc_system,
+                      SELECT coalesce(nullIf(toString(SpanAttributes.`rpc.method`), ''), SpanName) AS method,
+                             toString(SpanAttributes.`rpc.system.name`) AS rpc_system,
                              count() AS calls,
                              round(avg(Duration) / 1000000, 1) AS avg_ms,
                              round(quantile(0.95)(Duration) / 1000000, 1) AS p95_ms,
                              round(quantile(0.99)(Duration) / 1000000, 1) AS p99_ms
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['rpc.system.name'] != '' AND SpanKind = 'Server'
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`rpc.system.name`) != '' AND SpanKind = 'Server'
                       GROUP BY method, rpc_system
                       ORDER BY p95_ms DESC
                       LIMIT 30
@@ -285,13 +285,13 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT coalesce(nullIf(SpanAttributes['rpc.method'], ''), SpanName) AS method,
-                             SpanAttributes['rpc.system.name'] AS rpc_system,
+                      SELECT coalesce(nullIf(toString(SpanAttributes.`rpc.method`), ''), SpanName) AS method,
+                             toString(SpanAttributes.`rpc.system.name`) AS rpc_system,
                              count() AS calls,
                              round(sum(Duration) / 1000000000, 2) AS total_seconds,
-                             round(sum(Duration) / (SELECT sum(Duration) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['rpc.system.name'] != '' AND SpanKind = 'Server') * 100, 1) AS share_pct
+                             round(sum(Duration) / (SELECT sum(Duration) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`rpc.system.name`) != '' AND SpanKind = 'Server') * 100, 1) AS share_pct
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['rpc.system.name'] != '' AND SpanKind = 'Server'
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`rpc.system.name`) != '' AND SpanKind = 'Server'
                       GROUP BY method, rpc_system
                       ORDER BY total_seconds DESC
                       LIMIT 30
@@ -312,13 +312,13 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT coalesce(nullIf(SpanAttributes['rpc.method'], ''), SpanName) AS method,
+                      SELECT coalesce(nullIf(toString(SpanAttributes.`rpc.method`), ''), SpanName) AS method,
                              count() AS calls,
                              countIf(StatusCode = 'Error') AS errors,
-                             anyIf(SpanAttributes['rpc.response.status_code'], StatusCode = 'Error' AND SpanAttributes['rpc.response.status_code'] != '') AS sample_status,
-                             anyIf(SpanAttributes['error.type'], SpanAttributes['error.type'] != '') AS sample_error
+                             anyIf(toString(SpanAttributes.`rpc.response.status_code`), StatusCode = 'Error' AND toString(SpanAttributes.`rpc.response.status_code`) != '') AS sample_status,
+                             anyIf(toString(SpanAttributes.`error.type`), toString(SpanAttributes.`error.type`) != '') AS sample_error
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['rpc.system.name'] != '' AND SpanKind = 'Server'
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`rpc.system.name`) != '' AND SpanKind = 'Server'
                       GROUP BY method
                       HAVING errors > 0
                       ORDER BY errors DESC
@@ -342,7 +342,7 @@ document:
                     query: |-
                       SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} SECOND) AS ts, count() AS calls
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['rpc.system.name'] != '' AND SpanKind = 'Client'
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`rpc.system.name`) != '' AND SpanKind = 'Client'
                       GROUP BY ts
                       ORDER BY ts
       outbound-errors:
@@ -373,7 +373,7 @@ document:
                     query: |-
                       SELECT countIf(StatusCode = 'Error') / count() * 100 AS error_pct
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['rpc.system.name'] != '' AND SpanKind = 'Client'
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`rpc.system.name`) != '' AND SpanKind = 'Client'
       outbound-p95:
         kind: Panel
         spec:
@@ -394,7 +394,7 @@ document:
                     query: |-
                       SELECT round(quantile(0.95)(Duration) / 1000000, 1) AS p95
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['rpc.system.name'] != '' AND SpanKind = 'Client'
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`rpc.system.name`) != '' AND SpanKind = 'Client'
       outbound-by-peer:
         kind: Panel
         spec:
@@ -413,13 +413,13 @@ document:
                   spec:
                     query: |-
                       SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts,
-                             coalesce(nullIf(SpanAttributes['server.address'], ''), SpanName) AS peer,
+                             coalesce(nullIf(toString(SpanAttributes.`server.address`), ''), SpanName) AS peer,
                              count() AS calls
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['rpc.system.name'] != '' AND SpanKind = 'Client'
-                        AND coalesce(nullIf(SpanAttributes['server.address'], ''), SpanName) IN (
-                        SELECT coalesce(nullIf(SpanAttributes['server.address'], ''), SpanName) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['rpc.system.name'] != '' AND SpanKind = 'Client'
-                        GROUP BY coalesce(nullIf(SpanAttributes['server.address'], ''), SpanName) ORDER BY count() DESC LIMIT 8
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`rpc.system.name`) != '' AND SpanKind = 'Client'
+                        AND coalesce(nullIf(toString(SpanAttributes.`server.address`), ''), SpanName) IN (
+                        SELECT coalesce(nullIf(toString(SpanAttributes.`server.address`), ''), SpanName) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`rpc.system.name`) != '' AND SpanKind = 'Client'
+                        GROUP BY coalesce(nullIf(toString(SpanAttributes.`server.address`), ''), SpanName) ORDER BY count() DESC LIMIT 8
                       )
                       GROUP BY ts, peer
                       ORDER BY ts
@@ -441,13 +441,13 @@ document:
                   spec:
                     query: |-
                       SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts,
-                             SpanAttributes['rpc.response.status_code'] AS status_code,
+                             toString(SpanAttributes.`rpc.response.status_code`) AS status_code,
                              count() AS calls
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['rpc.system.name'] != '' AND SpanKind = 'Client' AND SpanAttributes['rpc.response.status_code'] != ''
-                        AND SpanAttributes['rpc.response.status_code'] IN (
-                        SELECT SpanAttributes['rpc.response.status_code'] FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['rpc.system.name'] != '' AND SpanKind = 'Client' AND SpanAttributes['rpc.response.status_code'] != ''
-                        GROUP BY SpanAttributes['rpc.response.status_code'] ORDER BY count() DESC LIMIT 8
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`rpc.system.name`) != '' AND SpanKind = 'Client' AND toString(SpanAttributes.`rpc.response.status_code`) != ''
+                        AND toString(SpanAttributes.`rpc.response.status_code`) IN (
+                        SELECT toString(SpanAttributes.`rpc.response.status_code`) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`rpc.system.name`) != '' AND SpanKind = 'Client' AND toString(SpanAttributes.`rpc.response.status_code`) != ''
+                        GROUP BY toString(SpanAttributes.`rpc.response.status_code`) ORDER BY count() DESC LIMIT 8
                       )
                       GROUP BY ts, status_code
                       ORDER BY ts
@@ -468,14 +468,14 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT coalesce(nullIf(SpanAttributes['server.address'], ''), SpanName) AS peer,
-                             coalesce(nullIf(SpanAttributes['rpc.method'], ''), SpanName) AS method,
+                      SELECT coalesce(nullIf(toString(SpanAttributes.`server.address`), ''), SpanName) AS peer,
+                             coalesce(nullIf(toString(SpanAttributes.`rpc.method`), ''), SpanName) AS method,
                              count() AS calls,
                              countIf(StatusCode = 'Error') AS errors,
                              round(avg(Duration) / 1000000, 1) AS avg_ms,
                              round(quantile(0.95)(Duration) / 1000000, 1) AS p95_ms
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['rpc.system.name'] != '' AND SpanKind = 'Client'
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`rpc.system.name`) != '' AND SpanKind = 'Client'
                       GROUP BY peer, method
                       ORDER BY calls DESC
                       LIMIT 30

--- a/packages/app/src/data/dashboards/built-in/catalog/application/server-functions.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/application/server-functions.yaml
@@ -51,7 +51,7 @@ document:
                     query: |-
                       SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} SECOND) AS ts, count() AS invocations
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['everr.server_function.name'] != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`everr.server_function.name`) != ''
                       GROUP BY ts
                       ORDER BY ts
       error-rate:
@@ -82,7 +82,7 @@ document:
                     query: |-
                       SELECT countIf(StatusCode = 'Error') / count() * 100 AS error_pct
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['everr.server_function.name'] != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`everr.server_function.name`) != ''
       p95-latency:
         kind: Panel
         spec:
@@ -103,7 +103,7 @@ document:
                     query: |-
                       SELECT round(quantile(0.95)(Duration) / 1000000, 1) AS p95
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['everr.server_function.name'] != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`everr.server_function.name`) != ''
       p99-latency:
         kind: Panel
         spec:
@@ -124,7 +124,7 @@ document:
                     query: |-
                       SELECT round(quantile(0.99)(Duration) / 1000000, 1) AS p99
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['everr.server_function.name'] != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`everr.server_function.name`) != ''
       by-function:
         kind: Panel
         spec:
@@ -144,13 +144,13 @@ document:
                   spec:
                     query: |-
                       SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts,
-                             SpanAttributes['everr.server_function.name'] AS fn,
+                             toString(SpanAttributes.`everr.server_function.name`) AS fn,
                              count() AS invocations
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['everr.server_function.name'] != ''
-                        AND SpanAttributes['everr.server_function.name'] IN (
-                        SELECT SpanAttributes['everr.server_function.name'] FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['everr.server_function.name'] != ''
-                        GROUP BY SpanAttributes['everr.server_function.name'] ORDER BY count() DESC LIMIT 8
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`everr.server_function.name`) != ''
+                        AND toString(SpanAttributes.`everr.server_function.name`) IN (
+                        SELECT toString(SpanAttributes.`everr.server_function.name`) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`everr.server_function.name`) != ''
+                        GROUP BY toString(SpanAttributes.`everr.server_function.name`) ORDER BY count() DESC LIMIT 8
                       )
                       GROUP BY ts, fn
                       ORDER BY ts
@@ -173,10 +173,10 @@ document:
                   spec:
                     query: |-
                       SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts,
-                             SpanAttributes['everr.server_function.transport'] AS transport,
+                             toString(SpanAttributes.`everr.server_function.transport`) AS transport,
                              count() AS invocations
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['everr.server_function.name'] != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`everr.server_function.name`) != ''
                       GROUP BY ts, transport
                       ORDER BY ts
       latency-by-function:
@@ -197,13 +197,13 @@ document:
                   spec:
                     query: |-
                       SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts,
-                             SpanAttributes['everr.server_function.name'] AS fn,
+                             toString(SpanAttributes.`everr.server_function.name`) AS fn,
                              round(quantile(0.95)(Duration) / 1000000, 1) AS p95_ms
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['everr.server_function.name'] != ''
-                        AND SpanAttributes['everr.server_function.name'] IN (
-                        SELECT SpanAttributes['everr.server_function.name'] FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['everr.server_function.name'] != ''
-                        GROUP BY SpanAttributes['everr.server_function.name'] ORDER BY count() DESC LIMIT 8
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`everr.server_function.name`) != ''
+                        AND toString(SpanAttributes.`everr.server_function.name`) IN (
+                        SELECT toString(SpanAttributes.`everr.server_function.name`) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`everr.server_function.name`) != ''
+                        GROUP BY toString(SpanAttributes.`everr.server_function.name`) ORDER BY count() DESC LIMIT 8
                       )
                       GROUP BY ts, fn
                       ORDER BY ts
@@ -224,13 +224,13 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT SpanAttributes['everr.server_function.name'] AS fn,
+                      SELECT toString(SpanAttributes.`everr.server_function.name`) AS fn,
                              count() AS invocations,
                              round(avg(Duration) / 1000000, 1) AS avg_ms,
                              round(quantile(0.95)(Duration) / 1000000, 1) AS p95_ms,
                              round(quantile(0.99)(Duration) / 1000000, 1) AS p99_ms
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['everr.server_function.name'] != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`everr.server_function.name`) != ''
                       GROUP BY fn
                       ORDER BY p95_ms DESC
                       LIMIT 30
@@ -251,12 +251,12 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT SpanAttributes['everr.server_function.name'] AS fn,
+                      SELECT toString(SpanAttributes.`everr.server_function.name`) AS fn,
                              count() AS invocations,
                              round(sum(Duration) / 1000000000, 2) AS total_seconds,
-                             round(sum(Duration) / (SELECT sum(Duration) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['everr.server_function.name'] != '') * 100, 1) AS share_pct
+                             round(sum(Duration) / (SELECT sum(Duration) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`everr.server_function.name`) != '') * 100, 1) AS share_pct
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['everr.server_function.name'] != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`everr.server_function.name`) != ''
                       GROUP BY fn
                       ORDER BY total_seconds DESC
                       LIMIT 30
@@ -277,12 +277,12 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT SpanAttributes['everr.server_function.name'] AS fn,
+                      SELECT toString(SpanAttributes.`everr.server_function.name`) AS fn,
                              count() AS invocations,
                              countIf(StatusCode = 'Error') AS errors,
                              anyIf(StatusMessage, StatusCode = 'Error' AND StatusMessage != '') AS sample_message
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['everr.server_function.name'] != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`everr.server_function.name`) != ''
                       GROUP BY fn
                       HAVING errors > 0
                       ORDER BY errors DESC

--- a/packages/app/src/data/dashboards/built-in/catalog/application/serverless-functions.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/application/serverless-functions.yaml
@@ -51,7 +51,7 @@ document:
                     query: |-
                       SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} SECOND) AS ts, count() AS invocations
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['faas.trigger'] != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`faas.trigger`) != ''
                       GROUP BY ts
                       ORDER BY ts
       error-rate:
@@ -82,7 +82,7 @@ document:
                     query: |-
                       SELECT countIf(StatusCode = 'Error') / count() * 100 AS error_pct
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['faas.trigger'] != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`faas.trigger`) != ''
       p95-duration:
         kind: Panel
         spec:
@@ -103,7 +103,7 @@ document:
                     query: |-
                       SELECT round(quantile(0.95)(Duration) / 1000000, 1) AS p95
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['faas.trigger'] != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`faas.trigger`) != ''
       cold-start-rate:
         kind: Panel
         spec:
@@ -130,9 +130,9 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT countIf(SpanAttributes['faas.coldstart'] = 'true') / count() * 100 AS pct
+                      SELECT countIf(toString(SpanAttributes.`faas.coldstart`) = 'true') / count() * 100 AS pct
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['faas.trigger'] != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`faas.trigger`) != ''
       invocations-by-function:
         kind: Panel
         spec:
@@ -150,12 +150,12 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts, coalesce(nullIf(ResourceAttributes['faas.name'], ''), ServiceName) AS function, count() AS invocations
+                      SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts, coalesce(nullIf(toString(ResourceAttributes.`faas.name`), ''), ServiceName) AS function, count() AS invocations
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['faas.trigger'] != ''
-                        AND coalesce(nullIf(ResourceAttributes['faas.name'], ''), ServiceName) IN (
-                        SELECT coalesce(nullIf(ResourceAttributes['faas.name'], ''), ServiceName) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['faas.trigger'] != ''
-                        GROUP BY coalesce(nullIf(ResourceAttributes['faas.name'], ''), ServiceName) ORDER BY count() DESC LIMIT 8
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`faas.trigger`) != ''
+                        AND coalesce(nullIf(toString(ResourceAttributes.`faas.name`), ''), ServiceName) IN (
+                        SELECT coalesce(nullIf(toString(ResourceAttributes.`faas.name`), ''), ServiceName) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`faas.trigger`) != ''
+                        GROUP BY coalesce(nullIf(toString(ResourceAttributes.`faas.name`), ''), ServiceName) ORDER BY count() DESC LIMIT 8
                       )
                       GROUP BY ts, function
                       ORDER BY ts
@@ -177,12 +177,12 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts, coalesce(nullIf(ResourceAttributes['faas.name'], ''), ServiceName) AS function, count() AS errors
+                      SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts, coalesce(nullIf(toString(ResourceAttributes.`faas.name`), ''), ServiceName) AS function, count() AS errors
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['faas.trigger'] != '' AND StatusCode = 'Error'
-                        AND coalesce(nullIf(ResourceAttributes['faas.name'], ''), ServiceName) IN (
-                        SELECT coalesce(nullIf(ResourceAttributes['faas.name'], ''), ServiceName) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['faas.trigger'] != '' AND StatusCode = 'Error'
-                        GROUP BY coalesce(nullIf(ResourceAttributes['faas.name'], ''), ServiceName) ORDER BY count() DESC LIMIT 8
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`faas.trigger`) != '' AND StatusCode = 'Error'
+                        AND coalesce(nullIf(toString(ResourceAttributes.`faas.name`), ''), ServiceName) IN (
+                        SELECT coalesce(nullIf(toString(ResourceAttributes.`faas.name`), ''), ServiceName) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`faas.trigger`) != '' AND StatusCode = 'Error'
+                        GROUP BY coalesce(nullIf(toString(ResourceAttributes.`faas.name`), ''), ServiceName) ORDER BY count() DESC LIMIT 8
                       )
                       GROUP BY ts, function
                       ORDER BY ts
@@ -211,7 +211,7 @@ document:
                                round(quantile(0.95)(Duration) / 1000000, 1) AS p95,
                                round(quantile(0.99)(Duration) / 1000000, 1) AS p99
                         FROM traces
-                        WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['faas.trigger'] != ''
+                        WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`faas.trigger`) != ''
                         GROUP BY ts
                       )
                       ARRAY JOIN [('P50', p50), ('P95', p95), ('P99', p99)] AS q
@@ -234,13 +234,13 @@ document:
                   spec:
                     query: |-
                       SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts,
-                             coalesce(nullIf(ResourceAttributes['faas.name'], ''), ServiceName) AS function,
+                             coalesce(nullIf(toString(ResourceAttributes.`faas.name`), ''), ServiceName) AS function,
                              round(quantile(0.95)(Duration) / 1000000, 1) AS p95_ms
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['faas.trigger'] != ''
-                        AND coalesce(nullIf(ResourceAttributes['faas.name'], ''), ServiceName) IN (
-                        SELECT coalesce(nullIf(ResourceAttributes['faas.name'], ''), ServiceName) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['faas.trigger'] != ''
-                        GROUP BY coalesce(nullIf(ResourceAttributes['faas.name'], ''), ServiceName) ORDER BY count() DESC LIMIT 8
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`faas.trigger`) != ''
+                        AND coalesce(nullIf(toString(ResourceAttributes.`faas.name`), ''), ServiceName) IN (
+                        SELECT coalesce(nullIf(toString(ResourceAttributes.`faas.name`), ''), ServiceName) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`faas.trigger`) != ''
+                        GROUP BY coalesce(nullIf(toString(ResourceAttributes.`faas.name`), ''), ServiceName) ORDER BY count() DESC LIMIT 8
                       )
                       GROUP BY ts, function
                       ORDER BY ts
@@ -265,10 +265,10 @@ document:
                       SELECT ts, counted.1 AS series, counted.2 AS value
                       FROM (
                         SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts,
-                               countIf(SpanAttributes['faas.coldstart'] = 'true') AS cold,
-                               countIf(NOT SpanAttributes['faas.coldstart'] = 'true') AS warm
+                               countIf(toString(SpanAttributes.`faas.coldstart`) = 'true') AS cold,
+                               countIf(NOT toString(SpanAttributes.`faas.coldstart`) = 'true') AS warm
                         FROM traces
-                        WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['faas.trigger'] != ''
+                        WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`faas.trigger`) != ''
                         GROUP BY ts
                       )
                       ARRAY JOIN [('Cold', cold), ('Warm', warm)] AS counted
@@ -294,10 +294,10 @@ document:
                       SELECT ts, q.1 AS series, q.2 AS value
                       FROM (
                         SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts,
-                               round(quantileIf(0.95)(Duration, SpanAttributes['faas.coldstart'] = 'true') / 1000000, 1) AS cold,
-                               round(quantileIf(0.95)(Duration, NOT SpanAttributes['faas.coldstart'] = 'true') / 1000000, 1) AS warm
+                               round(quantileIf(0.95)(Duration, toString(SpanAttributes.`faas.coldstart`) = 'true') / 1000000, 1) AS cold,
+                               round(quantileIf(0.95)(Duration, NOT toString(SpanAttributes.`faas.coldstart`) = 'true') / 1000000, 1) AS warm
                         FROM traces
-                        WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['faas.trigger'] != ''
+                        WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`faas.trigger`) != ''
                         GROUP BY ts
                       )
                       ARRAY JOIN [('Cold', cold), ('Warm', warm)] AS q
@@ -320,12 +320,12 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts, SpanAttributes['faas.trigger'] AS trigger, count() AS invocations
+                      SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts, toString(SpanAttributes.`faas.trigger`) AS trigger, count() AS invocations
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['faas.trigger'] != ''
-                        AND SpanAttributes['faas.trigger'] IN (
-                        SELECT SpanAttributes['faas.trigger'] FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['faas.trigger'] != ''
-                        GROUP BY SpanAttributes['faas.trigger'] ORDER BY count() DESC LIMIT 8
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`faas.trigger`) != ''
+                        AND toString(SpanAttributes.`faas.trigger`) IN (
+                        SELECT toString(SpanAttributes.`faas.trigger`) FROM traces WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`faas.trigger`) != ''
+                        GROUP BY toString(SpanAttributes.`faas.trigger`) ORDER BY count() DESC LIMIT 8
                       )
                       GROUP BY ts, trigger
                       ORDER BY ts
@@ -345,14 +345,14 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT coalesce(nullIf(ResourceAttributes['faas.name'], ''), ServiceName) AS function,
+                      SELECT coalesce(nullIf(toString(ResourceAttributes.`faas.name`), ''), ServiceName) AS function,
                              count() AS invocations,
                              round(quantile(0.50)(Duration) / 1000000, 1) AS p50_ms,
                              round(quantile(0.95)(Duration) / 1000000, 1) AS p95_ms,
                              round(countIf(StatusCode = 'Error') / count() * 100, 2) AS error_pct,
-                             round(countIf(SpanAttributes['faas.coldstart'] = 'true') / count() * 100, 1) AS cold_pct
+                             round(countIf(toString(SpanAttributes.`faas.coldstart`) = 'true') / count() * 100, 1) AS cold_pct
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['faas.trigger'] != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`faas.trigger`) != ''
                       GROUP BY function
                       ORDER BY invocations DESC
                       LIMIT 40
@@ -374,13 +374,13 @@ document:
                   spec:
                     query: |-
                       SELECT Timestamp AS ts,
-                             coalesce(nullIf(ResourceAttributes['faas.name'], ''), ServiceName) AS function,
-                             SpanAttributes['faas.trigger'] AS trigger,
-                             SpanAttributes['faas.invocation_id'] AS invocation_id,
+                             coalesce(nullIf(toString(ResourceAttributes.`faas.name`), ''), ServiceName) AS function,
+                             toString(SpanAttributes.`faas.trigger`) AS trigger,
+                             toString(SpanAttributes.`faas.invocation_id`) AS invocation_id,
                              round(Duration / 1000000, 1) AS duration_ms,
                              StatusMessage AS status
                       FROM traces
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND SpanAttributes['faas.trigger'] != '' AND StatusCode = 'Error'
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(SpanAttributes.`faas.trigger`) != '' AND StatusCode = 'Error'
                       ORDER BY ts DESC
                       LIMIT 50
     layouts:

--- a/packages/app/src/data/dashboards/built-in/catalog/browser/product-analytics.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/browser/product-analytics.yaml
@@ -49,9 +49,9 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT uniqExact(LogAttributes['everr.visitor.id']) AS visitors
+                      SELECT uniqExact(toString(LogAttributes.`everr.visitor.id`)) AS visitors
                       FROM logs
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND ResourceAttributes['telemetry.distro.name'] = '@everr/otel-web' AND EventName = 'everr.browser.page_view'
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(ResourceAttributes.`telemetry.distro.name`) = '@everr/otel-web' AND EventName = 'everr.browser.page_view'
       sessions:
         kind: Panel
         spec:
@@ -69,9 +69,9 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT uniqExact(LogAttributes['session.id']) AS sessions
+                      SELECT uniqExact(toString(LogAttributes.`session.id`)) AS sessions
                       FROM logs
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND ResourceAttributes['telemetry.distro.name'] = '@everr/otel-web' AND EventName = 'everr.browser.page_view'
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(ResourceAttributes.`telemetry.distro.name`) = '@everr/otel-web' AND EventName = 'everr.browser.page_view'
       page-views:
         kind: Panel
         spec:
@@ -118,8 +118,8 @@ document:
                       FROM (
                         SELECT dateDiff('second', min(Timestamp), max(Timestamp)) AS seconds
                         FROM logs
-                        WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND ResourceAttributes['telemetry.distro.name'] = '@everr/otel-web' AND LogAttributes['session.id'] != ''
-                        GROUP BY LogAttributes['session.id']
+                        WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(ResourceAttributes.`telemetry.distro.name`) = '@everr/otel-web' AND toString(LogAttributes.`session.id`) != ''
+                        GROUP BY toString(LogAttributes.`session.id`)
                       )
       bounce-rate:
         kind: Panel
@@ -150,12 +150,12 @@ document:
                     query: |-
                       SELECT round(countIf(views = 1 AND autocaptures = 0 AND seconds < 10) / count() * 100, 1) AS bounce_pct
                       FROM (
-                        SELECT LogAttributes['session.id'] AS session,
+                        SELECT toString(LogAttributes.`session.id`) AS session,
                                countIf(EventName = 'everr.browser.page_view') AS views,
                                countIf(startsWith(EventName, 'everr.browser.interaction.')) AS autocaptures,
-                               maxIf(toFloat64OrZero(LogAttributes['everr.page_view.duration']), EventName = 'everr.browser.page_leave') / 1000 AS seconds
+                               maxIf(toFloat64OrZero(toString(LogAttributes.`everr.page_view.duration`)), EventName = 'everr.browser.page_leave') / 1000 AS seconds
                         FROM logs
-                        WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND ResourceAttributes['telemetry.distro.name'] = '@everr/otel-web' AND LogAttributes['session.id'] != ''
+                        WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(ResourceAttributes.`telemetry.distro.name`) = '@everr/otel-web' AND toString(LogAttributes.`session.id`) != ''
                         GROUP BY session
                         HAVING views > 0
                       )
@@ -178,8 +178,8 @@ document:
                       SELECT ts, counted.1 AS series, counted.2 AS value
                       FROM (
                         SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts,
-                               uniqExact(LogAttributes['everr.visitor.id']) AS visitors,
-                               uniqExact(LogAttributes['session.id']) AS sessions,
+                               uniqExact(toString(LogAttributes.`everr.visitor.id`)) AS visitors,
+                               uniqExact(toString(LogAttributes.`session.id`)) AS sessions,
                                count() AS views
                         FROM logs
                         WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND EventName = 'everr.browser.page_view'
@@ -204,12 +204,12 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts, coalesce(nullIf(LogAttributes['everr.route.pattern'], ''), LogAttributes['url.path']) AS route, count() AS views
+                      SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts, coalesce(nullIf(toString(LogAttributes.`everr.route.pattern`), ''), toString(LogAttributes.`url.path`)) AS route, count() AS views
                       FROM logs
                       WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND EventName = 'everr.browser.page_view'
-                        AND coalesce(nullIf(LogAttributes['everr.route.pattern'], ''), LogAttributes['url.path']) IN (
-                        SELECT coalesce(nullIf(LogAttributes['everr.route.pattern'], ''), LogAttributes['url.path']) FROM logs WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND EventName = 'everr.browser.page_view'
-                        GROUP BY coalesce(nullIf(LogAttributes['everr.route.pattern'], ''), LogAttributes['url.path']) ORDER BY count() DESC LIMIT 8
+                        AND coalesce(nullIf(toString(LogAttributes.`everr.route.pattern`), ''), toString(LogAttributes.`url.path`)) IN (
+                        SELECT coalesce(nullIf(toString(LogAttributes.`everr.route.pattern`), ''), toString(LogAttributes.`url.path`)) FROM logs WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND EventName = 'everr.browser.page_view'
+                        GROUP BY coalesce(nullIf(toString(LogAttributes.`everr.route.pattern`), ''), toString(LogAttributes.`url.path`)) ORDER BY count() DESC LIMIT 8
                       )
                       GROUP BY ts, route
                       ORDER BY ts
@@ -237,15 +237,15 @@ document:
                              round(avgIf(seconds, left), 1) AS avg_seconds,
                              round(avgIf(scroll, left) * 100) AS avg_scroll_pct
                       FROM (
-                        SELECT coalesce(nullIf(LogAttributes['everr.route.pattern'], ''), LogAttributes['url.path']) AS route,
-                               LogAttributes['everr.visitor.id'] AS visitor,
+                        SELECT coalesce(nullIf(toString(LogAttributes.`everr.route.pattern`), ''), toString(LogAttributes.`url.path`)) AS route,
+                               toString(LogAttributes.`everr.visitor.id`) AS visitor,
                                countIf(EventName = 'everr.browser.page_leave') > 0 AS left,
                                countIf(startsWith(EventName, 'everr.browser.interaction.')) AS autocaptures,
-                               maxIf(toFloat64OrZero(LogAttributes['everr.page_view.duration']), EventName = 'everr.browser.page_leave') / 1000 AS seconds,
-                               maxIf(toFloat64OrZero(LogAttributes['everr.scroll.depth']), EventName = 'everr.browser.page_leave') AS scroll
+                               maxIf(toFloat64OrZero(toString(LogAttributes.`everr.page_view.duration`)), EventName = 'everr.browser.page_leave') / 1000 AS seconds,
+                               maxIf(toFloat64OrZero(toString(LogAttributes.`everr.scroll.depth`)), EventName = 'everr.browser.page_leave') AS scroll
                         FROM logs
-                        WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND ResourceAttributes['telemetry.distro.name'] = '@everr/otel-web' AND LogAttributes['everr.page_view.id'] != ''
-                        GROUP BY LogAttributes['everr.page_view.id'], route, visitor
+                        WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(ResourceAttributes.`telemetry.distro.name`) = '@everr/otel-web' AND toString(LogAttributes.`everr.page_view.id`) != ''
+                        GROUP BY toString(LogAttributes.`everr.page_view.id`), route, visitor
                       )
                       GROUP BY route
                       ORDER BY views DESC
@@ -267,14 +267,14 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT multiIf(LogAttributes['everr.referrer.url'] = '', 'direct', domain(LogAttributes['everr.referrer.url']) = '', 'other', domain(LogAttributes['everr.referrer.url'])) AS referrer,
-                             uniqExact(LogAttributes['session.id']) AS sessions,
-                             uniqExact(LogAttributes['everr.visitor.id']) AS visitors,
+                      SELECT multiIf(toString(LogAttributes.`everr.referrer.url`) = '', 'direct', domain(toString(LogAttributes.`everr.referrer.url`)) = '', 'other', domain(toString(LogAttributes.`everr.referrer.url`))) AS referrer,
+                             uniqExact(toString(LogAttributes.`session.id`)) AS sessions,
+                             uniqExact(toString(LogAttributes.`everr.visitor.id`)) AS visitors,
                              count() AS views
                       FROM logs
                       WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND EventName = 'everr.browser.page_view'
-                        AND LogAttributes['everr.navigation.type'] = 'initial'
-                        AND domain(LogAttributes['everr.referrer.url']) != domain(LogAttributes['url.full'])
+                        AND toString(LogAttributes.`everr.navigation.type`) = 'initial'
+                        AND domain(toString(LogAttributes.`everr.referrer.url`)) != domain(toString(LogAttributes.`url.full`))
                       GROUP BY referrer
                       ORDER BY sessions DESC
                       LIMIT 20
@@ -295,13 +295,13 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT multiIf(position(ResourceAttributes['user_agent.original'], 'Headless') > 0, 'Headless Chrome', position(ResourceAttributes['user_agent.original'], 'Edg/') > 0, 'Edge', position(ResourceAttributes['user_agent.original'], 'Firefox/') > 0, 'Firefox', position(ResourceAttributes['user_agent.original'], 'Chrome/') > 0, 'Chrome', position(ResourceAttributes['user_agent.original'], 'Safari/') > 0, 'Safari', 'Other') AS browser,
-                             extract(ResourceAttributes['user_agent.original'], '(?:Edg|Firefox|Chrome|Version)/([0-9]+)') AS version,
-                             uniqExact(LogAttributes['session.id']) AS sessions,
-                             uniqExact(LogAttributes['everr.visitor.id']) AS visitors,
+                      SELECT multiIf(position(toString(ResourceAttributes.`user_agent.original`), 'Headless') > 0, 'Headless Chrome', position(toString(ResourceAttributes.`user_agent.original`), 'Edg/') > 0, 'Edge', position(toString(ResourceAttributes.`user_agent.original`), 'Firefox/') > 0, 'Firefox', position(toString(ResourceAttributes.`user_agent.original`), 'Chrome/') > 0, 'Chrome', position(toString(ResourceAttributes.`user_agent.original`), 'Safari/') > 0, 'Safari', 'Other') AS browser,
+                             extract(toString(ResourceAttributes.`user_agent.original`), '(?:Edg|Firefox|Chrome|Version)/([0-9]+)') AS version,
+                             uniqExact(toString(LogAttributes.`session.id`)) AS sessions,
+                             uniqExact(toString(LogAttributes.`everr.visitor.id`)) AS visitors,
                              count() AS views
                       FROM logs
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND ResourceAttributes['telemetry.distro.name'] = '@everr/otel-web' AND EventName = 'everr.browser.page_view'
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(ResourceAttributes.`telemetry.distro.name`) = '@everr/otel-web' AND EventName = 'everr.browser.page_view'
                       GROUP BY browser, version
                       ORDER BY sessions DESC
                       LIMIT 20
@@ -323,9 +323,9 @@ document:
                     query: |-
                       SELECT EventName AS event,
                              count() AS occurrences,
-                             uniqExact(LogAttributes['session.id']) AS sessions
+                             uniqExact(toString(LogAttributes.`session.id`)) AS sessions
                       FROM logs
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND ResourceAttributes['telemetry.distro.name'] = '@everr/otel-web' AND EventName != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND toString(ResourceAttributes.`telemetry.distro.name`) = '@everr/otel-web' AND EventName != ''
                       GROUP BY event
                       ORDER BY occurrences DESC
                       LIMIT 20
@@ -346,10 +346,10 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT coalesce(nullIf(LogAttributes['everr.route.pattern'], ''), LogAttributes['url.path']) AS route,
-                             LogAttributes['everr.element.tag'] AS tag,
+                      SELECT coalesce(nullIf(toString(LogAttributes.`everr.route.pattern`), ''), toString(LogAttributes.`url.path`)) AS route,
+                             toString(LogAttributes.`everr.element.tag`) AS tag,
                              count() AS rage_clicks,
-                             substring(LogAttributes['everr.element.selector'], -40) AS selector_tail
+                             substring(toString(LogAttributes.`everr.element.selector`), -40) AS selector_tail
                       FROM logs
                       WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND EventName = 'everr.browser.interaction.rage_click'
                       GROUP BY route, tag, selector_tail

--- a/packages/app/src/data/dashboards/built-in/catalog/browser/web-vitals.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/browser/web-vitals.yaml
@@ -43,8 +43,8 @@ document:
             kind: ClickHouseSQLVariable
             spec:
               query: |-
-                SELECT DISTINCT coalesce(nullIf(LogAttributes['everr.route.pattern'], ''), LogAttributes['url.path']) AS route FROM logs
-                WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ResourceAttributes['telemetry.distro.name'] = '@everr/otel-web' AND coalesce(nullIf(LogAttributes['everr.route.pattern'], ''), LogAttributes['url.path']) != '' ORDER BY route
+                SELECT DISTINCT coalesce(nullIf(toString(LogAttributes.`everr.route.pattern`), ''), toString(LogAttributes.`url.path`)) AS route FROM logs
+                WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND toString(ResourceAttributes.`telemetry.distro.name`) = '@everr/otel-web' AND coalesce(nullIf(toString(LogAttributes.`everr.route.pattern`), ''), toString(LogAttributes.`url.path`)) != '' ORDER BY route
     refreshInterval: 5m
     panels:
       lcp:
@@ -80,10 +80,10 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT round(quantile(0.75)(toFloat64OrZero(LogAttributes['browser.web_vital.value'])), 0) AS p75
+                      SELECT round(quantile(0.75)(toFloat64OrZero(toString(LogAttributes.`browser.web_vital.value`))), 0) AS p75
                       FROM logs
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(LogAttributes['everr.route.pattern'], ''), LogAttributes['url.path']) IN $route AND (LogAttributes['browser.web_vital.name'] = 'cls' OR toFloat64OrZero(LogAttributes['browser.web_vital.value']) <= 60000) AND EventName = 'browser.web_vital'
-                        AND LogAttributes['browser.web_vital.name'] = 'lcp'
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(toString(LogAttributes.`everr.route.pattern`), ''), toString(LogAttributes.`url.path`)) IN $route AND (toString(LogAttributes.`browser.web_vital.name`) = 'cls' OR toFloat64OrZero(toString(LogAttributes.`browser.web_vital.value`)) <= 60000) AND EventName = 'browser.web_vital'
+                        AND toString(LogAttributes.`browser.web_vital.name`) = 'lcp'
       inp:
         kind: Panel
         spec:
@@ -117,10 +117,10 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT round(quantile(0.75)(toFloat64OrZero(LogAttributes['browser.web_vital.value'])), 0) AS p75
+                      SELECT round(quantile(0.75)(toFloat64OrZero(toString(LogAttributes.`browser.web_vital.value`))), 0) AS p75
                       FROM logs
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(LogAttributes['everr.route.pattern'], ''), LogAttributes['url.path']) IN $route AND (LogAttributes['browser.web_vital.name'] = 'cls' OR toFloat64OrZero(LogAttributes['browser.web_vital.value']) <= 60000) AND EventName = 'browser.web_vital'
-                        AND LogAttributes['browser.web_vital.name'] = 'inp'
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(toString(LogAttributes.`everr.route.pattern`), ''), toString(LogAttributes.`url.path`)) IN $route AND (toString(LogAttributes.`browser.web_vital.name`) = 'cls' OR toFloat64OrZero(toString(LogAttributes.`browser.web_vital.value`)) <= 60000) AND EventName = 'browser.web_vital'
+                        AND toString(LogAttributes.`browser.web_vital.name`) = 'inp'
       cls:
         kind: Panel
         spec:
@@ -153,10 +153,10 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT round(quantile(0.75)(toFloat64OrZero(LogAttributes['browser.web_vital.value'])), 3) AS p75
+                      SELECT round(quantile(0.75)(toFloat64OrZero(toString(LogAttributes.`browser.web_vital.value`))), 3) AS p75
                       FROM logs
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(LogAttributes['everr.route.pattern'], ''), LogAttributes['url.path']) IN $route AND (LogAttributes['browser.web_vital.name'] = 'cls' OR toFloat64OrZero(LogAttributes['browser.web_vital.value']) <= 60000) AND EventName = 'browser.web_vital'
-                        AND LogAttributes['browser.web_vital.name'] = 'cls'
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(toString(LogAttributes.`everr.route.pattern`), ''), toString(LogAttributes.`url.path`)) IN $route AND (toString(LogAttributes.`browser.web_vital.name`) = 'cls' OR toFloat64OrZero(toString(LogAttributes.`browser.web_vital.value`)) <= 60000) AND EventName = 'browser.web_vital'
+                        AND toString(LogAttributes.`browser.web_vital.name`) = 'cls'
       ttfb:
         kind: Panel
         spec:
@@ -190,10 +190,10 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT round(quantile(0.75)(toFloat64OrZero(LogAttributes['browser.web_vital.value'])), 0) AS p75
+                      SELECT round(quantile(0.75)(toFloat64OrZero(toString(LogAttributes.`browser.web_vital.value`))), 0) AS p75
                       FROM logs
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(LogAttributes['everr.route.pattern'], ''), LogAttributes['url.path']) IN $route AND (LogAttributes['browser.web_vital.name'] = 'cls' OR toFloat64OrZero(LogAttributes['browser.web_vital.value']) <= 60000) AND EventName = 'browser.web_vital'
-                        AND LogAttributes['browser.web_vital.name'] = 'ttfb'
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(toString(LogAttributes.`everr.route.pattern`), ''), toString(LogAttributes.`url.path`)) IN $route AND (toString(LogAttributes.`browser.web_vital.name`) = 'cls' OR toFloat64OrZero(toString(LogAttributes.`browser.web_vital.value`)) <= 60000) AND EventName = 'browser.web_vital'
+                        AND toString(LogAttributes.`browser.web_vital.name`) = 'ttfb'
       lcp-rating:
         kind: Panel
         spec:
@@ -215,10 +215,10 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts, LogAttributes['everr.browser.web_vital.rating'] AS rating, count() AS samples
+                      SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts, toString(LogAttributes.`everr.browser.web_vital.rating`) AS rating, count() AS samples
                       FROM logs
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(LogAttributes['everr.route.pattern'], ''), LogAttributes['url.path']) IN $route AND EventName = 'browser.web_vital'
-                        AND LogAttributes['browser.web_vital.name'] = 'lcp'
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(toString(LogAttributes.`everr.route.pattern`), ''), toString(LogAttributes.`url.path`)) IN $route AND EventName = 'browser.web_vital'
+                        AND toString(LogAttributes.`browser.web_vital.name`) = 'lcp'
                       GROUP BY ts, rating
                       ORDER BY ts, indexOf(['good', 'needs-improvement', 'poor'], rating)
       inp-rating:
@@ -239,10 +239,10 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts, LogAttributes['everr.browser.web_vital.rating'] AS rating, count() AS samples
+                      SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts, toString(LogAttributes.`everr.browser.web_vital.rating`) AS rating, count() AS samples
                       FROM logs
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(LogAttributes['everr.route.pattern'], ''), LogAttributes['url.path']) IN $route AND EventName = 'browser.web_vital'
-                        AND LogAttributes['browser.web_vital.name'] = 'inp'
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(toString(LogAttributes.`everr.route.pattern`), ''), toString(LogAttributes.`url.path`)) IN $route AND EventName = 'browser.web_vital'
+                        AND toString(LogAttributes.`browser.web_vital.name`) = 'inp'
                       GROUP BY ts, rating
                       ORDER BY ts, indexOf(['good', 'needs-improvement', 'poor'], rating)
       cls-rating:
@@ -263,10 +263,10 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts, LogAttributes['everr.browser.web_vital.rating'] AS rating, count() AS samples
+                      SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts, toString(LogAttributes.`everr.browser.web_vital.rating`) AS rating, count() AS samples
                       FROM logs
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(LogAttributes['everr.route.pattern'], ''), LogAttributes['url.path']) IN $route AND EventName = 'browser.web_vital'
-                        AND LogAttributes['browser.web_vital.name'] = 'cls'
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(toString(LogAttributes.`everr.route.pattern`), ''), toString(LogAttributes.`url.path`)) IN $route AND EventName = 'browser.web_vital'
+                        AND toString(LogAttributes.`browser.web_vital.name`) = 'cls'
                       GROUP BY ts, rating
                       ORDER BY ts, indexOf(['good', 'needs-improvement', 'poor'], rating)
       lcp-over-time:
@@ -289,12 +289,12 @@ document:
                       SELECT ts, q.2 AS series, q.3 AS value
                       FROM (
                         SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts,
-                               round(quantile(0.5)(toFloat64OrZero(LogAttributes['browser.web_vital.value'])), 0) AS p50,
-                               round(quantile(0.75)(toFloat64OrZero(LogAttributes['browser.web_vital.value'])), 0) AS p75,
-                               round(quantile(0.9)(toFloat64OrZero(LogAttributes['browser.web_vital.value'])), 0) AS p90
+                               round(quantile(0.5)(toFloat64OrZero(toString(LogAttributes.`browser.web_vital.value`))), 0) AS p50,
+                               round(quantile(0.75)(toFloat64OrZero(toString(LogAttributes.`browser.web_vital.value`))), 0) AS p75,
+                               round(quantile(0.9)(toFloat64OrZero(toString(LogAttributes.`browser.web_vital.value`))), 0) AS p90
                         FROM logs
-                        WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(LogAttributes['everr.route.pattern'], ''), LogAttributes['url.path']) IN $route AND (LogAttributes['browser.web_vital.name'] = 'cls' OR toFloat64OrZero(LogAttributes['browser.web_vital.value']) <= 60000) AND EventName = 'browser.web_vital'
-                          AND LogAttributes['browser.web_vital.name'] = 'lcp'
+                        WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(toString(LogAttributes.`everr.route.pattern`), ''), toString(LogAttributes.`url.path`)) IN $route AND (toString(LogAttributes.`browser.web_vital.name`) = 'cls' OR toFloat64OrZero(toString(LogAttributes.`browser.web_vital.value`)) <= 60000) AND EventName = 'browser.web_vital'
+                          AND toString(LogAttributes.`browser.web_vital.name`) = 'lcp'
                         GROUP BY ts
                       )
                       ARRAY JOIN [(0, 'Median', p50), (1, 'P75', p75), (2, 'P90', p90)] AS q
@@ -319,12 +319,12 @@ document:
                       SELECT ts, q.2 AS series, q.3 AS value
                       FROM (
                         SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts,
-                               round(quantile(0.5)(toFloat64OrZero(LogAttributes['browser.web_vital.value'])), 0) AS p50,
-                               round(quantile(0.75)(toFloat64OrZero(LogAttributes['browser.web_vital.value'])), 0) AS p75,
-                               round(quantile(0.9)(toFloat64OrZero(LogAttributes['browser.web_vital.value'])), 0) AS p90
+                               round(quantile(0.5)(toFloat64OrZero(toString(LogAttributes.`browser.web_vital.value`))), 0) AS p50,
+                               round(quantile(0.75)(toFloat64OrZero(toString(LogAttributes.`browser.web_vital.value`))), 0) AS p75,
+                               round(quantile(0.9)(toFloat64OrZero(toString(LogAttributes.`browser.web_vital.value`))), 0) AS p90
                         FROM logs
-                        WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(LogAttributes['everr.route.pattern'], ''), LogAttributes['url.path']) IN $route AND (LogAttributes['browser.web_vital.name'] = 'cls' OR toFloat64OrZero(LogAttributes['browser.web_vital.value']) <= 60000) AND EventName = 'browser.web_vital'
-                          AND LogAttributes['browser.web_vital.name'] = 'inp'
+                        WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(toString(LogAttributes.`everr.route.pattern`), ''), toString(LogAttributes.`url.path`)) IN $route AND (toString(LogAttributes.`browser.web_vital.name`) = 'cls' OR toFloat64OrZero(toString(LogAttributes.`browser.web_vital.value`)) <= 60000) AND EventName = 'browser.web_vital'
+                          AND toString(LogAttributes.`browser.web_vital.name`) = 'inp'
                         GROUP BY ts
                       )
                       ARRAY JOIN [(0, 'Median', p50), (1, 'P75', p75), (2, 'P90', p90)] AS q
@@ -348,12 +348,12 @@ document:
                       SELECT ts, q.2 AS series, q.3 AS value
                       FROM (
                         SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts,
-                               round(quantile(0.5)(toFloat64OrZero(LogAttributes['browser.web_vital.value'])), 3) AS p50,
-                               round(quantile(0.75)(toFloat64OrZero(LogAttributes['browser.web_vital.value'])), 3) AS p75,
-                               round(quantile(0.9)(toFloat64OrZero(LogAttributes['browser.web_vital.value'])), 3) AS p90
+                               round(quantile(0.5)(toFloat64OrZero(toString(LogAttributes.`browser.web_vital.value`))), 3) AS p50,
+                               round(quantile(0.75)(toFloat64OrZero(toString(LogAttributes.`browser.web_vital.value`))), 3) AS p75,
+                               round(quantile(0.9)(toFloat64OrZero(toString(LogAttributes.`browser.web_vital.value`))), 3) AS p90
                         FROM logs
-                        WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(LogAttributes['everr.route.pattern'], ''), LogAttributes['url.path']) IN $route AND (LogAttributes['browser.web_vital.name'] = 'cls' OR toFloat64OrZero(LogAttributes['browser.web_vital.value']) <= 60000) AND EventName = 'browser.web_vital'
-                          AND LogAttributes['browser.web_vital.name'] = 'cls'
+                        WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(toString(LogAttributes.`everr.route.pattern`), ''), toString(LogAttributes.`url.path`)) IN $route AND (toString(LogAttributes.`browser.web_vital.name`) = 'cls' OR toFloat64OrZero(toString(LogAttributes.`browser.web_vital.value`)) <= 60000) AND EventName = 'browser.web_vital'
+                          AND toString(LogAttributes.`browser.web_vital.name`) = 'cls'
                         GROUP BY ts
                       )
                       ARRAY JOIN [(0, 'Median', p50), (1, 'P75', p75), (2, 'P90', p90)] AS q
@@ -380,13 +380,13 @@ document:
                       SELECT ts, phase.2 AS series, phase.3 AS value
                       FROM (
                         SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts,
-                             round(quantile(0.75)(toFloat64OrZero(LogAttributes['everr.browser.web_vital.lcp.time_to_first_byte']))) AS phase_0,
-                             round(quantile(0.75)(toFloat64OrZero(LogAttributes['everr.browser.web_vital.lcp.resource_load_delay']))) AS phase_1,
-                             round(quantile(0.75)(toFloat64OrZero(LogAttributes['everr.browser.web_vital.lcp.resource_load_duration']))) AS phase_2,
-                             round(quantile(0.75)(toFloat64OrZero(LogAttributes['everr.browser.web_vital.lcp.element_render_delay']))) AS phase_3
+                             round(quantile(0.75)(toFloat64OrZero(toString(LogAttributes.`everr.browser.web_vital.lcp.time_to_first_byte`)))) AS phase_0,
+                             round(quantile(0.75)(toFloat64OrZero(toString(LogAttributes.`everr.browser.web_vital.lcp.resource_load_delay`)))) AS phase_1,
+                             round(quantile(0.75)(toFloat64OrZero(toString(LogAttributes.`everr.browser.web_vital.lcp.resource_load_duration`)))) AS phase_2,
+                             round(quantile(0.75)(toFloat64OrZero(toString(LogAttributes.`everr.browser.web_vital.lcp.element_render_delay`)))) AS phase_3
                         FROM logs
-                        WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(LogAttributes['everr.route.pattern'], ''), LogAttributes['url.path']) IN $route AND (LogAttributes['browser.web_vital.name'] = 'cls' OR toFloat64OrZero(LogAttributes['browser.web_vital.value']) <= 60000) AND EventName = 'browser.web_vital'
-                          AND LogAttributes['browser.web_vital.name'] = 'lcp'
+                        WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(toString(LogAttributes.`everr.route.pattern`), ''), toString(LogAttributes.`url.path`)) IN $route AND (toString(LogAttributes.`browser.web_vital.name`) = 'cls' OR toFloat64OrZero(toString(LogAttributes.`browser.web_vital.value`)) <= 60000) AND EventName = 'browser.web_vital'
+                          AND toString(LogAttributes.`browser.web_vital.name`) = 'lcp'
                         GROUP BY ts
                       )
                       ARRAY JOIN [(0, 'Time to first byte', phase_0), (1, 'Resource load delay', phase_1), (2, 'Resource load duration', phase_2), (3, 'Element render delay', phase_3)] AS phase
@@ -413,14 +413,14 @@ document:
                       SELECT ts, phase.2 AS series, phase.3 AS value
                       FROM (
                         SELECT toStartOfInterval(Timestamp, INTERVAL {step:UInt32} * 6 SECOND) AS ts,
-                             round(quantile(0.75)(toFloat64OrZero(LogAttributes['everr.browser.web_vital.ttfb.waiting_duration']))) AS phase_0,
-                             round(quantile(0.75)(toFloat64OrZero(LogAttributes['everr.browser.web_vital.ttfb.cache_duration']))) AS phase_1,
-                             round(quantile(0.75)(toFloat64OrZero(LogAttributes['everr.browser.web_vital.ttfb.dns_duration']))) AS phase_2,
-                             round(quantile(0.75)(toFloat64OrZero(LogAttributes['everr.browser.web_vital.ttfb.connection_duration']))) AS phase_3,
-                             round(quantile(0.75)(toFloat64OrZero(LogAttributes['everr.browser.web_vital.ttfb.request_duration']))) AS phase_4
+                             round(quantile(0.75)(toFloat64OrZero(toString(LogAttributes.`everr.browser.web_vital.ttfb.waiting_duration`)))) AS phase_0,
+                             round(quantile(0.75)(toFloat64OrZero(toString(LogAttributes.`everr.browser.web_vital.ttfb.cache_duration`)))) AS phase_1,
+                             round(quantile(0.75)(toFloat64OrZero(toString(LogAttributes.`everr.browser.web_vital.ttfb.dns_duration`)))) AS phase_2,
+                             round(quantile(0.75)(toFloat64OrZero(toString(LogAttributes.`everr.browser.web_vital.ttfb.connection_duration`)))) AS phase_3,
+                             round(quantile(0.75)(toFloat64OrZero(toString(LogAttributes.`everr.browser.web_vital.ttfb.request_duration`)))) AS phase_4
                         FROM logs
-                        WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(LogAttributes['everr.route.pattern'], ''), LogAttributes['url.path']) IN $route AND (LogAttributes['browser.web_vital.name'] = 'cls' OR toFloat64OrZero(LogAttributes['browser.web_vital.value']) <= 60000) AND EventName = 'browser.web_vital'
-                          AND LogAttributes['browser.web_vital.name'] = 'ttfb'
+                        WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(toString(LogAttributes.`everr.route.pattern`), ''), toString(LogAttributes.`url.path`)) IN $route AND (toString(LogAttributes.`browser.web_vital.name`) = 'cls' OR toFloat64OrZero(toString(LogAttributes.`browser.web_vital.value`)) <= 60000) AND EventName = 'browser.web_vital'
+                          AND toString(LogAttributes.`browser.web_vital.name`) = 'ttfb'
                         GROUP BY ts
                       )
                       ARRAY JOIN [(0, 'Waiting', phase_0), (1, 'Cache', phase_1), (2, 'DNS', phase_2), (3, 'Connection', phase_3), (4, 'Request', phase_4)] AS phase
@@ -442,18 +442,18 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT LogAttributes['everr.element.selector'] AS element,
+                      SELECT toString(LogAttributes.`everr.element.selector`) AS element,
                              coalesce(
-                               nullIf(LogAttributes['everr.browser.interaction.name'], ''),
-                               LogAttributes['everr.browser.interaction.type']
+                               nullIf(toString(LogAttributes.`everr.browser.interaction.name`), ''),
+                               toString(LogAttributes.`everr.browser.interaction.type`)
                              ) AS event,
-                             round(quantile(0.75)(toFloat64OrZero(LogAttributes['everr.browser.interaction.input_delay']))) AS input_delay_p75_ms,
+                             round(quantile(0.75)(toFloat64OrZero(toString(LogAttributes.`everr.browser.interaction.input_delay`)))) AS input_delay_p75_ms,
                              count() AS samples,
-                             coalesce(nullIf(LogAttributes['everr.route.pattern'], ''), LogAttributes['url.path']) AS route
+                             coalesce(nullIf(toString(LogAttributes.`everr.route.pattern`), ''), toString(LogAttributes.`url.path`)) AS route
                       FROM logs
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(LogAttributes['everr.route.pattern'], ''), LogAttributes['url.path']) IN $route AND (LogAttributes['browser.web_vital.name'] = 'cls' OR toFloat64OrZero(LogAttributes['browser.web_vital.value']) <= 60000) AND EventName = 'browser.web_vital'
-                        AND LogAttributes['browser.web_vital.name'] = 'inp'
-                        AND LogAttributes['everr.element.selector'] != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(toString(LogAttributes.`everr.route.pattern`), ''), toString(LogAttributes.`url.path`)) IN $route AND (toString(LogAttributes.`browser.web_vital.name`) = 'cls' OR toFloat64OrZero(toString(LogAttributes.`browser.web_vital.value`)) <= 60000) AND EventName = 'browser.web_vital'
+                        AND toString(LogAttributes.`browser.web_vital.name`) = 'inp'
+                        AND toString(LogAttributes.`everr.element.selector`) != ''
                       GROUP BY element, event, route
                       ORDER BY input_delay_p75_ms DESC
                       LIMIT 25
@@ -474,13 +474,13 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT LogAttributes['everr.browser.web_vital.lcp.target'] AS element,
-                             round(quantile(0.75)(toFloat64OrZero(LogAttributes['browser.web_vital.value']))) AS lcp_p75_ms,
+                      SELECT toString(LogAttributes.`everr.browser.web_vital.lcp.target`) AS element,
+                             round(quantile(0.75)(toFloat64OrZero(toString(LogAttributes.`browser.web_vital.value`)))) AS lcp_p75_ms,
                              count() AS samples
                       FROM logs
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(LogAttributes['everr.route.pattern'], ''), LogAttributes['url.path']) IN $route AND (LogAttributes['browser.web_vital.name'] = 'cls' OR toFloat64OrZero(LogAttributes['browser.web_vital.value']) <= 60000) AND EventName = 'browser.web_vital'
-                        AND LogAttributes['browser.web_vital.name'] = 'lcp'
-                        AND LogAttributes['everr.browser.web_vital.lcp.target'] != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(toString(LogAttributes.`everr.route.pattern`), ''), toString(LogAttributes.`url.path`)) IN $route AND (toString(LogAttributes.`browser.web_vital.name`) = 'cls' OR toFloat64OrZero(toString(LogAttributes.`browser.web_vital.value`)) <= 60000) AND EventName = 'browser.web_vital'
+                        AND toString(LogAttributes.`browser.web_vital.name`) = 'lcp'
+                        AND toString(LogAttributes.`everr.browser.web_vital.lcp.target`) != ''
                       GROUP BY element
                       HAVING samples >= 5
                       ORDER BY lcp_p75_ms DESC
@@ -502,14 +502,14 @@ document:
                   kind: ClickHouseSQL
                   spec:
                     query: |-
-                      SELECT LogAttributes['everr.browser.web_vital.cls.largest_shift_target'] AS element,
-                             round(quantile(0.75)(toFloat64OrZero(LogAttributes['everr.browser.web_vital.cls.largest_shift_value'])), 3) AS shift_p75,
-                             LogAttributes['everr.browser.web_vital.cls.load_state'] AS load_state,
+                      SELECT toString(LogAttributes.`everr.browser.web_vital.cls.largest_shift_target`) AS element,
+                             round(quantile(0.75)(toFloat64OrZero(toString(LogAttributes.`everr.browser.web_vital.cls.largest_shift_value`))), 3) AS shift_p75,
+                             toString(LogAttributes.`everr.browser.web_vital.cls.load_state`) AS load_state,
                              count() AS samples
                       FROM logs
-                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(LogAttributes['everr.route.pattern'], ''), LogAttributes['url.path']) IN $route AND EventName = 'browser.web_vital'
-                        AND LogAttributes['browser.web_vital.name'] = 'cls'
-                        AND LogAttributes['everr.browser.web_vital.cls.largest_shift_target'] != ''
+                      WHERE Timestamp >= {from:String} AND Timestamp <= {to:String} AND ServiceName IN $service AND coalesce(nullIf(toString(LogAttributes.`everr.route.pattern`), ''), toString(LogAttributes.`url.path`)) IN $route AND EventName = 'browser.web_vital'
+                        AND toString(LogAttributes.`browser.web_vital.name`) = 'cls'
+                        AND toString(LogAttributes.`everr.browser.web_vital.cls.largest_shift_target`) != ''
                       GROUP BY element, load_state
                       ORDER BY shift_p75 DESC
                       LIMIT 25

--- a/packages/app/src/data/home/server.ts
+++ b/packages/app/src/data/home/server.ts
@@ -191,16 +191,16 @@ function buildHomeQueries(granularity: BucketGranularity): {
         sum(runDurationMs) AS prTotalMs
       FROM (
         SELECT
-          ResourceAttributes['cicd.pipeline.run.id'] AS run_id,
-          max(ResourceAttributes['everr.git.pull_requests.url']) AS pr,
-          max(ResourceAttributes['cicd.pipeline.task.run.result']) AS result,
+          toString(ResourceAttributes.\`cicd.pipeline.run.id\`) AS run_id,
+          max(toString(ResourceAttributes.\`everr.git.pull_requests.url\`)) AS pr,
+          max(toString(ResourceAttributes.\`cicd.pipeline.task.run.result\`)) AS result,
           max(Timestamp) AS lastTimestamp,
           max(Duration) / 1000000 AS runDurationMs
         FROM traces
         WHERE Timestamp >= parseDateTimeBestEffort({fromTime:String})
           AND Timestamp <= parseDateTimeBestEffort({toTime:String})
-          AND mapContains(ResourceAttributes, 'cicd.pipeline.run.id')
-          AND ResourceAttributes['cicd.pipeline.run.id'] != ''
+          AND has(ResourceAttributesKeys, 'cicd.pipeline.run.id')
+          AND toString(ResourceAttributes.\`cicd.pipeline.run.id\`) != ''
         GROUP BY run_id
       )
       WHERE result != ''

--- a/packages/app/src/data/logs-explorer/server.test.ts
+++ b/packages/app/src/data/logs-explorer/server.test.ts
@@ -62,7 +62,7 @@ describe("getLogsExplorer", () => {
     expect(sql).toContain("IN {levels:Array(String)}");
     expect(sql).not.toContain("count()");
     expect(sql).not.toContain("toStartOfInterval");
-    expect(sql).not.toContain("ResourceAttributes['vcs.ref.head.name']");
+    expect(sql).not.toContain("ResourceAttributes.`vcs.ref.head.name`");
     expect(sql).not.toContain("cicd.pipeline.task.run.id");
     expect(sql).toContain("toString(cityHash64(Body)) AS bodyHash");
     expect(sql).not.toContain("PREWHERE");

--- a/packages/app/src/data/repo-detail/server.ts
+++ b/packages/app/src/data/repo-detail/server.ts
@@ -24,15 +24,15 @@ export const getRepoStats = createAuthenticatedServerFn({
 				avg(duration) as avgDuration
 			FROM (
 				SELECT
-					ResourceAttributes['cicd.pipeline.run.id'] as run_id,
-					anyLast(ResourceAttributes['cicd.pipeline.task.run.result']) as conclusion,
+					toString(ResourceAttributes.\`cicd.pipeline.run.id\`) as run_id,
+					anyLast(toString(ResourceAttributes.\`cicd.pipeline.task.run.result\`)) as conclusion,
 					max(Duration) / 1000000 as duration
 				FROM traces
 				WHERE Timestamp >= {fromTime:String} AND Timestamp <= {toTime:String}
-					AND ResourceAttributes['vcs.repository.name'] = {repo:String}
-					AND ResourceAttributes['cicd.pipeline.run.id'] != ''
-					AND SpanAttributes['everr.github.workflow_job_step.number'] = ''
-					AND ResourceAttributes['cicd.pipeline.task.run.result'] != ''
+					AND toString(ResourceAttributes.\`vcs.repository.name\`) = {repo:String}
+					AND toString(ResourceAttributes.\`cicd.pipeline.run.id\`) != ''
+					AND toString(SpanAttributes.\`everr.github.workflow_job_step.number\`) = ''
+					AND toString(ResourceAttributes.\`cicd.pipeline.task.run.result\`) != ''
 				GROUP BY run_id
 			)
 		`;
@@ -75,13 +75,13 @@ export const getRepoSuccessRateTrend = createAuthenticatedServerFn({
 			FROM (
 				SELECT
 					toDate(max(Timestamp)) as date,
-					ResourceAttributes['cicd.pipeline.run.id'] as run_id,
-					anyLast(ResourceAttributes['cicd.pipeline.task.run.result']) as conclusion
+					toString(ResourceAttributes.\`cicd.pipeline.run.id\`) as run_id,
+					anyLast(toString(ResourceAttributes.\`cicd.pipeline.task.run.result\`)) as conclusion
 				FROM traces
 				WHERE Timestamp >= {fromTime:String} AND Timestamp <= {toTime:String}
-					AND ResourceAttributes['vcs.repository.name'] = {repo:String}
-					AND ResourceAttributes['cicd.pipeline.run.id'] != ''
-					AND ResourceAttributes['cicd.pipeline.task.run.result'] != ''
+					AND toString(ResourceAttributes.\`vcs.repository.name\`) = {repo:String}
+					AND toString(ResourceAttributes.\`cicd.pipeline.run.id\`) != ''
+					AND toString(ResourceAttributes.\`cicd.pipeline.task.run.result\`) != ''
 				GROUP BY run_id
 			)
 			GROUP BY date
@@ -119,9 +119,9 @@ export const getRepoDurationTrend = createAuthenticatedServerFn({
 				quantile(0.95)(Duration) / 1000000 as p95Duration
 			FROM traces
 			WHERE Timestamp >= {fromTime:String} AND Timestamp <= {toTime:String}
-				AND ResourceAttributes['vcs.repository.name'] = {repo:String}
-				AND ResourceAttributes['cicd.pipeline.task.run.id'] != ''
-				AND SpanAttributes['everr.github.workflow_job_step.number'] = ''
+				AND toString(ResourceAttributes.\`vcs.repository.name\`) = {repo:String}
+				AND toString(ResourceAttributes.\`cicd.pipeline.task.run.id\`) != ''
+				AND toString(SpanAttributes.\`everr.github.workflow_job_step.number\`) = ''
 			GROUP BY date
 			ORDER BY date ASC WITH FILL FROM toDate({fromTime:String}) TO toDate({toTime:String}) + 1
 		`;
@@ -149,18 +149,18 @@ export const getRepoRecentRuns = createAuthenticatedServerFn({
     const sql = `
 			SELECT
 				TraceId as trace_id,
-				anyLast(ResourceAttributes['cicd.pipeline.run.id']) as run_id,
-				anyLast(ResourceAttributes['cicd.pipeline.name']) as workflowName,
-				anyLast(ResourceAttributes['vcs.ref.head.name']) as branch,
-				anyLast(ResourceAttributes['cicd.pipeline.task.run.result']) as conclusion,
+				anyLast(toString(ResourceAttributes.\`cicd.pipeline.run.id\`)) as run_id,
+				anyLast(toString(ResourceAttributes.\`cicd.pipeline.name\`)) as workflowName,
+				anyLast(toString(ResourceAttributes.\`vcs.ref.head.name\`)) as branch,
+				anyLast(toString(ResourceAttributes.\`cicd.pipeline.task.run.result\`)) as conclusion,
 				max(Timestamp) as timestamp,
-				anyLast(ResourceAttributes['cicd.pipeline.task.run.sender.login']) as sender
+				anyLast(toString(ResourceAttributes.\`cicd.pipeline.task.run.sender.login\`)) as sender
 			FROM traces
 			WHERE Timestamp >= {fromTime:String} AND Timestamp <= {toTime:String}
-				AND ResourceAttributes['vcs.repository.name'] = {repo:String}
-				AND ResourceAttributes['cicd.pipeline.run.id'] != ''
-				AND SpanAttributes['everr.github.workflow_job_step.number'] = ''
-				AND ResourceAttributes['cicd.pipeline.task.run.result'] != ''
+				AND toString(ResourceAttributes.\`vcs.repository.name\`) = {repo:String}
+				AND toString(ResourceAttributes.\`cicd.pipeline.run.id\`) != ''
+				AND toString(SpanAttributes.\`everr.github.workflow_job_step.number\`) = ''
+				AND toString(ResourceAttributes.\`cicd.pipeline.task.run.result\`) != ''
 			GROUP BY trace_id
 			ORDER BY timestamp DESC
 			LIMIT 20
@@ -196,20 +196,20 @@ export const getTopFailingJobs = createAuthenticatedServerFn({
 
     const sql = `
 			SELECT
-				ResourceAttributes['cicd.pipeline.task.name'] as jobName,
-				anyLast(ResourceAttributes['cicd.pipeline.name']) as workflowName,
+				toString(ResourceAttributes.\`cicd.pipeline.task.name\`) as jobName,
+				anyLast(toString(ResourceAttributes.\`cicd.pipeline.name\`)) as workflowName,
 				count(*) as totalRuns,
-				countIf(ResourceAttributes['cicd.pipeline.task.run.result'] = 'failure') as failureCount,
+				countIf(toString(ResourceAttributes.\`cicd.pipeline.task.run.result\`) = 'failure') as failureCount,
 				round(
-					countIf(ResourceAttributes['cicd.pipeline.task.run.result'] = 'failure') * 100.0
+					countIf(toString(ResourceAttributes.\`cicd.pipeline.task.run.result\`) = 'failure') * 100.0
 					/ nullIf(count(*), 0),
 					1
 				) as failureRate
 			FROM traces
 			WHERE Timestamp >= {fromTime:String} AND Timestamp <= {toTime:String}
-				AND ResourceAttributes['vcs.repository.name'] = {repo:String}
-				AND ResourceAttributes['cicd.pipeline.task.name'] != ''
-				AND SpanAttributes['everr.github.workflow_job_step.number'] = ''
+				AND toString(ResourceAttributes.\`vcs.repository.name\`) = {repo:String}
+				AND toString(ResourceAttributes.\`cicd.pipeline.task.name\`) != ''
+				AND toString(SpanAttributes.\`everr.github.workflow_job_step.number\`) = ''
 			GROUP BY jobName
 			HAVING failureCount > 0
 			ORDER BY failureCount DESC
@@ -251,17 +251,17 @@ export const getActiveBranches = createAuthenticatedServerFn({
 				round(countIf(conclusion = 'success') * 100.0 / nullIf(count(*), 0), 1) as successRate
 			FROM (
 				SELECT
-					ResourceAttributes['vcs.ref.head.name'] as branch,
+					toString(ResourceAttributes.\`vcs.ref.head.name\`) as branch,
 					TraceId as trace_id,
-					anyLast(ResourceAttributes['cicd.pipeline.run.id']) as run_id,
-					anyLast(ResourceAttributes['cicd.pipeline.task.run.result']) as conclusion,
+					anyLast(toString(ResourceAttributes.\`cicd.pipeline.run.id\`)) as run_id,
+					anyLast(toString(ResourceAttributes.\`cicd.pipeline.task.run.result\`)) as conclusion,
 					max(Timestamp) as timestamp
 				FROM traces
 				WHERE Timestamp >= {fromTime:String} AND Timestamp <= {toTime:String}
-					AND ResourceAttributes['vcs.repository.name'] = {repo:String}
-					AND ResourceAttributes['cicd.pipeline.run.id'] != ''
-					AND SpanAttributes['everr.github.workflow_job_step.number'] = ''
-					AND ResourceAttributes['cicd.pipeline.task.run.result'] != ''
+					AND toString(ResourceAttributes.\`vcs.repository.name\`) = {repo:String}
+					AND toString(ResourceAttributes.\`cicd.pipeline.run.id\`) != ''
+					AND toString(SpanAttributes.\`everr.github.workflow_job_step.number\`) = ''
+					AND toString(ResourceAttributes.\`cicd.pipeline.task.run.result\`) != ''
 				GROUP BY branch, trace_id
 			)
 			GROUP BY branch

--- a/packages/app/src/data/resource-usage.ts
+++ b/packages/app/src/data/resource-usage.ts
@@ -221,11 +221,11 @@ const getJobResourceUsage = createAuthenticatedServerFn({
     }): Promise<JobResourceUsage | null> => {
       const identifierSql = `
       SELECT
-        anyLast(ResourceAttributes['cicd.pipeline.run.id']) as runId,
-        anyLast(ResourceAttributes['cicd.pipeline.task.name']) as jobName
+        anyLast(toString(ResourceAttributes.\`cicd.pipeline.run.id\`)) as runId,
+        anyLast(toString(ResourceAttributes.\`cicd.pipeline.task.name\`)) as jobName
       FROM traces
       WHERE TraceId = {traceId:String}
-        AND ResourceAttributes['cicd.pipeline.task.run.id'] = {jobId:String}
+        AND toString(ResourceAttributes.\`cicd.pipeline.task.run.id\`) = {jobId:String}
     `;
 
       const identifierRows = await clickhouse.query<{

--- a/packages/app/src/data/run-query-helpers.test.ts
+++ b/packages/app/src/data/run-query-helpers.test.ts
@@ -10,9 +10,11 @@ describe("runSummarySubquery", () => {
     });
 
     expect(sql).toContain("TraceId as trace_id");
-    expect(sql).toContain("ResourceAttributes['cicd.pipeline.result']");
     expect(sql).toContain(
-      "ResourceAttributes['cicd.pipeline.task.run.result']",
+      "toString(ResourceAttributes.`cicd.pipeline.result`)",
+    );
+    expect(sql).toContain(
+      "toString(ResourceAttributes.`cicd.pipeline.task.run.result`)",
     );
     expect(sql).toContain("GROUP BY trace_id");
   });
@@ -20,7 +22,7 @@ describe("runSummarySubquery", () => {
   it("includes optional columns when requested", () => {
     const sql = runSummarySubquery({
       whereClause: "1 = 1",
-      groupByExpr: "ResourceAttributes['cicd.pipeline.run.id']",
+      groupByExpr: "toString(ResourceAttributes.`cicd.pipeline.run.id`)",
       groupByAlias: "run_id",
       includeRunAttempt: true,
       includeDuration: true,

--- a/packages/app/src/data/run-query-helpers.ts
+++ b/packages/app/src/data/run-query-helpers.ts
@@ -1,3 +1,5 @@
+import { attributeExists, attributeText } from "@everr/telemetry-explorer/sql";
+
 interface RunSummarySubqueryOptions {
   whereClause: string;
   groupByExpr: string;
@@ -9,26 +11,28 @@ interface RunSummarySubqueryOptions {
   includeJobCount?: boolean;
 }
 
-export const CONCLUSION_EXPR =
-  "coalesce(nullIf(argMaxIf(ResourceAttributes['cicd.pipeline.result'], Timestamp, ResourceAttributes['cicd.pipeline.result'] != ''), ''), argMaxIf(ResourceAttributes['cicd.pipeline.task.run.result'], Timestamp, ResourceAttributes['cicd.pipeline.task.run.result'] != ''))";
-
-/** `ResourceAttributes['key']` accessor. */
+/** Text of a resource attribute: `toString(ResourceAttributes.`key`)`. */
 export function resourceAttribute(key: string): string {
-  return `ResourceAttributes['${key}']`;
+  return attributeText("ResourceAttributes", key);
 }
+
+const PIPELINE_RESULT = resourceAttribute("cicd.pipeline.result");
+const TASK_RESULT = resourceAttribute("cicd.pipeline.task.run.result");
+
+export const CONCLUSION_EXPR = `coalesce(nullIf(argMaxIf(${PIPELINE_RESULT}, Timestamp, ${PIPELINE_RESULT} != ''), ''), argMaxIf(${TASK_RESULT}, Timestamp, ${TASK_RESULT} != ''))`;
 
 /**
- * Presence + non-empty check for a resource attribute. The `mapContains` term
- * lets the `idx_res_attr_key` bloom skip index prune granules that lack the key
- * before the value is read.
+ * Presence + non-empty check for a resource attribute. The `has` term on the
+ * keys array lets the `idx_res_attr_keys` bloom skip index prune granules
+ * that lack the key before the value is read.
  */
 export function nonEmptyResourceAttribute(key: string): string {
-  return `mapContains(ResourceAttributes, '${key}') AND ${resourceAttribute(key)} != ''`;
+  return `${attributeExists("ResourceAttributes", key)} AND ${resourceAttribute(key)} != ''`;
 }
 
-/** Equality on a resource attribute, key-index-prunable via `mapContains`. */
+/** Equality on a resource attribute, key-index-prunable via the keys array. */
 export function resourceAttributeEquals(key: string, param: string): string {
-  return `mapContains(ResourceAttributes, '${key}') AND ${resourceAttribute(key)} = {${param}:String}`;
+  return `${attributeExists("ResourceAttributes", key)} AND ${resourceAttribute(key)} = {${param}:String}`;
 }
 
 /**
@@ -47,17 +51,17 @@ export function runSummarySubquery({
 }: RunSummarySubqueryOptions): string {
   const selects: string[] = [
     `${groupByExpr} as ${groupByAlias}`,
-    "anyLast(ResourceAttributes['cicd.pipeline.run.id']) as run_id",
-    "anyLast(ResourceAttributes['cicd.pipeline.name']) as workflowName",
-    "anyLast(ResourceAttributes['vcs.repository.name']) as repo",
-    "anyLast(ResourceAttributes['vcs.ref.head.name']) as branch",
+    `anyLast(${resourceAttribute("cicd.pipeline.run.id")}) as run_id`,
+    `anyLast(${resourceAttribute("cicd.pipeline.name")}) as workflowName`,
+    `anyLast(${resourceAttribute("vcs.repository.name")}) as repo`,
+    `anyLast(${resourceAttribute("vcs.ref.head.name")}) as branch`,
     `${CONCLUSION_EXPR} as conclusion`,
     "max(Timestamp) as timestamp",
   ];
 
   if (includeRunAttempt) {
     selects.push(
-      "anyLast(toUInt32OrZero(ResourceAttributes['everr.github.workflow_job.run_attempt'])) as run_attempt",
+      `anyLast(toUInt32OrZero(${resourceAttribute("everr.github.workflow_job.run_attempt")})) as run_attempt`,
     );
   }
   if (includeDuration) {
@@ -65,12 +69,12 @@ export function runSummarySubquery({
   }
   if (includeSender) {
     selects.push(
-      "max(ResourceAttributes['cicd.pipeline.task.run.sender.login']) as sender",
+      `max(${resourceAttribute("cicd.pipeline.task.run.sender.login")}) as sender`,
     );
   }
   if (includeHeadSha) {
     selects.push(
-      "anyLast(ResourceAttributes['vcs.ref.head.revision']) as headSha",
+      `anyLast(${resourceAttribute("vcs.ref.head.revision")}) as headSha`,
     );
   }
   if (includeJobCount) {

--- a/packages/app/src/data/runs-list.test.ts
+++ b/packages/app/src/data/runs-list.test.ts
@@ -264,10 +264,10 @@ describe("getRunsList", () => {
     expect(mockedClickhouseQuery).toHaveBeenCalledTimes(1);
     expect(mockedClickhouseQuery.mock.calls[0]?.[0]).toContain("FROM (");
     expect(mockedClickhouseQuery.mock.calls[0]?.[0]).toContain(
-      "ResourceAttributes['cicd.pipeline.run.id'] LIKE {pattern:String}",
+      "toString(ResourceAttributes.`cicd.pipeline.run.id`) LIKE {pattern:String}",
     );
     expect(mockedClickhouseQuery.mock.calls[0]?.[0]).toContain(
-      "ResourceAttributes['cicd.pipeline.name'] ILIKE {pattern:String}",
+      "toString(ResourceAttributes.`cicd.pipeline.name`) ILIKE {pattern:String}",
     );
     expect(mockedClickhouseQuery.mock.calls[0]?.[2]).toEqual({
       pattern: "%Build%",

--- a/packages/app/src/data/runs-list/server.ts
+++ b/packages/app/src/data/runs-list/server.ts
@@ -317,11 +317,11 @@ export const searchRuns = createAuthenticatedServerFn({
       FROM (
         ${runSummarySubquery({
           whereClause: `Timestamp >= now() - INTERVAL 90 DAY
-            AND ResourceAttributes['cicd.pipeline.run.id'] != ''
-            AND ResourceAttributes['cicd.pipeline.task.run.result'] != ''
-            AND SpanAttributes['everr.github.workflow_job_step.number'] = ''
-            AND (ResourceAttributes['cicd.pipeline.run.id'] LIKE {pattern:String}
-              OR ResourceAttributes['cicd.pipeline.name'] ILIKE {pattern:String})`,
+            AND toString(ResourceAttributes.\`cicd.pipeline.run.id\`) != ''
+            AND toString(ResourceAttributes.\`cicd.pipeline.task.run.result\`) != ''
+            AND toString(SpanAttributes.\`everr.github.workflow_job_step.number\`) = ''
+            AND (toString(ResourceAttributes.\`cicd.pipeline.run.id\`) LIKE {pattern:String}
+              OR toString(ResourceAttributes.\`cicd.pipeline.name\`) ILIKE {pattern:String})`,
           groupByExpr: "TraceId",
           groupByAlias: "trace_id",
         })}

--- a/packages/app/src/data/runs/server.ts
+++ b/packages/app/src/data/runs/server.ts
@@ -38,12 +38,13 @@ function buildJobFilterClause(params: StepLogsJobFilter): {
   if (params.jobName !== undefined) {
     return {
       clause:
-        "AND ScopeAttributes['cicd.pipeline.task.name'] = {jobName:String}",
+        "AND toString(ScopeAttributes.`cicd.pipeline.task.name`) = {jobName:String}",
       queryParam: { jobName: params.jobName },
     };
   }
   return {
-    clause: "AND ScopeAttributes['cicd.pipeline.task.run.id'] = {jobId:String}",
+    clause:
+      "AND toString(ScopeAttributes.`cicd.pipeline.task.run.id`) = {jobId:String}",
     queryParam: { jobId: params.jobId },
   };
 }
@@ -64,7 +65,7 @@ async function countStepLogs(
     FROM logs
     WHERE TraceId = {traceId:String}
       ${jobClause}
-      AND LogAttributes['everr.github.workflow_job_step.number'] = {stepNumber:String}${egrepClause}
+      AND toString(LogAttributes.\`everr.github.workflow_job_step.number\`) = {stepNumber:String}${egrepClause}
   `;
   const queryParams: Record<string, string> = {
     traceId: params.traceId,
@@ -105,7 +106,7 @@ async function getRawStepLogs(
 		FROM logs
 		WHERE TraceId = {traceId:String}
 			${jobClause}
-			AND LogAttributes['everr.github.workflow_job_step.number'] = {stepNumber:String}${egrepClause}
+			AND toString(LogAttributes.\`everr.github.workflow_job_step.number\`) = {stepNumber:String}${egrepClause}
 		ORDER BY Timestamp ${order}
 		${limitClause}
 		${offsetClause}
@@ -205,18 +206,18 @@ export const getRunJobs = createAuthenticatedServerFn({
         firstFailingStep: string;
       }>(
         `SELECT
-            ResourceAttributes['cicd.pipeline.task.run.id'] as jobId,
-            anyLast(ResourceAttributes['cicd.pipeline.task.name']) as name,
-            anyLast(ResourceAttributes['cicd.pipeline.task.run.result']) as conclusion,
+            toString(ResourceAttributes.\`cicd.pipeline.task.run.id\`) as jobId,
+            anyLast(toString(ResourceAttributes.\`cicd.pipeline.task.name\`)) as name,
+            anyLast(toString(ResourceAttributes.\`cicd.pipeline.task.run.result\`)) as conclusion,
             max(Duration) / 1000000 as duration,
             minIf(
-              toUInt32OrZero(SpanAttributes['everr.github.workflow_job_step.number']),
-              SpanAttributes['everr.github.workflow_job_step.number'] != ''
+              toUInt32OrZero(toString(SpanAttributes.\`everr.github.workflow_job_step.number\`)),
+              toString(SpanAttributes.\`everr.github.workflow_job_step.number\`) != ''
                 AND lowerUTF8(StatusMessage) IN ('failure', 'failed')
             ) as firstFailingStep
           FROM traces
           WHERE TraceId = {traceId:String}
-            AND ResourceAttributes['cicd.pipeline.task.run.id'] != ''
+            AND toString(ResourceAttributes.\`cicd.pipeline.task.run.id\`) != ''
           GROUP BY jobId
           ORDER BY min(Timestamp)`,
         { traceId },
@@ -278,17 +279,17 @@ export const getAllJobsSteps = createAuthenticatedServerFn({
     const result: Record<string, Step[]> = {};
     const sql = `
       SELECT
-        ResourceAttributes['cicd.pipeline.task.run.id'] as jobId,
+        toString(ResourceAttributes.\`cicd.pipeline.task.run.id\`) as jobId,
         SpanName as name,
-        SpanAttributes['everr.github.workflow_job_step.number'] as stepNumber,
+        toString(SpanAttributes.\`everr.github.workflow_job_step.number\`) as stepNumber,
         StatusMessage as conclusion,
         Duration / 1000000 as duration,
         toUnixTimestamp64Milli(Timestamp) as startTime,
         toUnixTimestamp64Milli(Timestamp) + intDiv(Duration, 1000000) as endTime
       FROM traces
       WHERE TraceId = {traceId:String}
-        AND ResourceAttributes['cicd.pipeline.task.run.id'] IN {jobIds:Array(String)}
-        AND SpanAttributes['everr.github.workflow_job_step.number'] != ''
+        AND toString(ResourceAttributes.\`cicd.pipeline.task.run.id\`) IN {jobIds:Array(String)}
+        AND toString(SpanAttributes.\`everr.github.workflow_job_step.number\`) != ''
       ORDER BY jobId, toUInt32OrZero(stepNumber)
     `;
     const rows = await clickhouse.query<{
@@ -394,18 +395,18 @@ export const getRunSpans = createAuthenticatedServerFn({
 				toUnixTimestamp64Milli(Timestamp) + if(lowerUTF8(StatusMessage) = 'skip', toUInt64(0), intDiv(Duration, 1000000)) as endTime,
 				if(lowerUTF8(StatusMessage) = 'skip', toUInt64(0), intDiv(Duration, 1000000)) as duration,
 				StatusMessage as conclusion,
-				ResourceAttributes['cicd.pipeline.task.run.id'] as jobId,
-				ResourceAttributes['cicd.pipeline.task.name'] as jobName,
-				SpanAttributes['everr.github.workflow_job_step.number'] as stepNumber,
-				ResourceAttributes['everr.github.workflow_job.created_at'] as createdAt,
-				ResourceAttributes['everr.github.workflow_job.started_at'] as startedAt,
-				ResourceAttributes['vcs.ref.head.name'] as headBranch,
-				ResourceAttributes['vcs.ref.head.revision'] as headSha,
-				ResourceAttributes['cicd.worker.name'] as runnerName,
-				ResourceAttributes['cicd.pipeline.worker.labels'] as labels,
-				ResourceAttributes['cicd.pipeline.task.run.sender.login'] as sender,
-				ResourceAttributes['everr.github.workflow_job.run_attempt'] as runAttempt,
-				ResourceAttributes['cicd.pipeline.task.run.url.full'] as htmlUrl
+				toString(ResourceAttributes.\`cicd.pipeline.task.run.id\`) as jobId,
+				toString(ResourceAttributes.\`cicd.pipeline.task.name\`) as jobName,
+				toString(SpanAttributes.\`everr.github.workflow_job_step.number\`) as stepNumber,
+				toString(ResourceAttributes.\`everr.github.workflow_job.created_at\`) as createdAt,
+				toString(ResourceAttributes.\`everr.github.workflow_job.started_at\`) as startedAt,
+				toString(ResourceAttributes.\`vcs.ref.head.name\`) as headBranch,
+				toString(ResourceAttributes.\`vcs.ref.head.revision\`) as headSha,
+				toString(ResourceAttributes.\`cicd.worker.name\`) as runnerName,
+				toString(ResourceAttributes.\`cicd.pipeline.worker.labels\`) as labels,
+				toString(ResourceAttributes.\`cicd.pipeline.task.run.sender.login\`) as sender,
+				toString(ResourceAttributes.\`everr.github.workflow_job.run_attempt\`) as runAttempt,
+				toString(ResourceAttributes.\`cicd.pipeline.task.run.url.full\`) as htmlUrl
 			FROM traces
 			WHERE TraceId = {traceId:String}
 			ORDER BY startTime ASC

--- a/packages/app/src/data/workflows/server.ts
+++ b/packages/app/src/data/workflows/server.ts
@@ -37,7 +37,7 @@ const JOB_COST_FILTER = [
   nonEmptyResourceAttribute("cicd.pipeline.worker.labels"),
   nonEmptyResourceAttribute("cicd.pipeline.task.run.id"),
   `lowerUTF8(${resourceAttribute("cicd.pipeline.task.run.result")}) != 'skip'`,
-  "SpanAttributes['everr.github.workflow_job_step.number'] = ''",
+  "toString(SpanAttributes.`everr.github.workflow_job_step.number`) = ''",
 ].join(AND);
 
 export const getWorkflowCostSummary = createAuthenticatedServerFn({
@@ -72,7 +72,7 @@ export const getWorkflowCostSummary = createAuthenticatedServerFn({
       }>(
         `
 				SELECT
-					ResourceAttributes['cicd.pipeline.worker.labels'] as labels,
+					toString(ResourceAttributes.\`cicd.pipeline.worker.labels\`) as labels,
 					sumIf(Duration, Timestamp >= {fromTime:String}) / 1000000 as currentDurationMs,
 					sumIf(ceil(Duration / 60000000000.0), Timestamp >= {fromTime:String}) as currentRoundedMinutes,
 					sumIf(Duration, Timestamp < {fromTime:String}) / 1000000 as prevDurationMs,
@@ -103,7 +103,7 @@ export const getWorkflowCostSummary = createAuthenticatedServerFn({
 					FROM traces
 					WHERE Timestamp >= {prevFromTime:String} AND Timestamp <= {toTime:String}
 						AND ${RUN_FILTER}
-					GROUP BY ResourceAttributes['cicd.pipeline.run.id']
+					GROUP BY toString(ResourceAttributes.\`cicd.pipeline.run.id\`)
 				)
 			`,
         params,
@@ -118,7 +118,7 @@ export const getWorkflowCostSummary = createAuthenticatedServerFn({
         `
 				SELECT
 					toDate(Timestamp) as date,
-					ResourceAttributes['cicd.pipeline.worker.labels'] as labels,
+					toString(ResourceAttributes.\`cicd.pipeline.worker.labels\`) as labels,
 					sum(Duration) / 1000000 as durationMs,
 					sum(ceil(Duration / 60000000000.0)) as roundedMinutes
 				FROM traces
@@ -199,9 +199,9 @@ export const getWorkflowCostByJob = createAuthenticatedServerFn({
     }>(
       `
 			SELECT
-				ResourceAttributes['cicd.pipeline.task.name'] as job,
-				ResourceAttributes['cicd.pipeline.worker.labels'] as labels,
-				uniqExact(ResourceAttributes['cicd.pipeline.run.id']) as runs,
+				toString(ResourceAttributes.\`cicd.pipeline.task.name\`) as job,
+				toString(ResourceAttributes.\`cicd.pipeline.worker.labels\`) as labels,
+				uniqExact(toString(ResourceAttributes.\`cicd.pipeline.run.id\`)) as runs,
 				sum(Duration) / 1000000 as durationMs,
 				sum(ceil(Duration / 60000000000.0)) as roundedMinutes
 			FROM traces
@@ -270,8 +270,8 @@ export const getWorkflowRunTimelines = createAuthenticatedServerFn({
       `
 			SELECT
 				TraceId as trace_id,
-				anyLast(ResourceAttributes['cicd.pipeline.run.id']) as run_id,
-				anyLast(toUInt32OrZero(ResourceAttributes['everr.github.workflow_job.run_attempt'])) as run_attempt,
+				anyLast(toString(ResourceAttributes.\`cicd.pipeline.run.id\`)) as run_id,
+				anyLast(toUInt32OrZero(toString(ResourceAttributes.\`everr.github.workflow_job.run_attempt\`))) as run_attempt,
 				${CONCLUSION_EXPR} as conclusion,
 				max(Timestamp) as timestamp
 			FROM traces
@@ -307,17 +307,17 @@ export const getWorkflowRunTimelines = createAuthenticatedServerFn({
       `
 			SELECT
 				TraceId as trace_id,
-				ResourceAttributes['cicd.pipeline.task.run.id'] as jobId,
-				anyLast(ResourceAttributes['cicd.pipeline.task.name']) as name,
-				anyLast(ResourceAttributes['cicd.pipeline.task.run.result']) as conclusion,
-				anyLast(ResourceAttributes['cicd.pipeline.worker.labels']) as labels,
+				toString(ResourceAttributes.\`cicd.pipeline.task.run.id\`) as jobId,
+				anyLast(toString(ResourceAttributes.\`cicd.pipeline.task.name\`)) as name,
+				anyLast(toString(ResourceAttributes.\`cicd.pipeline.task.run.result\`)) as conclusion,
+				anyLast(toString(ResourceAttributes.\`cicd.pipeline.worker.labels\`)) as labels,
 				min(toUnixTimestamp64Milli(Timestamp)) as startMs,
 				max(toUnixTimestamp64Milli(Timestamp) + intDiv(Duration, 1000000)) as endMs,
 				max(Duration) / 1000000 as durationMs
 			FROM traces
 			WHERE TraceId IN {traceIds:Array(String)}
 				AND ${nonEmptyResourceAttribute("cicd.pipeline.task.run.id")}
-				AND SpanAttributes['everr.github.workflow_job_step.number'] = ''
+				AND toString(SpanAttributes.\`everr.github.workflow_job_step.number\`) = ''
 			GROUP BY trace_id, jobId
 			ORDER BY startMs ASC
 		`,
@@ -385,7 +385,7 @@ export const getWorkflowRecentRuns = createAuthenticatedServerFn({
       whereClause: `Timestamp >= {fromTime:String} AND Timestamp <= {toTime:String}
 					AND ${RUN_FILTER}
 					AND ${nonEmptyResourceAttribute("cicd.pipeline.task.run.result")}
-					AND SpanAttributes['everr.github.workflow_job_step.number'] = ''`,
+					AND toString(SpanAttributes.\`everr.github.workflow_job_step.number\`) = ''`,
       groupByExpr: "TraceId",
       groupByAlias: "trace_id",
       includeRunAttempt: true,
@@ -420,8 +420,8 @@ export const getWorkflowRecentRuns = createAuthenticatedServerFn({
       }>(
         `
 				SELECT
-					ResourceAttributes['cicd.pipeline.run.id'] as run_id,
-					ResourceAttributes['cicd.pipeline.worker.labels'] as labels,
+					toString(ResourceAttributes.\`cicd.pipeline.run.id\`) as run_id,
+					toString(ResourceAttributes.\`cicd.pipeline.worker.labels\`) as labels,
 					sum(Duration) / 1000000 as durationMs,
 					sum(ceil(Duration / 60000000000.0)) as roundedMinutes
 				FROM traces

--- a/packages/docs/content/docs/reference/attributes.mdx
+++ b/packages/docs/content/docs/reference/attributes.mdx
@@ -1,0 +1,59 @@
+---
+title: Attribute columns
+description: How to read span, log and resource attributes in SQL.
+---
+
+Logs and traces store their attributes in JSON columns: `LogAttributes`, `ScopeAttributes` and `ResourceAttributes` on `logs`, and `SpanAttributes` and `ResourceAttributes` on `traces`. Each column keeps the type the SDK sent, so an integer attribute is a number and a boolean is a boolean. Next to each column, an array named after it with the suffix `Keys` lists the keys present on the row, for example `LogAttributesKeys`.
+
+The metrics tables keep their maps: read `Attributes['key']` there.
+
+## Reading a key
+
+Put the key in backticks after the column and wrap the read in `toString`. Dots are part of the key. A missing key reads as an empty string.
+
+```sql
+SELECT toString(SpanAttributes.`http.route`) AS route, count()
+FROM traces
+WHERE Timestamp > now() - INTERVAL 1 HOUR
+GROUP BY route
+```
+
+## Comparing
+
+`toString` makes every comparison a text comparison, whatever type the SDK sent. For a number, convert the text.
+
+```sql
+WHERE toString(SpanAttributes.`http.request.method`) = 'POST'
+WHERE toUInt16OrZero(toString(SpanAttributes.`http.response.status_code`)) >= 500
+```
+
+A numeric comparison on the raw path, `` SpanAttributes.`http.response.status_code` >= 500 ``, works while every row it runs over holds a number. It fails with `NO_COMMON_TYPE` when a row holds text, which is what a `String` column does too. A query runs over your own rows only. Another tenant's types do not affect you. Two versions of your own SDK that disagree on the type do. The converted form works in every case. A typed read such as `` SpanAttributes.`k`.:Int64 `` is the one form to avoid: it returns `NULL` for every row whose stored type is different, silently.
+
+## Presence
+
+Test presence on the keys array; it is indexed. An empty-string test on the value also works but reads the value of every row in the window.
+
+```sql
+WHERE has(LogAttributesKeys, 'exception.type')
+WHERE NOT has(SpanAttributesKeys, 'everr.github.workflow_job_step.number')
+```
+
+## Listing keys
+
+```sql
+SELECT DISTINCT arrayJoin(LogAttributesKeys) AS key
+FROM logs
+WHERE Timestamp > now() - INTERVAL 1 HOUR
+ORDER BY key
+```
+
+## Moving from the map syntax
+
+| Before | After |
+|---|---|
+| `LogAttributes['k']` | `` toString(LogAttributes.`k`) `` |
+| `mapContains(LogAttributes, 'k')` | `has(LogAttributesKeys, 'k')` |
+| `toFloat64OrZero(LogAttributes['k'])` | `` toFloat64OrZero(toString(LogAttributes.`k`)) `` |
+| `mapKeys(LogAttributes)` | `LogAttributesKeys` |
+
+A map read on a JSON column is an error, not an empty result, so a saved query that still uses it fails loudly.

--- a/packages/docs/content/docs/reference/attributes.mdx
+++ b/packages/docs/content/docs/reference/attributes.mdx
@@ -5,6 +5,8 @@ description: How to read span, log and resource attributes in SQL.
 
 Logs and traces store their attributes in JSON columns: `LogAttributes`, `ScopeAttributes` and `ResourceAttributes` on `logs`, and `SpanAttributes` and `ResourceAttributes` on `traces`. Each column keeps the type the SDK sent, so an integer attribute is a number and a boolean is a boolean. Next to each column, an array named after it with the suffix `Keys` lists the keys present on the row, for example `LogAttributesKeys`.
 
+A `SELECT` of a whole attribute column returns a nested object, `{"http":{"route":"/x"}}` for the key `http.route`, not a flat map.
+
 The metrics tables keep their maps: read `Attributes['key']` there.
 
 ## Reading a key

--- a/packages/docs/content/docs/reference/meta.json
+++ b/packages/docs/content/docs/reference/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Reference",
   "defaultOpen": true,
-  "pages": ["cli", "mcp", "skills", "datemath", "retention", "dashboard-spec", "visualizations", "variables", "alert-spec", "alert-queries", "runbook-spec"]
+  "pages": ["cli", "mcp", "skills", "datemath", "retention", "attributes", "dashboard-spec", "visualizations", "variables", "alert-spec", "alert-queries", "runbook-spec"]
 }

--- a/packages/docs/src/components/agents-compare.tsx
+++ b/packages/docs/src/components/agents-compare.tsx
@@ -169,7 +169,7 @@ function GroundedColumn({ inView }: { inView: boolean }) {
         <div className="divide-y divide-fd-border/50 overflow-hidden rounded-lg border border-fd-border bg-fd-background/60">
           <QueryRow
             verb="everr cloud query"
-            sql="SELECT ResourceAttributes['service.version'] AS version, count() FROM traces WHERE ServiceName = 'checkout' AND StatusCode = 'Error' GROUP BY version"
+            sql="SELECT toString(ResourceAttributes.`service.version`) AS version, count() FROM traces WHERE ServiceName = 'checkout' AND StatusCode = 'Error' GROUP BY version"
             result={
               <>
                 37 errors ·{" "}

--- a/packages/telemetry-explorer/package.json
+++ b/packages/telemetry-explorer/package.json
@@ -7,6 +7,7 @@
     "./filters": "./src/filters/index.ts",
     "./logs": "./src/logs/index.ts",
     "./runs": "./src/runs/index.ts",
+    "./sql": "./src/sql/index.ts",
     "./styles.css": "./src/styles.css",
     "./traces": "./src/traces/index.ts"
   },

--- a/packages/telemetry-explorer/src/attribute-filter/sql/keys.test.ts
+++ b/packages/telemetry-explorer/src/attribute-filter/sql/keys.test.ts
@@ -14,10 +14,11 @@ describe("buildAttributeKeysQuery", () => {
       { timeRange: { from: "now-1h", to: "now" } },
       { tableName: "traces", sources: ["resource", "span"], columnFor },
     );
-    expect(sql).toContain("mapKeys(ResourceAttributes)");
+    expect(sql).toContain("arrayJoin(ResourceAttributesKeys)");
     expect(sql).toContain("'resource' AS source");
-    expect(sql).toContain("mapKeys(SpanAttributes)");
+    expect(sql).toContain("arrayJoin(SpanAttributesKeys)");
     expect(sql).toContain("'span' AS source");
+    expect(sql).not.toContain("mapKeys(");
     expect(sql).toContain("UNION ALL");
     expect(params.fromTime).toBeDefined();
     expect(params.toTime).toBeDefined();

--- a/packages/telemetry-explorer/src/attribute-filter/sql/keys.ts
+++ b/packages/telemetry-explorer/src/attribute-filter/sql/keys.ts
@@ -1,11 +1,14 @@
 import { resolveTimeRange, type TimeRange } from "@everr/ui/lib/time-range";
+import { attributeKeysColumn } from "../../sql/json-attributes";
 import { validateTableName } from "../../sql/table";
 import type { AttributeKey, AttributeSource } from "../schemas";
 import type { BuiltQuery } from "./types";
 
-// Cap each source independently so one high-cardinality map (e.g. log/span)
-// can't fill a single global limit and crowd out keys from the others. Key
-// names are low-cardinality in practice, so this effectively shows them all.
+// Cap each source independently so one high-cardinality keys array (e.g.
+// log/span) can't fill a single global limit and crowd out keys from the
+// others. Key names are low-cardinality in practice, so this effectively
+// shows them all. The keys array column costs only a few MiB per source to
+// scan, since it holds distinct key names rather than the attribute values.
 export const ATTRIBUTE_KEY_PER_SOURCE_LIMIT = 200;
 
 export interface AttributeKeyRowRaw {
@@ -41,7 +44,7 @@ export function buildAttributeKeysQuery(
   const selects = opts.sources.map(
     (source) => `
         SELECT key, source FROM (
-          SELECT DISTINCT arrayJoin(mapKeys(${opts.columnFor(source)})) AS key, '${source}' AS source
+          SELECT DISTINCT arrayJoin(${attributeKeysColumn(opts.columnFor(source))}) AS key, '${source}' AS source
           FROM ${opts.tableName}
           WHERE ${timeColumn} >= ${timeBound("fromTime")}
             AND ${timeColumn} <= ${timeBound("toTime")}${scope}

--- a/packages/telemetry-explorer/src/attribute-filter/sql/values.test.ts
+++ b/packages/telemetry-explorer/src/attribute-filter/sql/values.test.ts
@@ -18,8 +18,8 @@ describe("buildAttributeValuesQuery", () => {
       },
       { tableName: "traces", columnFor },
     );
-    expect(sql).toContain("SpanAttributes[{key:String}] AS v");
-    expect(sql).toContain("mapContains(SpanAttributes, {key:String})");
+    expect(sql).toContain("toString(SpanAttributes.`http.route`) AS v");
+    expect(sql).toContain("has(SpanAttributesKeys, {key:String})");
     expect(sql).toContain("LIMIT 100");
     expect(params.key).toBe("http.route");
     expect(params.fromTime).toBeDefined();
@@ -38,7 +38,7 @@ describe("buildAttributeValuesQuery", () => {
       { tableName: "traces", columnFor },
     );
     expect(sql).toContain(
-      "positionCaseInsensitive(SpanAttributes[{key:String}], {valueSearch:String}) > 0",
+      "positionCaseInsensitive(toString(SpanAttributes.`http.route`), {valueSearch:String}) > 0",
     );
     expect(params.valueSearch).toBe("/api");
   });

--- a/packages/telemetry-explorer/src/attribute-filter/sql/values.ts
+++ b/packages/telemetry-explorer/src/attribute-filter/sql/values.ts
@@ -1,4 +1,5 @@
 import { resolveTimeRange, type TimeRange } from "@everr/ui/lib/time-range";
+import { attributeKeysColumn, attributeText } from "../../sql/json-attributes";
 import { validateTableName } from "../../sql/table";
 import type { AttributeSource } from "../schemas";
 import type { BuiltQuery } from "./types";
@@ -35,6 +36,7 @@ export function buildAttributeValuesQuery(
   const timeBound =
     opts.timeBound ?? ((param) => `parseDateTimeBestEffort({${param}:String})`);
   const column = opts.columnFor(input.source);
+  const value = attributeText(column, input.key);
   const { fromISO, toISO } = resolveTimeRange(input.timeRange);
   const params: Record<string, unknown> = {
     fromTime: fromISO,
@@ -44,23 +46,21 @@ export function buildAttributeValuesQuery(
   const filters = [
     `${timeColumn} >= ${timeBound("fromTime")}`,
     `${timeColumn} <= ${timeBound("toTime")}`,
-    `mapContains(${column}, {key:String})`,
-    `${column}[{key:String}] != ''`,
+    `has(${attributeKeysColumn(column)}, {key:String})`,
+    `${value} != ''`,
   ];
   if (opts.rowPredicate) {
     filters.push(`(${opts.rowPredicate})`);
   }
   // Server-side substring match so high-cardinality values past the LIMIT
-  // cutoff remain reachable — the user types and the matching slice is fetched.
+  // cutoff remain reachable: the user types and the matching slice is fetched.
   const search = input.search?.trim();
   if (search) {
-    filters.push(
-      `positionCaseInsensitive(${column}[{key:String}], {valueSearch:String}) > 0`,
-    );
+    filters.push(`positionCaseInsensitive(${value}, {valueSearch:String}) > 0`);
     params.valueSearch = search;
   }
   const sql = `
-      SELECT DISTINCT ${column}[{key:String}] AS v
+      SELECT DISTINCT ${value} AS v
       FROM ${opts.tableName}
       WHERE ${filters.join("\n        AND ")}
       ORDER BY v

--- a/packages/telemetry-explorer/src/attribute-filter/sql/where.test.ts
+++ b/packages/telemetry-explorer/src/attribute-filter/sql/where.test.ts
@@ -24,7 +24,7 @@ describe("buildAttributeClauses", () => {
       columnFor,
     );
     expect(clauses[0]).toBe(
-      "mapContains(ResourceAttributes, {attrKey0:String}) AND ResourceAttributes[{attrKey0:String}] IN {attrVals0:Array(String)}",
+      "has(ResourceAttributesKeys, {attrKey0:String}) AND toString(ResourceAttributes.`deployment.environment`) IN {attrVals0:Array(String)}",
     );
     expect(params).toEqual({
       attrKey0: "deployment.environment",
@@ -38,7 +38,7 @@ describe("buildAttributeClauses", () => {
       columnFor,
     );
     expect(clauses[0]).toBe(
-      "(mapContains(LogAttributes, {attrKey0:String}) AND LogAttributes[{attrKey0:String}] NOT IN {attrVals0:Array(String)})",
+      "(has(LogAttributesKeys, {attrKey0:String}) AND toString(LogAttributes.`http.method`) NOT IN {attrVals0:Array(String)})",
     );
   });
 
@@ -48,7 +48,7 @@ describe("buildAttributeClauses", () => {
       columnFor,
     );
     expect(exists.clauses[0]).toBe(
-      "mapContains(ScopeAttributes, {attrKey0:String})",
+      "has(ScopeAttributesKeys, {attrKey0:String})",
     );
     expect(exists.params).toEqual({ attrKey0: "k" });
 
@@ -57,7 +57,7 @@ describe("buildAttributeClauses", () => {
       columnFor,
     );
     expect(missing.clauses[0]).toBe(
-      "NOT mapContains(SpanAttributes, {attrKey0:String})",
+      "NOT has(SpanAttributesKeys, {attrKey0:String})",
     );
   });
 
@@ -76,9 +76,18 @@ describe("buildAttributeClauses", () => {
       columnFor,
       3,
     );
-    expect(clauses[0]).toBe(
-      "mapContains(ResourceAttributes, {attrKey3:String})",
-    );
+    expect(clauses[0]).toBe("has(ResourceAttributesKeys, {attrKey3:String})");
     expect(params).toEqual({ attrKey3: "k" });
+  });
+
+  it("escapes the key in the identifier and leaves the param as typed", () => {
+    const { clauses, params } = buildAttributeClauses(
+      [{ source: "log", key: "a`b", op: "in", values: ["x"] }],
+      columnFor,
+    );
+    expect(clauses[0]).toBe(
+      "has(LogAttributesKeys, {attrKey0:String}) AND toString(LogAttributes.`a\\`b`) IN {attrVals0:Array(String)}",
+    );
+    expect(params.attrKey0).toBe("a`b");
   });
 });

--- a/packages/telemetry-explorer/src/attribute-filter/sql/where.ts
+++ b/packages/telemetry-explorer/src/attribute-filter/sql/where.ts
@@ -1,9 +1,12 @@
+import { attributeKeysColumn, attributeText } from "../../sql/json-attributes";
 import type { AttributeFilter, AttributeSource } from "../schemas";
 
-// Builds the attribute-map predicates shared by every domain's WHERE clause.
-// `columnFor` maps a source to its ClickHouse Map column; `startIndex` lets a
-// caller that already has positional params avoid name collisions. Param names
-// are `attrKey{i}` / `attrVals{i}`.
+// Builds the attribute predicates shared by every domain's WHERE clause.
+// `columnFor` maps a source to its JSON attribute column. The key goes into
+// the SQL text as a quoted identifier, because only `col.`key`` reads that
+// path's subcolumn, and into a parameter for the keys-array test, which the
+// bloom index prunes. `startIndex` lets a caller that already has positional
+// params avoid name collisions. Param names are `attrKey{i}` / `attrVals{i}`.
 export function buildAttributeClauses(
   attributes: AttributeFilter[],
   columnFor: (source: AttributeSource) => string,
@@ -17,36 +20,35 @@ export function buildAttributeClauses(
     const column = columnFor(filter.source);
     const keyParam = `attrKey${index}`;
     const valsParam = `attrVals${index}`;
-    const contains = `mapContains(${column}, {${keyParam}:String})`;
-    const access = `${column}[{${keyParam}:String}]`;
+    const exists = `has(${attributeKeysColumn(column)}, {${keyParam}:String})`;
+    const text = attributeText(column, filter.key);
 
     switch (filter.op) {
       case "in":
         if (filter.values.length === 0) return;
         params[keyParam] = filter.key;
-        clauses.push(
-          `${contains} AND ${access} IN {${valsParam}:Array(String)}`,
-        );
+        clauses.push(`${exists} AND ${text} IN {${valsParam}:Array(String)}`);
         params[valsParam] = filter.values;
         break;
       case "not_in":
-        // Require the key to exist: "is not" means present-with-a-different
+        // Require the key to exist: "is not" means present with a different
         // value, not absent. The dedicated `missing` op covers absence, which
-        // keeps the four operators a clean partition (in ∪ not_in = exists).
+        // keeps the four operators a clean partition: in plus not_in equals
+        // exists.
         if (filter.values.length === 0) return;
         params[keyParam] = filter.key;
         clauses.push(
-          `(${contains} AND ${access} NOT IN {${valsParam}:Array(String)})`,
+          `(${exists} AND ${text} NOT IN {${valsParam}:Array(String)})`,
         );
         params[valsParam] = filter.values;
         break;
       case "exists":
         params[keyParam] = filter.key;
-        clauses.push(contains);
+        clauses.push(exists);
         break;
       case "missing":
         params[keyParam] = filter.key;
-        clauses.push(`NOT ${contains}`);
+        clauses.push(`NOT ${exists}`);
         break;
     }
   });

--- a/packages/telemetry-explorer/src/errors/data/repository.test.ts
+++ b/packages/telemetry-explorer/src/errors/data/repository.test.ts
@@ -166,6 +166,57 @@ describe("ErrorsRepository.getIssue", () => {
     expect(detail.latest.resourceAttributes).toEqual({});
     expect(detail.occurrences).toHaveLength(1);
   });
+
+  it("flattens the nested JSON attributes of an occurrence into dotted keys", async () => {
+    execute
+      .mockResolvedValueOnce([
+        {
+          fingerprint: "fp-1",
+          exceptionType: "TypeError",
+          exceptionMessage: "boom",
+          body: "boom",
+          latestServiceName: "web",
+          services: ["web"],
+          occurrenceCount: "1",
+          traceCount: "1",
+          firstSeen: "2026-05-26 10:00:00.000000000",
+          lastSeen: "2026-05-26 10:05:00.000000000",
+          latestTraceId: "trace-1",
+          latestSpanId: "span-1",
+          latestTimestamp: "2026-05-26 10:05:00.000000000",
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          fingerprint: "fp-1",
+          timestamp: "2026-05-26 10:05:00.000000000",
+          serviceName: "web",
+          traceId: "trace-1",
+          spanId: "span-1",
+          body: "boom",
+          exceptionType: "TypeError",
+          exceptionMessage: "boom",
+          exceptionStacktrace: "at x",
+          resourceAttributes: { service: { name: "web" } },
+          logAttributes: { exception: { type: "E" } },
+          scopeAttributes: null,
+        },
+      ]);
+
+    const detail = await makeRepo().getIssue({
+      fingerprint: "fp-1",
+      fromTs: "2026-05-26 10:00:00",
+      toTs: "2026-05-26 11:00:00",
+      service: [],
+      occurrenceLimit: 50,
+    });
+
+    expect(detail.latest.resourceAttributes).toEqual({
+      "service.name": "web",
+    });
+    expect(detail.latest.logAttributes).toEqual({ "exception.type": "E" });
+    expect(detail.latest.scopeAttributes).toEqual({});
+  });
 });
 
 describe("ErrorsRepository.listServices", () => {

--- a/packages/telemetry-explorer/src/errors/data/repository.ts
+++ b/packages/telemetry-explorer/src/errors/data/repository.ts
@@ -13,6 +13,7 @@ import {
   buildAttributeValuesQuery,
   decodeAttributeValueRows,
 } from "../../attribute-filter/sql/values";
+import { flattenAttributes } from "../../sql/json-attributes";
 import {
   ERRORS_ATTRIBUTE_SOURCES,
   errorsAttributeColumn,
@@ -44,11 +45,14 @@ type ErrorIssueSummaryRow = Omit<
   traceCount: string | number;
 };
 
-type ErrorOccurrenceRow = Omit<ErrorOccurrence, "timestampRank"> & {
+type ErrorOccurrenceRow = Omit<
+  ErrorOccurrence,
+  "timestampRank" | "resourceAttributes" | "logAttributes" | "scopeAttributes"
+> & {
   timestampRank?: string | number;
-  resourceAttributes: Record<string, string> | null;
-  logAttributes: Record<string, string> | null;
-  scopeAttributes: Record<string, string> | null;
+  resourceAttributes: unknown;
+  logAttributes: unknown;
+  scopeAttributes: unknown;
 };
 
 type ServiceRow = { serviceName: string };
@@ -66,9 +70,9 @@ function mapOccurrence(row: ErrorOccurrenceRow): ErrorOccurrence {
     ...row,
     timestampRank:
       row.timestampRank === undefined ? 1 : Number(row.timestampRank),
-    resourceAttributes: row.resourceAttributes ?? {},
-    logAttributes: row.logAttributes ?? {},
-    scopeAttributes: row.scopeAttributes ?? {},
+    resourceAttributes: flattenAttributes(row.resourceAttributes),
+    logAttributes: flattenAttributes(row.logAttributes),
+    scopeAttributes: flattenAttributes(row.scopeAttributes),
   };
 }
 

--- a/packages/telemetry-explorer/src/errors/sql/fingerprint.ts
+++ b/packages/telemetry-explorer/src/errors/sql/fingerprint.ts
@@ -1,18 +1,20 @@
+import { attributeExists, attributeText } from "../../sql/json-attributes";
+
 // Everr's stable identity for an Error. The expression lives in the
 // `errorFingerprint` ClickHouse UDF
 // (clickhouse/init/04-create-error-fingerprint-function.sql and the local
 // collector's copy), so the web app, local collector, agents, and skills all
 // group Errors identically instead of each carrying a copy of the SQL. Callers
-// pass ServiceName and the whole LogAttributes; the UDF reads
-// error.fingerprint / exception.type / exception.message from it.
-export const ERROR_FINGERPRINT_SQL = `errorFingerprint(ServiceName, LogAttributes)`;
+// pass ServiceName and the three attributes the UDF reads, each as text, so
+// the query reads three subcolumns and never the whole LogAttributes column.
+export const ERROR_FINGERPRINT_SQL = `errorFingerprint(ServiceName, ${attributeText("LogAttributes", "error.fingerprint")}, ${attributeText("LogAttributes", "exception.type")}, ${attributeText("LogAttributes", "exception.message")})`;
 
 export const EXCEPTION_LOG_FILTER_SQL = `
-  mapContains(ResourceAttributes, 'service.name')
+  ${attributeExists("ResourceAttributes", "service.name")}
   AND SeverityNumber >= 17
   AND (
-    mapContains(LogAttributes, 'exception.type')
-    OR mapContains(LogAttributes, 'exception.message')
+    ${attributeExists("LogAttributes", "exception.type")}
+    OR ${attributeExists("LogAttributes", "exception.message")}
   )
 `;
 

--- a/packages/telemetry-explorer/src/errors/sql/issues.test.ts
+++ b/packages/telemetry-explorer/src/errors/sql/issues.test.ts
@@ -29,7 +29,7 @@ describe("error attribute filtering", () => {
       },
       "logs",
     );
-    expect(sql).toContain("mapContains(ResourceAttributes, {attrKey0:String})");
+    expect(sql).toContain("has(ResourceAttributesKeys, {attrKey0:String})");
     expect(params.attrKey0).toBe("deployment.environment");
     expect(params.attrVals0).toEqual(["prod"]);
   });
@@ -44,7 +44,7 @@ describe("error attribute filtering", () => {
       },
       "logs",
     );
-    expect(sql).toContain("mapContains(LogAttributes, {attrKey0:String})");
+    expect(sql).toContain("has(LogAttributesKeys, {attrKey0:String})");
   });
 
   it("omits attribute clauses when none are given", () => {

--- a/packages/telemetry-explorer/src/errors/sql/issues.ts
+++ b/packages/telemetry-explorer/src/errors/sql/issues.ts
@@ -42,8 +42,8 @@ function buildExceptionLogsCte(
   }
   if (input.q) {
     filters.push(`(
-      positionCaseInsensitive(LogAttributes['exception.type'], {q:String}) > 0
-      OR positionCaseInsensitive(LogAttributes['exception.message'], {q:String}) > 0
+      positionCaseInsensitive(toString(LogAttributes.\`exception.type\`), {q:String}) > 0
+      OR positionCaseInsensitive(toString(LogAttributes.\`exception.message\`), {q:String}) > 0
       OR positionCaseInsensitive(Body, {q:String}) > 0
     )`);
     params.q = input.q;
@@ -105,8 +105,8 @@ export function buildSummaryQuery(
       WITH ${cte.sql}
       SELECT
         fingerprint,
-        argMax(LogAttributes['exception.type'], Timestamp) AS exceptionType,
-        argMax(LogAttributes['exception.message'], Timestamp) AS exceptionMessage,
+        argMax(toString(LogAttributes.\`exception.type\`), Timestamp) AS exceptionType,
+        argMax(toString(LogAttributes.\`exception.message\`), Timestamp) AS exceptionMessage,
         argMax(Body, Timestamp) AS body,
         argMax(ServiceName, Timestamp) AS latestServiceName,
         groupUniqArray(ServiceName) AS services,
@@ -162,9 +162,9 @@ export function buildOccurrencesQuery(
         TraceId AS traceId,
         SpanId AS spanId,
         Body AS body,
-        LogAttributes['exception.type'] AS exceptionType,
-        LogAttributes['exception.message'] AS exceptionMessage,
-        LogAttributes['exception.stacktrace'] AS exceptionStacktrace,
+        toString(LogAttributes.\`exception.type\`) AS exceptionType,
+        toString(LogAttributes.\`exception.message\`) AS exceptionMessage,
+        toString(LogAttributes.\`exception.stacktrace\`) AS exceptionStacktrace,
         ResourceAttributes AS resourceAttributes,
         LogAttributes AS logAttributes,
         ScopeAttributes AS scopeAttributes

--- a/packages/telemetry-explorer/src/errors/ui/error-handoff-button.test.ts
+++ b/packages/telemetry-explorer/src/errors/ui/error-handoff-button.test.ts
@@ -30,7 +30,9 @@ describe("buildErrorHandoffPrompt", () => {
     expect(prompt).toContain("everr cloud query");
     // The embedded query calls the shared fingerprint UDF, narrowed to this
     // Fingerprint.
-    expect(prompt).toContain("errorFingerprint(ServiceName, LogAttributes)");
+    expect(prompt).toContain(
+      "errorFingerprint(ServiceName, toString(LogAttributes.`error.fingerprint`), toString(LogAttributes.`exception.type`), toString(LogAttributes.`exception.message`))",
+    );
     expect(prompt).toContain("= 'fp-1'");
   });
 

--- a/packages/telemetry-explorer/src/errors/ui/error-handoff-button.tsx
+++ b/packages/telemetry-explorer/src/errors/ui/error-handoff-button.tsx
@@ -13,7 +13,7 @@ import {
 function occurrencesQuery(fingerprint: string): string {
   return [
     "SELECT toString(Timestamp) AS timestamp, ServiceName, TraceId,",
-    "  LogAttributes['exception.stacktrace'] AS stacktrace",
+    "  toString(LogAttributes.`exception.stacktrace`) AS stacktrace",
     "FROM logs",
     "WHERE Timestamp > now() - INTERVAL 7 DAY",
     `  AND ${EXCEPTION_LOG_FILTER_SQL.trim()}`,

--- a/packages/telemetry-explorer/src/logs/sql/detail.test.ts
+++ b/packages/telemetry-explorer/src/logs/sql/detail.test.ts
@@ -34,4 +34,24 @@ describe("mapDetailRow", () => {
     expect(detail.severityNumber).toBe(17);
     expect(detail.timestamp).toMatch(/^2026-03-09T12:00:00/);
   });
+
+  it("flattens the nested JSON attributes into dotted keys", () => {
+    const detail = mapDetailRow({
+      timestampRaw: "2026-09-07 10:00:00.000000000",
+      level: "info",
+      severityText: "INFO",
+      severityNumber: 9,
+      serviceName: "api",
+      traceId: "",
+      spanId: "",
+      resourceAttributes: { service: { name: "api" } },
+      logAttributes: { http: { response: { status_code: 500 } } },
+      scopeAttributes: null,
+    });
+    expect(detail.resourceAttributes).toEqual({ "service.name": "api" });
+    expect(detail.logAttributes).toEqual({
+      "http.response.status_code": "500",
+    });
+    expect(detail.scopeAttributes).toEqual({});
+  });
 });

--- a/packages/telemetry-explorer/src/logs/sql/detail.ts
+++ b/packages/telemetry-explorer/src/logs/sql/detail.ts
@@ -1,3 +1,4 @@
+import { flattenAttributes } from "../../sql/json-attributes";
 import type { LogDetail, LogIdentity, LogLevel } from "../schemas";
 import { normalizeTimestampToUtc } from "../util/timestamp";
 import type { BuiltQuery } from "./explorer";
@@ -12,9 +13,9 @@ export interface DetailRowRaw {
   serviceName: string;
   traceId: string;
   spanId: string;
-  resourceAttributes: Record<string, string> | null;
-  logAttributes: Record<string, string> | null;
-  scopeAttributes: Record<string, string> | null;
+  resourceAttributes: unknown;
+  logAttributes: unknown;
+  scopeAttributes: unknown;
 }
 
 export function buildDetailQuery(
@@ -55,8 +56,8 @@ export function mapDetailRow(row: DetailRowRaw): LogDetail {
     serviceName: row.serviceName,
     traceId: row.traceId,
     spanId: row.spanId,
-    resourceAttributes: row.resourceAttributes ?? {},
-    logAttributes: row.logAttributes ?? {},
-    scopeAttributes: row.scopeAttributes ?? {},
+    resourceAttributes: flattenAttributes(row.resourceAttributes),
+    logAttributes: flattenAttributes(row.logAttributes),
+    scopeAttributes: flattenAttributes(row.scopeAttributes),
   };
 }

--- a/packages/telemetry-explorer/src/logs/sql/where.test.ts
+++ b/packages/telemetry-explorer/src/logs/sql/where.test.ts
@@ -55,11 +55,9 @@ describe("buildWhereClause", () => {
         },
       ],
     });
+    expect(clause).toContain("has(ResourceAttributesKeys, {attrKey0:String})");
     expect(clause).toContain(
-      "mapContains(ResourceAttributes, {attrKey0:String})",
-    );
-    expect(clause).toContain(
-      "ResourceAttributes[{attrKey0:String}] IN {attrVals0:Array(String)}",
+      "toString(ResourceAttributes.`deployment.environment`) IN {attrVals0:Array(String)}",
     );
     expect(params).toEqual({
       attrKey0: "deployment.environment",
@@ -76,7 +74,7 @@ describe("buildWhereClause", () => {
       ],
     });
     expect(clause).toContain(
-      "(mapContains(LogAttributes, {attrKey0:String}) AND LogAttributes[{attrKey0:String}] NOT IN {attrVals0:Array(String)})",
+      "(has(LogAttributesKeys, {attrKey0:String}) AND toString(LogAttributes.`http.method`) NOT IN {attrVals0:Array(String)})",
     );
   });
 
@@ -87,7 +85,7 @@ describe("buildWhereClause", () => {
       attributes: [{ source: "scope", key: "lib", op: "exists", values: [] }],
     });
     expect(exists.clause).toContain(
-      "mapContains(ScopeAttributes, {attrKey0:String})",
+      "has(ScopeAttributesKeys, {attrKey0:String})",
     );
     expect(exists.params).toEqual({ attrKey0: "lib" });
 
@@ -99,7 +97,7 @@ describe("buildWhereClause", () => {
       ],
     });
     expect(missing.clause).toContain(
-      "NOT mapContains(ResourceAttributes, {attrKey0:String})",
+      "NOT has(ResourceAttributesKeys, {attrKey0:String})",
     );
   });
 
@@ -166,7 +164,7 @@ describe("buildWhereClause", () => {
     // first filter (index 0) is skipped; second keeps its index-1 names
     expect(params).toEqual({ attrKey1: "b", attrVals1: ["x"] });
     expect(clause).toContain(
-      "LogAttributes[{attrKey1:String}] IN {attrVals1:Array(String)}",
+      "toString(LogAttributes.`b`) IN {attrVals1:Array(String)}",
     );
   });
 });

--- a/packages/telemetry-explorer/src/sql/index.ts
+++ b/packages/telemetry-explorer/src/sql/index.ts
@@ -1,0 +1,7 @@
+export {
+  attributeExists,
+  attributeKeysColumn,
+  attributeText,
+  flattenAttributes,
+  jsonPath,
+} from "./json-attributes";

--- a/packages/telemetry-explorer/src/sql/json-attributes.test.ts
+++ b/packages/telemetry-explorer/src/sql/json-attributes.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  attributeExists,
+  attributeKeysColumn,
+  attributeText,
+  flattenAttributes,
+  jsonPath,
+} from "./json-attributes";
+
+describe("jsonPath", () => {
+  it("renders the key as a quoted identifier after the column", () => {
+    expect(jsonPath("LogAttributes", "http.route")).toBe(
+      "LogAttributes.`http.route`",
+    );
+  });
+
+  it("escapes backticks and backslashes inside the key", () => {
+    expect(jsonPath("LogAttributes", "a`b")).toBe("LogAttributes.`a\\`b`");
+    expect(jsonPath("LogAttributes", "a\\b")).toBe("LogAttributes.`a\\\\b`");
+  });
+
+  it("leaves quotes, spaces and dots as they are", () => {
+    expect(jsonPath("SpanAttributes", "it's a key")).toBe(
+      "SpanAttributes.`it's a key`",
+    );
+  });
+});
+
+describe("attributeText", () => {
+  it("wraps the path in toString so comparisons are string equality", () => {
+    expect(attributeText("LogAttributes", "status")).toBe(
+      "toString(LogAttributes.`status`)",
+    );
+  });
+});
+
+describe("attributeKeysColumn and attributeExists", () => {
+  it("names the keys column next to the attribute column", () => {
+    expect(attributeKeysColumn("LogAttributes")).toBe("LogAttributesKeys");
+  });
+
+  it("tests presence on the keys column with an escaped literal", () => {
+    expect(attributeExists("LogAttributes", "http.route")).toBe(
+      "has(LogAttributesKeys, 'http.route')",
+    );
+    expect(attributeExists("LogAttributes", "it's")).toBe(
+      "has(LogAttributesKeys, 'it\\'s')",
+    );
+  });
+});
+
+describe("flattenAttributes", () => {
+  it("joins nested objects with dots and stringifies every leaf", () => {
+    expect(
+      flattenAttributes({
+        http: { route: "/x", response: { status_code: 500 } },
+        ok: true,
+      }),
+    ).toEqual({
+      "http.route": "/x",
+      "http.response.status_code": "500",
+      ok: "true",
+    });
+  });
+
+  it("returns an empty map for null, undefined, arrays and scalars", () => {
+    expect(flattenAttributes(null)).toEqual({});
+    expect(flattenAttributes(undefined)).toEqual({});
+    expect(flattenAttributes(["a"])).toEqual({});
+    expect(flattenAttributes("x")).toEqual({});
+  });
+
+  it("keeps array leaves as JSON text and skips null leaves", () => {
+    expect(flattenAttributes({ tags: ["a", "b"], gone: null })).toEqual({
+      tags: '["a","b"]',
+    });
+  });
+
+  it("passes a flat map through unchanged", () => {
+    expect(flattenAttributes({ "service.name": "api" })).toEqual({
+      "service.name": "api",
+    });
+  });
+});

--- a/packages/telemetry-explorer/src/sql/json-attributes.ts
+++ b/packages/telemetry-explorer/src/sql/json-attributes.ts
@@ -1,0 +1,61 @@
+// Attribute columns on logs and traces are ClickHouse JSON columns. A path is
+// read as `column.`key``: that form reads only the path's subcolumn, while
+// getSubcolumn(column, {key:String}) reads the whole column, so the key goes
+// into the SQL text as an identifier and never into a parameter. Quoted
+// identifiers and string literals both use backslash escapes.
+function quoteIdentifier(name: string): string {
+  return `\`${name.replace(/\\/g, "\\\\").replace(/`/g, "\\`")}\``;
+}
+
+function quoteLiteral(value: string): string {
+  return `'${value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
+}
+
+export function jsonPath(column: string, key: string): string {
+  return `${column}.${quoteIdentifier(key)}`;
+}
+
+// Values are typed, so a read goes through toString: string equality whatever
+// the producer sent, the same subcolumn read, and '' for a missing key, which
+// is what the Map column gave.
+export function attributeText(column: string, key: string): string {
+  return `toString(${jsonPath(column, key)})`;
+}
+
+export function attributeKeysColumn(column: string): string {
+  return `${column}Keys`;
+}
+
+// Presence is tested on the keys array, which the bloom index serves. A test
+// on the value reads the subcolumn of every granule instead.
+export function attributeExists(column: string, key: string): string {
+  return `has(${attributeKeysColumn(column)}, ${quoteLiteral(key)})`;
+}
+
+// ClickHouse returns a JSON column as a nested object: a key `http.route`
+// comes back as {"http":{"route":...}}. OTel attribute keys are flat, so the
+// nesting is undone by joining with dots. Every leaf becomes text; 64-bit
+// integers already arrive quoted.
+export function flattenAttributes(value: unknown): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return out;
+  }
+  const walk = (node: Record<string, unknown>, prefix: string) => {
+    for (const [name, leaf] of Object.entries(node)) {
+      const key = prefix ? `${prefix}.${name}` : name;
+      if (leaf === null || leaf === undefined) continue;
+      if (Array.isArray(leaf)) {
+        out[key] = JSON.stringify(leaf);
+        continue;
+      }
+      if (typeof leaf === "object") {
+        walk(leaf as Record<string, unknown>, key);
+        continue;
+      }
+      out[key] = String(leaf);
+    }
+  };
+  walk(value as Record<string, unknown>, "");
+  return out;
+}

--- a/packages/telemetry-explorer/src/sql/resource-attributes.ts
+++ b/packages/telemetry-explorer/src/sql/resource-attributes.ts
@@ -1,7 +1,9 @@
+import { attributeExists, attributeText } from "./json-attributes";
+
 export function resourceAttribute(key: string): string {
-  return `ResourceAttributes['${key}']`;
+  return attributeText("ResourceAttributes", key);
 }
 
 export function resourceAttributeKeyExists(key: string): string {
-  return `mapContains(ResourceAttributes, '${key}')`;
+  return attributeExists("ResourceAttributes", key);
 }

--- a/packages/telemetry-explorer/src/traces/data/repository.test.ts
+++ b/packages/telemetry-explorer/src/traces/data/repository.test.ts
@@ -194,11 +194,9 @@ describe("TracesRepository.search", () => {
     expect(sql).not.toContain("{toTs:DateTime64(9)}");
     expect(sql).toContain("parseDateTime64BestEffort({fromTs:String}, 9)");
     expect(sql).toContain("parseDateTime64BestEffort({toTs:String}, 9)");
+    expect(sql).toContain("has(ResourceAttributesKeys, 'service.namespace')");
     expect(sql).toContain(
-      "mapContains(ResourceAttributes, 'service.namespace')",
-    );
-    expect(sql).toContain(
-      "ResourceAttributes['service.namespace'] IN {namespace:Array(String)}",
+      "toString(ResourceAttributes.`service.namespace`) IN {namespace:Array(String)}",
     );
   });
 
@@ -218,10 +216,10 @@ describe("TracesRepository.search", () => {
 
     const [sql] = query.mock.calls[0] ?? [];
     expect(sql).not.toContain(
-      "mapContains(ResourceAttributes, 'service.namespace')",
+      "has(ResourceAttributesKeys, 'service.namespace')",
     );
     expect(sql).toContain(
-      "ResourceAttributes['service.namespace'] IN {namespace:Array(String)}",
+      "toString(ResourceAttributes.`service.namespace`) IN {namespace:Array(String)}",
     );
   });
 
@@ -352,6 +350,44 @@ describe("TracesRepository.getTrace", () => {
     ]);
   });
 
+  it("flattens the nested JSON attribute columns into dotted keys", async () => {
+    query.mockResolvedValueOnce([
+      {
+        traceId: "t1",
+        spanId: "s1",
+        parentSpanId: "",
+        spanName: "root",
+        serviceName: "web",
+        serviceNamespace: "app",
+        timestamp: "2026-05-20 12:00:00.000",
+        timestampNs: "1000",
+        duration: "500",
+        statusCode: "Ok",
+        spanKind: "Server",
+        spanAttributes: { http: { route: "/x" } },
+        resourceAttributes: { service: { name: "api" } },
+        eventNames: ["exception"],
+        eventTimestamps: ["1010"],
+        eventAttributes: [{ exception: { type: "E" } }],
+        linkTraceIds: [],
+        linkSpanIds: [],
+        linkAttributes: [],
+      },
+    ]);
+
+    const result = await makeRepo().getTrace({
+      traceId: "t1",
+      fromTs: "2026-05-20 11:00:00.000",
+      toTs: "2026-05-20 13:00:00.000",
+    });
+
+    expect(result[0]?.spanAttributes).toEqual({ "http.route": "/x" });
+    expect(result[0]?.resourceAttributes).toEqual({ "service.name": "api" });
+    expect(result[0]?.events[0]?.attributes).toEqual({
+      "exception.type": "E",
+    });
+  });
+
   it("propagates query errors", async () => {
     query.mockRejectedValueOnce(new Error("not found"));
     await expect(
@@ -380,7 +416,7 @@ describe("TracesRepository.listServiceIdentities", () => {
     expect(result).toEqual(rows);
     const [sql, params] = query.mock.calls[0] ?? [];
     expect(sql).toContain("SELECT DISTINCT");
-    expect(sql).toContain("ResourceAttributes['service.namespace']");
+    expect(sql).toContain("toString(ResourceAttributes.`service.namespace`)");
     expect(params).toEqual({
       fromTs: "2026-05-20 11:00:00.000",
       toTs: "2026-05-20 13:00:00.000",

--- a/packages/telemetry-explorer/src/traces/data/repository.test.ts
+++ b/packages/telemetry-explorer/src/traces/data/repository.test.ts
@@ -417,7 +417,7 @@ describe("trace search attribute filtering", () => {
 
     const [sql, params] = query.mock.calls[0] ?? [];
     expect(sql).toContain("SELECT DISTINCT TraceId");
-    expect(sql).toContain("mapContains(SpanAttributes, {attrKey0:String})");
+    expect(sql).toContain("has(SpanAttributesKeys, {attrKey0:String})");
     expect(params.attrKey0).toBe("http.route");
     expect(params.attrVals0).toEqual(["/x"]);
   });
@@ -439,7 +439,7 @@ describe("trace search attribute filtering", () => {
     // A trace is excluded when *any* span has the key, rather than matched when
     // any span lacks it — otherwise every trace with a keyless DB span matches.
     expect(sql).toContain("TraceId NOT IN (");
-    expect(sql).toContain("mapContains(SpanAttributes,");
+    expect(sql).toContain("has(SpanAttributesKeys,");
     // No "any-span" candidate IN subquery, since there is no positive operator.
     expect(sql).not.toContain("AND TraceId IN (");
     expect(Object.values(params)).toContain("http.route");

--- a/packages/telemetry-explorer/src/traces/data/repository.ts
+++ b/packages/telemetry-explorer/src/traces/data/repository.ts
@@ -14,6 +14,7 @@ import {
   decodeAttributeValueRows,
 } from "../../attribute-filter/sql/values";
 import { buildAttributeClauses } from "../../attribute-filter/sql/where";
+import { attributeText, flattenAttributes } from "../../sql/json-attributes";
 import {
   resourceAttribute,
   resourceAttributeKeyExists,
@@ -31,13 +32,18 @@ import type {
 } from "./schemas";
 import type { ServiceIdentity, Span, TraceSummary } from "./types";
 
-type SpanRow = Omit<Span, "events" | "links"> & {
+type SpanRow = Omit<
+  Span,
+  "events" | "links" | "spanAttributes" | "resourceAttributes"
+> & {
+  spanAttributes: unknown;
+  resourceAttributes: unknown;
   eventNames: string[];
   eventTimestamps: string[];
-  eventAttributes: Record<string, string>[];
+  eventAttributes: unknown[];
   linkTraceIds: string[];
   linkSpanIds: string[];
-  linkAttributes: Record<string, string>[];
+  linkAttributes: unknown[];
 };
 
 const FROM_TS_SQL = "parseDateTime64BestEffort({fromTs:String}, 9)";
@@ -49,13 +55,13 @@ const SERVICE_NAMESPACE_RESOURCE_ATTRIBUTE = "service.namespace";
 // stable OpenTelemetry attribute. `http.status_code` is the name before version
 // 1.23 that some SDKs still send.
 //
-// A key that is absent from a Map reads as '' in ClickHouse. The second choice
-// is therefore a test for an empty string, and no test for null is necessary. A
-// span that is not an HTTP span gives ''.
+// toString of a missing path is '' in ClickHouse, the same as a key absent
+// from a Map. The second choice is therefore a test for an empty string, and
+// no test for null is necessary. A span that is not an HTTP span gives ''.
 const ROOT_HTTP_STATUS_CODE_SQL = `if(
-  SpanAttributes['http.response.status_code'] != '',
-  SpanAttributes['http.response.status_code'],
-  SpanAttributes['http.status_code']
+  ${attributeText("SpanAttributes", "http.response.status_code")} != '',
+  ${attributeText("SpanAttributes", "http.response.status_code")},
+  ${attributeText("SpanAttributes", "http.status_code")}
 )`;
 
 // Traces store Timestamp as DateTime64(9); attribute discovery must parse its
@@ -363,6 +369,8 @@ export type TracesRepositoryLike = Pick<
 
 function rowToSpan(row: SpanRow): Span {
   const {
+    spanAttributes,
+    resourceAttributes,
     eventNames,
     eventTimestamps,
     eventAttributes,
@@ -373,15 +381,17 @@ function rowToSpan(row: SpanRow): Span {
   } = row;
   return {
     ...rest,
+    spanAttributes: flattenAttributes(spanAttributes),
+    resourceAttributes: flattenAttributes(resourceAttributes),
     events: eventNames.map((name, i) => ({
       name,
       timestamp: eventTimestamps[i] ?? "",
-      attributes: eventAttributes[i] ?? {},
+      attributes: flattenAttributes(eventAttributes[i]),
     })),
     links: linkTraceIds.map((traceId, i) => ({
       traceId,
       spanId: linkSpanIds[i] ?? "",
-      attributes: linkAttributes[i] ?? {},
+      attributes: flattenAttributes(linkAttributes[i]),
     })),
   };
 }


### PR DESCRIPTION
Stacked on `ttl-improvements` (#426). Review this branch alone; the text below folds into #426 when it merges.

## What changes

**Log and span attributes are JSON columns**, exactly as upstream's exporter writes them with `json: true`: typed values and a `*Keys` array per attribute column with a `bloom_filter` index. A filter on one key, the key list of the filter UI and the values of one key read one column instead of the whole map. Measured on 26.5 with 4M rows: 4 to 7 ms against 24 to 32 on a filter, 9 against 36 on the key list and 42 against 312 at 1.3M rows, 10 to 16 against 37 to 80 on a value list. The one loss is the full-row fetch, 46 ms against 15. Every JSON column is `JSON(max_dynamic_paths = 256)`; the value is measured on production before the cut-over, see below. The strip of `everr.retention.days` is a `SKIP` on the column type. `errorFingerprint` takes the three attributes as text. Metrics keep their maps: the map is the series key there. Users of `/sql` and of as-code dashboards and alerts get a syntax change, documented in `reference/attributes`; the built-in dashboards and the resources under `everr/` are rewritten.

The local store (chDB) gets the same columns and bumps `localSchemaVersion` to 2, so a store built with Map columns is rebuilt once.

The trace id lookup view carries the JSON form of the stamp expressions. Since 5ea35d231 on `ttl-improvements` it reads the landing table instead of `app.traces`, so the collector user needs nothing in `app`.

## Read form

| Read | Form |
|---|---|
| Value of one key | `` toString(LogAttributes.`http.route`) `` (a missing key reads as `''`) |
| Presence | `has(LogAttributesKeys, 'http.route')` (indexed) |
| Number | `` toUInt16OrZero(toString(SpanAttributes.`http.response.status_code`)) `` |
| Key list | `arrayJoin(LogAttributesKeys)` |

Two traps. A comparison on the raw path, `` SpanAttributes.`k` >= 500 ``, fails with `NO_COMMON_TYPE` as soon as the rows it runs over hold a number and a text for the same key. A typed subcolumn, `` SpanAttributes.`k`.:Int64 ``, reads `NULL` for every row whose stored type is different, silently. The converted form works in every case.

## Rollout

Replaces step 3 of #426's rollout once merged.

Run `clickhouse/migrations/2026-09-03-direct-ingest.sh`, then deploy the collector with `json: true`, in that order: the JSON exporter's inserts fail against Map landing tables and the reverse too; the exporter's queue retries what falls in between. From the app deploy until this script ends, the app's reads fail (its queries use the JSON form against the Map columns): the runs list and detail, workflows, repo detail, cost analysis, the home CI panel, the explorers and the built-in dashboards. The three steps run back to back in one window. The script refuses to start if unstamped rows arrived in the last 10 minutes, drops every view, landing table and `app.*` table, re-runs `init/03`, `init/04`, `init/05`, `init/10` and `init/12`, creates the per-org policy on the lookup table for every `sql_api_org_*` user, drops the dictionary and checks all nine views came back. Then `everr apply ./everr` for the repo's own alert, dashboard and runbook queries.

## Open before merge

- `everr-deploy`: `json: true` on the ClickHouse exporter in `infra-v2/config/otel-collector-config.yaml`, deployed right after the cut-over.
- The shadow table on production for 24 hours (statements in the branch's plan), read for merge memory, merge duration and files per part. That reading confirms or changes `max_dynamic_paths = 256` before the cut-over.
- PR #426's description takes the "What changes" bullet and the rollout step when this branch merges.

## Verified

- `packages/telemetry-explorer`: 256 tests in 45 files pass, `pnpm typecheck` and `biome check src` clean; the desktop app's `tsc --noEmit` is clean against the changed `Span` and `ErrorOccurrence` types.
- `packages/app`: 444 tests in 47 files pass, `pnpm typecheck` clean, `biome check` clean on the changed files.
- Built-in dashboard catalog: 154 tests in 13 files pass and the manifest loads after the rewrite of 297 map reads.
- ClickHouse image built from `clickhouse/` and started on 26.5: all init scripts ran, 9 materialized views exist, `app.logs` shows `JSON(max_dynamic_paths = 256)` on the three attribute columns with `SKIP everr.retention.days` on `ResourceAttributes` and the three keys indexes. A log insert with a typed and a text `everr.retention.days` stamps `retention_days = 30` on both rows and strips the key from the document and the keys array; an insert without it is refused with the guard's message. A trace insert lands in `app.traces` and the trace id lookup table with `` toString(SpanAttributes.`everr.github.workflow_job_step.number`) `` reading `3` from an `Int64`. `errorFingerprint` folds the digits of two messages to one value and honors an explicit fingerprint.
- Collector: `config.example.yml` and the local `config.yml` parse with `json: true`.
- chDB: `go test ./...` passes in `collector/exporter/chdbexporter` and `collector/internal/localgateway/config`, `make lint` clean; `TestChDBRoundTripStoresTypedJSONAttributes` inserts a log and a span through the exporter and reads a typed `Int64` back through the JSON path.
- Docs: `pnpm types:check` passes in `packages/docs`.
- Rebuilt the dev stack from an empty volume: all init scripts ran, the app's queries ran against the JSON tables, and a container built from the branch accepts the collector user's JSON insert into the lookup table with its `otel.*` grants only.
