### PR TITLE
Add telemetry usage dashboard

### DIFF
--- a/collector/config.example.yml
+++ b/collector/config.example.yml
@@ -50,30 +50,6 @@ receivers:
         auth:
           authenticator: everr_apikey
 
-  # >>> DEV ONLY: DELETE THIS RECEIVER FOR PRODUCTION <<<
-  # Dev-only self-telemetry ingest for the locally running app (server and
-  # browser) and other first-party dev tools. Unauthenticated on purpose: it
-  # is only exposed on the dev machine by docker-compose (bound to loopback)
-  # and carries no customer data. Its pipelines stamp the internal dev tenant
-  # and ship to BOTH the dev clickhouse and the desktop everr instance.
-  #
-  # This writes to the same clickhouse as the public path with no auth at all,
-  # so a production copy of this file must not carry it. Both endpoints bind
-  # to loopback, so a copy that keeps the block by mistake is still not
-  # reachable off the box: the banner is not the only thing standing between
-  # a copy and an unauthenticated cross-tenant write. Every dev-only block
-  # in this file is marked with the same `DEV ONLY` banner; grep for it.
-  otlp/dev:
-    protocols:
-      http:
-        endpoint: 127.0.0.1:4320
-        cors:
-          allowed_origins:
-            - http://localhost:5173
-            - http://127.0.0.1:5173
-      grpc:
-        endpoint: 127.0.0.1:4319
-
 processors:
   everr_usage: {}
   delta_to_cumulative/usage:
@@ -150,31 +126,6 @@ processors:
         key: everr.retention.days
         from_context: auth.retention_metrics_days
 
-  # >>> DEV ONLY: DELETE THIS PROCESSOR FOR PRODUCTION <<<
-  # Dev self-telemetry: stamp everything onto the internal dev tenant so it is
-  # browsable in the cloud app. Retention is literal because this receiver is
-  # unauthenticated and has no auth context to supply the signal's window.
-  resource/dev_tenant:
-    attributes:
-      - action: upsert
-        key: everr.tenant.id
-        value: ${env:DEV_SELF_TENANT_ID:-replace-with-your-dev-org-id}
-  resource/dev_retention_traces:
-    attributes:
-      - action: upsert
-        key: everr.retention.days
-        value: "14"
-  resource/dev_retention_logs:
-    attributes:
-      - action: upsert
-        key: everr.retention.days
-        value: "14"
-  resource/dev_retention_metrics:
-    attributes:
-      - action: upsert
-        key: everr.retention.days
-        value: "14"
-
 exporters:
   debug:
     verbosity: detailed
@@ -237,12 +188,6 @@ exporters:
     retry_on_failure:
       enabled: true
       max_elapsed_time: 0s
-  # >>> DEV ONLY: DELETE THIS EXPORTER FOR PRODUCTION <<<
-  # Forward to the dev machine's local everr desktop instance so distributed
-  # traces assemble whole there (app half + engine half in one store).
-  otlphttp/localdev:
-    endpoint: ${env:EVERR_DEV_OTLP_ENDPOINT:-http://host.docker.internal:54318}
-
 service:
   extensions: [everr_apikey, everr_usage, file_storage/ingestion]
   pipelines:
@@ -281,48 +226,3 @@ service:
       receivers: [otlp/public]
       processors: [attributes/strip_user_tenant, resource/public_tenant, resource/public_retention_logs, everr_usage]
       exporters: [clickhouse, everr_usage_connector]
-
-    # >>> DEV ONLY: DELETE THESE THREE PIPELINES FOR PRODUCTION <<<
-    # Dev self-telemetry (app server + browser, dev tools): both stores.
-    traces/dev:
-      receivers: [otlp/dev]
-      processors: [attributes/strip_user_tenant, resource/dev_tenant, resource/dev_retention_traces]
-      exporters: [clickhouse, otlphttp/localdev]
-    metrics/dev:
-      receivers: [otlp/dev]
-      processors: [filter/reserved_everr, attributes/strip_user_tenant, resource/dev_tenant, resource/dev_retention_metrics]
-      exporters: [clickhouse, otlphttp/localdev]
-    logs/dev:
-      receivers: [otlp/dev]
-      processors: [attributes/strip_user_tenant, resource/dev_tenant, resource/dev_retention_logs]
-      exporters: [clickhouse, otlphttp/localdev]
-
-  # Ship the collector's own telemetry (its logs, metrics, and internal
-  # traces) to the dev-machine's local everr collector so we can observe the
-  # collector itself the same way we observe everything else.
-  telemetry:
-    logs:
-      level: debug
-      processors:
-        - batch:
-            exporter:
-              otlp:
-                protocol: http/protobuf
-                endpoint: http://host.docker.internal:54318
-                insecure: true
-    metrics:
-      readers:
-        - periodic:
-            exporter:
-              otlp:
-                protocol: http/protobuf
-                endpoint: http://host.docker.internal:54318
-                insecure: true
-    traces:
-      processors:
-        - batch:
-            exporter:
-              otlp:
-                protocol: http/protobuf
-                endpoint: http://host.docker.internal:54318
-                insecure: true

--- a/collector/exporter/chdbexporter/exporter_chdb_roundtrip_test.go
+++ b/collector/exporter/chdbexporter/exporter_chdb_roundtrip_test.go
@@ -29,7 +29,8 @@ import (
 // nanoseconds, and one encoding has to be right for both.
 
 var (
-	roundTripTime      = time.Date(2026, 9, 5, 12, 34, 56, 123456789, time.UTC)
+	roundTripTime = time.Now().UTC().Add(-time.Hour).Truncate(time.Second).
+			Add(123456789 * time.Nanosecond)
 	roundTripStartTime = roundTripTime.Add(-90 * time.Second)
 	roundTripExemplar  = roundTripTime.Add(-5 * time.Second)
 )

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/barchart.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/barchart.md
@@ -6,8 +6,7 @@ A bar chart over time **or** over categories. It infers its structure from the c
 
 | Option | Type | Default | Values | Effect |
 | --- | --- | --- | --- | --- |
-| `unit` | string | `""` | any string | Unit of the numeric query result. It remains a literal suffix unless `displayUnit` is set. |
-| `displayUnit` | string | none | `auto` | Scale recognized byte or duration units on value-axis ticks, labels, and tooltips. The input `unit` may already be prefixed, such as `GiBy`, the common `GiB` alias, or `ms`. |
+| `valueFormat` | object | none | see shared rule | Numeric presentation; read `rules/value-format.md` for scaling, precision, rates and custom labels. |
 | `showLegend` | boolean | `false` | `true` | Show the series legend. Only the literal `true` enables it. |
 | `stacking` | string | `none` | `none`, `stacked`, `percent` | `none` draws series side by side; `stacked` piles them into one bar per x value; `percent` additionally normalizes each stack to 100% — the value axis becomes percentages while tooltips keep raw values. |
 | `orientation` | string | `vertical` | `vertical`, `horizontal` | `vertical` draws bars bottom-up; `horizontal` draws them left-to-right with categories on the y-axis — prefer it for categorical data with long labels. |
@@ -18,15 +17,16 @@ A bar chart over time **or** over categories. It infers its structure from the c
 plugin:
   kind: BarChart
   spec:
-    unit: req
     showLegend: true
     stacking: stacked
     orientation: vertical
     showValues: false
     colors: { good: "#0cce6b", poor: "#ff4e42" } # optional
+    valueFormat:
+      unit: '{request}'
 ```
 
-These seven are the complete set. There is **no** `yAxis` / `min` / `max`, `barWidth`, `legend` object, `thresholds`, or `decimals`. A series that `colors` does not name takes its color from a fixed 6-color palette assigned by order (wrapping after 6).
+The table lists the supported options. There is **no** `yAxis` / `min` / `max`, `barWidth`, `legend` object, `thresholds`, or `decimals`. A series that `colors` does not name takes its color from a fixed 6-color palette assigned by order (wrapping after 6).
 
 ## Data shape
 

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/barchart.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/barchart.md
@@ -26,7 +26,7 @@ plugin:
       unit: '{request}'
 ```
 
-The table lists the supported options. There is **no** `yAxis` / `min` / `max`, `barWidth`, `legend` object, `thresholds`, or `decimals`. A series that `colors` does not name takes its color from a fixed 6-color palette assigned by order (wrapping after 6).
+The table lists the supported top-level options. There is **no** `yAxis` / `min` / `max`, `barWidth`, `legend` object, `thresholds`, or top-level `decimals`. Set precision with `valueFormat.decimals`. A series that `colors` does not name takes its color from a fixed 6-color palette assigned by order (wrapping after 6).
 
 ## Data shape
 

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/barchart.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/barchart.md
@@ -6,7 +6,8 @@ A bar chart over time **or** over categories. It infers its structure from the c
 
 | Option | Type | Default | Values | Effect |
 | --- | --- | --- | --- | --- |
-| `unit` | string | `""` | any string | Suffix on value-axis ticks and tooltip values. Raw concatenation, **no space** — `unit: ms` renders `123ms`. |
+| `unit` | string | `""` | any string | Unit of the numeric query result. It remains a literal suffix unless `displayUnit` is set. |
+| `displayUnit` | string | none | `auto` | Scale recognized byte or duration units on value-axis ticks, labels, and tooltips. The input `unit` may already be prefixed, such as `GiBy`, the common `GiB` alias, or `ms`. |
 | `showLegend` | boolean | `false` | `true` | Show the series legend. Only the literal `true` enables it. |
 | `stacking` | string | `none` | `none`, `stacked`, `percent` | `none` draws series side by side; `stacked` piles them into one bar per x value; `percent` additionally normalizes each stack to 100% — the value axis becomes percentages while tooltips keep raw values. |
 | `orientation` | string | `vertical` | `vertical`, `horizontal` | `vertical` draws bars bottom-up; `horizontal` draws them left-to-right with categories on the y-axis — prefer it for categorical data with long labels. |
@@ -25,7 +26,7 @@ plugin:
     colors: { good: "#0cce6b", poor: "#ff4e42" } # optional
 ```
 
-These six are the complete set. There is **no** `yAxis` / `min` / `max`, `barWidth`, `legend` object, `thresholds`, or `decimals`. A series that `colors` does not name takes its color from a fixed 6-color palette assigned by order (wrapping after 6).
+These seven are the complete set. There is **no** `yAxis` / `min` / `max`, `barWidth`, `legend` object, `thresholds`, or `decimals`. A series that `colors` does not name takes its color from a fixed 6-color palette assigned by order (wrapping after 6).
 
 ## Data shape
 

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/dashboards.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/dashboards.md
@@ -7,12 +7,11 @@ An Everr dashboard is a Perses-style YAML or JSON file, named `<slug>.dashboard.
 ```yaml
 kind: Dashboard
 metadata:
-  name: <slug>               # required; lowercase letters/digits/hyphens, 1–200 chars, the URL segment
+  name: <slug>               # required; lowercase letters/digits/hyphens, 1 to 200 chars, the URL segment
   project: platform          # optional; defaults to "default"; namespaces identity + URL
 spec:
   display: { name: ..., description: ... }   # optional
   timeRange: { from: now/M, to: now }        # optional; explicit default range
-  duration: 1h               # optional; seeds the time-range picker (e.g. 1h, 24h)
   refreshInterval: 30s       # optional; seeds auto-refresh
   variables: [ ... ]         # optional; see rules/queries.md
   panels: { <key>: Panel }   # required; map of panel key -> panel (see rules/queries.md)
@@ -20,9 +19,12 @@ spec:
 ```
 
 Identity is `project` + `slug` → URL `/dashboards/<project>/<slug>`.
-When both are present, `timeRange` takes precedence over `duration`.
 
-## Layout — panels only render if a layout references them
+Author Everr dashboards with `timeRange`. Perses `duration` remains accepted
+as compatibility input and is normalized to `{ from: now-<duration>, to: now }`
+when `timeRange` is absent.
+
+## Layout: panels only render if a layout references them
 
 ```yaml
 layouts:
@@ -47,7 +49,9 @@ metadata:
 spec:
   display:
     name: Checkout API
-  duration: 1h
+  timeRange:
+    from: now-1h
+    to: now
   refreshInterval: 30s
   variables:
     - kind: ListVariable
@@ -148,4 +152,4 @@ spec:
 | Mistake | Fix |
 | --- | --- |
 | Panel defined but not on the grid | A panel renders only if a `layouts` item `$ref`s it. |
-| Hard-coded `toStartOfMinute` on a chart viewable over days | Bucket with `INTERVAL {step:UInt32} SECOND` — see `rules/queries.md`. |
+| Hard-coded `toStartOfMinute` on a chart viewable over days | Bucket with `INTERVAL {step:UInt32} SECOND`, see `rules/queries.md`. |

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/dashboards.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/dashboards.md
@@ -72,7 +72,7 @@ spec:
         display: { name: p95 request latency (ms) }
         plugin:
           kind: TimeSeriesChart
-          spec: { unit: ms, showLegend: true }
+          spec: { showLegend: true, valueFormat: { unit: ms } }
         queries:
           - kind: ClickHouseSQL
             spec:
@@ -95,13 +95,14 @@ spec:
           kind: StatChart
           spec:
             calculation: last
-            unit: "%"
             thresholds:
               mode: absolute
               defaultColor: "#22c55e"
               steps:
                 - { value: 1, color: "#f59e0b" }
                 - { value: 5, color: "#ef4444" }
+            valueFormat:
+              unit: "%"
         queries:
           - kind: ClickHouseSQL
             spec:

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/dashboards.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/dashboards.md
@@ -11,6 +11,7 @@ metadata:
   project: platform          # optional; defaults to "default"; namespaces identity + URL
 spec:
   display: { name: ..., description: ... }   # optional
+  timeRange: { from: now/M, to: now }        # optional; explicit default range
   duration: 1h               # optional; seeds the time-range picker (e.g. 1h, 24h)
   refreshInterval: 30s       # optional; seeds auto-refresh
   variables: [ ... ]         # optional; see rules/queries.md
@@ -19,6 +20,7 @@ spec:
 ```
 
 Identity is `project` + `slug` → URL `/dashboards/<project>/<slug>`.
+When both are present, `timeRange` takes precedence over `duration`.
 
 ## Layout — panels only render if a layout references them
 

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/gaugechart.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/gaugechart.md
@@ -7,8 +7,7 @@ One or more gauges, each showing a single value filled between `min` and `max`, 
 | Option | Type | Default | Values | Effect |
 | --- | --- | --- | --- | --- |
 | `calculation` | string | `last` | `last`, `first`, `mean`, `min`, `max`, `sum`, `count`, `range`, `diff` | How each gauge's column is reduced to one number. `count` = number of points, `range` = max − min, `diff` = last − first. An unknown value is rejected by `everr apply`. |
-| `unit` | string | `""` | any string | Suffix after the value. |
-| `decimals` | number | none | `0`–`10` | Fixed fraction digits. Omitted: up to 2, trailing zeros dropped. |
+| `valueFormat` | object | none | see shared rule | Numeric presentation; read `rules/value-format.md` for scaling, precision, rates and custom labels. |
 | `min` | number | `0` | any number | Gauge axis lower bound. |
 | `max` | number | `100` | any number | Gauge axis upper bound. **Set it to the metric's real ceiling** — the default 100 only suits percentages. Inverting the bounds (`min > max`) inverts the arc, so a lower value reads as fuller — useful for "lower is better" metrics. |
 | `showLabel` | boolean | `false` | `true` | Show the column-name label even on a single-gauge panel (multi-gauge always shows it). |
@@ -32,18 +31,19 @@ plugin:
   kind: GaugeChart
   spec:
     calculation: mean
-    unit: "%"
-    decimals: 1
     min: 0
     max: 100
     thresholds:
-      defaultColor: "#22c55e"            # green below the first step
+      defaultColor: "#22c55e" # green below the first step
       steps:
-        - { value: 70, color: "#f59e0b" }  # amber once value ≥ 70
-        - { value: 90, color: "#ef4444" }  # red once value ≥ 90
+        - { value: 70, color: "#f59e0b" } # amber once value ≥ 70
+        - { value: 90, color: "#ef4444" } # red once value ≥ 90
+    valueFormat:
+      unit: "%"
+      decimals: 1
 ```
 
-There is **no** `title`, `orientation`, `sparkline`, or `colorMode`. `calculation`, `unit`, `min`/`max`, and `thresholds` apply to **every** gauge uniformly.
+There is **no** `title`, `orientation`, `sparkline`, or `colorMode`. `calculation`, `valueFormat`, `min`/`max`, and `thresholds` apply to **every** gauge uniformly.
 
 ## Data shape — one gauge per numeric column per query
 
@@ -58,4 +58,4 @@ There is **no** `title`, `orientation`, `sparkline`, or `colorMode`. `calculatio
 - A query that returns no value still renders its gauge (empty arc, `noValue` text) — it does not silently vanish from a multi-query panel.
 - **`percent` thresholds** compare against `thresholds.max`, falling back to the gauge `max` — unlike StatChart there is no series-max fallback, so single-value queries behave predictably.
 - Threshold ticks only render for steps that have a `color` and fall strictly inside `(min, max)`.
-- Values ≥ 1 million **abbreviate** (`1234567` → `1.23M`, then `B`, `T`); the `min`/`max` end labels use the same formatting.
+- Values use at most two decimal places by default. Set `valueFormat.scale: decimal` to abbreviate large counts.

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/geomap.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/geomap.md
@@ -13,7 +13,7 @@ A world map. Two modes: `points` plots latitude/longitude markers sized by a val
 | `aggregation` | string | `sum` | `sum`, `avg`, `min`, `max`, `last` | Choropleth: how rows mapping to the same country combine. `sum` is only correct for additive metrics (request counts); use `avg`/`max` for latencies, percentiles, rates. `last` follows result-set order — only meaningful with an `ORDER BY`. |
 | `valueColumn` | string | `value` | column name | Sizes markers (points) / shades countries (choropleth). |
 | `labelColumn` | string | — | column name | Tooltip title. Falls back to the country name (choropleth) or raw coordinates (points). |
-| `unit` | string | `""` | any string | Suffix on tooltip and legend values (space-separated). |
+| `valueFormat` | object | none | see shared rule | Numeric presentation; read `rules/value-format.md` for scaling, precision, rates and custom labels. |
 | `showLegend` | boolean | `true` | `false` | Points: the value→marker-size mapping plus per-query color swatches when the panel has multiple queries. Choropleth: the color ramp with its bounds. |
 | `colorScheme` | string | `blue` | `blue`, `green`, `orange`, `red` | Marker base color / choropleth ramp color. |
 | `projection` | string | `naturalEarth1` | `naturalEarth1`, `mercator`, `equalEarth` | Map projection. |
@@ -29,7 +29,7 @@ plugin:
   spec: { mode: choropleth, regionColumn: country, valueColumn: requests, aggregation: sum, colorScheme: blue }
 ```
 
-These sixteen are the complete set. There is **no** zoom/pan config, custom geojson, city/state-level regions (countries only), heatmap mode, cluster mode, or per-marker color column. Marker color encodes which *query* a row came from, not a data column.
+The table lists the supported options. There is **no** zoom/pan config, custom geojson, city/state-level regions (countries only), heatmap mode, cluster mode, or per-marker color column. Marker color encodes which *query* a row came from, not a data column.
 
 ## Data shape
 

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/heatmap.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/heatmap.md
@@ -8,7 +8,7 @@ A **time × bucket grid of color-intensity cells** — request-duration histogra
 | --- | --- | --- | --- | --- |
 | `yColumn` | string | first non-time column | column name | Y-bucket column. |
 | `valueColumn` | string | first remaining numeric column | column name | Cell intensity column. |
-| `unit` | string | `""` | any | Value formatting in cells, tooltip and legend. |
+| `valueFormat` | object | none | see shared rule | Numeric presentation; read `rules/value-format.md` for scaling, precision, rates and custom labels. |
 | `showLegend` | boolean | `true` | `false` | Color ramp legend (min → max) below the grid. |
 | `showValues` | boolean | `false` | `true` | Render the value inside cells wide enough to fit it. |
 | `colorScheme` | enum | `spectral` | `spectral`, `greenYellowRed`, `blues`, `greens`, `oranges`, `reds` | Cell color ramp. `spectral` = cool blue → yellow → hot red; `greenYellowRed` = green → amber → red; the rest are single-hue light→dark. |
@@ -23,9 +23,10 @@ plugin:
   spec:
     yColumn: bucket
     valueColumn: requests
-    unit: req
     colorScheme: spectral
     scaleType: log
+    valueFormat:
+      unit: '{request}'
 ```
 
 There is **no** `calculation`, `thresholds`, axis options, or client-side bucketing of raw values — compute the y buckets in SQL.

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/nodegraph.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/nodegraph.md
@@ -9,7 +9,7 @@ A **directed graph of nodes and weighted edges** with a deterministic force-dire
 | `sourceColumn` | string | `source` | column name | Edge source column; falls back to the first column when absent. |
 | `targetColumn` | string | `target` | column name | Edge target column; falls back to the second column when absent. |
 | `valueColumn` | string | `value` | column name | Edge weight column — drives edge thickness and node size. Falls back to the first remaining numeric column; without one every edge weighs 1. |
-| `unit` | string | `""` | any | Value formatting in tooltips and edge labels. |
+| `valueFormat` | object | none | see shared rule | Numeric presentation; read `rules/value-format.md` for scaling, precision, rates and custom labels. |
 | `directed` | boolean | `true` | `false` | Draw arrowheads pointing at each edge's target. |
 | `showValues` | boolean | `false` | `true` | Render the edge's value at its midpoint. |
 | `maxNodes` | number | unset | ≥ 2 | Keep only the `maxNodes` highest-value nodes (and the edges between them); the rest are hidden behind a "not shown" badge. There is also a built-in 250-node layout limit. |
@@ -21,7 +21,8 @@ plugin:
     sourceColumn: client
     targetColumn: server
     valueColumn: calls
-    unit: req
+    valueFormat:
+      unit: '{request}'
 ```
 
 There is **no** node coloring/grouping option, no separate nodes query, no pinning, and no layout option — nodes are derived from the edge rows only.
@@ -51,4 +52,4 @@ LIMIT 200
 - **Node value = sum of all touching edge weights** (in + out); the tooltip also shows the in/out edge counts.
 - Keep **node cardinality low** (≲ 50 for readability; hard layout cap at 250) — `GROUP BY` to coarse entities (services, not endpoints) and `LIMIT` in SQL, or set `maxNodes` to keep the heaviest nodes.
 - Without a numeric column every edge weighs 1, so a plain two-column edge list still sizes nodes by edge count.
-- Use `unit` for the tooltip/edge-label formatting; format anything fancier in SQL (the weight must stay numeric).
+- Use `valueFormat` for numeric presentation; keep weights numeric.

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/queries.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/queries.md
@@ -146,7 +146,7 @@ For `allowAllValue`, "All" expands to every loaded option as a quoted list; set 
 | PromQL / `rate()` / `$__rate_interval` / `PrometheusTimeSeriesQuery` | Queries are **ClickHouse SQL**; the only query plugin is `ClickHouseSQL`. |
 | No `{from:String}`/`{to:String}` in the `WHERE` | Add `WHERE Timestamp >= {from:String} AND Timestamp <= {to:String}` — it is not auto-injected. |
 | Time-series x-axis blank | Alias the time column to `ts`/`time`/`timestamp` so it's detected. |
-| Inventing viz options (`yAxis`, `legend`, `columnSettings`, `format.unit`, `calculation: last-number`, axis min/max) | Only the options in each viz's rule file exist. Format/round in SQL, not via spec. |
+| Inventing viz options (`yAxis`, `legend`, `columnSettings`, `format.unit`, `calculation: last-number`, axis min/max) | Only the options in each viz's rule file exist. Use `valueFormat` for supported numeric presentation. Shape values in SQL when no supported spec option applies. |
 | `PrometheusLabelValuesVariable` or other variable plugins | Only `StaticListVariable` and `ClickHouseSQLVariable`. |
 | Single `ClickHouseSQL` in the query block | Both the query `kind` and the inner `plugin.kind` are `ClickHouseSQL`. |
 | `Duration` treated as ms/seconds | It's **nanoseconds** — divide by `1e6` (ms) or `1e9` (s). |

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/queries.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/queries.md
@@ -21,7 +21,7 @@ panels:
       display: { name: Error rate }      # description optional
       plugin:
         kind: TimeSeriesChart            # TimeSeriesChart | BarChart | Table | StatChart | GaugeChart | GeoMap | Treemap | StateTimeline | StatusHistory | Heatmap | NodeGraph
-        spec: { unit: "%", showLegend: true }
+        spec: { showLegend: true, valueFormat: { unit: "%" } }
       queries:
         - kind: ClickHouseSQL            # outer query kind
           spec:
@@ -64,7 +64,7 @@ Data shape per visualization (the viz infers everything from your columns):
 | --- | --- |
 | `TimeSeriesChart` | a time column (aliased above) + numeric series columns. A non-numeric **string** column pivots one value column into one line per label (e.g. `GROUP BY ts, ServiceName`) — but **only with exactly one numeric column** (see `rules/timeseries.md`). |
 | `BarChart` | same as `TimeSeriesChart` (time column + numeric series, string pivot with exactly one numeric column) — or, **without** a time column, the first string column becomes the category axis (see `rules/barchart.md`). |
-| `Table` | any columns, rendered as-is in query order (no formatting — do it in SQL). |
+| `Table` | any columns, rendered in query order, with optional numeric value formatting. |
 | `StatChart` | one or more numeric columns — **one tile per numeric column** (each reduced by `calculation`). A string column creates no tile. Include a time column for per-tile sparklines. |
 | `GaugeChart` | same shape as `StatChart` — one gauge per numeric column, reduced by `calculation`. Pick the gauge's `min`/`max` in the spec; no time axis needed. |
 | `GeoMap` | points mode: numeric lat/lon columns (+ optional value/label); choropleth mode: an ISO-3166 alpha-2/alpha-3 country-code column + a numeric value column (see `rules/geomap.md`). No time axis. |
@@ -73,6 +73,8 @@ Data shape per visualization (the viz infers everything from your columns):
 | `StatusHistory` | same shapes as `StateTimeline`, but each sample is an **independent cell** — nothing holds until the next sample; missing samples stay visibly empty (see `rules/statushistory.md`). |
 | `Heatmap` | a time column (aliased above) + a bucket column (y-axis) + a numeric value column (cell color) — `GROUP BY` time and bucket; same-cell rows sum (see `rules/heatmap.md`). |
 | `NodeGraph` | an edge list: a source column + a target column + an optional numeric weight column (see `rules/nodegraph.md`). No time axis; always `LIMIT`. |
+
+Numeric value presentation: read `rules/value-format.md` when setting scaling, precision, arbitrary labels, rates, durations, or table column formats.
 
 ## Visualization options
 

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/runbooks.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/runbooks.md
@@ -73,7 +73,7 @@ spec:
   display: { name: Error rate }
   plugin:
     kind: TimeSeriesChart
-    spec: { unit: "%", showLegend: true }
+    spec: { showLegend: true, valueFormat: { unit: "%" } }
   queries:
     - kind: ClickHouseSQL
       spec:

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/statchart.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/statchart.md
@@ -7,9 +7,11 @@ One or more big single-value tiles, each optionally with a sparkline and thresho
 | Option | Type | Default | Values | Effect |
 | --- | --- | --- | --- | --- |
 | `calculation` | string | `last` | `last`, `first`, `mean`, `min`, `max`, `sum`, `count`, `range`, `diff` | How each tile's column is reduced to one number. `count` = number of points, `range` = max − min, `diff` = last − first. An unknown value is rejected by `everr apply`. |
-| `unit` | string | `""` | any string | Suffix after the value. |
+| `unit` | string | `""` | any string | Unit of the numeric query result. It remains a literal suffix unless `displayUnit` is set. |
+| `displayUnit` | string | none | `auto` | Scale recognized byte or duration units for display. The input `unit` may already be prefixed, such as `GiBy`, the common `GiB` alias, or `ms`. |
 | `decimals` | number | none | `0`–`10` | Fixed fraction digits. Omitted: up to 2, trailing zeros dropped. |
 | `sparkline` | boolean | `false` | `true` | Draw a trend line under the value. **Needs a time column and ≥2 points** (see Data shape) or nothing draws. |
+| `colors` | map | `{}` | series label to CSS color | Pin sparkline colors by series label. Unmapped series keep the default accent color. Threshold colors take precedence. |
 | `colorMode` | string | `value` | `value`, `background` | `value` tints the number with the threshold color; `background` fills the whole tile. No effect without `thresholds`. |
 | `showLabel` | boolean | `false` | `true` | Show the column-name label even on a single-tile panel (multi-tile always shows it). |
 | `noValue` | string | `–` | any string | Text rendered for a query that produced no value (empty result / no numeric column). |
@@ -32,6 +34,7 @@ plugin:
     unit: "%"
     decimals: 1
     sparkline: true
+    colors: { p50: "#a78bfa", p95: "#fde047" }
     thresholds:
       mode: absolute
       defaultColor: "#22c55e"            # green below the first step
@@ -55,4 +58,5 @@ There is **no** `title`, `orientation`, or `graphMode`. `calculation`, `unit`, a
 - A query that returns no value still renders its tile with the `noValue` text — it does not silently vanish from a multi-query panel.
 - **`percent` mode** without `thresholds.max` compares against the tile's own series max, so a single-value (time-less) tile is always 100% — set `max` or use it with a sparkline series.
 - The resolved threshold color tints **both** the number and the sparkline (`colorMode: background` fills the tile instead).
+- A `colors` entry changes only that series' sparkline. Threshold colors still win when configured.
 - Value text scales down as tiles crowd the panel.

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/statchart.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/statchart.md
@@ -7,9 +7,7 @@ One or more big single-value tiles, each optionally with a sparkline and thresho
 | Option | Type | Default | Values | Effect |
 | --- | --- | --- | --- | --- |
 | `calculation` | string | `last` | `last`, `first`, `mean`, `min`, `max`, `sum`, `count`, `range`, `diff` | How each tile's column is reduced to one number. `count` = number of points, `range` = max − min, `diff` = last − first. An unknown value is rejected by `everr apply`. |
-| `unit` | string | `""` | any string | Unit of the numeric query result. It remains a literal suffix unless `displayUnit` is set. |
-| `displayUnit` | string | none | `auto` | Scale recognized byte or duration units for display. The input `unit` may already be prefixed, such as `GiBy`, the common `GiB` alias, or `ms`. |
-| `decimals` | number | none | `0`–`10` | Fixed fraction digits. Omitted: up to 2, trailing zeros dropped. |
+| `valueFormat` | object | none | see shared rule | Numeric presentation; read `rules/value-format.md` for scaling, precision, rates and custom labels. |
 | `sparkline` | boolean | `false` | `true` | Draw a trend line under the value. **Needs a time column and ≥2 points** (see Data shape) or nothing draws. |
 | `colors` | map | `{}` | series label to CSS color | Pin sparkline colors by series label. Unmapped series keep the default accent color. Threshold colors take precedence. |
 | `colorMode` | string | `value` | `value`, `background` | `value` tints the number with the threshold color; `background` fills the whole tile. No effect without `thresholds`. |
@@ -31,19 +29,20 @@ plugin:
   kind: StatChart
   spec:
     calculation: last
-    unit: "%"
-    decimals: 1
     sparkline: true
     colors: { p50: "#a78bfa", p95: "#fde047" }
     thresholds:
       mode: absolute
-      defaultColor: "#22c55e"            # green below the first step
+      defaultColor: "#22c55e" # green below the first step
       steps:
-        - { value: 1, color: "#f59e0b" }   # amber once value ≥ 1
-        - { value: 5, color: "#ef4444" }   # red once value ≥ 5
+        - { value: 1, color: "#f59e0b" } # amber once value ≥ 1
+        - { value: 5, color: "#ef4444" } # red once value ≥ 5
+    valueFormat:
+      unit: "%"
+      decimals: 1
 ```
 
-There is **no** `title`, `orientation`, or `graphMode`. `calculation`, `unit`, and `thresholds` apply to **every** tile uniformly.
+There is **no** `title`, `orientation`, or `graphMode`. `calculation`, `valueFormat`, and `thresholds` apply to **every** tile uniformly.
 
 ## Data shape — one tile per numeric column per query
 
@@ -54,7 +53,7 @@ There is **no** `title`, `orientation`, or `graphMode`. `calculation`, `unit`, a
 ## Behaviors to know
 
 - A **single tile hides its label** unless `showLabel: true`; with multiple tiles each shows its column name. Choose column aliases accordingly.
-- Values ≥ 1 million **abbreviate** (`1234567` → `1.23M`, then `B`, `T`); smaller values keep thousands grouping.
+- Values use at most two decimal places by default. Set `valueFormat.scale: decimal` to abbreviate large counts.
 - A query that returns no value still renders its tile with the `noValue` text — it does not silently vanish from a multi-query panel.
 - **`percent` mode** without `thresholds.max` compares against the tile's own series max, so a single-value (time-less) tile is always 100% — set `max` or use it with a sparkline series.
 - The resolved threshold color tints **both** the number and the sparkline (`colorMode: background` fills the tile instead).

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/table.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/table.md
@@ -1,12 +1,14 @@
 # Table
 
-Renders query rows as a plain table. Columns and their order come entirely from the `SELECT`; there is no column, formatting, sort, or pagination configuration.
+Renders query rows as a plain table. Columns and their order come entirely from the `SELECT`; numeric presentation supports a panel default and column overrides.
 
 ## Options (`plugin.spec`)
 
 | Option | Type | Default | Values | Effect |
 | --- | --- | --- | --- | --- |
 | `stickyHeader` | boolean | `false` | `true` | Keep the header row visible while the body scrolls. Only the literal `true` enables it. |
+| `valueFormat` | object | none | see shared rule | Default numeric format; read `rules/value-format.md`. |
+| `columns` | map | `{}` | column name to `{ valueFormat }` | Override the default format for a named column. |
 
 ```yaml
 plugin:
@@ -14,13 +16,13 @@ plugin:
   spec: { stickyHeader: true }
 ```
 
-`stickyHeader` is the only option. There is **no** `columns`, `columnSettings`, `unit`, `format`, `sort`, `align`, `pagination`, `pageSize`, or `density`.
+Read `rules/value-format.md` when configuring numeric formatting. Sorting and pagination remain unconfigured.
 
 ## Data shape
 
-Any columns. They render **as-is, in `SELECT` order**, with the column alias as the header. There is no type-aware formatting:
+Any columns. They render **as-is, in `SELECT` order**, with the column alias as the header. Numeric cells can use the shared format:
 
-- **Numbers are not formatted** — no thousands separators, rounding, units, or alignment. Format in SQL: `round(quantile(0.95)(Duration) / 1e6, 1) AS p95_ms`. Convey the unit through the alias or panel title; a literal "ms" suffix is not rendered.
+- Numbers default to at most two decimal places. Panel and column `valueFormat` options control precision, units, and scaling. String values are preserved, including numeric strings.
 - **`NULL` cells render the literal text `NULL`** (muted). Use `coalesce` / `ifNull` in SQL if you want blanks or a placeholder.
 
 ## Behaviors to know

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/timeseries.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/timeseries.md
@@ -6,8 +6,7 @@ A line chart over time (or a stacked area chart with `stacked: true`). It infers
 
 | Option | Type | Default | Values | Effect |
 | --- | --- | --- | --- | --- |
-| `unit` | string | `""` | any string | Unit of the numeric query result. It remains a literal suffix unless `displayUnit` is set. |
-| `displayUnit` | string | none | `auto` | Scale recognized byte or duration units on y-axis ticks and tooltip values. The input `unit` may already be prefixed, such as `GiBy`, the common `GiB` alias, or `ms`. |
+| `valueFormat` | object | none | see shared rule | Numeric presentation; read `rules/value-format.md` for scaling, precision, rates and custom labels. |
 | `showLegend` | boolean | `false` | `true` | Show the series legend. Only the literal `true` enables it. |
 | `lineWidth` | number | `1.5` | any number | Line stroke width. |
 | `curveType` | string | `monotone` | `monotone`, `linear`, `natural`, `stepBefore`, `stepAfter` | Line interpolation. An unknown value falls back to the renderer default. |
@@ -17,10 +16,10 @@ A line chart over time (or a stacked area chart with `stacked: true`). It infers
 ```yaml
 plugin:
   kind: TimeSeriesChart
-  spec: { unit: ms, displayUnit: auto, showLegend: true, lineWidth: 1.5, curveType: monotone, connectNulls: false, stacked: false }
+  spec: { valueFormat: { unit: ms, scale: duration }, showLegend: true, lineWidth: 1.5, curveType: monotone, connectNulls: false, stacked: false }
 ```
 
-These seven are the complete set. There is **no** `yAxis` / `min` / `max`, `legend` object, separate area / fill option, `thresholds`, `decimals`, `pointRadius`, or per-series color. Series colors come from a fixed 6-color palette assigned by order (wrapping after 6) and are not configurable.
+The table lists the supported options. There is **no** `yAxis` / `min` / `max`, `legend` object, separate area / fill option, `thresholds`, `decimals`, `pointRadius`, or per-series color. Series colors come from a fixed 6-color palette assigned by order (wrapping after 6) and are not configurable.
 
 ## Data shape
 

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/timeseries.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/timeseries.md
@@ -19,7 +19,7 @@ plugin:
   spec: { valueFormat: { unit: ms, scale: duration }, showLegend: true, lineWidth: 1.5, curveType: monotone, connectNulls: false, stacked: false }
 ```
 
-The table lists the supported options. There is **no** `yAxis` / `min` / `max`, `legend` object, separate area / fill option, `thresholds`, `decimals`, `pointRadius`, or per-series color. Series colors come from a fixed 6-color palette assigned by order (wrapping after 6) and are not configurable.
+The table lists the supported top-level options. There is **no** `yAxis` / `min` / `max`, `legend` object, separate area / fill option, `thresholds`, top-level `decimals`, `pointRadius`, or per-series color. Set precision with `valueFormat.decimals`. Series colors come from a fixed 6-color palette assigned by order (wrapping after 6) and are not configurable.
 
 ## Data shape
 

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/timeseries.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/timeseries.md
@@ -6,7 +6,8 @@ A line chart over time (or a stacked area chart with `stacked: true`). It infers
 
 | Option | Type | Default | Values | Effect |
 | --- | --- | --- | --- | --- |
-| `unit` | string | `""` | any string | Suffix on y-axis ticks and tooltip values. Raw concatenation, **no space** — `unit: ms` renders `123ms`. |
+| `unit` | string | `""` | any string | Unit of the numeric query result. It remains a literal suffix unless `displayUnit` is set. |
+| `displayUnit` | string | none | `auto` | Scale recognized byte or duration units on y-axis ticks and tooltip values. The input `unit` may already be prefixed, such as `GiBy`, the common `GiB` alias, or `ms`. |
 | `showLegend` | boolean | `false` | `true` | Show the series legend. Only the literal `true` enables it. |
 | `lineWidth` | number | `1.5` | any number | Line stroke width. |
 | `curveType` | string | `monotone` | `monotone`, `linear`, `natural`, `stepBefore`, `stepAfter` | Line interpolation. An unknown value falls back to the renderer default. |
@@ -16,10 +17,10 @@ A line chart over time (or a stacked area chart with `stacked: true`). It infers
 ```yaml
 plugin:
   kind: TimeSeriesChart
-  spec: { unit: ms, showLegend: true, lineWidth: 1.5, curveType: monotone, connectNulls: false, stacked: false }
+  spec: { unit: ms, displayUnit: auto, showLegend: true, lineWidth: 1.5, curveType: monotone, connectNulls: false, stacked: false }
 ```
 
-These six are the complete set. There is **no** `yAxis` / `min` / `max`, `legend` object, separate area / fill option, `thresholds`, `decimals`, `pointRadius`, or per-series color. Series colors come from a fixed 6-color palette assigned by order (wrapping after 6) and are not configurable.
+These seven are the complete set. There is **no** `yAxis` / `min` / `max`, `legend` object, separate area / fill option, `thresholds`, `decimals`, `pointRadius`, or per-series color. Series colors come from a fixed 6-color palette assigned by order (wrapping after 6) and are not configurable.
 
 ## Data shape
 

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/treemap.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/treemap.md
@@ -20,7 +20,7 @@ plugin:
   spec: { nameColumn: route, valueColumn: requests, groupColumn: service, valueFormat: { unit: '{request}' } }
 ```
 
-The table lists the supported options. There is **no** nesting depth, drill-down, color-by-value ramp, per-tile color column, aggregation option (duplicates always sum — pre-aggregate in SQL for anything else), or sort option. To cap tile count, prefer `maxTiles` (folds the tail into an "Other" tile, preserving the total) over SQL `LIMIT` (silently drops the tail).
+The table lists the supported options. There is **no** nesting depth, drill-down, color-by-value ramp, per-tile color column, aggregation option (duplicates always sum, so pre-aggregate in SQL for anything else), or sort option. To cap tile count, prefer `maxTiles` (folds the tail into an "Other" tile, preserving the total) over SQL `LIMIT` (silently drops the tail).
 
 ## Data shape
 

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/treemap.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/treemap.md
@@ -10,17 +10,17 @@ Tiles whose **areas are proportional to a numeric column** — part-of-whole bre
 | `valueColumn` | string | `value` | column name | Tile size. **Must be positive** — rows with a value ≤ 0 (or non-numeric) have no area and are dropped. Rows repeating the same label are **summed**. |
 | `groupColumn` | string | — | column name | Group tiles: one color per group value, legend lists the groups, the same label may appear once per group. Rows with a NULL group are dropped. |
 | `maxTiles` | number | — | ≥ 2 | Cap the tile count: the largest `maxTiles - 1` tiles stay, the rest merge into one muted, ungrouped "Other (n)" tile. Unset renders every row. |
-| `unit` | string | `""` | any string | Suffix on tile and tooltip values (space-separated). |
+| `valueFormat` | object | none | see shared rule | Numeric presentation; read `rules/value-format.md` for scaling, precision, rates and custom labels. |
 | `showValues` | boolean | `true` | `false` | Render the value inside tiles large enough to fit it. |
 | `showLegend` | boolean | `true` | `false` | Group color legend — only appears when there are groups (from `groupColumn` or multiple queries). |
 
 ```yaml
 plugin:
   kind: Treemap
-  spec: { nameColumn: route, valueColumn: requests, groupColumn: service, unit: req }
+  spec: { nameColumn: route, valueColumn: requests, groupColumn: service, valueFormat: { unit: '{request}' } }
 ```
 
-These seven are the complete set. There is **no** nesting depth, drill-down, color-by-value ramp, per-tile color column, aggregation option (duplicates always sum — pre-aggregate in SQL for anything else), or sort option. To cap tile count, prefer `maxTiles` (folds the tail into an "Other" tile, preserving the total) over SQL `LIMIT` (silently drops the tail).
+The table lists the supported options. There is **no** nesting depth, drill-down, color-by-value ramp, per-tile color column, aggregation option (duplicates always sum — pre-aggregate in SQL for anything else), or sort option. To cap tile count, prefer `maxTiles` (folds the tail into an "Other" tile, preserving the total) over SQL `LIMIT` (silently drops the tail).
 
 ## Data shape
 

--- a/crates/everr-core/assets/skills/everr-setup-resources/rules/value-format.md
+++ b/crates/everr-core/assets/skills/everr-setup-resources/rules/value-format.md
@@ -1,0 +1,45 @@
+# Value formatting
+
+Numeric visualizations accept `valueFormat` in `plugin.spec`. Omitting it uses an empty unit, no scaling, and at most two decimal places (trailing zeros dropped).
+
+Use the case-sensitive UCUM codes prescribed by [OpenTelemetry instrument units](https://opentelemetry.io/docs/specs/semconv/general/metrics/#instrument-units): prefer non-prefixed units such as `By`, seconds (`s`) for durations, `1` for dimensionless utilization, and singular annotations such as `{request}` for counts. The panel must declare the unit actually returned by the query, even when that query returns a prefixed unit such as `ms`. Quote `"1"` and annotations in YAML.
+
+Common codes receive readable display labels: `By` becomes `B`, `Cel` becomes `°C`, `us` becomes `µs`, `1` has no suffix, and `{request}` becomes `request`. These labels also work in rates with a supported time denominator, such as `By/s` and `{request}/s`. Codes remain unchanged in the configuration. Unknown expressions remain literal: this is a presentation subset, not a full UCUM validator or conversion engine. In particular, `B` is not a byte alias (UCUM defines it as bel), and `1` does not implicitly turn a fraction into a percentage.
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `unit` | `""` | UCUM/OTel code of the query result; unknown custom units remain literal labels. |
+| `scale` | `none` | `none`, `decimal`, `binary`, or `duration`. |
+| `decimals` | omitted | Fixed fraction digits (0 to 10); omitted uses up to 2 without trailing zeros. |
+| `display` | `value` | `value` preserves ordinary unit formatting; `percent` displays a dimensionless ratio as a percentage. |
+
+```yaml
+valueFormat: { unit: "{request}/s", scale: decimal, decimals: 1 }
+```
+
+- `none`: preserve the input magnitude, e.g. `8200 connections` displays as `8,200 connections`.
+- `decimal`: abbreviate in powers of 1000 (`k`, `M`, `G`, etc.). `12500 widgets/s` displays as `12.5k widgets/s`.
+- With `Hz`, `W`, `J`, `V`, or `A`, decimal prefixes attach to the unit: `3200000000 Hz` displays as `3.2 GHz`, and `1500 W` as `1.5 kW`. This changes prefix placement only; values below 1000 retain their input unit, and already-prefixed inputs are not reinterpreted.
+- `binary`: abbreviate in powers of 1024 (`Ki`, `Mi`, `Gi`, etc.). `2621440 By/s` displays as `2.5 MiB/s`.
+- `duration`: choose a time unit from nanoseconds through days. Declare the query's actual unit: `ns`, `us`, `ms`, `s`, `min`, `h`, or `d`. With `unit: s`, `0.025` displays as `25 ms` and `90` as `1.5 min`. Other input units are rejected for duration scaling. Use the ASCII code `us`; its display label is `µs`.
+- With a time unit, `decimal` selects seconds or decimal subdivisions, so `90000 ms` displays as `90 s` without advancing to minutes.
+- Custom labels and rates need no registration. The query calculates the rate or percentage: `2.3` with `unit: "%"` means `2.3%`, not a fraction.
+- For decimal/binary scaling, the number is in the declared unit; existing prefixes are not interpreted. Use `By` or `By/s` for bytes, and `bit` or `bit/s` for bits. These attach the display prefix to the symbol; other units keep it with the number.
+- A missing label gives `12.5k`. Other labels are space-separated, except `%`.
+- Time-series, bar, and gauge axes share one display scale across their ticks. Individual values and tooltips choose their own scale. Formatting never changes geometry, aggregation, or threshold comparisons; thresholds remain in input units.
+
+Top-level `unit`, `decimals`, and `displayUnit` have been removed. Move them into `valueFormat`. For example, `unit: ms` with `decimals: 1` becomes `valueFormat: { unit: ms, decimals: 1 }`. Replace `unit: By, displayUnit: auto` with `valueFormat: { unit: By, scale: binary }`. Choose `scale: decimal` explicitly for abbreviated counts; the old implicit million/billion abbreviations no longer apply.
+
+Table supports a panel default and `columns.<column-name>.valueFormat` overrides. An override replaces the entire default format. Only numeric cells are formatted; text and null cells retain their existing behavior.
+
+To show an OTel utilization ratio as a percentage, use `valueFormat: { unit: "1", display: percent }`: `0.75` displays as `75%`. This requires `unit: "1"` and `scale: none` (the default). Precision applies to the displayed percentage; negative values and values above 1 are not clamped. Ordinary `unit: "1"` still displays `0.75`, while `unit: "%"` means the query already returns percentages and is not multiplied again. Gauge bounds and absolute thresholds remain raw ratios: use `max: 1` and a threshold of `0.8` for 80%. This is independent of bar stacking normalization and percent-mode thresholds.
+
+```yaml
+columns:
+  throughput:
+    valueFormat: { unit: "{request}/s", scale: decimal }
+  bandwidth:
+    valueFormat: { unit: By/s, scale: binary }
+  latency:
+    valueFormat: { unit: s, scale: duration }
+```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -52,11 +52,6 @@ services:
       - "8080:8080"
       - "4317:4317"
       - "4318:4318"
-      # Dev-only unauthenticated self-telemetry ingest (otlp/dev receiver):
-      # the locally running app ships here; the collector fans out to both
-      # the dev clickhouse and the desktop everr instance.
-      - "127.0.0.1:4319:4319"
-      - "127.0.0.1:4320:4320"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:

--- a/everr/cloud-query.dashboard.yaml
+++ b/everr/cloud-query.dashboard.yaml
@@ -89,8 +89,9 @@ spec:
           kind: StatChart
           spec:
             calculation: last
-            unit: ms
-            decimals: 0
+            valueFormat:
+              unit: ms
+              decimals: 0
         queries:
           - kind: ClickHouseSQL
             spec:
@@ -132,10 +133,11 @@ spec:
         plugin:
           kind: TimeSeriesChart
           spec:
-            unit: ms
             showLegend: true
             lineWidth: 1.5
             curveType: monotone
+            valueFormat:
+              unit: ms
         queries:
           - kind: ClickHouseSQL
             spec:
@@ -248,14 +250,15 @@ spec:
           kind: StatChart
           spec:
             calculation: last
-            unit: "%"
-            decimals: 0
             thresholds:
               mode: absolute
               defaultColor: "#ef4444"
               steps:
                 - { value: 50, color: "#f59e0b" }
                 - { value: 90, color: "#22c55e" }
+            valueFormat:
+              unit: "%"
+              decimals: 0
         queries:
           - kind: ClickHouseSQL
             spec:

--- a/everr/cloud-query.dashboard.yaml
+++ b/everr/cloud-query.dashboard.yaml
@@ -9,7 +9,9 @@ spec:
       (ok / user_error / system_error), latency, the slowest queries with a
       trace to open, per-tenant usage, and how reliably the CLI leg of each
       trace is landing.
-  duration: 24h
+  timeRange:
+    from: now-24h
+    to: now
   refreshInterval: 1m
   panels:
     total-requests:

--- a/everr/cloud-query.runbook.yaml
+++ b/everr/cloud-query.runbook.yaml
@@ -71,10 +71,11 @@ spec:
         plugin:
           kind: TimeSeriesChart
           spec:
-            unit: ms
             showLegend: true
             lineWidth: 1.5
             curveType: monotone
+            valueFormat:
+              unit: ms
         queries:
           - kind: ClickHouseSQL
             spec:
@@ -100,10 +101,11 @@ spec:
         plugin:
           kind: TimeSeriesChart
           spec:
-            unit: ms
             showLegend: true
             lineWidth: 1.5
             curveType: monotone
+            valueFormat:
+              unit: ms
         queries:
           - kind: ClickHouseSQL
             spec:

--- a/everr/collector-oom.runbook.yaml
+++ b/everr/collector-oom.runbook.yaml
@@ -18,10 +18,11 @@ spec:
         plugin:
           kind: TimeSeriesChart
           spec:
-            unit: MiB
             showLegend: true
             lineWidth: 1.5
             curveType: monotone
+            valueFormat:
+              unit: MiBy
         queries:
           - kind: ClickHouseSQL
             spec:
@@ -76,10 +77,11 @@ spec:
         plugin:
           kind: TimeSeriesChart
           spec:
-            unit: ms
             showLegend: false
             lineWidth: 1.5
             curveType: monotone
+            valueFormat:
+              unit: ms
         queries:
           - kind: ClickHouseSQL
             spec:
@@ -134,14 +136,15 @@ spec:
           kind: StatChart
           spec:
             calculation: last
-            unit: " MiB"
-            decimals: 0
             colorMode: background
             thresholds:
               mode: absolute
               defaultColor: "#22c55e"
               steps:
                 - { value: 1024, color: "#ef4444" }
+            valueFormat:
+              unit: MiBy
+              decimals: 0
         queries:
           - kind: ClickHouseSQL
             spec:
@@ -175,14 +178,15 @@ spec:
           kind: StatChart
           spec:
             calculation: last
-            unit: " ms"
-            decimals: 0
             colorMode: background
             thresholds:
               mode: absolute
               defaultColor: "#22c55e"
               steps:
                 - { value: 5000, color: "#ef4444" }
+            valueFormat:
+              unit: ms
+              decimals: 0
         queries:
           - kind: ClickHouseSQL
             spec:

--- a/everr/demo/bar-chart.dashboard.yaml
+++ b/everr/demo/bar-chart.dashboard.yaml
@@ -6,7 +6,7 @@ spec:
   display:
     name: Bar Chart
     description: >-
-      BarChart regression sheet — every option (unit, showLegend, stacking
+      BarChart regression sheet: every option (unit, displayUnit, showLegend, stacking
       none/stacked/percent, orientation vertical/horizontal, showValues) and
       behavior (time axis, categorical axis, grouped pivot, multi-query merge,
       empty result) exercised with deterministic TestData.
@@ -120,13 +120,14 @@ spec:
       spec:
         display:
           name: "Bar: horizontal categories, values"
-          description: "orientation: horizontal · showValues: true · unit: req · category axis (no time column), query order kept"
+          description: "orientation: horizontal · showValues: true · unit: By · displayUnit: auto · category axis (no time column), query order kept"
         plugin:
           kind: BarChart
           spec:
             orientation: horizontal
             showValues: true
-            unit: req
+            unit: By
+            displayUnit: auto
         queries:
           - kind: TestData
             spec:
@@ -134,13 +135,13 @@ spec:
                 kind: TestData
                 spec:
                   scenario: csv
-                  columns: [endpoint, requests]
+                  columns: [endpoint, bytes]
                   rows:
-                    - ["/api/users", 1240]
-                    - ["/api/orders", 870]
-                    - ["/api/search", 605]
-                    - ["/api/login", 432]
-                    - ["/healthz", 121]
+                    - ["/api/users", 5368709120]
+                    - ["/api/orders", 3758096384]
+                    - ["/api/search", 2684354560]
+                    - ["/api/login", 1879048192]
+                    - ["/healthz", 536870912]
     bar-categorical-pivot:
       kind: Panel
       spec:

--- a/everr/demo/bar-chart.dashboard.yaml
+++ b/everr/demo/bar-chart.dashboard.yaml
@@ -6,7 +6,7 @@ spec:
   display:
     name: Bar Chart
     description: >-
-      BarChart regression sheet: every option (unit, displayUnit, showLegend, stacking
+      BarChart regression sheet: every option (unit, valueFormat, showLegend, stacking
       none/stacked/percent, orientation vertical/horizontal, showValues) and
       behavior (time axis, categorical axis, grouped pivot, multi-query merge,
       empty result) exercised with deterministic TestData.
@@ -64,8 +64,9 @@ spec:
           kind: BarChart
           spec:
             stacking: none
-            unit: ms
             showLegend: true
+            valueFormat:
+              unit: ms
         queries:
           - kind: TestData
             spec:
@@ -122,14 +123,13 @@ spec:
       spec:
         display:
           name: "Bar: horizontal categories, values"
-          description: "orientation: horizontal · showValues: true · unit: By · displayUnit: auto · category axis (no time column), query order kept"
+          description: "orientation: horizontal · showValues: true · valueFormat: binary B · category axis (no time column), query order kept"
         plugin:
           kind: BarChart
           spec:
             orientation: horizontal
             showValues: true
-            unit: By
-            displayUnit: auto
+            valueFormat: { unit: By, scale: binary }
         queries:
           - kind: TestData
             spec:
@@ -247,6 +247,130 @@ spec:
                   scenario: csv
                   columns: [endpoint, requests]
                   rows: []
+    format-none:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: none"
+          description: "valueFormat: none, unit: {connection}, decimals: 2"
+        plugin:
+          kind: BarChart
+          spec: { valueFormat: { unit: '{connection}', scale: none, decimals: 2 }, showValues: true }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 12
+                  columns: [{ name: ts, time: true }, { name: value, walk: { start: 12500, noise: 1250, min: 0 } }]
+    format-decimal:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: decimal"
+          description: "valueFormat: decimal, unit: widgets/s, decimals: 2"
+        plugin:
+          kind: BarChart
+          spec: { valueFormat: { unit: widgets/s, scale: decimal, decimals: 2 }, showValues: true }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 12
+                  columns: [{ name: ts, time: true }, { name: value, walk: { start: 12500, noise: 1250, min: 0 } }]
+    format-binary:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: binary"
+          description: "valueFormat: binary, unit: By/s, decimals: 2"
+        plugin:
+          kind: BarChart
+          spec: { valueFormat: { unit: By/s, scale: binary, decimals: 2 }, showValues: true }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 12
+                  columns: [{ name: ts, time: true }, { name: value, walk: { start: 2621440, noise: 262144, min: 0 } }]
+    format-duration:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: duration"
+          description: "valueFormat: duration, unit: s, decimals: 1"
+        plugin:
+          kind: BarChart
+          spec: { valueFormat: { unit: s, scale: duration, decimals: 1 }, showValues: true }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 12
+                  columns: [{ name: ts, time: true }, { name: value, walk: { start: 0.025, noise: 0.0025, min: 0 } }]
+    format-percent:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: ratio as percent"
+          description: "unit: 1, display: percent; raw query ratios are unchanged"
+        plugin:
+          kind: BarChart
+          spec:
+            valueFormat:
+              unit: "1"
+              display: percent
+            showValues: true
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 12
+                  columns:
+                    - name: ts
+                      time: true
+                    - name: value
+                      const: 0.75
+    format-si:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: SI prefixes"
+          description: "unit: Hz, scale: decimal; conventional GHz label"
+        plugin:
+          kind: BarChart
+          spec:
+            valueFormat:
+              unit: Hz
+              scale: decimal
+            showValues: true
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 12
+                  columns:
+                    - name: ts
+                      time: true
+                    - name: value
+                      const: 3200000000
   layouts:
     - kind: Grid
       spec:
@@ -259,3 +383,9 @@ spec:
           - { x: 8,  y: 16, width: 8,  height: 8, content: { $ref: "#/spec/panels/bar-multi-query" } }
           - { x: 16, y: 16, width: 8,  height: 8, content: { $ref: "#/spec/panels/bar-empty" } }
           - { x: 0,  y: 24, width: 24, height: 8, content: { $ref: "#/spec/panels/bar-long-labels" } }
+          - { x: 0, y: 32, width: 12, height: 9, content: { $ref: "#/spec/panels/format-none" } }
+          - { x: 12, y: 32, width: 12, height: 9, content: { $ref: "#/spec/panels/format-decimal" } }
+          - { x: 0, y: 41, width: 12, height: 9, content: { $ref: "#/spec/panels/format-binary" } }
+          - { x: 12, y: 41, width: 12, height: 9, content: { $ref: "#/spec/panels/format-duration" } }
+          - { x: 0, y: 50, width: 12, height: 8, content: { $ref: "#/spec/panels/format-percent" } }
+          - { x: 12, y: 50, width: 12, height: 8, content: { $ref: "#/spec/panels/format-si" } }

--- a/everr/demo/bar-chart.dashboard.yaml
+++ b/everr/demo/bar-chart.dashboard.yaml
@@ -10,7 +10,9 @@ spec:
       none/stacked/percent, orientation vertical/horizontal, showValues) and
       behavior (time axis, categorical axis, grouped pivot, multi-query merge,
       empty result) exercised with deterministic TestData.
-  duration: 7d
+  timeRange:
+    from: now-7d
+    to: now
   refreshInterval: 1m
   panels:
     # ── Options + core behaviors ─────────────────────────────────────

--- a/everr/demo/gauge.dashboard.yaml
+++ b/everr/demo/gauge.dashboard.yaml
@@ -28,14 +28,15 @@ spec:
           kind: GaugeChart
           spec:
             calculation: last
-            unit: "%"
-            decimals: 1
             thresholds:
               mode: absolute
               defaultColor: "#22c55e"
               steps:
                 - { value: 70, color: "#f59e0b" }
                 - { value: 90, color: "#ef4444" }
+            valueFormat:
+              unit: "%"
+              decimals: 1
         queries:
           - kind: TestData
             spec:
@@ -56,8 +57,9 @@ spec:
           kind: GaugeChart
           spec:
             calculation: first
-            decimals: 0
             max: 500
+            valueFormat:
+              decimals: 0
         queries:
           - kind: TestData
             spec:
@@ -78,9 +80,10 @@ spec:
           kind: GaugeChart
           spec:
             calculation: mean
-            unit: s
-            decimals: 2
             max: 2
+            valueFormat:
+              unit: s
+              decimals: 2
         queries:
           - kind: TestData
             spec:
@@ -101,8 +104,9 @@ spec:
           kind: GaugeChart
           spec:
             calculation: min
-            unit: ms
             max: 50
+            valueFormat:
+              unit: ms
         queries:
           - kind: TestData
             spec:
@@ -262,11 +266,12 @@ spec:
         plugin:
           kind: GaugeChart
           spec:
-            unit: "%"
             thresholds:
               defaultColor: "#22c55e"
               steps:
                 - { value: 90, color: "#ef4444" }
+            valueFormat:
+              unit: "%"
         queries:
           - kind: TestData
             spec:
@@ -286,7 +291,6 @@ spec:
         plugin:
           kind: GaugeChart
           spec:
-            unit: "%"
             min: 100
             max: 0
             thresholds:
@@ -294,6 +298,8 @@ spec:
               defaultColor: "#22c55e"
               steps:
                 - { value: 40, color: "#ef4444" }
+            valueFormat:
+              unit: "%"
         queries:
           - kind: TestData
             spec:
@@ -313,13 +319,14 @@ spec:
         plugin:
           kind: GaugeChart
           spec:
-            unit: "%"
             thresholds:
               mode: absolute
               defaultColor: "#22c55e"
               steps:
                 - { value: 50, color: "#f59e0b" }
                 - { value: 80, color: "#ef4444" }
+            valueFormat:
+              unit: "%"
         queries:
           - kind: TestData
             spec:
@@ -369,8 +376,9 @@ spec:
           kind: GaugeChart
           spec:
             calculation: last
-            unit: ms
             max: 300
+            valueFormat:
+              unit: ms
         queries:
           - kind: TestData
             spec:
@@ -413,7 +421,6 @@ spec:
           kind: GaugeChart
           spec:
             variant: arc
-            unit: "%"
             showThresholdLabels: true
             thresholds:
               mode: absolute
@@ -421,6 +428,8 @@ spec:
               steps:
                 - { value: 70, color: "#f59e0b" }
                 - { value: 90, color: "#ef4444" }
+            valueFormat:
+              unit: "%"
         queries:
           - kind: TestData
             spec:
@@ -440,8 +449,9 @@ spec:
         plugin:
           kind: GaugeChart
           spec:
-            unit: "%"
             showAxis: false
+            valueFormat:
+              unit: "%"
         queries:
           - kind: TestData
             spec:
@@ -462,14 +472,15 @@ spec:
           kind: GaugeChart
           spec:
             variant: horizontal
-            unit: "%"
-            decimals: 1
             thresholds:
               mode: absolute
               defaultColor: "#22c55e"
               steps:
                 - { value: 50, color: "#f59e0b" }
                 - { value: 80, color: "#ef4444" }
+            valueFormat:
+              unit: "%"
+              decimals: 1
         queries:
           - kind: TestData
             spec:
@@ -490,7 +501,6 @@ spec:
           kind: GaugeChart
           spec:
             variant: horizontal
-            unit: ms
             max: 500
             showAxis: false
             showThresholdLabels: true
@@ -500,6 +510,8 @@ spec:
               steps:
                 - { value: 200, color: "#f59e0b" }
                 - { value: 400, color: "#ef4444" }
+            valueFormat:
+              unit: ms
         queries:
           - kind: TestData
             spec:
@@ -520,7 +532,6 @@ spec:
           kind: GaugeChart
           spec:
             variant: horizontal
-            unit: "%"
             min: 100
             max: 0
             thresholds:
@@ -528,6 +539,8 @@ spec:
               defaultColor: "#22c55e"
               steps:
                 - { value: 40, color: "#ef4444" }
+            valueFormat:
+              unit: "%"
         queries:
           - kind: TestData
             spec:
@@ -538,6 +551,138 @@ spec:
                   columns: [cache_hit, uptime, success]
                   rows:
                     - [20, 85, 99]
+    format-none:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: none"
+          description: "valueFormat: none, unit: {connection}, decimals: 2"
+        plugin:
+          kind: GaugeChart
+          spec: { valueFormat: { unit: '{connection}', scale: none, decimals: 2 }, max: 25000, showThresholdLabels: true, thresholds: { steps: [{ value: 6250, color: "#22c55e" }] } }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns: [{ name: value, const: 12500 }]
+    format-decimal:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: decimal"
+          description: "valueFormat: decimal, unit: widgets/s, decimals: 2"
+        plugin:
+          kind: GaugeChart
+          spec: { valueFormat: { unit: widgets/s, scale: decimal, decimals: 2 }, max: 25000, showThresholdLabels: true, thresholds: { steps: [{ value: 6250, color: "#22c55e" }] } }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns: [{ name: value, const: 12500 }]
+    format-binary:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: binary"
+          description: "valueFormat: binary, unit: By/s, decimals: 2"
+        plugin:
+          kind: GaugeChart
+          spec: { valueFormat: { unit: By/s, scale: binary, decimals: 2 }, max: 5242880, showThresholdLabels: true, thresholds: { steps: [{ value: 1310720, color: "#22c55e" }] } }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns: [{ name: value, const: 2621440 }]
+    format-duration:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: duration"
+          description: "valueFormat: duration, unit: s, decimals: 1"
+        plugin:
+          kind: GaugeChart
+          spec: { valueFormat: { unit: s, scale: duration, decimals: 1 }, max: 0.05, showThresholdLabels: true, thresholds: { steps: [{ value: 0.0125, color: "#22c55e" }] } }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns: [{ name: value, const: 0.025 }]
+    format-percent:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: ratio as percent"
+          description: "unit: 1, display: percent; raw query ratios are unchanged"
+        plugin:
+          kind: GaugeChart
+          spec:
+            valueFormat:
+              unit: "1"
+              display: percent
+            max: 1
+            showThresholdLabels: true
+            thresholds:
+              defaultColor: "#22c55e"
+              steps:
+                - value: 0.8
+                  color: "#ef4444"
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns:
+                    - name: value
+                      const: 0.75
+    format-si:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: SI prefixes"
+          description: "unit: Hz, scale: decimal; conventional GHz label"
+        plugin:
+          kind: GaugeChart
+          spec:
+            valueFormat:
+              unit: Hz
+              scale: decimal
+            max: 4000000000
+            showThresholdLabels: true
+            thresholds:
+              defaultColor: "#22c55e"
+              steps:
+                - value: 3500000000
+                  color: "#ef4444"
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns:
+                    - name: value
+                      const: 3200000000
   layouts:
     - kind: Grid
       spec:
@@ -563,3 +708,9 @@ spec:
           - { x: 8,  y: 31, width: 8,  height: 5, content: { $ref: "#/spec/panels/gauge-horizontal" } }
           - { x: 16, y: 31, width: 8,  height: 5, content: { $ref: "#/spec/panels/gauge-horizontal-threshold-labels" } }
           - { x: 0,  y: 36, width: 12, height: 7, content: { $ref: "#/spec/panels/gauge-horizontal-inverted-multi" } }
+          - { x: 0, y: 43, width: 12, height: 9, content: { $ref: "#/spec/panels/format-none" } }
+          - { x: 12, y: 43, width: 12, height: 9, content: { $ref: "#/spec/panels/format-decimal" } }
+          - { x: 0, y: 52, width: 12, height: 9, content: { $ref: "#/spec/panels/format-binary" } }
+          - { x: 12, y: 52, width: 12, height: 9, content: { $ref: "#/spec/panels/format-duration" } }
+          - { x: 0, y: 61, width: 12, height: 8, content: { $ref: "#/spec/panels/format-percent" } }
+          - { x: 12, y: 61, width: 12, height: 8, content: { $ref: "#/spec/panels/format-si" } }

--- a/everr/demo/gauge.dashboard.yaml
+++ b/everr/demo/gauge.dashboard.yaml
@@ -12,7 +12,9 @@ spec:
       showAxis, showThresholdLabels) and behavior (spec defaults, clamping
       past the bounds, multi-query placeholder, multi-gauge, empty, inverted
       bounds) exercised with deterministic TestData.
-  duration: 7d
+  timeRange:
+    from: now-7d
+    to: now
   refreshInterval: 1m
   panels:
     # ── Calculations + options ───────────────────────────────────────

--- a/everr/demo/geo-map.dashboard.yaml
+++ b/everr/demo/geo-map.dashboard.yaml
@@ -12,7 +12,9 @@ spec:
       minRadius/maxRadius range, showLegend on/off, multi-query overlay, the
       unmapped-rows badge, and the empty state, driven by the deterministic geo
       and csv TestData scenarios.
-  duration: 7d
+  timeRange:
+    from: now-7d
+    to: now
   refreshInterval: 1m
   panels:
     geo-points:

--- a/everr/demo/geo-map.dashboard.yaml
+++ b/everr/demo/geo-map.dashboard.yaml
@@ -331,6 +331,138 @@ spec:
               plugin:
                 kind: TestData
                 spec: { scenario: csv, columns: [lat, lon, value], rows: [] }
+    format-none:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: none"
+          description: "valueFormat: none, unit: {connection}, decimals: 2"
+        plugin:
+          kind: GeoMap
+          spec: { valueFormat: { unit: '{connection}', scale: none, decimals: 2 }, mode: choropleth }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns: [{ name: region, values: [PT, US, DE] }, { name: value, const: 12500 }]
+    format-decimal:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: decimal"
+          description: "valueFormat: decimal, unit: widgets/s, decimals: 2"
+        plugin:
+          kind: GeoMap
+          spec: { valueFormat: { unit: widgets/s, scale: decimal, decimals: 2 }, mode: choropleth }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns: [{ name: region, values: [PT, US, DE] }, { name: value, const: 12500 }]
+    format-binary:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: binary"
+          description: "valueFormat: binary, unit: By/s, decimals: 2"
+        plugin:
+          kind: GeoMap
+          spec: { valueFormat: { unit: By/s, scale: binary, decimals: 2 }, mode: choropleth }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns: [{ name: region, values: [PT, US, DE] }, { name: value, const: 2621440 }]
+    format-duration:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: duration"
+          description: "valueFormat: duration, unit: s, decimals: 1"
+        plugin:
+          kind: GeoMap
+          spec: { valueFormat: { unit: s, scale: duration, decimals: 1 }, mode: choropleth }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns: [{ name: region, values: [PT, US, DE] }, { name: value, const: 0.025 }]
+    format-percent:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: ratio as percent"
+          description: "unit: 1, display: percent; raw query ratios are unchanged"
+        plugin:
+          kind: GeoMap
+          spec:
+            valueFormat:
+              unit: "1"
+              display: percent
+            mode: choropleth
+            aggregation: avg
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns:
+                    - name: region
+                      values:
+                        - PT
+                        - US
+                        - DE
+                    - name: value
+                      const: 0.75
+    format-si:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: SI prefixes"
+          description: "unit: Hz, scale: decimal; conventional GHz label"
+        plugin:
+          kind: GeoMap
+          spec:
+            valueFormat:
+              unit: Hz
+              scale: decimal
+            mode: choropleth
+            aggregation: avg
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns:
+                    - name: region
+                      values:
+                        - PT
+                        - US
+                        - DE
+                    - name: value
+                      const: 3200000000
   layouts:
     - kind: Grid
       spec:
@@ -358,3 +490,9 @@ spec:
           - { x: 0,  y: 75, width: 12, height: 9,  content: { $ref: "#/spec/panels/geo-points-radius" } }
           - { x: 12, y: 75, width: 12, height: 9,  content: { $ref: "#/spec/panels/geo-points-unmapped" } }
           - { x: 0,  y: 84, width: 12, height: 9,  content: { $ref: "#/spec/panels/geo-empty" } }
+          - { x: 0, y: 93, width: 12, height: 9, content: { $ref: "#/spec/panels/format-none" } }
+          - { x: 12, y: 93, width: 12, height: 9, content: { $ref: "#/spec/panels/format-decimal" } }
+          - { x: 0, y: 102, width: 12, height: 9, content: { $ref: "#/spec/panels/format-binary" } }
+          - { x: 12, y: 102, width: 12, height: 9, content: { $ref: "#/spec/panels/format-duration" } }
+          - { x: 0, y: 111, width: 12, height: 8, content: { $ref: "#/spec/panels/format-percent" } }
+          - { x: 12, y: 111, width: 12, height: 8, content: { $ref: "#/spec/panels/format-si" } }

--- a/everr/demo/heatmap.dashboard.yaml
+++ b/everr/demo/heatmap.dashboard.yaml
@@ -45,13 +45,14 @@ spec:
       spec:
         display:
           name: "Heatmap: values in cells"
-          description: "showValues: true · unit: req · colorScheme: greens — value text inside cells wide enough to fit it, text contrast follows cell luminance; sparse rows leave gaps"
+          description: "showValues: true · unit: {request} · colorScheme: greens — value text inside cells wide enough to fit it, text contrast follows cell luminance; sparse rows leave gaps"
         plugin:
           kind: Heatmap
           spec:
             showValues: true
-            unit: req
             colorScheme: greens
+            valueFormat:
+              unit: '{request}'
         queries:
           - kind: TestData
             spec:
@@ -148,8 +149,9 @@ spec:
         plugin:
           kind: Heatmap
           spec:
-            unit: ms
             colorScheme: greenYellowRed
+            valueFormat:
+              unit: ms
         queries:
           - kind: TestData
             spec:
@@ -283,6 +285,134 @@ spec:
                   rows:
                     - ["<10ms", 12]
                     - ["<100ms", 48]
+    format-none:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: none"
+          description: "valueFormat: none, unit: {connection}, decimals: 2"
+        plugin:
+          kind: Heatmap
+          spec: { valueFormat: { unit: '{connection}', scale: none, decimals: 2 }, showValues: true }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 12
+                  columns: [{ name: ts, time: true }, { name: bucket, const: api }, { name: value, walk: { start: 12500, noise: 1250, min: 0 } }]
+    format-decimal:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: decimal"
+          description: "valueFormat: decimal, unit: widgets/s, decimals: 2"
+        plugin:
+          kind: Heatmap
+          spec: { valueFormat: { unit: widgets/s, scale: decimal, decimals: 2 }, showValues: true }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 12
+                  columns: [{ name: ts, time: true }, { name: bucket, const: api }, { name: value, walk: { start: 12500, noise: 1250, min: 0 } }]
+    format-binary:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: binary"
+          description: "valueFormat: binary, unit: By/s, decimals: 2"
+        plugin:
+          kind: Heatmap
+          spec: { valueFormat: { unit: By/s, scale: binary, decimals: 2 }, showValues: true }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 12
+                  columns: [{ name: ts, time: true }, { name: bucket, const: api }, { name: value, walk: { start: 2621440, noise: 262144, min: 0 } }]
+    format-duration:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: duration"
+          description: "valueFormat: duration, unit: s, decimals: 1"
+        plugin:
+          kind: Heatmap
+          spec: { valueFormat: { unit: s, scale: duration, decimals: 1 }, showValues: true }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 12
+                  columns: [{ name: ts, time: true }, { name: bucket, const: api }, { name: value, walk: { start: 0.025, noise: 0.0025, min: 0 } }]
+    format-percent:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: ratio as percent"
+          description: "unit: 1, display: percent; raw query ratios are unchanged"
+        plugin:
+          kind: Heatmap
+          spec:
+            valueFormat:
+              unit: "1"
+              display: percent
+            showValues: true
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 12
+                  columns:
+                    - name: ts
+                      time: true
+                    - name: bucket
+                      const: api
+                    - name: value
+                      const: 0.75
+    format-si:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: SI prefixes"
+          description: "unit: Hz, scale: decimal; conventional GHz label"
+        plugin:
+          kind: Heatmap
+          spec:
+            valueFormat:
+              unit: Hz
+              scale: decimal
+            showValues: true
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 12
+                  columns:
+                    - name: ts
+                      time: true
+                    - name: bucket
+                      const: api
+                    - name: value
+                      const: 3200000000
   layouts:
     - kind: Grid
       spec:
@@ -298,3 +428,9 @@ spec:
           - { x: 0,  y: 24, width: 8,  height: 5, content: { $ref: "#/spec/panels/hm-multi-query" } }
           - { x: 8,  y: 24, width: 8,  height: 5, content: { $ref: "#/spec/panels/hm-empty" } }
           - { x: 16, y: 24, width: 8,  height: 5, content: { $ref: "#/spec/panels/hm-no-time" } }
+          - { x: 0, y: 29, width: 12, height: 9, content: { $ref: "#/spec/panels/format-none" } }
+          - { x: 12, y: 29, width: 12, height: 9, content: { $ref: "#/spec/panels/format-decimal" } }
+          - { x: 0, y: 38, width: 12, height: 9, content: { $ref: "#/spec/panels/format-binary" } }
+          - { x: 12, y: 38, width: 12, height: 9, content: { $ref: "#/spec/panels/format-duration" } }
+          - { x: 0, y: 47, width: 12, height: 8, content: { $ref: "#/spec/panels/format-percent" } }
+          - { x: 12, y: 47, width: 12, height: 8, content: { $ref: "#/spec/panels/format-si" } }

--- a/everr/demo/heatmap.dashboard.yaml
+++ b/everr/demo/heatmap.dashboard.yaml
@@ -11,7 +11,9 @@ spec:
       values, min/max domain, cellGap) and behavior (spec defaults, numeric
       bucket ordering, multi-query summing, empty, no time column) exercised
       with deterministic TestData.
-  duration: 7d
+  timeRange:
+    from: now-7d
+    to: now
   refreshInterval: 1m
   panels:
     # ── Formats and options ──────────────────────────────────────────

--- a/everr/demo/node-graph.dashboard.yaml
+++ b/everr/demo/node-graph.dashboard.yaml
@@ -49,14 +49,15 @@ spec:
       spec:
         display:
           name: "NodeGraph: custom columns + unit"
-          description: "sourceColumn: caller · targetColumn: callee · valueColumn: calls · unit: req"
+          description: "sourceColumn: caller · targetColumn: callee · valueColumn: calls · unit: {request}"
         plugin:
           kind: NodeGraph
           spec:
             sourceColumn: caller
             targetColumn: callee
             valueColumn: calls
-            unit: req
+            valueFormat:
+              unit: '{request}'
         queries:
           - kind: TestData
             spec:
@@ -121,7 +122,7 @@ spec:
           description: "showValues: true → value label at each edge midpoint · unit: ms"
         plugin:
           kind: NodeGraph
-          spec: { showValues: true, unit: ms }
+          spec: { showValues: true, valueFormat: { unit: ms } }
         queries:
           - kind: TestData
             spec:
@@ -165,7 +166,7 @@ spec:
           description: "a→b and b→a are distinct edges, drawn offset so both stay visible"
         plugin:
           kind: NodeGraph
-          spec: { unit: msg }
+          spec: { valueFormat: { unit: '{message}' } }
         queries:
           - kind: TestData
             spec:
@@ -271,6 +272,142 @@ spec:
               plugin:
                 kind: TestData
                 spec: { scenario: csv, columns: [source, target, value], rows: [] }
+    format-none:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: none"
+          description: "valueFormat: none, unit: {connection}, decimals: 2"
+        plugin:
+          kind: NodeGraph
+          spec: { valueFormat: { unit: '{connection}', scale: none, decimals: 2 }, showValues: true }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns: [{ name: source, values: [api, worker] }, { name: target, values: [db, cache] }, { name: value, const: 12500 }]
+    format-decimal:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: decimal"
+          description: "valueFormat: decimal, unit: widgets/s, decimals: 2"
+        plugin:
+          kind: NodeGraph
+          spec: { valueFormat: { unit: widgets/s, scale: decimal, decimals: 2 }, showValues: true }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns: [{ name: source, values: [api, worker] }, { name: target, values: [db, cache] }, { name: value, const: 12500 }]
+    format-binary:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: binary"
+          description: "valueFormat: binary, unit: By/s, decimals: 2"
+        plugin:
+          kind: NodeGraph
+          spec: { valueFormat: { unit: By/s, scale: binary, decimals: 2 }, showValues: true }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns: [{ name: source, values: [api, worker] }, { name: target, values: [db, cache] }, { name: value, const: 2621440 }]
+    format-duration:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: duration"
+          description: "valueFormat: duration, unit: s, decimals: 1"
+        plugin:
+          kind: NodeGraph
+          spec: { valueFormat: { unit: s, scale: duration, decimals: 1 }, showValues: true }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns: [{ name: source, values: [api, worker] }, { name: target, values: [db, cache] }, { name: value, const: 0.025 }]
+    format-percent:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: ratio as percent"
+          description: "unit: 1, display: percent; raw query ratios are unchanged"
+        plugin:
+          kind: NodeGraph
+          spec:
+            valueFormat:
+              unit: "1"
+              display: percent
+            showValues: true
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns:
+                    - name: source
+                      values:
+                        - api
+                        - worker
+                    - name: target
+                      values:
+                        - db
+                        - cache
+                    - name: value
+                      const: 0.75
+    format-si:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: SI prefixes"
+          description: "unit: Hz, scale: decimal; conventional GHz label"
+        plugin:
+          kind: NodeGraph
+          spec:
+            valueFormat:
+              unit: Hz
+              scale: decimal
+            showValues: true
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns:
+                    - name: source
+                      values:
+                        - api
+                        - worker
+                    - name: target
+                      values:
+                        - db
+                        - cache
+                    - name: value
+                      const: 3200000000
   layouts:
     - kind: Grid
       spec:
@@ -286,3 +423,9 @@ spec:
           - { x: 12, y: 39, width: 12, height: 9,  content: { $ref: "#/spec/panels/node-graph-dropped" } }
           - { x: 0,  y: 48, width: 12, height: 9,  content: { $ref: "#/spec/panels/node-graph-maxnodes" } }
           - { x: 12, y: 48, width: 12, height: 9,  content: { $ref: "#/spec/panels/node-graph-empty" } }
+          - { x: 0, y: 57, width: 12, height: 9, content: { $ref: "#/spec/panels/format-none" } }
+          - { x: 12, y: 57, width: 12, height: 9, content: { $ref: "#/spec/panels/format-decimal" } }
+          - { x: 0, y: 66, width: 12, height: 9, content: { $ref: "#/spec/panels/format-binary" } }
+          - { x: 12, y: 66, width: 12, height: 9, content: { $ref: "#/spec/panels/format-duration" } }
+          - { x: 0, y: 75, width: 12, height: 8, content: { $ref: "#/spec/panels/format-percent" } }
+          - { x: 12, y: 75, width: 12, height: 8, content: { $ref: "#/spec/panels/format-si" } }

--- a/everr/demo/node-graph.dashboard.yaml
+++ b/everr/demo/node-graph.dashboard.yaml
@@ -12,7 +12,9 @@ spec:
       multi-query summing, dropped rows (nulls + self-loops), maxNodes
       trimming, and the empty state, driven by the deterministic csv
       TestData scenario.
-  duration: 7d
+  timeRange:
+    from: now-7d
+    to: now
   refreshInterval: 1m
   panels:
     node-graph-defaults:

--- a/everr/demo/stat.dashboard.yaml
+++ b/everr/demo/stat.dashboard.yaml
@@ -10,7 +10,9 @@ spec:
       displayUnit, decimals, sparkline, colors, thresholds absolute/percent, colorMode, showLabel,
       noValue) and behavior (multi-query, placeholder tile, row-order sparkline,
       multi-tile, empty) exercised with deterministic TestData.
-  duration: 7d
+  timeRange:
+    from: now-7d
+    to: now
   refreshInterval: 1m
   panels:
     # ── Calculations + options ───────────────────────────────────────

--- a/everr/demo/stat.dashboard.yaml
+++ b/everr/demo/stat.dashboard.yaml
@@ -7,7 +7,7 @@ spec:
     name: Stat
     description: >-
       StatChart regression sheet: every option (all 9 calculations, unit,
-      displayUnit, decimals, sparkline, colors, thresholds absolute/percent, colorMode, showLabel,
+      valueFormat, decimals, sparkline, colors, thresholds absolute/percent, colorMode, showLabel,
       noValue) and behavior (multi-query, placeholder tile, row-order sparkline,
       multi-tile, empty) exercised with deterministic TestData.
   timeRange:
@@ -26,8 +26,6 @@ spec:
           kind: StatChart
           spec:
             calculation: last
-            unit: ms
-            decimals: 1
             sparkline: true
             thresholds:
               mode: absolute
@@ -35,6 +33,9 @@ spec:
               steps:
                 - { value: 10000, color: "#f59e0b" }
                 - { value: 60000, color: "#ef4444" }
+            valueFormat:
+              unit: ms
+              decimals: 1
         queries:
           - kind: TestData
             spec:
@@ -55,7 +56,8 @@ spec:
           kind: StatChart
           spec:
             calculation: first
-            decimals: 0
+            valueFormat:
+              decimals: 0
         queries:
           - kind: TestData
             spec:
@@ -71,14 +73,12 @@ spec:
       spec:
         display:
           name: "Stat: mean"
-          description: "calculation: mean · unit: By · displayUnit: auto · decimals: 2"
+          description: "calculation: mean · valueFormat: binary B · decimals: 2"
         plugin:
           kind: StatChart
           spec:
             calculation: mean
-            unit: By
-            displayUnit: auto
-            decimals: 2
+            valueFormat: { unit: By, scale: binary, decimals: 2 }
         queries:
           - kind: TestData
             spec:
@@ -99,7 +99,8 @@ spec:
           kind: StatChart
           spec:
             calculation: min
-            unit: ms
+            valueFormat:
+              unit: ms
         queries:
           - kind: TestData
             spec:
@@ -326,6 +327,128 @@ spec:
                   scenario: csv
                   columns: [ts, value]
                   rows: []
+    format-none:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: none"
+          description: "valueFormat: none, unit: {connection}, decimals: 2"
+        plugin:
+          kind: StatChart
+          spec: { valueFormat: { unit: '{connection}', scale: none, decimals: 2 } }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 12
+                  columns: [{ name: ts, time: true }, { name: value, walk: { start: 12500, noise: 1250, min: 0 } }]
+    format-decimal:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: decimal"
+          description: "valueFormat: decimal, unit: widgets/s, decimals: 2"
+        plugin:
+          kind: StatChart
+          spec: { valueFormat: { unit: widgets/s, scale: decimal, decimals: 2 } }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 12
+                  columns: [{ name: ts, time: true }, { name: value, walk: { start: 12500, noise: 1250, min: 0 } }]
+    format-binary:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: binary"
+          description: "valueFormat: binary, unit: By/s, decimals: 2"
+        plugin:
+          kind: StatChart
+          spec: { valueFormat: { unit: By/s, scale: binary, decimals: 2 } }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 12
+                  columns: [{ name: ts, time: true }, { name: value, walk: { start: 2621440, noise: 262144, min: 0 } }]
+    format-duration:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: duration"
+          description: "valueFormat: duration, unit: s, decimals: 1"
+        plugin:
+          kind: StatChart
+          spec: { valueFormat: { unit: s, scale: duration, decimals: 1 } }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 12
+                  columns: [{ name: ts, time: true }, { name: value, walk: { start: 0.025, noise: 0.0025, min: 0 } }]
+    format-percent:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: ratio as percent"
+          description: "unit: 1, display: percent; raw query ratios are unchanged"
+        plugin:
+          kind: StatChart
+          spec:
+            valueFormat:
+              unit: "1"
+              display: percent
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 12
+                  columns:
+                    - name: ts
+                      time: true
+                    - name: value
+                      const: 0.75
+    format-si:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: SI prefixes"
+          description: "unit: Hz, scale: decimal; conventional GHz label"
+        plugin:
+          kind: StatChart
+          spec:
+            valueFormat:
+              unit: Hz
+              scale: decimal
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 12
+                  columns:
+                    - name: ts
+                      time: true
+                    - name: value
+                      const: 3200000000
   layouts:
     - kind: Grid
       spec:
@@ -343,3 +466,9 @@ spec:
           - { x: 12, y: 15, width: 12, height: 6, content: { $ref: "#/spec/panels/stat-row-order-sparkline" } }
           - { x: 0,  y: 21, width: 16, height: 6, content: { $ref: "#/spec/panels/stat-multi-tile" } }
           - { x: 16, y: 21, width: 8,  height: 6, content: { $ref: "#/spec/panels/stat-empty" } }
+          - { x: 0, y: 27, width: 12, height: 9, content: { $ref: "#/spec/panels/format-none" } }
+          - { x: 12, y: 27, width: 12, height: 9, content: { $ref: "#/spec/panels/format-decimal" } }
+          - { x: 0, y: 36, width: 12, height: 9, content: { $ref: "#/spec/panels/format-binary" } }
+          - { x: 12, y: 36, width: 12, height: 9, content: { $ref: "#/spec/panels/format-duration" } }
+          - { x: 0, y: 45, width: 12, height: 8, content: { $ref: "#/spec/panels/format-percent" } }
+          - { x: 12, y: 45, width: 12, height: 8, content: { $ref: "#/spec/panels/format-si" } }

--- a/everr/demo/stat.dashboard.yaml
+++ b/everr/demo/stat.dashboard.yaml
@@ -6,8 +6,8 @@ spec:
   display:
     name: Stat
     description: >-
-      StatChart regression sheet — every option (all 9 calculations, unit,
-      decimals, sparkline, thresholds absolute/percent, colorMode, showLabel,
+      StatChart regression sheet: every option (all 9 calculations, unit,
+      displayUnit, decimals, sparkline, colors, thresholds absolute/percent, colorMode, showLabel,
       noValue) and behavior (multi-query, placeholder tile, row-order sparkline,
       multi-tile, empty) exercised with deterministic TestData.
   duration: 7d
@@ -69,12 +69,13 @@ spec:
       spec:
         display:
           name: "Stat: mean"
-          description: "calculation: mean · unit: s · decimals: 2"
+          description: "calculation: mean · unit: By · displayUnit: auto · decimals: 2"
         plugin:
           kind: StatChart
           spec:
             calculation: mean
-            unit: s
+            unit: By
+            displayUnit: auto
             decimals: 2
         queries:
           - kind: TestData
@@ -85,7 +86,7 @@ spec:
                   scenario: random_walk
                   seed: 23
                   series:
-                    - { name: avg_s, start: 0.6, noise: 0.1, min: 0 }
+                    - { name: avg_bytes, start: 6442450944, noise: 536870912, min: 0 }
     stat-min:
       kind: Panel
       spec:
@@ -282,12 +283,16 @@ spec:
       spec:
         display:
           name: "Stat: multi-tile (3 columns)"
-          description: "One query, three numeric columns → one tile each (multi-tile layout) · sparkline"
+          description: "One query, three numeric columns → one tile each (multi-tile layout) · sparkline · colors"
         plugin:
           kind: StatChart
           spec:
             calculation: last
             sparkline: true
+            colors:
+              p50_ms: "#a78bfa"
+              p95_ms: "#fde047"
+              p99_ms: "#22d3ee"
         queries:
           - kind: TestData
             spec:

--- a/everr/demo/state-timeline.dashboard.yaml
+++ b/everr/demo/state-timeline.dashboard.yaml
@@ -11,7 +11,9 @@ spec:
       colors mapping, rowHeight) and behavior (spec defaults, numeric states,
       null gaps, multi-query lanes, empty, no time column) exercised with
       deterministic TestData.
-  duration: 7d
+  timeRange:
+    from: now-7d
+    to: now
   refreshInterval: 1m
   panels:
     # ── Formats and options ──────────────────────────────────────────

--- a/everr/demo/status-history.dashboard.yaml
+++ b/everr/demo/status-history.dashboard.yaml
@@ -11,7 +11,9 @@ spec:
       rowHeight, colWidth) and behavior (spec defaults, missing-sample slots,
       numeric statuses, single sample fallback, multi-query lanes, empty, no
       time column) exercised with deterministic TestData.
-  duration: 7d
+  timeRange:
+    from: now-7d
+    to: now
   refreshInterval: 1m
   panels:
     # ── Formats and options ──────────────────────────────────────────

--- a/everr/demo/table.dashboard.yaml
+++ b/everr/demo/table.dashboard.yaml
@@ -120,6 +120,168 @@ spec:
                   scenario: csv
                   columns: [severity, logs]
                   rows: []
+    format-none:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: none"
+          description: "valueFormat: none, unit: {connection}, decimals: 2, latency column override"
+        plugin:
+          kind: Table
+          spec: { valueFormat: { unit: '{connection}', scale: none, decimals: 2 }, columns: { latency: { valueFormat: { unit: s, scale: duration } } } }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns: [{ name: name, const: api }, { name: value, const: 12500 }, { name: latency, const: 0.025 }]
+    format-decimal:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: decimal"
+          description: "valueFormat: decimal, unit: widgets/s, decimals: 2, latency column override"
+        plugin:
+          kind: Table
+          spec: { valueFormat: { unit: widgets/s, scale: decimal, decimals: 2 }, columns: { latency: { valueFormat: { unit: s, scale: duration } } } }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns: [{ name: name, const: api }, { name: value, const: 12500 }, { name: latency, const: 0.025 }]
+    format-binary:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: binary"
+          description: "valueFormat: binary, unit: By/s, decimals: 2, latency column override"
+        plugin:
+          kind: Table
+          spec: { valueFormat: { unit: By/s, scale: binary, decimals: 2 }, columns: { latency: { valueFormat: { unit: s, scale: duration } } } }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns: [{ name: name, const: api }, { name: value, const: 2621440 }, { name: latency, const: 0.025 }]
+    format-duration:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: duration"
+          description: "valueFormat: duration, unit: s, decimals: 1, latency column override"
+        plugin:
+          kind: Table
+          spec: { valueFormat: { unit: s, scale: duration, decimals: 1 }, columns: { latency: { valueFormat: { unit: s, scale: duration } } } }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns: [{ name: name, const: api }, { name: value, const: 0.025 }, { name: latency, const: 0.025 }]
+    format-ucum:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: OTel / UCUM codes"
+          description: "By/s, Cel, us, 1, {request}, {request}/s, and an unknown custom unit"
+        plugin:
+          kind: Table
+          spec:
+            columns:
+              bandwidth: { valueFormat: { unit: By/s, scale: binary } }
+              temperature: { valueFormat: { unit: Cel } }
+              latency: { valueFormat: { unit: us } }
+              utilization: { valueFormat: { unit: "1" } }
+              count: { valueFormat: { unit: "{request}", scale: decimal } }
+              rate: { valueFormat: { unit: "{request}/s", scale: decimal } }
+              custom: { valueFormat: { unit: widgets/s, scale: decimal } }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: csv
+                  columns: [bandwidth, temperature, latency, utilization, count, rate, custom]
+                  rows: [[2621440, 21.234, 25, 0.5, 12500, 3500, 4200]]
+    format-percent:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: ratio as percent"
+          description: "unit: 1, display: percent; raw query ratios are unchanged"
+        plugin:
+          kind: Table
+          spec:
+            valueFormat:
+              unit: "1"
+              display: percent
+            columns:
+              latency:
+                valueFormat:
+                  unit: s
+                  scale: duration
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns:
+                    - name: name
+                      const: api
+                    - name: value
+                      const: 0.75
+                    - name: latency
+                      const: 0.025
+    format-si:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: SI prefixes"
+          description: "unit: Hz, scale: decimal; conventional GHz label"
+        plugin:
+          kind: Table
+          spec:
+            valueFormat:
+              unit: Hz
+              scale: decimal
+            columns:
+              latency:
+                valueFormat:
+                  unit: s
+                  scale: duration
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns:
+                    - name: name
+                      const: api
+                    - name: value
+                      const: 3200000000
+                    - name: latency
+                      const: 0.025
   layouts:
     - kind: Grid
       spec:
@@ -128,3 +290,10 @@ spec:
           - { x: 0,  y: 10, width: 24, height: 8,  content: { $ref: "#/spec/panels/table-multi-query" } }
           - { x: 0,  y: 18, width: 12, height: 6,  content: { $ref: "#/spec/panels/table-empty" } }
           - { x: 12, y: 18, width: 12, height: 6,  content: { $ref: "#/spec/panels/table-multi-empty" } }
+          - { x: 0, y: 24, width: 12, height: 9, content: { $ref: "#/spec/panels/format-none" } }
+          - { x: 12, y: 24, width: 12, height: 9, content: { $ref: "#/spec/panels/format-decimal" } }
+          - { x: 0, y: 33, width: 12, height: 9, content: { $ref: "#/spec/panels/format-binary" } }
+          - { x: 12, y: 33, width: 12, height: 9, content: { $ref: "#/spec/panels/format-duration" } }
+          - { x: 0, y: 42, width: 24, height: 6, content: { $ref: "#/spec/panels/format-ucum" } }
+          - { x: 0, y: 48, width: 12, height: 8, content: { $ref: "#/spec/panels/format-percent" } }
+          - { x: 12, y: 48, width: 12, height: 8, content: { $ref: "#/spec/panels/format-si" } }

--- a/everr/demo/table.dashboard.yaml
+++ b/everr/demo/table.dashboard.yaml
@@ -9,7 +9,9 @@ spec:
       Table regression sheet — stickyHeader option and behaviors (multi-query
       selector, NULL rendering, scroll, single-query empty, all-frames-empty)
       exercised with deterministic TestData.
-  duration: 7d
+  timeRange:
+    from: now-7d
+    to: now
   refreshInterval: 1m
   panels:
     table-sticky:

--- a/everr/demo/time-series.dashboard.yaml
+++ b/everr/demo/time-series.dashboard.yaml
@@ -10,7 +10,9 @@ spec:
       lineWidth, curveType, connectNulls, stacked) and behavior (grouped pivot,
       multi-column, multi-query, null gaps, empty result) exercised with
       deterministic TestData.
-  duration: 7d
+  timeRange:
+    from: now-7d
+    to: now
   refreshInterval: 1m
   panels:
     # ── Options + core behaviors ─────────────────────────────────────

--- a/everr/demo/time-series.dashboard.yaml
+++ b/everr/demo/time-series.dashboard.yaml
@@ -6,7 +6,7 @@ spec:
   display:
     name: Time Series
     description: >-
-      TimeSeriesChart regression sheet: every option (unit, displayUnit, showLegend,
+      TimeSeriesChart regression sheet: every option (unit, valueFormat, showLegend,
       lineWidth, curveType, connectNulls, stacked) and behavior (grouped pivot,
       multi-column, multi-query, null gaps, empty result) exercised with
       deterministic TestData.
@@ -25,11 +25,12 @@ spec:
         plugin:
           kind: TimeSeriesChart
           spec:
-            unit: ""
             showLegend: true
             lineWidth: 1.5
             curveType: monotone
             connectNulls: false
+            valueFormat:
+              unit: ""
         queries:
           - kind: TestData
             spec:
@@ -52,11 +53,12 @@ spec:
         plugin:
           kind: TimeSeriesChart
           spec:
-            unit: ms
             showLegend: true
             lineWidth: 2
             curveType: stepAfter
             connectNulls: false
+            valueFormat:
+              unit: ms
         queries:
           - kind: TestData
             spec:
@@ -77,11 +79,12 @@ spec:
         plugin:
           kind: TimeSeriesChart
           spec:
-            unit: ""
             showLegend: false
             lineWidth: 3
             curveType: linear
             connectNulls: true
+            valueFormat:
+              unit: ""
         queries:
           - kind: TestData
             spec:
@@ -97,12 +100,11 @@ spec:
       spec:
         display:
           name: "TS: natural, byte units"
-          description: "curveType: natural · unit: By · displayUnit: auto"
+          description: "curveType: natural · valueFormat: binary B"
         plugin:
           kind: TimeSeriesChart
           spec:
-            unit: By
-            displayUnit: auto
+            valueFormat: { unit: By, scale: binary }
             showLegend: false
             lineWidth: 1.5
             curveType: natural
@@ -126,11 +128,12 @@ spec:
         plugin:
           kind: TimeSeriesChart
           spec:
-            unit: ""
             showLegend: false
             lineWidth: 1
             curveType: stepBefore
             connectNulls: false
+            valueFormat:
+              unit: ""
         queries:
           - kind: TestData
             spec:
@@ -150,12 +153,13 @@ spec:
         plugin:
           kind: TimeSeriesChart
           spec:
-            unit: ""
             showLegend: true
             lineWidth: 1.5
             curveType: monotone
             connectNulls: false
             stacked: true
+            valueFormat:
+              unit: ""
         queries:
           - kind: TestData
             spec:
@@ -178,12 +182,13 @@ spec:
         plugin:
           kind: TimeSeriesChart
           spec:
-            unit: ""
             showLegend: true
             lineWidth: 1
             curveType: stepAfter
             connectNulls: false
             stacked: true
+            valueFormat:
+              unit: ""
         queries:
           - kind: TestData
             spec:
@@ -205,11 +210,12 @@ spec:
         plugin:
           kind: TimeSeriesChart
           spec:
-            unit: ""
             showLegend: true
             lineWidth: 1.5
             curveType: monotone
             connectNulls: false
+            valueFormat:
+              unit: ""
         queries:
           - kind: TestData
             spec:
@@ -238,11 +244,12 @@ spec:
         plugin:
           kind: TimeSeriesChart
           spec:
-            unit: ""
             showLegend: false
             lineWidth: 1.5
             curveType: monotone
             connectNulls: false
+            valueFormat:
+              unit: ""
         queries:
           - kind: TestData
             spec:
@@ -252,6 +259,128 @@ spec:
                   scenario: csv
                   columns: [ts, value]
                   rows: []
+    format-none:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: none"
+          description: "valueFormat: none, unit: {connection}, decimals: 2"
+        plugin:
+          kind: TimeSeriesChart
+          spec: { valueFormat: { unit: '{connection}', scale: none, decimals: 2 } }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 12
+                  columns: [{ name: ts, time: true }, { name: value, walk: { start: 12500, noise: 1250, min: 0 } }]
+    format-decimal:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: decimal"
+          description: "valueFormat: decimal, unit: widgets/s, decimals: 2"
+        plugin:
+          kind: TimeSeriesChart
+          spec: { valueFormat: { unit: widgets/s, scale: decimal, decimals: 2 } }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 12
+                  columns: [{ name: ts, time: true }, { name: value, walk: { start: 12500, noise: 1250, min: 0 } }]
+    format-binary:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: binary"
+          description: "valueFormat: binary, unit: By/s, decimals: 2"
+        plugin:
+          kind: TimeSeriesChart
+          spec: { valueFormat: { unit: By/s, scale: binary, decimals: 2 } }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 12
+                  columns: [{ name: ts, time: true }, { name: value, walk: { start: 2621440, noise: 262144, min: 0 } }]
+    format-duration:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: duration"
+          description: "valueFormat: duration, unit: s, decimals: 1"
+        plugin:
+          kind: TimeSeriesChart
+          spec: { valueFormat: { unit: s, scale: duration, decimals: 1 } }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 12
+                  columns: [{ name: ts, time: true }, { name: value, walk: { start: 0.025, noise: 0.0025, min: 0 } }]
+    format-percent:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: ratio as percent"
+          description: "unit: 1, display: percent; raw query ratios are unchanged"
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            valueFormat:
+              unit: "1"
+              display: percent
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 12
+                  columns:
+                    - name: ts
+                      time: true
+                    - name: value
+                      const: 0.75
+    format-si:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: SI prefixes"
+          description: "unit: Hz, scale: decimal; conventional GHz label"
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            valueFormat:
+              unit: Hz
+              scale: decimal
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 12
+                  columns:
+                    - name: ts
+                      time: true
+                    - name: value
+                      const: 3200000000
   layouts:
     - kind: Grid
       spec:
@@ -265,3 +394,9 @@ spec:
           - { x: 12, y: 15, width: 12, height: 8, content: { $ref: "#/spec/panels/ts-stacked-sparse-step" } }
           - { x: 0,  y: 23, width: 16, height: 8, content: { $ref: "#/spec/panels/ts-multi-query" } }
           - { x: 16, y: 23, width: 8,  height: 8, content: { $ref: "#/spec/panels/ts-empty" } }
+          - { x: 0, y: 31, width: 12, height: 9, content: { $ref: "#/spec/panels/format-none" } }
+          - { x: 12, y: 31, width: 12, height: 9, content: { $ref: "#/spec/panels/format-decimal" } }
+          - { x: 0, y: 40, width: 12, height: 9, content: { $ref: "#/spec/panels/format-binary" } }
+          - { x: 12, y: 40, width: 12, height: 9, content: { $ref: "#/spec/panels/format-duration" } }
+          - { x: 0, y: 49, width: 12, height: 8, content: { $ref: "#/spec/panels/format-percent" } }
+          - { x: 12, y: 49, width: 12, height: 8, content: { $ref: "#/spec/panels/format-si" } }

--- a/everr/demo/time-series.dashboard.yaml
+++ b/everr/demo/time-series.dashboard.yaml
@@ -6,7 +6,7 @@ spec:
   display:
     name: Time Series
     description: >-
-      TimeSeriesChart regression sheet — every option (unit, showLegend,
+      TimeSeriesChart regression sheet: every option (unit, displayUnit, showLegend,
       lineWidth, curveType, connectNulls, stacked) and behavior (grouped pivot,
       multi-column, multi-query, null gaps, empty result) exercised with
       deterministic TestData.
@@ -94,12 +94,13 @@ spec:
       kind: Panel
       spec:
         display:
-          name: "TS: natural, seconds unit"
-          description: "curveType: natural · unit: s"
+          name: "TS: natural, byte units"
+          description: "curveType: natural · unit: By · displayUnit: auto"
         plugin:
           kind: TimeSeriesChart
           spec:
-            unit: s
+            unit: By
+            displayUnit: auto
             showLegend: false
             lineWidth: 1.5
             curveType: natural
@@ -113,7 +114,7 @@ spec:
                   scenario: random_walk
                   seed: 5
                   series:
-                    - { name: avg_s, start: 0.5, noise: 0.1, min: 0 }
+                    - { name: volume, start: 3221225472, noise: 268435456, min: 0 }
     ts-step-before:
       kind: Panel
       spec:

--- a/everr/demo/treemap.dashboard.yaml
+++ b/everr/demo/treemap.dashboard.yaml
@@ -46,10 +46,10 @@ spec:
       spec:
         display:
           name: "Treemap: custom columns + unit"
-          description: "nameColumn: route · valueColumn: requests · unit: req"
+          description: "nameColumn: route · valueColumn: requests · unit: {request}"
         plugin:
           kind: Treemap
-          spec: { nameColumn: route, valueColumn: requests, unit: req }
+          spec: { nameColumn: route, valueColumn: requests, valueFormat: { unit: '{request}' } }
         queries:
           - kind: TestData
             spec:
@@ -72,7 +72,7 @@ spec:
           description: "groupColumn: service → one color per group · showLegend: true"
         plugin:
           kind: Treemap
-          spec: { groupColumn: service, unit: req, showLegend: true }
+          spec: { groupColumn: service, showLegend: true, valueFormat: { unit: '{request}' } }
         queries:
           - kind: TestData
             spec:
@@ -216,7 +216,7 @@ spec:
           description: "maxTiles: 6 → top 5 tiles + muted 'Other (7)' tile for the long tail"
         plugin:
           kind: Treemap
-          spec: { maxTiles: 6, unit: req }
+          spec: { maxTiles: 6, valueFormat: { unit: '{request}' } }
         queries:
           - kind: TestData
             spec:
@@ -253,6 +253,134 @@ spec:
               plugin:
                 kind: TestData
                 spec: { scenario: csv, columns: [name, value], rows: [] }
+    format-none:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: none"
+          description: "valueFormat: none, unit: {connection}, decimals: 2"
+        plugin:
+          kind: Treemap
+          spec: { valueFormat: { unit: '{connection}', scale: none, decimals: 2 } }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns: [{ name: name, values: [api, worker, web] }, { name: value, const: 12500 }]
+    format-decimal:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: decimal"
+          description: "valueFormat: decimal, unit: widgets/s, decimals: 2"
+        plugin:
+          kind: Treemap
+          spec: { valueFormat: { unit: widgets/s, scale: decimal, decimals: 2 } }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns: [{ name: name, values: [api, worker, web] }, { name: value, const: 12500 }]
+    format-binary:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: binary"
+          description: "valueFormat: binary, unit: By/s, decimals: 2"
+        plugin:
+          kind: Treemap
+          spec: { valueFormat: { unit: By/s, scale: binary, decimals: 2 } }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns: [{ name: name, values: [api, worker, web] }, { name: value, const: 2621440 }]
+    format-duration:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: duration"
+          description: "valueFormat: duration, unit: s, decimals: 1"
+        plugin:
+          kind: Treemap
+          spec: { valueFormat: { unit: s, scale: duration, decimals: 1 } }
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns: [{ name: name, values: [api, worker, web] }, { name: value, const: 0.025 }]
+    format-percent:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: ratio as percent"
+          description: "unit: 1, display: percent; raw query ratios are unchanged"
+        plugin:
+          kind: Treemap
+          spec:
+            valueFormat:
+              unit: "1"
+              display: percent
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns:
+                    - name: name
+                      values:
+                        - api
+                        - worker
+                        - web
+                    - name: value
+                      const: 0.75
+    format-si:
+      kind: Panel
+      spec:
+        display:
+          name: "Format: SI prefixes"
+          description: "unit: Hz, scale: decimal; conventional GHz label"
+        plugin:
+          kind: Treemap
+          spec:
+            valueFormat:
+              unit: Hz
+              scale: decimal
+        queries:
+          - kind: TestData
+            spec:
+              plugin:
+                kind: TestData
+                spec:
+                  scenario: table
+                  rows: 3
+                  columns:
+                    - name: name
+                      values:
+                        - api
+                        - worker
+                        - web
+                    - name: value
+                      const: 3200000000
   layouts:
     - kind: Grid
       spec:
@@ -267,3 +395,9 @@ spec:
           - { x: 0,  y: 39, width: 12, height: 9,  content: { $ref: "#/spec/panels/treemap-maxtiles" } }
           - { x: 12, y: 39, width: 12, height: 9,  content: { $ref: "#/spec/panels/treemap-dropped" } }
           - { x: 0,  y: 48, width: 12, height: 9,  content: { $ref: "#/spec/panels/treemap-empty" } }
+          - { x: 0, y: 57, width: 12, height: 9, content: { $ref: "#/spec/panels/format-none" } }
+          - { x: 12, y: 57, width: 12, height: 9, content: { $ref: "#/spec/panels/format-decimal" } }
+          - { x: 0, y: 66, width: 12, height: 9, content: { $ref: "#/spec/panels/format-binary" } }
+          - { x: 12, y: 66, width: 12, height: 9, content: { $ref: "#/spec/panels/format-duration" } }
+          - { x: 0, y: 75, width: 12, height: 8, content: { $ref: "#/spec/panels/format-percent" } }
+          - { x: 12, y: 75, width: 12, height: 8, content: { $ref: "#/spec/panels/format-si" } }

--- a/everr/demo/treemap.dashboard.yaml
+++ b/everr/demo/treemap.dashboard.yaml
@@ -11,7 +11,9 @@ spec:
       cycling when ungrouped, multi-query grouping, duplicate-name summing,
       maxTiles tail collapsing into the Other tile, the dropped-rows badge,
       and the empty state, driven by the deterministic csv TestData scenario.
-  duration: 7d
+  timeRange:
+    from: now-7d
+    to: now
   refreshInterval: 1m
   panels:
     treemap-defaults:

--- a/everr/demo/variables.dashboard.yaml
+++ b/everr/demo/variables.dashboard.yaml
@@ -115,11 +115,12 @@ spec:
         plugin:
           kind: TimeSeriesChart
           spec:
-            unit: ""
             showLegend: true
             lineWidth: 1.5
             curveType: monotone
             connectNulls: false
+            valueFormat:
+              unit: ""
         queries:
           - kind: TestData
             spec:
@@ -140,11 +141,12 @@ spec:
         plugin:
           kind: TimeSeriesChart
           spec:
-            unit: ms
             showLegend: true
             lineWidth: 2
             curveType: stepAfter
             connectNulls: false
+            valueFormat:
+              unit: ms
         queries:
           - kind: TestData
             spec:

--- a/everr/demo/variables.dashboard.yaml
+++ b/everr/demo/variables.dashboard.yaml
@@ -9,7 +9,9 @@ spec:
       Variable toolbar regression sheet: ten variables at once, mixing
       single/multi selects, allow-all, hidden, text inputs, and a live
       ClickHouse-backed list, to check how the toolbar wraps and aligns.
-  duration: 7d
+  timeRange:
+    from: now-7d
+    to: now
   refreshInterval: 1m
   variables:
     - kind: ListVariable

--- a/everr/errors-to-fix.dashboard.yaml
+++ b/everr/errors-to-fix.dashboard.yaml
@@ -58,14 +58,15 @@ spec:
           kind: StatChart
           spec:
             calculation: last
-            unit: "%"
-            decimals: 2
             thresholds:
               mode: absolute
               defaultColor: "#22c55e"
               steps:
                 - { value: 1, color: "#f59e0b" }
                 - { value: 5, color: "#ef4444" }
+            valueFormat:
+              unit: "%"
+              decimals: 2
         queries:
           - kind: ClickHouseSQL
             spec:

--- a/everr/errors-to-fix.dashboard.yaml
+++ b/everr/errors-to-fix.dashboard.yaml
@@ -8,7 +8,9 @@ spec:
       Triage board for open errors: volume and rate at a glance, error groups
       ranked by occurrences with a sample trace to jump into, failing
       operations, and the latest error logs.
-  duration: 24h
+  timeRange:
+    from: now-24h
+    to: now
   refreshInterval: 1m
   variables:
     - kind: ListVariable

--- a/everr/eventloop-delay.runbook.yaml
+++ b/everr/eventloop-delay.runbook.yaml
@@ -18,10 +18,11 @@ spec:
         plugin:
           kind: TimeSeriesChart
           spec:
-            unit: ms
             showLegend: true
             lineWidth: 1.5
             curveType: monotone
+            valueFormat:
+              unit: ms
         queries:
           - kind: ClickHouseSQL
             spec:
@@ -52,10 +53,11 @@ spec:
         plugin:
           kind: TimeSeriesChart
           spec:
-            unit: "%"
             showLegend: false
             lineWidth: 1.5
             curveType: monotone
+            valueFormat:
+              unit: "%"
         queries:
           - kind: ClickHouseSQL
             spec:
@@ -80,10 +82,11 @@ spec:
         plugin:
           kind: TimeSeriesChart
           spec:
-            unit: MB
             showLegend: false
             lineWidth: 1.5
             curveType: monotone
+            valueFormat:
+              unit: MB
         queries:
           - kind: ClickHouseSQL
             spec:
@@ -185,10 +188,11 @@ spec:
         plugin:
           kind: TimeSeriesChart
           spec:
-            unit: ms
             showLegend: true
             lineWidth: 1.5
             curveType: monotone
+            valueFormat:
+              unit: ms
         queries:
           - kind: ClickHouseSQL
             spec:

--- a/packages/app/.env.example
+++ b/packages/app/.env.example
@@ -69,12 +69,12 @@ POLAR_PRO_PRODUCT_ID=
 INGEST_VERIFY_SHARED_SECRET="replace-with-a-long-random-value"
 
 # Telemetry
-# Defaults to the local collector when unset. Override this for a custom
-# collector. Set EVERR_INGEST_KEY only in the deployment secret manager for
-# hosted ingest. To get dev telemetry in both the dev stack and the desktop
-# instance, point this at the docker collector's dev receiver
-# (http://127.0.0.1:4320), which fans out to both.
-OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:54318
+# OTEL_EXPORTER_OTLP_ENDPOINT is an unauthenticated custom collector override.
+# For authenticated Everr ingest, set EVERR_INGEST_KEY and optionally override
+# the hosted endpoint with EVERR_INGEST_ENDPOINT, for example the local public
+# receiver at http://127.0.0.1:4318.
+OTEL_EXPORTER_OTLP_ENDPOINT=
+EVERR_INGEST_ENDPOINT=http://127.0.0.1:4318
 EVERR_INGEST_KEY=
 SERVICE_VERSION=
 DEPLOYMENT_ENVIRONMENT=

--- a/packages/app/src/components/dashboards/dashboards-list.tsx
+++ b/packages/app/src/components/dashboards/dashboards-list.tsx
@@ -11,6 +11,7 @@ import {
   CirclePlus,
   Cpu,
   Database,
+  Gauge,
   Globe,
   RotateCw,
   TriangleAlert,
@@ -82,6 +83,7 @@ const CATEGORY_ICON: Record<
   Runtime: Cpu,
   Databases: Database,
   Infrastructure: Boxes,
+  Everr: Gauge,
   Browser: Globe,
 };
 

--- a/packages/app/src/components/dashboards/visualizations/bar-chart/bar-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/bar-chart/bar-chart-visualization.tsx
@@ -17,6 +17,7 @@ import {
   YAxis,
 } from "recharts";
 import type { VisualizationProps } from "../index";
+import { MIN_VALUE_AXIS_WIDTH, valueAxisWidth } from "../value-axis";
 import { createValueFormatter } from "../value-format";
 import { buildBarChartModel, X_KEY } from "./bar-chart-data";
 import type { BarChartSpec } from "./spec";
@@ -259,11 +260,8 @@ export function BarChartVisualization({
               horizontal
                 ? 90
                 : spec.valueFormat && stacking !== "percent"
-                  ? Math.max(
-                      60,
-                      formatAxisValue(-axisMagnitude).length * 7 + 16,
-                    )
-                  : 60
+                  ? valueAxisWidth([-axisMagnitude], formatAxisValue)
+                  : MIN_VALUE_AXIS_WIDTH
             }
             tickLine={false}
             axisLine={false}

--- a/packages/app/src/components/dashboards/visualizations/bar-chart/bar-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/bar-chart/bar-chart-visualization.tsx
@@ -17,6 +17,7 @@ import {
   YAxis,
 } from "recharts";
 import type { VisualizationProps } from "../index";
+import { formatValue } from "../value-format";
 import { buildBarChartModel, X_KEY } from "./bar-chart-data";
 import type { BarChartSpec } from "./spec";
 
@@ -111,7 +112,15 @@ export function BarChartVisualization({
   spec,
   data,
 }: VisualizationProps<BarChartSpec>) {
-  const { unit, showLegend, stacking, orientation, showValues, colors } = spec;
+  const {
+    unit,
+    displayUnit,
+    showLegend,
+    stacking,
+    orientation,
+    showValues,
+    colors,
+  } = spec;
 
   const { chartData, valueKeys, chartConfig, isTimeAxis } = useMemo(
     () => buildBarChartModel(data ?? [], colors),
@@ -183,11 +192,8 @@ export function BarChartVisualization({
   const formatValueTick = (v: number) =>
     stacking === "percent"
       ? `${Math.round(v * 100)}%`
-      : unit
-        ? `${v}${unit}`
-        : String(v);
-  const formatValue = (v: number) =>
-    unit ? `${v.toLocaleString()}${unit}` : v.toLocaleString();
+      : formatValue(v, unit, { displayUnit, locale: false });
+  const formatBarValue = (v: number) => formatValue(v, unit, { displayUnit });
 
   // Dense (time-bucketed) data produces one category per bucket — thin the
   // tick labels instead of letting them overlap.
@@ -265,7 +271,7 @@ export function BarChartVisualization({
                   className="fill-foreground"
                   fontSize={10}
                   formatter={(v: unknown) =>
-                    typeof v === "number" ? formatValue(v) : ""
+                    typeof v === "number" ? formatBarValue(v) : ""
                   }
                 />
               )}
@@ -287,7 +293,7 @@ export function BarChartVisualization({
                 key,
                 color: chartConfig[key]?.color,
                 label: chartConfig[key]?.label ?? key,
-                value: formatValue(tooltipRow[key] as number),
+                value: formatBarValue(tooltipRow[key] as number),
               }))}
           />
         </CursorTooltip>

--- a/packages/app/src/components/dashboards/visualizations/bar-chart/bar-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/bar-chart/bar-chart-visualization.tsx
@@ -17,7 +17,7 @@ import {
   YAxis,
 } from "recharts";
 import type { VisualizationProps } from "../index";
-import { formatValue } from "../value-format";
+import { createValueFormatter } from "../value-format";
 import { buildBarChartModel, X_KEY } from "./bar-chart-data";
 import type { BarChartSpec } from "./spec";
 
@@ -112,15 +112,8 @@ export function BarChartVisualization({
   spec,
   data,
 }: VisualizationProps<BarChartSpec>) {
-  const {
-    unit,
-    displayUnit,
-    showLegend,
-    stacking,
-    orientation,
-    showValues,
-    colors,
-  } = spec;
+  const formatter = createValueFormatter(spec.valueFormat);
+  const { showLegend, stacking, orientation, showValues, colors } = spec;
 
   const { chartData, valueKeys, chartConfig, isTimeAxis } = useMemo(
     () => buildBarChartModel(data ?? [], colors),
@@ -188,12 +181,25 @@ export function BarChartVisualization({
   const formatXTick = isTimeAxis
     ? createTimeTickFormatter(spanMs)
     : (x: string | number) => String(x);
+  let axisMagnitude = 0;
+  for (const row of chartData) {
+    let positive = 0;
+    let negative = 0;
+    for (const key of valueKeys) {
+      const value = row[key];
+      if (typeof value !== "number" || !Number.isFinite(value)) continue;
+      if (stacked) {
+        positive += Math.max(0, value);
+        negative += Math.min(0, value);
+      } else axisMagnitude = Math.max(axisMagnitude, Math.abs(value));
+    }
+    if (stacked) axisMagnitude = Math.max(axisMagnitude, positive, -negative);
+  }
+  const formatAxisValue = formatter.axis(axisMagnitude);
   // With percent stacking the value axis runs 0..1 (stackOffset="expand").
   const formatValueTick = (v: number) =>
-    stacking === "percent"
-      ? `${Math.round(v * 100)}%`
-      : formatValue(v, unit, { displayUnit, locale: false });
-  const formatBarValue = (v: number) => formatValue(v, unit, { displayUnit });
+    stacking === "percent" ? `${Math.round(v * 100)}%` : formatAxisValue(v);
+  const formatBarValue = formatter.format;
 
   // Dense (time-bucketed) data produces one category per bucket — thin the
   // tick labels instead of letting them overlap.
@@ -249,7 +255,16 @@ export function BarChartVisualization({
           />
           <YAxis
             {...(horizontal ? categoryAxisProps : valueAxisProps)}
-            width={horizontal ? 90 : 60}
+            width={
+              horizontal
+                ? 90
+                : spec.valueFormat && stacking !== "percent"
+                  ? Math.max(
+                      60,
+                      formatAxisValue(-axisMagnitude).length * 7 + 16,
+                    )
+                  : 60
+            }
             tickLine={false}
             axisLine={false}
             tickMargin={8}

--- a/packages/app/src/components/dashboards/visualizations/bar-chart/spec.ts
+++ b/packages/app/src/components/dashboards/visualizations/bar-chart/spec.ts
@@ -1,4 +1,5 @@
 import * as z from "zod";
+import { valueFormatSpec } from "../value-format-spec";
 
 /**
  * BarChart plugin options. Loose so unknown keys flow through verbatim
@@ -6,8 +7,7 @@ import * as z from "zod";
  * is defaulted so `{}` always parses — the lenient render path relies on it.
  */
 export const barChartSpec = z.looseObject({
-  unit: z.string().default(""),
-  displayUnit: z.literal("auto").optional(),
+  valueFormat: valueFormatSpec.optional(),
   showLegend: z.boolean().default(false),
   /** `stacked` piles series into one bar per x value; `percent` additionally
    * normalizes each stack to 100% (the value axis becomes percentages). */

--- a/packages/app/src/components/dashboards/visualizations/bar-chart/spec.ts
+++ b/packages/app/src/components/dashboards/visualizations/bar-chart/spec.ts
@@ -7,6 +7,7 @@ import * as z from "zod";
  */
 export const barChartSpec = z.looseObject({
   unit: z.string().default(""),
+  displayUnit: z.literal("auto").optional(),
   showLegend: z.boolean().default(false),
   /** `stacked` piles series into one bar per x value; `percent` additionally
    * normalizes each stack to 100% (the value axis becomes percentages). */

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-axis.test.ts
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-axis.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { ThresholdsSpec } from "../stat-chart/stat-calculations";
+import { createValueFormatter } from "../value-format";
 import {
   axisFraction,
   bandColors,
   fillSegments,
-  formatAxisEnd,
   thresholdMarks,
 } from "./gauge-axis";
 
@@ -41,6 +41,23 @@ describe("axisFraction", () => {
 });
 
 describe("thresholdMarks", () => {
+  it("formats ratio thresholds as percent without changing their positions", () => {
+    const labels = createValueFormatter({
+      unit: "1",
+      scale: "none",
+      display: "percent",
+    }).axis(1);
+    expect(
+      thresholdMarks(
+        { mode: "absolute", steps: [{ value: 0.8, color: RED }] },
+        0,
+        1,
+        labels,
+      ),
+    ).toEqual([{ fraction: 0.8, text: "80%", color: RED }]);
+    expect(axisFraction(0.75, 0, 1)).toBe(0.75);
+    expect([0, 1].map(labels)).toEqual(["0%", "100%"]);
+  });
   it("projects absolute steps and sorts along the axis", () => {
     expect(thresholdMarks(absolute, 0, 100)).toEqual([
       { fraction: 0.5, text: "50", color: AMBER },
@@ -60,7 +77,14 @@ describe("thresholdMarks", () => {
   });
 
   it("suffixes the unit on the label", () => {
-    expect(thresholdMarks(absolute, 0, 100, "ms")[0]?.text).toBe("50ms");
+    expect(
+      thresholdMarks(
+        absolute,
+        0,
+        100,
+        createValueFormatter({ unit: "ms", scale: "none" }).format,
+      )[0]?.text,
+    ).toBe("50 ms");
   });
 
   it("drops steps outside the axis span, inverted bounds included", () => {
@@ -148,20 +172,5 @@ describe("duplicate steps", () => {
       { from: 0, to: 0.5, color: GREEN },
       { from: 0.5, to: 0.9, color: RED },
     ]);
-  });
-});
-
-describe("formatAxisEnd", () => {
-  it("suffixes the unit on a non-zero end", () => {
-    expect(formatAxisEnd(100, "%")).toBe("100%");
-    expect(formatAxisEnd(-500, "ms")).toBe("-500ms");
-  });
-
-  it("leaves a zero end bare", () => {
-    expect(formatAxisEnd(0, "%")).toBe("0");
-  });
-
-  it("works without a unit", () => {
-    expect(formatAxisEnd(50)).toBe("50");
   });
 });

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-axis.ts
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-axis.ts
@@ -1,8 +1,8 @@
 import {
-  formatStatValue,
   resolveThresholdColor,
   type ThresholdsSpec,
 } from "../stat-chart/stat-calculations";
+import { createValueFormatter } from "../value-format";
 
 /**
  * Calculates the position of `value` on the gauge axis, from 0 to 1. The
@@ -13,24 +13,6 @@ import {
 export function axisFraction(value: number, min: number, max: number): number {
   if (max === min) return 0;
   return Math.min(1, Math.max(0, (value - min) / (max - min)));
-}
-
-/**
- * Formats a value on the axis: the min and max ends, and the threshold ticks.
- * The axis always uses the default precision. The `decimals` option applies
- * to the gauge value only.
- */
-function formatAxisValue(value: number, unit?: string): string {
-  return `${formatStatValue(value, undefined)}${unit ?? ""}`;
-}
-
-/**
- * Formats one end of the axis. If the end value is 0, the label does not show
- * the unit, because "0" is clear without it. The end labels are also the
- * smallest text on the gauge.
- */
-export function formatAxisEnd(value: number, unit?: string): string {
-  return formatAxisValue(value, value === 0 ? undefined : unit);
 }
 
 export interface ThresholdMark {
@@ -59,7 +41,7 @@ export function thresholdMarks(
   thresholds: ThresholdsSpec | undefined,
   min: number,
   max: number,
-  unit?: string,
+  formatValue: (value: number) => string = createValueFormatter().format,
 ): ThresholdMark[] {
   if (!thresholds?.steps) return [];
   const ref = thresholds.max ?? max;
@@ -72,7 +54,7 @@ export function thresholdMarks(
     if (value <= lower || value >= upper) continue;
     marks.push({
       fraction: axisFraction(value, min, max),
-      text: formatAxisValue(value, unit),
+      text: formatValue(value),
       color: step.color,
     });
   }

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.test.tsx
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { GaugeChartVisualization } from "./gauge-chart-visualization";
+import { gaugeChartSpec } from "./spec";
+
+const props = {
+  timeRange: { from: new Date(0), to: new Date(60_000) },
+  onTimeRangeChange: () => {},
+};
+
+describe("GaugeChartVisualization", () => {
+  it.each([
+    "horizontal",
+    "arc",
+  ] as const)("attaches percent units in the %s gauge", (variant) => {
+    render(
+      <GaugeChartVisualization
+        {...props}
+        spec={gaugeChartSpec.parse({
+          variant,
+          valueFormat: { unit: "1", display: "percent" },
+        })}
+        data={[[{ utilization: 0.75 }]]}
+      />,
+    );
+
+    const unit = screen.getByText("%");
+    expect(unit).not.toHaveClass("ml-1");
+    expect(unit).not.toHaveAttribute("dx");
+  });
+
+  it.each([
+    "horizontal",
+    "arc",
+  ] as const)("separates ordinary units in the %s gauge", (variant) => {
+    render(
+      <GaugeChartVisualization
+        {...props}
+        spec={gaugeChartSpec.parse({
+          variant,
+          max: 1,
+          valueFormat: { unit: "s", scale: "duration" },
+        })}
+        data={[[{ latency: 0.025 }]]}
+      />,
+    );
+
+    const unit = screen.getByText("ms");
+    if (variant === "horizontal") {
+      expect(unit).toHaveClass("ml-1");
+    } else {
+      expect(unit).toHaveAttribute("dx", "1.5");
+    }
+  });
+});

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.tsx
@@ -50,6 +50,7 @@ interface TileProps {
   value: number | undefined;
   valueText: string;
   unit: string;
+  unitSeparator: "" | " ";
   fraction: number;
   ticks: Tick[];
   showAxis: boolean;
@@ -152,6 +153,7 @@ export function GaugeChartVisualization({
           value,
           valueText,
           unit: formatted?.unit ?? "",
+          unitSeparator: formatted?.separator ?? "",
           fraction,
           ticks,
           showAxis,
@@ -194,6 +196,7 @@ function GaugeBar({
   value,
   valueText,
   unit,
+  unitSeparator,
   fraction,
   ticks,
   showAxis,
@@ -218,7 +221,14 @@ function GaugeBar({
           {valueText}
         </span>
         {value !== undefined && unit && (
-          <span className="ml-1 text-xs text-muted-foreground">{unit}</span>
+          <span
+            className={cn(
+              "text-xs text-muted-foreground",
+              unitSeparator && "ml-1",
+            )}
+          >
+            {unit}
+          </span>
         )}
       </p>
       <div className="relative pt-2">
@@ -282,6 +292,7 @@ function GaugeArc({
   value,
   valueText,
   unit,
+  unitSeparator,
   fraction,
   ticks,
   showAxis,
@@ -293,7 +304,11 @@ function GaugeArc({
 }: TileProps & { ariaLabel: string; color: string }) {
   const valueScale = Math.min(
     1,
-    88 / Math.max(1, valueText.length * 7.8 + unit.length * 4.2 + 1.5),
+    88 /
+      Math.max(
+        1,
+        valueText.length * 7.8 + unit.length * 4.2 + (unitSeparator ? 1.5 : 0),
+      ),
   );
   return (
     <div className="flex min-w-28 flex-1 flex-col items-center">
@@ -370,7 +385,7 @@ function GaugeArc({
             {valueText}
             {value !== undefined && unit && (
               <tspan
-                dx={1.5}
+                dx={unitSeparator ? 1.5 : undefined}
                 fontSize={7 * valueScale}
                 className="fill-muted-foreground font-normal"
               >

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/gauge-chart-visualization.tsx
@@ -4,17 +4,14 @@ import { Gauge } from "lucide-react";
 import { useMemo } from "react";
 import { queryLabel, SERIES_COLORS } from "../data-utils";
 import type { VisualizationProps } from "../index";
-import {
-  formatStatValue,
-  resolveThresholdColor,
-} from "../stat-chart/stat-calculations";
+import { resolveThresholdColor } from "../stat-chart/stat-calculations";
 import { computeStatTiles } from "../stat-chart/stat-series";
+import { createValueFormatter } from "../value-format";
 import {
   axisFraction,
   bandColors,
   type FillSegment,
   fillSegments,
-  formatAxisEnd,
   type ThresholdMark,
   thresholdMarks,
 } from "./gauge-axis";
@@ -67,8 +64,6 @@ export function GaugeChartVisualization({
 }: VisualizationProps<GaugeChartSpec>) {
   const {
     calculation,
-    unit,
-    decimals,
     min,
     max,
     thresholds,
@@ -78,6 +73,14 @@ export function GaugeChartVisualization({
     showAxis,
     showThresholdLabels,
   } = spec;
+  const formatter = useMemo(
+    () => createValueFormatter(spec.valueFormat),
+    [spec],
+  );
+  const axisFormatter = useMemo(
+    () => formatter.axis(Math.max(Math.abs(min), Math.abs(max))),
+    [formatter, min, max],
+  );
 
   const tiles = useMemo(
     () => (data ? computeStatTiles(data, calculation) : []),
@@ -86,8 +89,8 @@ export function GaugeChartVisualization({
   const hasAnyValue = tiles.some((t) => t.value !== undefined);
   const fallbackColor = SERIES_COLORS[0] ?? "currentColor";
   const marks = useMemo(
-    () => thresholdMarks(thresholds, min, max, unit),
-    [thresholds, min, max, unit],
+    () => thresholdMarks(thresholds, min, max, axisFormatter),
+    [thresholds, min, max, axisFormatter],
   );
   const ticks = useMemo(
     () => marks.filter((m): m is Tick => m.color !== undefined),
@@ -113,8 +116,8 @@ export function GaugeChartVisualization({
 
   const horizontal = variant === "horizontal";
   const multi = tiles.length > 1;
-  const minText = formatAxisEnd(min, unit);
-  const maxText = formatAxisEnd(max, unit);
+  const minText = axisFormatter(min);
+  const maxText = axisFormatter(max);
 
   return (
     <ScrollArea
@@ -131,8 +134,9 @@ export function GaugeChartVisualization({
         const name = tile.label || queryLabel(tile.frame);
         const fraction =
           value !== undefined ? axisFraction(value, min, max) : 0;
-        const valueText =
-          value === undefined ? noValue : formatStatValue(value, decimals);
+        const formatted =
+          value === undefined ? undefined : formatter.parts(value);
+        const valueText = formatted?.value ?? noValue;
         const label = (multi || showLabel) && (
           <p
             className={cn(
@@ -147,7 +151,7 @@ export function GaugeChartVisualization({
           label,
           value,
           valueText,
-          unit,
+          unit: formatted?.unit ?? "",
           fraction,
           ticks,
           showAxis,
@@ -156,7 +160,7 @@ export function GaugeChartVisualization({
           maxText,
         };
         const key = `${tile.frame}-${tile.label}`;
-        const ariaLabel = `${name}: ${valueText}${unit ? ` ${unit}` : ""}`;
+        const ariaLabel = `${name}: ${value === undefined ? noValue : formatter.format(value)}`;
 
         return horizontal ? (
           <GaugeBar
@@ -287,6 +291,10 @@ function GaugeArc({
   ariaLabel,
   color,
 }: TileProps & { ariaLabel: string; color: string }) {
+  const valueScale = Math.min(
+    1,
+    88 / Math.max(1, valueText.length * 7.8 + unit.length * 4.2 + 1.5),
+  );
   return (
     <div className="flex min-w-28 flex-1 flex-col items-center">
       {label}
@@ -337,7 +345,10 @@ function GaugeArc({
                     x={labelPos.x}
                     y={labelPos.y}
                     textAnchor="middle"
-                    fontSize={5}
+                    fontSize={Math.min(
+                      5,
+                      32 / Math.max(1, tick.text.length * 0.6),
+                    )}
                     className="fill-muted-foreground tabular-nums"
                   >
                     {tick.text}
@@ -350,7 +361,7 @@ function GaugeArc({
             x={CX}
             y={46}
             textAnchor="middle"
-            fontSize={13}
+            fontSize={13 * valueScale}
             className={cn(
               "font-semibold tabular-nums",
               value === undefined ? "fill-muted-foreground" : "fill-foreground",
@@ -360,7 +371,7 @@ function GaugeArc({
             {value !== undefined && unit && (
               <tspan
                 dx={1.5}
-                fontSize={7}
+                fontSize={7 * valueScale}
                 className="fill-muted-foreground font-normal"
               >
                 {unit}
@@ -372,8 +383,8 @@ function GaugeArc({
               <text
                 x={CX - R}
                 y={62}
-                textAnchor="middle"
-                fontSize={5.5}
+                textAnchor="start"
+                fontSize={Math.min(5.5, 36 / Math.max(1, minText.length * 0.6))}
                 className="fill-muted-foreground tabular-nums"
               >
                 {minText}
@@ -381,8 +392,8 @@ function GaugeArc({
               <text
                 x={CX + R}
                 y={62}
-                textAnchor="middle"
-                fontSize={5.5}
+                textAnchor="end"
+                fontSize={Math.min(5.5, 36 / Math.max(1, maxText.length * 0.6))}
                 className="fill-muted-foreground tabular-nums"
               >
                 {maxText}

--- a/packages/app/src/components/dashboards/visualizations/gauge-chart/spec.ts
+++ b/packages/app/src/components/dashboards/visualizations/gauge-chart/spec.ts
@@ -1,5 +1,6 @@
 import * as z from "zod";
 import { calculationSpec, thresholdsSpec } from "../stat-chart/spec";
+import { valueFormatSpec } from "../value-format-spec";
 
 /**
  * The options of the GaugeChart plugin. The object is loose, because unknown
@@ -8,13 +9,8 @@ import { calculationSpec, thresholdsSpec } from "../stat-chart/spec";
  * parse. The lenient render path needs this.
  */
 export const gaugeChartSpec = z.looseObject({
+  valueFormat: valueFormatSpec.optional(),
   calculation: calculationSpec.default("last"),
-  unit: z.string().default(""),
-  /**
-   * The number of fraction digits. If you do not set it, the value shows a
-   * maximum of 2 digits, and the zeros at the end are removed.
-   */
-  decimals: z.number().int().min(0).max(10).optional(),
   /** The lower bound of the gauge axis. */
   min: z.number().default(0),
   /**

--- a/packages/app/src/components/dashboards/visualizations/geo-map/geo-map-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/geo-map/geo-map-visualization.tsx
@@ -11,7 +11,7 @@ import { useMemo, useState } from "react";
 import { colorRamp, normalizeValue, schemeBaseColor } from "../color-scale";
 import { queryLabel, SERIES_COLORS } from "../data-utils";
 import type { VisualizationProps } from "../index";
-import { formatStatValue } from "../stat-chart/stat-calculations";
+import { createValueFormatter } from "../value-format";
 import {
   deriveDomain,
   extractMarkers,
@@ -81,6 +81,7 @@ export function GeoMapVisualization({
   spec,
   data,
 }: VisualizationProps<GeoMapSpec>) {
+  const formatter = createValueFormatter(spec.valueFormat);
   const countries = getWorldCountries();
 
   const projection = useMemo(
@@ -105,10 +106,7 @@ export function GeoMapVisualization({
 
   const [hover, setHover] = useState<Hover | null>(null);
 
-  const fmt = (v: number | null) =>
-    v == null
-      ? "–"
-      : `${formatStatValue(v, undefined)}${spec.unit ? ` ${spec.unit}` : ""}`;
+  const fmt = (v: number | null) => (v == null ? "–" : formatter.format(v));
 
   const content = useMemo(() => {
     if (!data) return null;

--- a/packages/app/src/components/dashboards/visualizations/geo-map/spec.ts
+++ b/packages/app/src/components/dashboards/visualizations/geo-map/spec.ts
@@ -1,11 +1,13 @@
 import * as z from "zod";
 import { COLOR_SCHEMES, SCALE_TYPES } from "../color-scale";
+import { valueFormatSpec } from "../value-format-spec";
 
 /**
  * GeoMap plugin options. Loose so unknown keys flow through verbatim; every
  * field defaulted/optional so `{}` parses (the lenient render path needs it).
  */
 export const geoMapSpec = z.looseObject({
+  valueFormat: valueFormatSpec.optional(),
   mode: z.enum(["points", "choropleth"]).default("points"),
 
   // points mode: coordinate columns
@@ -27,7 +29,6 @@ export const geoMapSpec = z.looseObject({
   /** Tooltip title; falls back to region/coords when omitted. */
   labelColumn: z.string().optional(),
   /** Value formatting in tooltip + legend. */
-  unit: z.string().default(""),
   showLegend: z.boolean().default(true),
   colorScheme: z.enum(COLOR_SCHEMES).default("blue"),
   /** Map projection. */

--- a/packages/app/src/components/dashboards/visualizations/heatmap/heatmap-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/heatmap/heatmap-visualization.tsx
@@ -10,7 +10,7 @@ import {
   SERIES_COLORS,
 } from "../data-utils";
 import type { VisualizationProps } from "../index";
-import { formatStatValue } from "../stat-chart/stat-calculations";
+import { createValueFormatter } from "../value-format";
 import { heatmapColor, heatmapColorRgb, isDarkColor } from "./heatmap-colors";
 import { buildHeatmapModel, type HeatmapCell } from "./heatmap-data";
 import type { HeatmapSpec } from "./spec";
@@ -20,10 +20,6 @@ const MAX_X_TICKS = 6;
 /** Bucket label gutter width — the axis row and brush overlay offset by the
  * same amount so they stay aligned with the cell tracks. */
 const LABEL_WIDTH = 96;
-
-function formatValue(value: number, unit: string): string {
-  return `${formatStatValue(value, undefined)}${unit ? ` ${unit}` : ""}`;
-}
 
 interface HoverState {
   bucket: string;
@@ -38,6 +34,7 @@ export function HeatmapVisualization({
   timeRange,
   onTimeRangeChange,
 }: VisualizationProps<HeatmapSpec>) {
+  const formatter = createValueFormatter(spec.valueFormat);
   const trackRef = useRef<HTMLDivElement>(null);
   const trackRectRef = useRef<DOMRect | null>(null);
   const [brushStart, setBrushStart] = useState<number | null>(null);
@@ -200,7 +197,7 @@ export function HeatmapVisualization({
                             className="hidden @[2rem]:block truncate text-[10px] font-medium tabular-nums"
                             style={{ color: dark ? "white" : "black" }}
                           >
-                            {formatValue(cell.value, spec.unit)}
+                            {formatter.format(cell.value)}
                           </span>
                         )}
                       </div>
@@ -250,7 +247,7 @@ export function HeatmapVisualization({
       {spec.showLegend && (
         <div className="flex shrink-0 items-center justify-center gap-2 pt-1.5 text-xs">
           <span className="text-muted-foreground tabular-nums">
-            {formatValue(d0, spec.unit)}
+            {formatter.format(d0)}
           </span>
           <span className="inline-block h-2.5 w-28 rounded-sm bg-muted align-middle">
             <span
@@ -271,7 +268,7 @@ export function HeatmapVisualization({
             />
           </span>
           <span className="text-muted-foreground tabular-nums">
-            {formatValue(d1, spec.unit)}
+            {formatter.format(d1)}
           </span>
         </div>
       )}
@@ -285,7 +282,7 @@ export function HeatmapVisualization({
                 key: hover.bucket,
                 color: cellAppearance(hover.cell.value).fill,
                 label: hover.bucket,
-                value: formatValue(hover.cell.value, spec.unit),
+                value: formatter.format(hover.cell.value),
               },
             ]}
           />

--- a/packages/app/src/components/dashboards/visualizations/heatmap/spec.ts
+++ b/packages/app/src/components/dashboards/visualizations/heatmap/spec.ts
@@ -1,5 +1,6 @@
 import * as z from "zod";
 import { SCALE_TYPES } from "../color-scale";
+import { valueFormatSpec } from "../value-format-spec";
 import { HEATMAP_COLOR_SCHEMES } from "./heatmap-colors";
 
 /**
@@ -9,6 +10,7 @@ import { HEATMAP_COLOR_SCHEMES } from "./heatmap-colors";
  * relies on it.
  */
 export const heatmapSpec = z.looseObject({
+  valueFormat: valueFormatSpec.optional(),
   /** Y-bucket column; defaults to the first non-time column. */
   yColumn: z.string().optional(),
   /**
@@ -17,7 +19,6 @@ export const heatmapSpec = z.looseObject({
    */
   valueColumn: z.string().optional(),
   /** Value formatting in cells, tooltip and legend. */
-  unit: z.string().default(""),
   /** Color ramp legend (min → max) below the grid. */
   showLegend: z.boolean().default(true),
   /** Render the value inside cells wide enough to fit it. */

--- a/packages/app/src/components/dashboards/visualizations/node-graph/node-graph-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/node-graph/node-graph-visualization.tsx
@@ -3,7 +3,7 @@ import { Share2 } from "lucide-react";
 import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import { SERIES_COLORS } from "../data-utils";
 import type { VisualizationProps } from "../index";
-import { formatStatValue } from "../stat-chart/stat-calculations";
+import { createValueFormatter } from "../value-format";
 import { layoutGraph } from "./force-layout";
 import {
   buildNodeGraph,
@@ -20,10 +20,6 @@ const ARROW_LENGTH = 9;
 const MAX_LABEL_CHARS = 16;
 
 const NODE_COLOR = SERIES_COLORS[0]!;
-
-function formatValue(value: number, unit: string): string {
-  return `${formatStatValue(value, undefined)}${unit ? ` ${unit}` : ""}`;
-}
 
 /** Value → [min, max] with area (not radius/width) tracking the value. */
 function sqrtScale(
@@ -83,6 +79,7 @@ export function NodeGraphVisualization({
   spec,
   data,
 }: VisualizationProps<NodeGraphSpec>) {
+  const formatter = createValueFormatter(spec.valueFormat);
   const model = useMemo(
     () => (data ? buildNodeGraph(data, spec) : null),
     [data, spec],
@@ -236,7 +233,7 @@ export function NodeGraphVisualization({
                       textAnchor="middle"
                       pointerEvents="none"
                     >
-                      {formatValue(edge.value, spec.unit)}
+                      {formatter.format(edge.value)}
                     </text>
                   )}
                   {/* invisible wide hit area for the tooltip */}
@@ -320,7 +317,7 @@ export function NodeGraphVisualization({
                   />
                   <span className="text-muted-foreground">{hover.node.id}</span>
                   <span className="text-right font-medium tabular-nums">
-                    {formatValue(hover.node.value, spec.unit)}
+                    {formatter.format(hover.node.value)}
                   </span>
                 </div>
                 <div className="mt-1 text-muted-foreground">
@@ -333,7 +330,7 @@ export function NodeGraphVisualization({
                   {hover.edge.source} → {hover.edge.target}
                 </div>
                 <div className="text-right font-medium tabular-nums">
-                  {formatValue(hover.edge.value, spec.unit)}
+                  {formatter.format(hover.edge.value)}
                 </div>
               </>
             )}

--- a/packages/app/src/components/dashboards/visualizations/node-graph/spec.ts
+++ b/packages/app/src/components/dashboards/visualizations/node-graph/spec.ts
@@ -1,4 +1,5 @@
 import * as z from "zod";
+import { valueFormatSpec } from "../value-format-spec";
 
 /**
  * NodeGraph plugin options. Loose so unknown keys flow through verbatim
@@ -7,6 +8,7 @@ import * as z from "zod";
  * relies on it.
  */
 export const nodeGraphSpec = z.looseObject({
+  valueFormat: valueFormatSpec.optional(),
   /** Edge source column; falls back to the first column when absent. */
   sourceColumn: z.string().default("source"),
   /** Edge target column; falls back to the second column when absent. */
@@ -17,7 +19,6 @@ export const nodeGraphSpec = z.looseObject({
    */
   valueColumn: z.string().default("value"),
   /** Value formatting in tooltips and edge labels. */
-  unit: z.string().default(""),
   /** Draw arrowheads pointing at each edge's target. */
   directed: z.boolean().default(true),
   /** Render the edge's value at its midpoint. */

--- a/packages/app/src/components/dashboards/visualizations/parse-spec.test.ts
+++ b/packages/app/src/components/dashboards/visualizations/parse-spec.test.ts
@@ -7,13 +7,11 @@ import { timeSeriesChartSpec } from "./time-series-chart/spec";
 describe("parseSpecLenient", () => {
   it("returns the parsed spec with no warnings for valid input", () => {
     const { spec, warnings } = parseSpecLenient(timeSeriesChartSpec, {
-      unit: "ms",
-      displayUnit: "auto",
+      valueFormat: { unit: "s", scale: "duration" },
       lineWidth: 2,
     });
     expect(warnings).toEqual([]);
-    expect(spec.unit).toBe("ms");
-    expect(spec.displayUnit).toBe("auto");
+    expect(spec.valueFormat).toEqual({ unit: "s", scale: "duration" });
     expect(spec.lineWidth).toBe(2);
     expect(spec.curveType).toBe("monotone");
   });
@@ -21,22 +19,20 @@ describe("parseSpecLenient", () => {
   it("drops an invalid option to its default and warns with the path", () => {
     const { spec, warnings } = parseSpecLenient(timeSeriesChartSpec, {
       lineWidth: "3",
-      unit: "ms",
+      valueFormat: { unit: "ms" },
     });
     expect(spec.lineWidth).toBe(1.5);
-    expect(spec.unit).toBe("ms");
+    expect(spec.valueFormat?.unit).toBe("ms");
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toMatch(/^lineWidth: /);
   });
 
-  it("rejects a fixed display unit because the input unit already fixes it", () => {
+  it("warns about incompatible duration input units", () => {
     const { spec, warnings } = parseSpecLenient(timeSeriesChartSpec, {
-      unit: "GiBy",
-      displayUnit: "GiBy",
+      valueFormat: { unit: "widgets", scale: "duration" },
     });
-    expect(spec.unit).toBe("GiBy");
-    expect(spec.displayUnit).toBeUndefined();
-    expect(warnings[0]).toMatch(/^displayUnit: /);
+    expect(spec.valueFormat).toBeUndefined();
+    expect(warnings[0]).toMatch(/^valueFormat\.unit: /);
   });
 
   it("warns once per invalid option and keeps the valid ones", () => {
@@ -54,10 +50,10 @@ describe("parseSpecLenient", () => {
   it("drops a structurally invalid nested option entirely", () => {
     const { spec, warnings } = parseSpecLenient(statChartSpec, {
       thresholds: { steps: [{ value: "high" }] },
-      unit: "%",
+      valueFormat: { unit: "%" },
     });
     expect(spec.thresholds).toBeUndefined();
-    expect(spec.unit).toBe("%");
+    expect(spec.valueFormat?.unit).toBe("%");
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toMatch(/^thresholds\.steps\.0\.value: /);
   });
@@ -78,6 +74,29 @@ describe("parseSpecLenient", () => {
 });
 
 describe("panel plugin spec contracts", () => {
+  it.each([
+    "TimeSeriesChart",
+    "BarChart",
+    "StatChart",
+    "GaugeChart",
+    "Table",
+    "GeoMap",
+    "Treemap",
+    "Heatmap",
+    "NodeGraph",
+  ])("%s validates and defaults the shared format", (kind) => {
+    const schema = panelPluginSpecs[kind];
+    expect(
+      schema?.safeParse({ valueFormat: { scale: "invalid" } }).success,
+    ).toBe(false);
+    expect(
+      schema?.safeParse({ valueFormat: { scale: "duration", unit: "widgets" } })
+        .success,
+    ).toBe(false);
+    expect(schema?.parse({ valueFormat: {} })).toMatchObject({
+      valueFormat: { unit: "", scale: "none" },
+    });
+  });
   it("every registered spec schema parses {} (lenient fallback never throws)", () => {
     for (const [kind, schema] of Object.entries(panelPluginSpecs)) {
       expect(schema.safeParse({}).success, `${kind} must parse {}`).toBe(true);

--- a/packages/app/src/components/dashboards/visualizations/parse-spec.test.ts
+++ b/packages/app/src/components/dashboards/visualizations/parse-spec.test.ts
@@ -8,10 +8,12 @@ describe("parseSpecLenient", () => {
   it("returns the parsed spec with no warnings for valid input", () => {
     const { spec, warnings } = parseSpecLenient(timeSeriesChartSpec, {
       unit: "ms",
+      displayUnit: "auto",
       lineWidth: 2,
     });
     expect(warnings).toEqual([]);
     expect(spec.unit).toBe("ms");
+    expect(spec.displayUnit).toBe("auto");
     expect(spec.lineWidth).toBe(2);
     expect(spec.curveType).toBe("monotone");
   });
@@ -25,6 +27,16 @@ describe("parseSpecLenient", () => {
     expect(spec.unit).toBe("ms");
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toMatch(/^lineWidth: /);
+  });
+
+  it("rejects a fixed display unit because the input unit already fixes it", () => {
+    const { spec, warnings } = parseSpecLenient(timeSeriesChartSpec, {
+      unit: "GiBy",
+      displayUnit: "GiBy",
+    });
+    expect(spec.unit).toBe("GiBy");
+    expect(spec.displayUnit).toBeUndefined();
+    expect(warnings[0]).toMatch(/^displayUnit: /);
   });
 
   it("warns once per invalid option and keeps the valid ones", () => {

--- a/packages/app/src/components/dashboards/visualizations/stat-chart/spec.ts
+++ b/packages/app/src/components/dashboards/visualizations/stat-chart/spec.ts
@@ -1,4 +1,5 @@
 import * as z from "zod";
+import { valueFormatSpec } from "../value-format-spec";
 
 const thresholdStep = z.looseObject({
   value: z.number(),
@@ -36,11 +37,8 @@ export const calculationSpec = z.enum([
 ]);
 
 export const statChartSpec = z.looseObject({
+  valueFormat: valueFormatSpec.optional(),
   calculation: calculationSpec.default("last"),
-  unit: z.string().default(""),
-  displayUnit: z.literal("auto").optional(),
-  /** Fixed fraction digits; omitted = up to 2, trailing zeros dropped. */
-  decimals: z.number().int().min(0).max(10).optional(),
   sparkline: z.boolean().default(false),
   /** Fixed series label to CSS color mapping for sparklines. Unmapped series
    * keep the existing shared accent color. */

--- a/packages/app/src/components/dashboards/visualizations/stat-chart/spec.ts
+++ b/packages/app/src/components/dashboards/visualizations/stat-chart/spec.ts
@@ -38,9 +38,13 @@ export const calculationSpec = z.enum([
 export const statChartSpec = z.looseObject({
   calculation: calculationSpec.default("last"),
   unit: z.string().default(""),
+  displayUnit: z.literal("auto").optional(),
   /** Fixed fraction digits; omitted = up to 2, trailing zeros dropped. */
   decimals: z.number().int().min(0).max(10).optional(),
   sparkline: z.boolean().default(false),
+  /** Fixed series label to CSS color mapping for sparklines. Unmapped series
+   * keep the existing shared accent color. */
+  colors: z.record(z.string(), z.string()).default({}),
   thresholds: thresholdsSpec.optional(),
   /** "background" fills the tile with the threshold color instead of tinting the value text. */
   colorMode: z.enum(["value", "background"]).default("value"),

--- a/packages/app/src/components/dashboards/visualizations/stat-chart/stat-calculations.test.ts
+++ b/packages/app/src/components/dashboards/visualizations/stat-chart/stat-calculations.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  calculate,
-  formatStatValue,
-  resolveThresholdColor,
-} from "./stat-calculations";
+import { calculate, resolveThresholdColor } from "./stat-calculations";
 
 describe("calculate", () => {
   const values = [4, 2, 8, 6];
@@ -85,38 +81,5 @@ describe("resolveThresholdColor", () => {
     expect(resolveThresholdColor(60, pct, 60)).toBe("#888888");
     // value 170 of 200 → 85% → crosses the 80 step.
     expect(resolveThresholdColor(170, pct, 60)).toBe("#ef4444");
-  });
-});
-
-describe("formatStatValue", () => {
-  it("limits to two fraction digits", () => {
-    // compare against toLocaleString so the test is locale-independent
-    expect(formatStatValue(Math.PI)).toBe((3.14).toLocaleString());
-  });
-  it("groups thousands below the abbreviation cutoff", () => {
-    expect(formatStatValue(123456)).toBe((123456).toLocaleString());
-  });
-  it("abbreviates millions, billions, and trillions", () => {
-    expect(formatStatValue(1234567)).toBe(`${(1.23).toLocaleString()}M`);
-    expect(formatStatValue(2_500_000_000)).toBe(`${(2.5).toLocaleString()}B`);
-    expect(formatStatValue(7.2e12)).toBe(`${(7.2).toLocaleString()}T`);
-  });
-  it("abbreviates negative magnitudes", () => {
-    expect(formatStatValue(-1500000)).toBe(`${(-1.5).toLocaleString()}M`);
-  });
-  it("fixes fraction digits when decimals is set", () => {
-    expect(formatStatValue(3, 2)).toBe(
-      (3).toLocaleString(undefined, {
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
-      }),
-    );
-    expect(formatStatValue(3.4567, 0)).toBe((3).toLocaleString());
-    expect(formatStatValue(1234567, 1)).toBe(
-      `${(1.2).toLocaleString(undefined, {
-        minimumFractionDigits: 1,
-        maximumFractionDigits: 1,
-      })}M`,
-    );
   });
 });

--- a/packages/app/src/components/dashboards/visualizations/stat-chart/stat-calculations.ts
+++ b/packages/app/src/components/dashboards/visualizations/stat-chart/stat-calculations.ts
@@ -1,3 +1,4 @@
+import { formatCompactValue } from "../value-format";
 import type { CalculationType, ThresholdsSpec } from "./spec";
 
 export type { CalculationType, ThresholdsSpec } from "./spec";
@@ -54,12 +55,6 @@ export function resolveThresholdColor(
   return color;
 }
 
-const ABBREVIATIONS: ReadonlyArray<[number, string]> = [
-  [1e12, "T"],
-  [1e9, "B"],
-  [1e6, "M"],
-];
-
 /**
  * Locale-formatted value for the stat tile. Magnitudes >= 1e6 abbreviate
  * (1234567 -> "1.23M") so large counts don't overflow the tile; thousands
@@ -67,14 +62,5 @@ const ABBREVIATIONS: ReadonlyArray<[number, string]> = [
  * means up to 2 with trailing zeros dropped.
  */
 export function formatStatValue(value: number, decimals?: number): string {
-  const fraction: Intl.NumberFormatOptions =
-    decimals !== undefined
-      ? { minimumFractionDigits: decimals, maximumFractionDigits: decimals }
-      : { maximumFractionDigits: 2 };
-  for (const [factor, suffix] of ABBREVIATIONS) {
-    if (Math.abs(value) >= factor) {
-      return `${(value / factor).toLocaleString(undefined, fraction)}${suffix}`;
-    }
-  }
-  return value.toLocaleString(undefined, fraction);
+  return formatCompactValue(value, decimals);
 }

--- a/packages/app/src/components/dashboards/visualizations/stat-chart/stat-calculations.ts
+++ b/packages/app/src/components/dashboards/visualizations/stat-chart/stat-calculations.ts
@@ -1,4 +1,3 @@
-import { formatCompactValue } from "../value-format";
 import type { CalculationType, ThresholdsSpec } from "./spec";
 
 export type { CalculationType, ThresholdsSpec } from "./spec";
@@ -53,14 +52,4 @@ export function resolveThresholdColor(
     if (compare >= step.value) color = step.color ?? color;
   }
   return color;
-}
-
-/**
- * Locale-formatted value for the stat tile. Magnitudes >= 1e6 abbreviate
- * (1234567 -> "1.23M") so large counts don't overflow the tile; thousands
- * stay exact with grouping. `decimals` fixes the fraction digits; omitted
- * means up to 2 with trailing zeros dropped.
- */
-export function formatStatValue(value: number, decimals?: number): string {
-  return formatCompactValue(value, decimals);
 }

--- a/packages/app/src/components/dashboards/visualizations/stat-chart/stat-chart-visualization.test.tsx
+++ b/packages/app/src/components/dashboards/visualizations/stat-chart/stat-chart-visualization.test.tsx
@@ -20,7 +20,7 @@ describe("StatChartVisualization", () => {
       />,
     );
     expect(screen.getByText("75")).toHaveStyle({ color: "rgb(0, 128, 0)" });
-    expect(screen.getByText("%")).toBeInTheDocument();
+    expect(screen.getByText("%")).not.toHaveClass("ml-1");
   });
   it("formats seconds while thresholds still compare the raw value", () => {
     render(
@@ -38,7 +38,7 @@ describe("StatChartVisualization", () => {
       />,
     );
     expect(screen.getByText("25")).toHaveStyle({ color: "rgb(0, 128, 0)" });
-    expect(screen.getByText("ms")).toBeInTheDocument();
+    expect(screen.getByText("ms")).toHaveClass("ml-1");
   });
   it("renders semantic byte units without decimal magnitude abbreviations", () => {
     render(

--- a/packages/app/src/components/dashboards/visualizations/stat-chart/stat-chart-visualization.test.tsx
+++ b/packages/app/src/components/dashboards/visualizations/stat-chart/stat-chart-visualization.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { statChartSpec } from "./spec";
+import { StatChartVisualization } from "./stat-chart-visualization";
+
+describe("StatChartVisualization", () => {
+  it("renders semantic byte units without decimal magnitude abbreviations", () => {
+    render(
+      <StatChartVisualization
+        spec={statChartSpec.parse({ unit: "By", displayUnit: "auto" })}
+        data={[[{ volume: 5 * 1024 ** 3 }]]}
+        timeRange={{ from: new Date(0), to: new Date(60_000) }}
+        onTimeRangeChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("5")).toBeInTheDocument();
+    expect(screen.getByText("GiB")).toBeInTheDocument();
+    expect(screen.queryByText("5B")).toBeNull();
+  });
+});

--- a/packages/app/src/components/dashboards/visualizations/stat-chart/stat-chart-visualization.test.tsx
+++ b/packages/app/src/components/dashboards/visualizations/stat-chart/stat-chart-visualization.test.tsx
@@ -4,10 +4,48 @@ import { statChartSpec } from "./spec";
 import { StatChartVisualization } from "./stat-chart-visualization";
 
 describe("StatChartVisualization", () => {
+  it("displays percent while absolute thresholds compare the original ratio", () => {
+    render(
+      <StatChartVisualization
+        spec={statChartSpec.parse({
+          valueFormat: { unit: "1", display: "percent" },
+          thresholds: {
+            defaultColor: "green",
+            steps: [{ value: 0.8, color: "red" }],
+          },
+        })}
+        data={[[{ utilization: 0.75 }]]}
+        timeRange={{ from: new Date(0), to: new Date(60000) }}
+        onTimeRangeChange={() => {}}
+      />,
+    );
+    expect(screen.getByText("75")).toHaveStyle({ color: "rgb(0, 128, 0)" });
+    expect(screen.getByText("%")).toBeInTheDocument();
+  });
+  it("formats seconds while thresholds still compare the raw value", () => {
+    render(
+      <StatChartVisualization
+        spec={statChartSpec.parse({
+          valueFormat: { unit: "s", scale: "duration" },
+          thresholds: {
+            defaultColor: "green",
+            steps: [{ value: 1, color: "red" }],
+          },
+        })}
+        data={[[{ latency: 0.025 }]]}
+        timeRange={{ from: new Date(0), to: new Date(60000) }}
+        onTimeRangeChange={() => {}}
+      />,
+    );
+    expect(screen.getByText("25")).toHaveStyle({ color: "rgb(0, 128, 0)" });
+    expect(screen.getByText("ms")).toBeInTheDocument();
+  });
   it("renders semantic byte units without decimal magnitude abbreviations", () => {
     render(
       <StatChartVisualization
-        spec={statChartSpec.parse({ unit: "By", displayUnit: "auto" })}
+        spec={statChartSpec.parse({
+          valueFormat: { unit: "By", scale: "binary" },
+        })}
         data={[[{ volume: 5 * 1024 ** 3 }]]}
         timeRange={{ from: new Date(0), to: new Date(60_000) }}
         onTimeRangeChange={() => {}}

--- a/packages/app/src/components/dashboards/visualizations/stat-chart/stat-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/stat-chart/stat-chart-visualization.tsx
@@ -3,10 +3,12 @@ import { cn } from "@everr/ui/lib/utils";
 import { Hash } from "lucide-react";
 import { useMemo } from "react";
 import { Area, AreaChart, XAxis } from "recharts";
-import { queryLabel, SERIES_COLORS } from "../data-utils";
+import { queryLabel } from "../data-utils";
 import type { VisualizationProps } from "../index";
+import { formatValueParts } from "../value-format";
 import type { StatChartSpec } from "./spec";
-import { formatStatValue, resolveThresholdColor } from "./stat-calculations";
+import { resolveThresholdColor } from "./stat-calculations";
+import { resolveStatSparklineColor } from "./stat-colors";
 import { computeStatTiles } from "./stat-series";
 
 /** Value text scales down as tiles crowd the panel. */
@@ -29,8 +31,10 @@ export function StatChartVisualization({
   const {
     calculation,
     unit,
+    displayUnit,
     decimals,
     sparkline: showSparkline,
+    colors,
     thresholds,
     colorMode,
     showLabel,
@@ -63,6 +67,14 @@ export function StatChartVisualization({
       {tiles.map((tile) => {
         const value = tile.value;
         const label = tile.label || queryLabel(tile.frame);
+        const formatted =
+          value === undefined
+            ? undefined
+            : formatValueParts(value, unit, {
+                decimals,
+                compact: true,
+                displayUnit,
+              });
         const seriesMax =
           tile.points.length > 0
             ? Math.max(...tile.points.map((p) => p.value))
@@ -72,9 +84,12 @@ export function StatChartVisualization({
             ? resolveThresholdColor(value, thresholds, seriesMax)
             : undefined;
         const background = colorMode === "background" && color !== undefined;
-        const sparklineColor = background
-          ? "rgba(255, 255, 255, 0.9)"
-          : (color ?? SERIES_COLORS[0]!);
+        const sparklineColor = resolveStatSparklineColor(
+          label,
+          colors,
+          color,
+          background,
+        );
         return (
           <div
             key={`${tile.frame}-${tile.label}`}
@@ -104,10 +119,8 @@ export function StatChartVisualization({
                 )}
                 style={!background && color ? { color } : undefined}
               >
-                {value === undefined
-                  ? noValue
-                  : formatStatValue(value, decimals)}
-                {value !== undefined && unit && (
+                {value === undefined ? noValue : formatted?.value}
+                {formatted?.unit && (
                   <span
                     className={cn(
                       unitSize,
@@ -115,7 +128,7 @@ export function StatChartVisualization({
                       background ? "text-white/70" : "text-muted-foreground",
                     )}
                   >
-                    {unit}
+                    {formatted.unit}
                   </span>
                 )}
               </p>

--- a/packages/app/src/components/dashboards/visualizations/stat-chart/stat-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/stat-chart/stat-chart-visualization.tsx
@@ -5,7 +5,7 @@ import { useMemo } from "react";
 import { Area, AreaChart, XAxis } from "recharts";
 import { queryLabel } from "../data-utils";
 import type { VisualizationProps } from "../index";
-import { formatValueParts } from "../value-format";
+import { createValueFormatter } from "../value-format";
 import type { StatChartSpec } from "./spec";
 import { resolveThresholdColor } from "./stat-calculations";
 import { resolveStatSparklineColor } from "./stat-colors";
@@ -28,11 +28,9 @@ export function StatChartVisualization({
   spec,
   data,
 }: VisualizationProps<StatChartSpec>) {
+  const formatter = createValueFormatter(spec.valueFormat);
   const {
     calculation,
-    unit,
-    displayUnit,
-    decimals,
     sparkline: showSparkline,
     colors,
     thresholds,
@@ -68,13 +66,7 @@ export function StatChartVisualization({
         const value = tile.value;
         const label = tile.label || queryLabel(tile.frame);
         const formatted =
-          value === undefined
-            ? undefined
-            : formatValueParts(value, unit, {
-                decimals,
-                compact: true,
-                displayUnit,
-              });
+          value === undefined ? undefined : formatter.parts(value);
         const seriesMax =
           tile.points.length > 0
             ? Math.max(...tile.points.map((p) => p.value))

--- a/packages/app/src/components/dashboards/visualizations/stat-chart/stat-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/stat-chart/stat-chart-visualization.tsx
@@ -116,7 +116,7 @@ export function StatChartVisualization({
                   <span
                     className={cn(
                       unitSize,
-                      "ml-1",
+                      formatted.separator && "ml-1",
                       background ? "text-white/70" : "text-muted-foreground",
                     )}
                   >

--- a/packages/app/src/components/dashboards/visualizations/stat-chart/stat-colors.test.ts
+++ b/packages/app/src/components/dashboards/visualizations/stat-chart/stat-colors.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { SERIES_COLORS } from "../data-utils";
+import { resolveStatSparklineColor } from "./stat-colors";
+
+describe("resolveStatSparklineColor", () => {
+  it("keeps the shared accent color when no series override is configured", () => {
+    expect(resolveStatSparklineColor("Logs", {}, undefined, false)).toBe(
+      SERIES_COLORS[0],
+    );
+  });
+
+  it("uses the color configured for the series label", () => {
+    expect(
+      resolveStatSparklineColor(
+        "Traces",
+        { Traces: "#fde047" },
+        undefined,
+        false,
+      ),
+    ).toBe("#fde047");
+  });
+
+  it("keeps threshold and filled-background colors ahead of series overrides", () => {
+    const colors = { Metrics: "#22d3ee" };
+    expect(resolveStatSparklineColor("Metrics", colors, "#ef4444", false)).toBe(
+      "#ef4444",
+    );
+    expect(resolveStatSparklineColor("Metrics", colors, "#ef4444", true)).toBe(
+      "rgba(255, 255, 255, 0.9)",
+    );
+  });
+});

--- a/packages/app/src/components/dashboards/visualizations/stat-chart/stat-colors.ts
+++ b/packages/app/src/components/dashboards/visualizations/stat-chart/stat-colors.ts
@@ -1,0 +1,13 @@
+import { SERIES_COLORS } from "../data-utils";
+
+const FILLED_TILE_SPARKLINE_COLOR = "rgba(255, 255, 255, 0.9)";
+
+export function resolveStatSparklineColor(
+  label: string,
+  colors: Record<string, string>,
+  thresholdColor: string | undefined,
+  background: boolean,
+): string {
+  if (background) return FILLED_TILE_SPARKLINE_COLOR;
+  return thresholdColor ?? colors[label] ?? SERIES_COLORS[0] ?? "currentColor";
+}

--- a/packages/app/src/components/dashboards/visualizations/table/spec.ts
+++ b/packages/app/src/components/dashboards/visualizations/table/spec.ts
@@ -1,4 +1,5 @@
 import * as z from "zod";
+import { valueFormatSpec } from "../value-format-spec";
 
 /**
  * Table plugin options. Loose so unknown keys flow through verbatim
@@ -6,6 +7,13 @@ import * as z from "zod";
  * is defaulted so `{}` always parses — the lenient render path relies on it.
  */
 export const tableSpec = z.looseObject({
+  valueFormat: valueFormatSpec.optional(),
+  columns: z
+    .record(
+      z.string(),
+      z.looseObject({ valueFormat: valueFormatSpec.optional() }),
+    )
+    .default({}),
   stickyHeader: z.boolean().default(false),
 });
 

--- a/packages/app/src/components/dashboards/visualizations/table/table-visualization.test.tsx
+++ b/packages/app/src/components/dashboards/visualizations/table/table-visualization.test.tsx
@@ -18,6 +18,10 @@ function renderTable(data: QueryResultRow[][]) {
 }
 
 describe("TableVisualization", () => {
+  it("uses the shared two-decimal default for numeric cells", () => {
+    renderTable([[{ value: 42.56789 }]]);
+    expect(screen.getByText("42.57")).toBeInTheDocument();
+  });
   it("shows no selector for a single query", () => {
     renderTable([[{ a: 1 }]]);
     expect(screen.queryByText("Query B")).toBeNull();
@@ -41,5 +45,52 @@ describe("TableVisualization", () => {
     renderTable([[{ a: 1 }], []]);
     expect(screen.getByText("Query A")).toBeInTheDocument();
     expect(screen.getByText("Query B")).toBeInTheDocument();
+  });
+});
+
+describe("TableVisualization value formats", () => {
+  it("applies column overrides and leaves text and null cells intact", () => {
+    render(
+      <TableVisualization
+        spec={tableSpec.parse({
+          valueFormat: { unit: "widgets", scale: "decimal" },
+          columns: {
+            bandwidth: { valueFormat: { unit: "By/s", scale: "binary" } },
+            latency: { valueFormat: { unit: "s", scale: "duration" } },
+            utilization: { valueFormat: { unit: "1", display: "percent" } },
+            frequency: { valueFormat: { unit: "Hz", scale: "decimal" } },
+            unformatted: { valueFormat: {} },
+          },
+        })}
+        data={[
+          [
+            {
+              count: 12500,
+              bandwidth: 2621440,
+              latency: 0.025,
+              utilization: 0.75,
+              frequency: 3.2e9,
+              text: "12500",
+              missing: null,
+              unformatted: 12000,
+            },
+          ],
+        ]}
+        timeRange={{ from: new Date(0), to: new Date(60000) }}
+        onTimeRangeChange={() => {}}
+      />,
+    );
+    for (const label of [
+      "12.5k widgets",
+      "2.5 MiB/s",
+      "25 ms",
+      "75%",
+      "3.2 GHz",
+      "12500",
+      "NULL",
+      "12,000",
+    ]) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
   });
 });

--- a/packages/app/src/components/dashboards/visualizations/table/table-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/table/table-visualization.tsx
@@ -8,20 +8,28 @@ import { TableIcon } from "lucide-react";
 import { useState } from "react";
 import { queryLabel } from "../data-utils";
 import type { QueryResultRow, VisualizationProps } from "../index";
+import { createValueFormatter } from "../value-format";
 import type { TableSpec } from "./spec";
 
-function buildColumns(rows: QueryResultRow[]): Column<QueryResultRow>[] {
+function buildColumns(
+  rows: QueryResultRow[],
+  spec: TableSpec,
+): Column<QueryResultRow>[] {
   const first = rows[0];
   if (!first) return [];
-  return Object.keys(first).map((key) => ({
-    header: key,
-    cell: (row: QueryResultRow) => {
-      const val = row[key];
-      if (val == null)
-        return <span className="text-muted-foreground">NULL</span>;
-      return String(val);
-    },
-  }));
+  return Object.keys(first).map((key) => {
+    const valueFormat = spec.columns[key]?.valueFormat ?? spec.valueFormat;
+    const formatter = createValueFormatter(valueFormat);
+    return {
+      header: key,
+      cell: (row: QueryResultRow) => {
+        const val = row[key];
+        if (val == null)
+          return <span className="text-muted-foreground">NULL</span>;
+        return typeof val === "number" ? formatter.format(val) : String(val);
+      },
+    };
+  });
 }
 
 export function TableVisualization({
@@ -49,7 +57,7 @@ export function TableVisualization({
     );
   }
 
-  const columns = buildColumns(rows);
+  const columns = buildColumns(rows, spec);
 
   return (
     <div className="flex h-full flex-col border-t border-border">

--- a/packages/app/src/components/dashboards/visualizations/time-series-chart/spec.ts
+++ b/packages/app/src/components/dashboards/visualizations/time-series-chart/spec.ts
@@ -7,6 +7,7 @@ import * as z from "zod";
  */
 export const timeSeriesChartSpec = z.looseObject({
   unit: z.string().default(""),
+  displayUnit: z.literal("auto").optional(),
   showLegend: z.boolean().default(false),
   lineWidth: z.number().positive().default(1.5),
   curveType: z

--- a/packages/app/src/components/dashboards/visualizations/time-series-chart/spec.ts
+++ b/packages/app/src/components/dashboards/visualizations/time-series-chart/spec.ts
@@ -1,4 +1,5 @@
 import * as z from "zod";
+import { valueFormatSpec } from "../value-format-spec";
 
 /**
  * TimeSeriesChart plugin options. Loose so unknown keys flow through verbatim
@@ -6,8 +7,7 @@ import * as z from "zod";
  * is defaulted so `{}` always parses — the lenient render path relies on it.
  */
 export const timeSeriesChartSpec = z.looseObject({
-  unit: z.string().default(""),
-  displayUnit: z.literal("auto").optional(),
+  valueFormat: valueFormatSpec.optional(),
   showLegend: z.boolean().default(false),
   lineWidth: z.number().positive().default(1.5),
   curveType: z

--- a/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-chart-visualization.tsx
@@ -30,6 +30,7 @@ import {
   SERIES_COLORS,
 } from "../data-utils";
 import type { VisualizationProps } from "../index";
+import { formatValue } from "../value-format";
 import type { TimeSeriesChartSpec } from "./spec";
 import { buildChartModel, buildStackedData, TS_KEY } from "./time-series-data";
 
@@ -59,8 +60,15 @@ export function TimeSeriesChartVisualization({
   timeRange,
   onTimeRangeChange,
 }: VisualizationProps<TimeSeriesChartSpec>) {
-  const { showLegend, connectNulls, lineWidth, unit, curveType, stacked } =
-    spec;
+  const {
+    showLegend,
+    connectNulls,
+    lineWidth,
+    unit,
+    displayUnit,
+    curveType,
+    stacked,
+  } = spec;
 
   const containerRef = useRef<HTMLDivElement>(null);
   const plotRectRef = useRef<DOMRect | null>(null);
@@ -281,7 +289,9 @@ export function TimeSeriesChartVisualization({
             // would have chosen.
             domain={yAxis.domain}
             ticks={yAxis.ticks}
-            tickFormatter={(v) => (unit ? `${v}${unit}` : String(v))}
+            tickFormatter={(v) =>
+              formatValue(Number(v), unit, { displayUnit, locale: false })
+            }
           />
           {showLegend && <ChartLegend content={<ChartLegendContent />} />}
           {valueKeys.map((key) =>
@@ -354,7 +364,10 @@ export function TimeSeriesChartVisualization({
                   key,
                   color: chartConfig[key]?.color,
                   label: chartConfig[key]?.label ?? key,
-                  value: unit ? `${val}${unit}` : String(val),
+                  value: formatValue(val as number, unit, {
+                    displayUnit,
+                    locale: false,
+                  }),
                   // Calls out the row the pointer is on, so overlapping series
                   // can be told apart by aiming at one of them.
                   active: nearestKeys.has(key),

--- a/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-chart-visualization.tsx
@@ -30,6 +30,7 @@ import {
   SERIES_COLORS,
 } from "../data-utils";
 import type { VisualizationProps } from "../index";
+import { MIN_VALUE_AXIS_WIDTH, valueAxisWidth } from "../value-axis";
 import { createValueFormatter } from "../value-format";
 import type { TimeSeriesChartSpec } from "./spec";
 import { buildChartModel, buildStackedData, TS_KEY } from "./time-series-data";
@@ -279,13 +280,8 @@ export function TimeSeriesChartVisualization({
           <YAxis
             width={
               spec.valueFormat
-                ? Math.max(
-                    60,
-                    ...yAxis.ticks.map(
-                      (tick) => formatAxisValue(tick).length * 7 + 16,
-                    ),
-                  )
-                : 60
+                ? valueAxisWidth(yAxis.ticks, formatAxisValue)
+                : MIN_VALUE_AXIS_WIDTH
             }
             tickLine={false}
             axisLine={false}

--- a/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-chart-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/time-series-chart/time-series-chart-visualization.tsx
@@ -30,7 +30,7 @@ import {
   SERIES_COLORS,
 } from "../data-utils";
 import type { VisualizationProps } from "../index";
-import { formatValue } from "../value-format";
+import { createValueFormatter } from "../value-format";
 import type { TimeSeriesChartSpec } from "./spec";
 import { buildChartModel, buildStackedData, TS_KEY } from "./time-series-data";
 
@@ -60,15 +60,8 @@ export function TimeSeriesChartVisualization({
   timeRange,
   onTimeRangeChange,
 }: VisualizationProps<TimeSeriesChartSpec>) {
-  const {
-    showLegend,
-    connectNulls,
-    lineWidth,
-    unit,
-    displayUnit,
-    curveType,
-    stacked,
-  } = spec;
+  const formatter = createValueFormatter(spec.valueFormat);
+  const { showLegend, connectNulls, lineWidth, curveType, stacked } = spec;
 
   const containerRef = useRef<HTMLDivElement>(null);
   const plotRectRef = useRef<DOMRect | null>(null);
@@ -131,6 +124,9 @@ export function TimeSeriesChartVisualization({
     }
     return niceLinearDomain(lo, hi);
   }, [stackedData, seriesData, valueKeys]);
+  const formatAxisValue = formatter.axis(
+    Math.max(...yAxis.domain.map(Math.abs)),
+  );
 
   const handleChartMouseMove = useCallback(
     (e: React.MouseEvent) => {
@@ -281,6 +277,16 @@ export function TimeSeriesChartVisualization({
             allowDataOverflow
           />
           <YAxis
+            width={
+              spec.valueFormat
+                ? Math.max(
+                    60,
+                    ...yAxis.ticks.map(
+                      (tick) => formatAxisValue(tick).length * 7 + 16,
+                    ),
+                  )
+                : 60
+            }
             tickLine={false}
             axisLine={false}
             tickMargin={8}
@@ -289,9 +295,7 @@ export function TimeSeriesChartVisualization({
             // would have chosen.
             domain={yAxis.domain}
             ticks={yAxis.ticks}
-            tickFormatter={(v) =>
-              formatValue(Number(v), unit, { displayUnit, locale: false })
-            }
+            tickFormatter={(v) => formatAxisValue(Number(v))}
           />
           {showLegend && <ChartLegend content={<ChartLegendContent />} />}
           {valueKeys.map((key) =>
@@ -364,10 +368,7 @@ export function TimeSeriesChartVisualization({
                   key,
                   color: chartConfig[key]?.color,
                   label: chartConfig[key]?.label ?? key,
-                  value: formatValue(val as number, unit, {
-                    displayUnit,
-                    locale: false,
-                  }),
+                  value: formatter.format(val as number),
                   // Calls out the row the pointer is on, so overlapping series
                   // can be told apart by aiming at one of them.
                   active: nearestKeys.has(key),

--- a/packages/app/src/components/dashboards/visualizations/treemap/spec.ts
+++ b/packages/app/src/components/dashboards/visualizations/treemap/spec.ts
@@ -1,10 +1,12 @@
 import * as z from "zod";
+import { valueFormatSpec } from "../value-format-spec";
 
 /**
  * Treemap plugin options. Loose so unknown keys flow through verbatim; every
  * field defaulted/optional so `{}` parses (the lenient render path needs it).
  */
 export const treemapSpec = z.looseObject({
+  valueFormat: valueFormatSpec.optional(),
   /** Tile label column. */
   nameColumn: z.string().default("name"),
   /** Tile size column — rows with a non-positive value have no area and are dropped. */
@@ -21,7 +23,6 @@ export const treemapSpec = z.looseObject({
    */
   maxTiles: z.number().int().min(2).optional(),
   /** Value formatting in tiles + tooltip. */
-  unit: z.string().default(""),
   /** Render the value inside tiles that are large enough. */
   showValues: z.boolean().default(true),
   /** Group color legend — only shown when there are groups. */

--- a/packages/app/src/components/dashboards/visualizations/treemap/treemap-visualization.tsx
+++ b/packages/app/src/components/dashboards/visualizations/treemap/treemap-visualization.tsx
@@ -2,14 +2,10 @@ import { SeriesTooltipContent } from "@everr/ui/components/series-tooltip";
 import { LayoutGrid } from "lucide-react";
 import { useMemo } from "react";
 import type { VisualizationProps } from "../index";
-import { formatStatValue } from "../stat-chart/stat-calculations";
+import { createValueFormatter } from "../value-format";
 import type { TreemapSpec } from "./spec";
 import { TreemapChart } from "./treemap-chart";
 import { buildTreemapTiles } from "./treemap-data";
-
-function formatValue(value: number, unit: string): string {
-  return `${formatStatValue(value, undefined)}${unit ? ` ${unit}` : ""}`;
-}
 
 function EmptyState() {
   return (
@@ -24,6 +20,7 @@ export function TreemapVisualization({
   spec,
   data,
 }: VisualizationProps<TreemapSpec>) {
+  const formatter = createValueFormatter(spec.valueFormat);
   const model = useMemo(
     () => (data ? buildTreemapTiles(data, spec) : null),
     [data, spec],
@@ -54,7 +51,7 @@ export function TreemapVisualization({
         <TreemapChart
           data={chartData}
           tileValueText={
-            spec.showValues ? (t) => formatValue(t.value, spec.unit) : undefined
+            spec.showValues ? (t) => formatter.format(t.value) : undefined
           }
           renderTooltip={(t) => (
             <SeriesTooltipContent
@@ -64,7 +61,7 @@ export function TreemapVisualization({
                   key: t.name,
                   color: t.fill,
                   label: t.name,
-                  value: formatValue(t.value, spec.unit),
+                  value: formatter.format(t.value),
                 },
               ]}
             />

--- a/packages/app/src/components/dashboards/visualizations/value-axis.ts
+++ b/packages/app/src/components/dashboards/visualizations/value-axis.ts
@@ -1,0 +1,16 @@
+export const MIN_VALUE_AXIS_WIDTH = 60;
+const APPROXIMATE_CHARACTER_WIDTH = 7;
+const TICK_PADDING = 16;
+
+export function valueAxisWidth(
+  values: number[],
+  format: (value: number) => string,
+): number {
+  return Math.max(
+    MIN_VALUE_AXIS_WIDTH,
+    ...values.map(
+      (value) =>
+        format(value).length * APPROXIMATE_CHARACTER_WIDTH + TICK_PADDING,
+    ),
+  );
+}

--- a/packages/app/src/components/dashboards/visualizations/value-format-spec.ts
+++ b/packages/app/src/components/dashboards/visualizations/value-format-spec.ts
@@ -1,0 +1,37 @@
+import * as z from "zod";
+
+export const durationUnits: Readonly<Record<string, number>> = {
+  ns: 1e-9,
+  us: 1e-6,
+  ms: 1e-3,
+  s: 1,
+  min: 60,
+  h: 3600,
+  d: 86400,
+};
+
+export const valueFormatSpec = z
+  .looseObject({
+    unit: z.string().default(""),
+    scale: z.enum(["none", "decimal", "binary", "duration"]).default("none"),
+    decimals: z.number().int().min(0).max(10).optional(),
+    display: z.enum(["value", "percent"]).optional(),
+  })
+  .refine(
+    (format) =>
+      format.scale !== "duration" || Object.hasOwn(durationUnits, format.unit),
+    {
+      path: ["unit"],
+      message: "Duration scaling requires ns, us, ms, s, min, h, or d",
+    },
+  )
+  .refine((format) => format.display !== "percent" || format.unit === "1", {
+    path: ["display"],
+    message: "Percent display requires the dimensionless unit 1",
+  })
+  .refine((format) => format.display !== "percent" || format.scale === "none", {
+    path: ["scale"],
+    message: "Percent display requires scale none",
+  });
+
+export type ValueFormat = z.infer<typeof valueFormatSpec>;

--- a/packages/app/src/components/dashboards/visualizations/value-format.test.ts
+++ b/packages/app/src/components/dashboards/visualizations/value-format.test.ts
@@ -1,73 +1,239 @@
 import { describe, expect, it } from "vitest";
-import {
-  formatCompactValue,
-  formatValue,
-  formatValueParts,
-} from "./value-format";
+import { createValueFormatter } from "./value-format";
+import { valueFormatSpec } from "./value-format-spec";
 
-describe("formatValue", () => {
-  it("auto-scales raw bytes with binary units", () => {
-    const options = { displayUnit: "auto" as const };
-    expect(formatValue(0, "By", options)).toBe("0 B");
-    expect(formatValue(1023, "By", options)).toBe(
-      `${(1023).toLocaleString()} B`,
+const formatter = (
+  unit: string,
+  scale: "none" | "decimal" | "binary" | "duration",
+  decimals?: number,
+) => createValueFormatter({ unit, scale, decimals });
+
+describe("value formatting", () => {
+  it.each([
+    [3.2e9, "Hz", "3.2 GHz"],
+    [1500, "W", "1.5 kW"],
+    [2.5e6, "J", "2.5 MJ"],
+    [12000, "V", "12 kV"],
+    [-2500, "A", "-2.5 kA"],
+    [0, "Hz", "0 Hz"],
+    [0.25, "A", "0.25 A"],
+  ] as const)("places SI prefixes on %s %s", (value, unit, expected) => {
+    const result = formatter(unit, "decimal");
+    expect(result.format(value)).toBe(expected);
+    expect(result.axis(Math.abs(value))(value)).toBe(expected);
+  });
+
+  it("keeps SI axis prefixes stable without reinterpreting input prefixes or custom labels", () => {
+    const axis = formatter("Hz", "decimal").axis(4e9);
+    expect([0, 1e9, -2e9].map(axis)).toEqual(["0 GHz", "1 GHz", "-2 GHz"]);
+    expect(formatter("Hz", "decimal", 2).parts(3.2e9)).toEqual({
+      value: "3.20",
+      unit: "GHz",
+    });
+    expect(formatter("GHz", "none").format(3.2)).toBe("3.2 GHz");
+    expect(formatter("widgets", "decimal").format(1500)).toBe("1.5k widgets");
+    expect(formatter("Hz", "binary").format(2048)).toBe("2Ki Hz");
+  });
+
+  it.each([
+    [0, "0%"],
+    [0.75, "75%"],
+    [1, "100%"],
+    [-0.125, "-12.5%"],
+    [1.25, "125%"],
+    [0.123456, "12.35%"],
+    [Infinity, "∞%"],
+    [NaN, "NaN%"],
+  ])("explicitly displays the ratio %s as a percentage", (value, expected) => {
+    const result = createValueFormatter(
+      valueFormatSpec.parse({ unit: "1", display: "percent" }),
     );
-    expect(formatValue(1024, "By", options)).toBe("1 KiB");
-    expect(formatValue(1.5 * 1024 ** 2, "By", options)).toBe("1.5 MiB");
-    expect(formatValue(2.25 * 1024 ** 3, "By", options)).toBe("2.25 GiB");
-    expect(formatValue(-3 * 1024 ** 4, "By", options)).toBe("-3 TiB");
+    expect(result.format(value)).toBe(expected);
+    expect(result.axis(1)(value)).toBe(expected);
   });
 
-  it("normalizes pre-scaled byte query results before choosing a display unit", () => {
-    expect(formatValue(1.5, "GiBy", { displayUnit: "auto" })).toBe("1.5 GiB");
-    expect(formatValue(1.5, "GiB", { displayUnit: "auto" })).toBe("1.5 GiB");
-    expect(formatValue(1536, "MiB", { displayUnit: "auto" })).toBe("1.5 GiB");
-    expect(formatValue(1500, "MB", { displayUnit: "auto" })).toBe("1.5 GB");
-  });
-
-  it("auto-scales duration query results", () => {
-    expect(formatValue(1500, "ms", { displayUnit: "auto" })).toBe("1.5 s");
-    expect(formatValue(0.5, "ms", { displayUnit: "auto" })).toBe("500 µs");
-    expect(formatValue(90, "s", { displayUnit: "auto" })).toBe("1.5 min");
-  });
-
-  it("honors fixed decimals while auto-scaling", () => {
+  it("keeps percentage precision explicit and leaves ordinary ratios and percentages unchanged", () => {
+    const result = createValueFormatter(
+      valueFormatSpec.parse({ unit: "1", display: "percent", decimals: 2 }),
+    );
+    expect(result.parts(0.75)).toEqual({ value: "75.00", unit: "%" });
+    expect(formatter("1", "none").format(0.75)).toBe("0.75");
+    expect(formatter("%", "none").format(0.75)).toBe("0.75%");
     expect(
-      formatValue(1.5 * 1024 ** 3, "By", {
-        decimals: 2,
-        displayUnit: "auto",
-      }),
-    ).toBe(
-      `${(1.5).toLocaleString(undefined, {
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
-      })} GiB`,
+      createValueFormatter(
+        valueFormatSpec.parse({ unit: "1", display: "value" }),
+      ).format(0.75),
+    ).toBe("0.75");
+  });
+
+  it.each([
+    { unit: "By", display: "percent" },
+    { unit: "%", display: "percent" },
+    { display: "percent" },
+    { unit: "1", display: "percent", scale: "decimal" },
+    { unit: "1", display: "percent", scale: "binary" },
+    { unit: "1", display: "unknown" },
+  ])("rejects incompatible percentage options %o", (spec) => {
+    expect(valueFormatSpec.safeParse(spec).success).toBe(false);
+  });
+  it("uses the same default precision without format options", () => {
+    const defaults = createValueFormatter();
+    expect(defaults.format(42.56789)).toBe("42.57");
+    expect(defaults.format(42)).toBe("42");
+    expect(defaults.axis(100)(42.56789)).toBe("42.57");
+  });
+  it.each([
+    [12500, "requests/s", "decimal", "12.5k requests/s"],
+    [3500, "widgets/s", "decimal", "3.5k widgets/s"],
+    [4200000, "tokens/min", "decimal", "4.2M tokens/min"],
+    [1e9, "events", "decimal", "1G events"],
+    [1536, "By", "binary", "1.5 KiB"],
+    [2621440, "By/s", "binary", "2.5 MiB/s"],
+    [-3072, "By/s", "binary", "-3 KiB/s"],
+    [99.9, "%", "none", "99.9%"],
+    [12500, "", "decimal", "12.5k"],
+    [0, "widgets/s", "decimal", "0 widgets/s"],
+    [0.25, "widgets", "decimal", "0.25 widgets"],
+    [1023, "By", "binary", "1,023 B"],
+    [1024, "By", "binary", "1 KiB"],
+  ] as const)("formats %s with %s/%s", (value, unit, scale, expected) => {
+    expect(formatter(unit, scale).format(value)).toBe(expected);
+  });
+
+  it.each([
+    [0.025, "s", "25 ms"],
+    [1.5, "s", "1.5 s"],
+    [90, "s", "1.5 min"],
+    [0.25, "ms", "250 µs"],
+    [1500, "ms", "1.5 s"],
+    [90000, "ms", "1.5 min"],
+    [1500000, "ns", "1.5 ms"],
+    [1500, "us", "1.5 ms"],
+    [90, "min", "1.5 h"],
+    [48, "h", "2 d"],
+    [0.5, "d", "12 h"],
+    [-90, "s", "-1.5 min"],
+    [0, "s", "0 s"],
+  ])("scales duration %s %s", (value, unit, expected) => {
+    expect(formatter(String(unit), "duration").format(Number(value))).toBe(
+      expected,
     );
   });
 
-  it("preserves literal units", () => {
-    expect(formatValue(1234, "ms", { locale: false })).toBe("1234ms");
-    expect(formatValue(1234, "req")).toBe(`${(1234).toLocaleString()}req`);
-    expect(formatValue(1.5, "GiBy")).toBe("1.5GiBy");
-    expect(formatValue(1234, "req", { displayUnit: "auto" })).toBe(
-      `${(1234).toLocaleString()}req`,
-    );
+  it("can keep durations in decimal time steps", () => {
+    expect(formatter("ms", "decimal").format(90000)).toBe("90 s");
+    expect(formatter("s", "decimal").format(0.025)).toBe("25 ms");
   });
 
-  it("returns semantic value and unit separately for stat tiles", () => {
+  it.each([
+    [1536, "By", "none", "1,536 B"],
+    [1.5, "MiBy", "none", "1.5 MiB"],
+    [2.5, "GiBy/s", "none", "2.5 GiB/s"],
+    [3, "MBy", "none", "3 MB"],
+    [2500000, "By/s", "decimal", "2.5 MB/s"],
+    [2500000, "bit/s", "decimal", "2.5 Mbit/s"],
+    [21.234, "Cel", "none", "21.23 °C"],
+    [25, "us", "none", "25 µs"],
+    [0, "us", "duration", "0 µs"],
+    [0.5, "1", "none", "0.5"],
+    [12500, "1", "decimal", "12.5k"],
+    [12500, "{request}", "decimal", "12.5k request"],
+    [12500, "{request}/s", "decimal", "12.5k request/s"],
+    [42, "{connection}", "none", "42 connection"],
+    [42, "1/s", "none", "42 1/s"],
+    [42, "B", "none", "42 B"],
+    [2048, "B", "binary", "2Ki B"],
+    [42, "unmapped/unit", "none", "42 unmapped/unit"],
+    [42, "{unclosed", "none", "42 {unclosed"],
+  ] as const)("presents UCUM code %s %s (%s)", (value, unit, scale, expected) => {
+    const result = formatter(unit, scale);
+    expect(result.format(value)).toBe(expected);
+    expect(result.axis(value)(value)).toBe(expected.replace("1,536", "1536"));
+  });
+
+  it("keeps UCUM codes in the spec and maps non-finite unit labels", () => {
+    expect(valueFormatSpec.parse({ unit: "By" }).unit).toBe("By");
+    expect(formatter("Cel", "none").parts(21)).toEqual({
+      value: "21",
+      unit: "°C",
+    });
+    expect(formatter("By", "binary").format(NaN)).toBe("NaN B");
+    expect(formatter("1", "none").format(Infinity)).toBe("∞");
     expect(
-      formatValueParts(5 * 1024 ** 3, "By", { displayUnit: "auto" }),
-    ).toEqual({
+      valueFormatSpec.safeParse({ unit: "µs", scale: "duration" }).success,
+    ).toBe(false);
+  });
+
+  it("preserves unscaled input units and explicit precision", () => {
+    expect(formatter("s", "none", 3).format(0.025)).toBe("0.025 s");
+    expect(formatter("%", "none", 2).format(2.3)).toBe("2.30%");
+    expect(formatter("By", "binary", 2).format(1536)).toBe("1.50 KiB");
+    expect(formatter("connections", "none", 0).format(8200)).toBe(
+      "8,200 connections",
+    );
+  });
+
+  it("fixes axis scales across zero, negative and small ticks", () => {
+    const bytes = formatter("By", "binary");
+    const axis = bytes.axis(2 * 1024 ** 2);
+    expect([0, 1024 ** 2 / 2, 1024 ** 2, -(1024 ** 2)].map(axis)).toEqual([
+      "0 MiB",
+      "0.5 MiB",
+      "1 MiB",
+      "-1 MiB",
+    ]);
+    expect(bytes.format(1024)).toBe("1 KiB");
+    expect(formatter("s", "duration").axis(90)(30)).toBe("0.5 min");
+  });
+
+  it("returns separate number and unit parts for tiles", () => {
+    expect(formatter("By", "binary").parts(5 * 1024 ** 3)).toEqual({
       value: "5",
       unit: "GiB",
     });
   });
-});
 
-describe("formatCompactValue", () => {
-  it("keeps the existing decimal magnitude abbreviations", () => {
-    expect(formatCompactValue(2_500_000_000)).toBe(
-      `${(2.5).toLocaleString()}B`,
-    );
+  it.each([
+    [42, "42 ms"],
+    [42.5, "42.5 ms"],
+    [42.56789, "42.57 ms"],
+    [1234.56789, "1234.57 ms"],
+  ])("uses at most two decimals for axes and tooltips: %s", (value, expected) => {
+    const formatter = createValueFormatter({ unit: "ms", scale: "none" });
+    expect(formatter.format(value)).toBe(expected.replace("1234", "1,234"));
+    expect(formatter.axis(2000)(value)).toBe(expected);
+  });
+
+  it("honors explicit precision in formatter axes and tooltips", () => {
+    const formatter = createValueFormatter({
+      unit: "ms",
+      scale: "none",
+      decimals: 3,
+    });
+    expect(formatter.format(42)).toBe("42.000 ms");
+    expect(formatter.axis(100)(42.56789)).toBe("42.568 ms");
+  });
+
+  it("handles non-finite values without selecting a misleading scale", () => {
+    expect(formatter("By", "binary").format(Infinity)).toBe("∞ B");
+    expect(formatter("s", "duration").format(NaN)).toBe("NaN s");
+  });
+
+  it("validates duration input units while allowing arbitrary labels elsewhere", () => {
+    expect(
+      valueFormatSpec.safeParse({ unit: "widgets/s", scale: "decimal" })
+        .success,
+    ).toBe(true);
+    expect(
+      valueFormatSpec.safeParse({ unit: "widgets/s", scale: "duration" })
+        .success,
+    ).toBe(false);
+    expect(
+      valueFormatSpec.safeParse({ unit: "constructor", scale: "duration" })
+        .success,
+    ).toBe(false);
+    expect(valueFormatSpec.safeParse({ decimals: 11 }).success).toBe(false);
+    expect(valueFormatSpec.safeParse({ decimals: -1 }).success).toBe(false);
+    expect(valueFormatSpec.safeParse({ scale: "auto" }).success).toBe(false);
   });
 });

--- a/packages/app/src/components/dashboards/visualizations/value-format.test.ts
+++ b/packages/app/src/components/dashboards/visualizations/value-format.test.ts
@@ -29,6 +29,7 @@ describe("value formatting", () => {
     expect(formatter("Hz", "decimal", 2).parts(3.2e9)).toEqual({
       value: "3.20",
       unit: "GHz",
+      separator: " ",
     });
     expect(formatter("GHz", "none").format(3.2)).toBe("3.2 GHz");
     expect(formatter("widgets", "decimal").format(1500)).toBe("1.5k widgets");
@@ -56,7 +57,11 @@ describe("value formatting", () => {
     const result = createValueFormatter(
       valueFormatSpec.parse({ unit: "1", display: "percent", decimals: 2 }),
     );
-    expect(result.parts(0.75)).toEqual({ value: "75.00", unit: "%" });
+    expect(result.parts(0.75)).toEqual({
+      value: "75.00",
+      unit: "%",
+      separator: "",
+    });
     expect(formatter("1", "none").format(0.75)).toBe("0.75");
     expect(formatter("%", "none").format(0.75)).toBe("0.75%");
     expect(
@@ -156,6 +161,7 @@ describe("value formatting", () => {
     expect(formatter("Cel", "none").parts(21)).toEqual({
       value: "21",
       unit: "°C",
+      separator: " ",
     });
     expect(formatter("By", "binary").format(NaN)).toBe("NaN B");
     expect(formatter("1", "none").format(Infinity)).toBe("∞");
@@ -190,6 +196,7 @@ describe("value formatting", () => {
     expect(formatter("By", "binary").parts(5 * 1024 ** 3)).toEqual({
       value: "5",
       unit: "GiB",
+      separator: " ",
     });
   });
 

--- a/packages/app/src/components/dashboards/visualizations/value-format.test.ts
+++ b/packages/app/src/components/dashboards/visualizations/value-format.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatCompactValue,
+  formatValue,
+  formatValueParts,
+} from "./value-format";
+
+describe("formatValue", () => {
+  it("auto-scales raw bytes with binary units", () => {
+    const options = { displayUnit: "auto" as const };
+    expect(formatValue(0, "By", options)).toBe("0 B");
+    expect(formatValue(1023, "By", options)).toBe(
+      `${(1023).toLocaleString()} B`,
+    );
+    expect(formatValue(1024, "By", options)).toBe("1 KiB");
+    expect(formatValue(1.5 * 1024 ** 2, "By", options)).toBe("1.5 MiB");
+    expect(formatValue(2.25 * 1024 ** 3, "By", options)).toBe("2.25 GiB");
+    expect(formatValue(-3 * 1024 ** 4, "By", options)).toBe("-3 TiB");
+  });
+
+  it("normalizes pre-scaled byte query results before choosing a display unit", () => {
+    expect(formatValue(1.5, "GiBy", { displayUnit: "auto" })).toBe("1.5 GiB");
+    expect(formatValue(1.5, "GiB", { displayUnit: "auto" })).toBe("1.5 GiB");
+    expect(formatValue(1536, "MiB", { displayUnit: "auto" })).toBe("1.5 GiB");
+    expect(formatValue(1500, "MB", { displayUnit: "auto" })).toBe("1.5 GB");
+  });
+
+  it("auto-scales duration query results", () => {
+    expect(formatValue(1500, "ms", { displayUnit: "auto" })).toBe("1.5 s");
+    expect(formatValue(0.5, "ms", { displayUnit: "auto" })).toBe("500 µs");
+    expect(formatValue(90, "s", { displayUnit: "auto" })).toBe("1.5 min");
+  });
+
+  it("honors fixed decimals while auto-scaling", () => {
+    expect(
+      formatValue(1.5 * 1024 ** 3, "By", {
+        decimals: 2,
+        displayUnit: "auto",
+      }),
+    ).toBe(
+      `${(1.5).toLocaleString(undefined, {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      })} GiB`,
+    );
+  });
+
+  it("preserves literal units", () => {
+    expect(formatValue(1234, "ms", { locale: false })).toBe("1234ms");
+    expect(formatValue(1234, "req")).toBe(`${(1234).toLocaleString()}req`);
+    expect(formatValue(1.5, "GiBy")).toBe("1.5GiBy");
+    expect(formatValue(1234, "req", { displayUnit: "auto" })).toBe(
+      `${(1234).toLocaleString()}req`,
+    );
+  });
+
+  it("returns semantic value and unit separately for stat tiles", () => {
+    expect(
+      formatValueParts(5 * 1024 ** 3, "By", { displayUnit: "auto" }),
+    ).toEqual({
+      value: "5",
+      unit: "GiB",
+    });
+  });
+});
+
+describe("formatCompactValue", () => {
+  it("keeps the existing decimal magnitude abbreviations", () => {
+    expect(formatCompactValue(2_500_000_000)).toBe(
+      `${(2.5).toLocaleString()}B`,
+    );
+  });
+});

--- a/packages/app/src/components/dashboards/visualizations/value-format.ts
+++ b/packages/app/src/components/dashboards/visualizations/value-format.ts
@@ -1,0 +1,201 @@
+const COMPACT_SUFFIXES: ReadonlyArray<[number, string]> = [
+  [1e12, "T"],
+  [1e9, "B"],
+  [1e6, "M"],
+];
+
+type UnitDimension = "bytes" | "duration";
+type UnitSystem = "binary" | "decimal" | "duration";
+
+interface SemanticUnit {
+  dimension: UnitDimension;
+  factor: number;
+  label: string;
+  system: UnitSystem;
+}
+
+const UNITS: Readonly<Record<string, SemanticUnit>> = {
+  By: { dimension: "bytes", factor: 1, label: "B", system: "binary" },
+  bytes: { dimension: "bytes", factor: 1, label: "B", system: "binary" },
+  B: { dimension: "bytes", factor: 1, label: "B", system: "binary" },
+  kBy: { dimension: "bytes", factor: 1e3, label: "kB", system: "decimal" },
+  KBy: { dimension: "bytes", factor: 1e3, label: "kB", system: "decimal" },
+  KB: { dimension: "bytes", factor: 1e3, label: "kB", system: "decimal" },
+  MBy: { dimension: "bytes", factor: 1e6, label: "MB", system: "decimal" },
+  MB: { dimension: "bytes", factor: 1e6, label: "MB", system: "decimal" },
+  GBy: { dimension: "bytes", factor: 1e9, label: "GB", system: "decimal" },
+  GB: { dimension: "bytes", factor: 1e9, label: "GB", system: "decimal" },
+  TBy: { dimension: "bytes", factor: 1e12, label: "TB", system: "decimal" },
+  TB: { dimension: "bytes", factor: 1e12, label: "TB", system: "decimal" },
+  PBy: { dimension: "bytes", factor: 1e15, label: "PB", system: "decimal" },
+  PB: { dimension: "bytes", factor: 1e15, label: "PB", system: "decimal" },
+  KiBy: { dimension: "bytes", factor: 1024, label: "KiB", system: "binary" },
+  KiB: { dimension: "bytes", factor: 1024, label: "KiB", system: "binary" },
+  MiBy: {
+    dimension: "bytes",
+    factor: 1024 ** 2,
+    label: "MiB",
+    system: "binary",
+  },
+  MiB: {
+    dimension: "bytes",
+    factor: 1024 ** 2,
+    label: "MiB",
+    system: "binary",
+  },
+  GiBy: {
+    dimension: "bytes",
+    factor: 1024 ** 3,
+    label: "GiB",
+    system: "binary",
+  },
+  GiB: {
+    dimension: "bytes",
+    factor: 1024 ** 3,
+    label: "GiB",
+    system: "binary",
+  },
+  TiBy: {
+    dimension: "bytes",
+    factor: 1024 ** 4,
+    label: "TiB",
+    system: "binary",
+  },
+  TiB: {
+    dimension: "bytes",
+    factor: 1024 ** 4,
+    label: "TiB",
+    system: "binary",
+  },
+  PiBy: {
+    dimension: "bytes",
+    factor: 1024 ** 5,
+    label: "PiB",
+    system: "binary",
+  },
+  PiB: {
+    dimension: "bytes",
+    factor: 1024 ** 5,
+    label: "PiB",
+    system: "binary",
+  },
+  ns: { dimension: "duration", factor: 1e-9, label: "ns", system: "duration" },
+  us: { dimension: "duration", factor: 1e-6, label: "µs", system: "duration" },
+  µs: {
+    dimension: "duration",
+    factor: 1e-6,
+    label: "µs",
+    system: "duration",
+  },
+  ms: { dimension: "duration", factor: 1e-3, label: "ms", system: "duration" },
+  s: { dimension: "duration", factor: 1, label: "s", system: "duration" },
+  min: { dimension: "duration", factor: 60, label: "min", system: "duration" },
+  h: { dimension: "duration", factor: 3600, label: "h", system: "duration" },
+  d: { dimension: "duration", factor: 86400, label: "d", system: "duration" },
+};
+
+const BINARY_BYTE_UNITS = ["PiBy", "TiBy", "GiBy", "MiBy", "KiBy", "By"];
+const DECIMAL_BYTE_UNITS = ["PBy", "TBy", "GBy", "MBy", "kBy", "By"];
+const DURATION_UNITS = ["d", "h", "min", "s", "ms", "us", "ns"];
+
+interface FormatValueOptions {
+  decimals?: number;
+  compact?: boolean;
+  displayUnit?: "auto";
+  locale?: boolean;
+  unitSeparator?: string;
+}
+
+export interface FormattedValueParts {
+  value: string;
+  unit: string;
+}
+
+function fractionDigits(decimals?: number): Intl.NumberFormatOptions {
+  return decimals === undefined
+    ? { maximumFractionDigits: 2 }
+    : { minimumFractionDigits: decimals, maximumFractionDigits: decimals };
+}
+
+export function formatCompactValue(value: number, decimals?: number): string {
+  const fraction = fractionDigits(decimals);
+  for (const [factor, suffix] of COMPACT_SUFFIXES) {
+    if (Math.abs(value) >= factor) {
+      return `${(value / factor).toLocaleString(undefined, fraction)}${suffix}`;
+    }
+  }
+  return value.toLocaleString(undefined, fraction);
+}
+
+function autoUnit(input: SemanticUnit, baseValue: number): SemanticUnit {
+  const candidates =
+    input.dimension === "duration"
+      ? DURATION_UNITS
+      : input.system === "decimal"
+        ? DECIMAL_BYTE_UNITS
+        : BINARY_BYTE_UNITS;
+  if (baseValue === 0) return input;
+  const magnitude = Math.abs(baseValue);
+  for (const candidate of candidates) {
+    const resolved = UNITS[candidate];
+    if (resolved && magnitude >= resolved.factor) return resolved;
+  }
+  return UNITS[candidates.at(-1) ?? ""] ?? input;
+}
+
+function semanticParts(
+  value: number,
+  unit: string,
+  decimals?: number,
+): FormattedValueParts | undefined {
+  const input = UNITS[unit];
+  if (!input) return undefined;
+  const baseValue = value * input.factor;
+  const output = autoUnit(input, baseValue);
+  return {
+    value: (baseValue / output.factor).toLocaleString(
+      undefined,
+      fractionDigits(decimals),
+    ),
+    unit: output.label,
+  };
+}
+
+export function formatValueParts(
+  value: number,
+  unit: string,
+  options: Pick<
+    FormatValueOptions,
+    "decimals" | "compact" | "displayUnit"
+  > = {},
+): FormattedValueParts {
+  if (options.displayUnit === "auto") {
+    const semantic = semanticParts(value, unit, options.decimals);
+    if (semantic) return semantic;
+  }
+
+  return {
+    value: options.compact
+      ? formatCompactValue(value, options.decimals)
+      : value.toLocaleString(undefined, fractionDigits(options.decimals)),
+    unit,
+  };
+}
+
+export function formatValue(
+  value: number,
+  unit: string,
+  options: FormatValueOptions = {},
+): string {
+  if (options.displayUnit === "auto") {
+    const semantic = semanticParts(value, unit, options.decimals);
+    if (semantic) return `${semantic.value} ${semantic.unit}`;
+  }
+
+  const formatted = options.compact
+    ? formatCompactValue(value, options.decimals)
+    : options.locale === false
+      ? String(value)
+      : value.toLocaleString(undefined, fractionDigits(options.decimals));
+  return unit ? `${formatted}${options.unitSeparator ?? ""}${unit}` : formatted;
+}

--- a/packages/app/src/components/dashboards/visualizations/value-format.ts
+++ b/packages/app/src/components/dashboards/visualizations/value-format.ts
@@ -1,201 +1,127 @@
-const COMPACT_SUFFIXES: ReadonlyArray<[number, string]> = [
-  [1e12, "T"],
-  [1e9, "B"],
-  [1e6, "M"],
+import { durationUnits, type ValueFormat } from "./value-format-spec";
+
+const DECIMAL_PREFIXES = ["", "k", "M", "G", "T", "P", "E", "Z", "Y"];
+const BINARY_PREFIXES = ["", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi", "Yi"];
+const DURATION_STEPS: ReadonlyArray<readonly [number, string]> = [
+  [86400, "d"],
+  [3600, "h"],
+  [60, "min"],
+  [1, "s"],
+  [1e-3, "ms"],
+  [1e-6, "us"],
+  [1e-9, "ns"],
 ];
+const DECIMAL_DURATION_STEPS = DURATION_STEPS.filter(([factor]) => factor <= 1);
 
-type UnitDimension = "bytes" | "duration";
-type UnitSystem = "binary" | "decimal" | "duration";
-
-interface SemanticUnit {
-  dimension: UnitDimension;
-  factor: number;
-  label: string;
-  system: UnitSystem;
-}
-
-const UNITS: Readonly<Record<string, SemanticUnit>> = {
-  By: { dimension: "bytes", factor: 1, label: "B", system: "binary" },
-  bytes: { dimension: "bytes", factor: 1, label: "B", system: "binary" },
-  B: { dimension: "bytes", factor: 1, label: "B", system: "binary" },
-  kBy: { dimension: "bytes", factor: 1e3, label: "kB", system: "decimal" },
-  KBy: { dimension: "bytes", factor: 1e3, label: "kB", system: "decimal" },
-  KB: { dimension: "bytes", factor: 1e3, label: "kB", system: "decimal" },
-  MBy: { dimension: "bytes", factor: 1e6, label: "MB", system: "decimal" },
-  MB: { dimension: "bytes", factor: 1e6, label: "MB", system: "decimal" },
-  GBy: { dimension: "bytes", factor: 1e9, label: "GB", system: "decimal" },
-  GB: { dimension: "bytes", factor: 1e9, label: "GB", system: "decimal" },
-  TBy: { dimension: "bytes", factor: 1e12, label: "TB", system: "decimal" },
-  TB: { dimension: "bytes", factor: 1e12, label: "TB", system: "decimal" },
-  PBy: { dimension: "bytes", factor: 1e15, label: "PB", system: "decimal" },
-  PB: { dimension: "bytes", factor: 1e15, label: "PB", system: "decimal" },
-  KiBy: { dimension: "bytes", factor: 1024, label: "KiB", system: "binary" },
-  KiB: { dimension: "bytes", factor: 1024, label: "KiB", system: "binary" },
-  MiBy: {
-    dimension: "bytes",
-    factor: 1024 ** 2,
-    label: "MiB",
-    system: "binary",
-  },
-  MiB: {
-    dimension: "bytes",
-    factor: 1024 ** 2,
-    label: "MiB",
-    system: "binary",
-  },
-  GiBy: {
-    dimension: "bytes",
-    factor: 1024 ** 3,
-    label: "GiB",
-    system: "binary",
-  },
-  GiB: {
-    dimension: "bytes",
-    factor: 1024 ** 3,
-    label: "GiB",
-    system: "binary",
-  },
-  TiBy: {
-    dimension: "bytes",
-    factor: 1024 ** 4,
-    label: "TiB",
-    system: "binary",
-  },
-  TiB: {
-    dimension: "bytes",
-    factor: 1024 ** 4,
-    label: "TiB",
-    system: "binary",
-  },
-  PiBy: {
-    dimension: "bytes",
-    factor: 1024 ** 5,
-    label: "PiB",
-    system: "binary",
-  },
-  PiB: {
-    dimension: "bytes",
-    factor: 1024 ** 5,
-    label: "PiB",
-    system: "binary",
-  },
-  ns: { dimension: "duration", factor: 1e-9, label: "ns", system: "duration" },
-  us: { dimension: "duration", factor: 1e-6, label: "µs", system: "duration" },
-  µs: {
-    dimension: "duration",
-    factor: 1e-6,
-    label: "µs",
-    system: "duration",
-  },
-  ms: { dimension: "duration", factor: 1e-3, label: "ms", system: "duration" },
-  s: { dimension: "duration", factor: 1, label: "s", system: "duration" },
-  min: { dimension: "duration", factor: 60, label: "min", system: "duration" },
-  h: { dimension: "duration", factor: 3600, label: "h", system: "duration" },
-  d: { dimension: "duration", factor: 86400, label: "d", system: "duration" },
-};
-
-const BINARY_BYTE_UNITS = ["PiBy", "TiBy", "GiBy", "MiBy", "KiBy", "By"];
-const DECIMAL_BYTE_UNITS = ["PBy", "TBy", "GBy", "MBy", "kBy", "By"];
-const DURATION_UNITS = ["d", "h", "min", "s", "ms", "us", "ns"];
-
-interface FormatValueOptions {
-  decimals?: number;
-  compact?: boolean;
-  displayUnit?: "auto";
-  locale?: boolean;
-  unitSeparator?: string;
-}
-
-export interface FormattedValueParts {
+interface FormattedValueParts {
   value: string;
   unit: string;
 }
 
-function fractionDigits(decimals?: number): Intl.NumberFormatOptions {
-  return decimals === undefined
-    ? { maximumFractionDigits: 2 }
-    : { minimumFractionDigits: decimals, maximumFractionDigits: decimals };
+/** Present common OTel/UCUM codes without treating unknown units as aliases. */
+function unitLabel(unit: string): string {
+  if (unit === "1") return "";
+  const rate = /^(.*)\/(ns|us|ms|s|min|h|d)$/.exec(unit);
+  const atom = rate?.[1] ?? unit;
+  const bytes = /^((?:[KMGT]i|[kMGTPEZYmunp])?)By$/.exec(atom);
+  const label = bytes
+    ? `${bytes[1]}B`
+    : atom === "Cel"
+      ? "°C"
+      : atom === "us"
+        ? "µs"
+        : /^\{[^{}]+\}$/.test(atom)
+          ? atom.slice(1, -1)
+          : atom;
+  return rate ? `${label}/${rate[2] === "us" ? "µs" : rate[2]}` : label;
 }
 
-export function formatCompactValue(value: number, decimals?: number): string {
-  const fraction = fractionDigits(decimals);
-  for (const [factor, suffix] of COMPACT_SUFFIXES) {
-    if (Math.abs(value) >= factor) {
-      return `${(value / factor).toLocaleString(undefined, fraction)}${suffix}`;
+function numberFormatter(decimals?: number, useGrouping = true) {
+  return new Intl.NumberFormat(undefined, {
+    useGrouping,
+    minimumFractionDigits: decimals ?? 0,
+    maximumFractionDigits: decimals ?? 2,
+  });
+}
+
+/** Resolves presentation once; all geometry and thresholds keep raw query values. */
+export function createValueFormatter(
+  format: ValueFormat = { unit: "", scale: "none" },
+) {
+  const { unit, decimals } = format;
+  const percent = format.display === "percent";
+  const label = percent ? "%" : unitLabel(unit);
+  const numbers = numberFormatter(decimals);
+  const axisNumbers = numberFormatter(decimals, false);
+  const separator = label === "%" ? "" : " ";
+
+  function parts(
+    value: number,
+    reference = value,
+    axis = false,
+  ): FormattedValueParts {
+    const formatter = axis ? axisNumbers : numbers;
+    if (percent) return { value: formatter.format(value * 100), unit: label };
+    if (!Number.isFinite(value))
+      return { value: formatter.format(value), unit: label };
+    const magnitude = Number.isFinite(reference)
+      ? Math.abs(reference)
+      : Math.abs(value);
+    if (
+      format.scale === "duration" ||
+      (format.scale === "decimal" && Object.hasOwn(durationUnits, unit))
+    ) {
+      const inputFactor = durationUnits[unit] ?? 1;
+      const steps =
+        format.scale === "duration" ? DURATION_STEPS : DECIMAL_DURATION_STEPS;
+      const [factor, label] =
+        magnitude === 0
+          ? [inputFactor, unit]
+          : (steps.find(([factor]) => magnitude * inputFactor >= factor) ?? [
+              1e-9,
+              "ns",
+            ]);
+      return {
+        value: formatter.format(value * (inputFactor / factor)),
+        unit: unitLabel(label),
+      };
     }
+    if (format.scale === "decimal" || format.scale === "binary") {
+      const base = format.scale === "binary" ? 1024 : 1000;
+      const prefixes =
+        format.scale === "binary" ? BINARY_PREFIXES : DECIMAL_PREFIXES;
+      let index = 0;
+      while (index < prefixes.length - 1 && magnitude >= base ** (index + 1))
+        index++;
+      const prefix = prefixes[index] ?? "";
+      // SI symbols use decimal prefixes; binary prefixes remain byte/bit-specific.
+      const prefixOnUnit =
+        /^(By|bit)(\/.*)?$/.test(unit) ||
+        (format.scale === "decimal" && /^(Hz|W|J|V|A)$/.test(unit));
+      return prefixOnUnit
+        ? {
+            value: formatter.format(value / base ** index),
+            unit: prefix + label,
+          }
+        : {
+            value: formatter.format(value / base ** index) + prefix,
+            unit: label,
+          };
+    }
+    return { value: formatter.format(value), unit: label };
   }
-  return value.toLocaleString(undefined, fraction);
-}
 
-function autoUnit(input: SemanticUnit, baseValue: number): SemanticUnit {
-  const candidates =
-    input.dimension === "duration"
-      ? DURATION_UNITS
-      : input.system === "decimal"
-        ? DECIMAL_BYTE_UNITS
-        : BINARY_BYTE_UNITS;
-  if (baseValue === 0) return input;
-  const magnitude = Math.abs(baseValue);
-  for (const candidate of candidates) {
-    const resolved = UNITS[candidate];
-    if (resolved && magnitude >= resolved.factor) return resolved;
-  }
-  return UNITS[candidates.at(-1) ?? ""] ?? input;
-}
-
-function semanticParts(
-  value: number,
-  unit: string,
-  decimals?: number,
-): FormattedValueParts | undefined {
-  const input = UNITS[unit];
-  if (!input) return undefined;
-  const baseValue = value * input.factor;
-  const output = autoUnit(input, baseValue);
-  return {
-    value: (baseValue / output.factor).toLocaleString(
-      undefined,
-      fractionDigits(decimals),
-    ),
-    unit: output.label,
-  };
-}
-
-export function formatValueParts(
-  value: number,
-  unit: string,
-  options: Pick<
-    FormatValueOptions,
-    "decimals" | "compact" | "displayUnit"
-  > = {},
-): FormattedValueParts {
-  if (options.displayUnit === "auto") {
-    const semantic = semanticParts(value, unit, options.decimals);
-    if (semantic) return semantic;
+  function join(formatted: FormattedValueParts) {
+    return formatted.unit
+      ? formatted.value + separator + formatted.unit
+      : formatted.value;
   }
 
   return {
-    value: options.compact
-      ? formatCompactValue(value, options.decimals)
-      : value.toLocaleString(undefined, fractionDigits(options.decimals)),
-    unit,
+    parts: (value: number) => parts(value),
+    format: (value: number) => join(parts(value)),
+    /** Fix one scale for the entire axis, selected from its largest magnitude. */
+    axis: (reference: number) => (value: number) =>
+      join(parts(value, reference, true)),
   };
-}
-
-export function formatValue(
-  value: number,
-  unit: string,
-  options: FormatValueOptions = {},
-): string {
-  if (options.displayUnit === "auto") {
-    const semantic = semanticParts(value, unit, options.decimals);
-    if (semantic) return `${semantic.value} ${semantic.unit}`;
-  }
-
-  const formatted = options.compact
-    ? formatCompactValue(value, options.decimals)
-    : options.locale === false
-      ? String(value)
-      : value.toLocaleString(undefined, fractionDigits(options.decimals));
-  return unit ? `${formatted}${options.unitSeparator ?? ""}${unit}` : formatted;
 }

--- a/packages/app/src/components/dashboards/visualizations/value-format.ts
+++ b/packages/app/src/components/dashboards/visualizations/value-format.ts
@@ -16,7 +16,10 @@ const DECIMAL_DURATION_STEPS = DURATION_STEPS.filter(([factor]) => factor <= 1);
 interface FormattedValueParts {
   value: string;
   unit: string;
+  separator: "" | " ";
 }
+
+type RawFormattedValueParts = Omit<FormattedValueParts, "separator">;
 
 /** Present common OTel/UCUM codes without treating unknown units as aliases. */
 function unitLabel(unit: string): string {
@@ -55,11 +58,11 @@ export function createValueFormatter(
   const axisNumbers = numberFormatter(decimals, false);
   const separator = label === "%" ? "" : " ";
 
-  function parts(
+  function rawParts(
     value: number,
     reference = value,
     axis = false,
-  ): FormattedValueParts {
+  ): RawFormattedValueParts {
     const formatter = axis ? axisNumbers : numbers;
     if (percent) return { value: formatter.format(value * 100), unit: label };
     if (!Number.isFinite(value))
@@ -111,9 +114,21 @@ export function createValueFormatter(
     return { value: formatter.format(value), unit: label };
   }
 
+  function parts(
+    value: number,
+    reference = value,
+    axis = false,
+  ): FormattedValueParts {
+    const formatted = rawParts(value, reference, axis);
+    return {
+      ...formatted,
+      separator: formatted.unit ? separator : "",
+    };
+  }
+
   function join(formatted: FormattedValueParts) {
     return formatted.unit
-      ? formatted.value + separator + formatted.unit
+      ? formatted.value + formatted.separator + formatted.unit
       : formatted.value;
   }
 

--- a/packages/app/src/data/dashboards/apply.server.ts
+++ b/packages/app/src/data/dashboards/apply.server.ts
@@ -13,7 +13,7 @@ import {
 } from "@/data/previews/scope";
 import { dashboards } from "@/db/schema";
 import { buildDesiredSet } from "./desired";
-import type { Dashboard } from "./schema";
+import type { DashboardResource } from "./schema";
 
 export interface ApplyDashboardsResult {
   created: string[];
@@ -93,7 +93,7 @@ export const applyDashboardSpecs: Reconciler = async ({
       project: d.project,
       slug: d.slug,
       folderPath: d.folderPath,
-      document: d.document as Dashboard,
+      document: d.document as DashboardResource,
     });
   }
   // Adoption: take over the other repo's live row by its global identity,
@@ -104,7 +104,7 @@ export const applyDashboardSpecs: Reconciler = async ({
       .update(dashboards)
       .set({
         repoid: namespace.repoid,
-        document: d.document as Dashboard,
+        document: d.document as DashboardResource,
         folderPath: d.folderPath,
         updatedAt: new Date(),
       })
@@ -121,7 +121,7 @@ export const applyDashboardSpecs: Reconciler = async ({
     await exec
       .update(dashboards)
       .set({
-        document: d.document as Dashboard,
+        document: d.document as DashboardResource,
         folderPath: d.folderPath,
         updatedAt: new Date(),
       })

--- a/packages/app/src/data/dashboards/built-in/catalog/application/http-endpoints.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/application/http-endpoints.yaml
@@ -15,7 +15,9 @@ document:
   spec:
     display:
       name: HTTP Endpoints
-    duration: 6h
+    timeRange:
+      from: now-6h
+      to: now
     refreshInterval: 1m
     variables:
       - kind: ListVariable

--- a/packages/app/src/data/dashboards/built-in/catalog/application/http-endpoints.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/application/http-endpoints.yaml
@@ -65,8 +65,6 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: "%"
-              decimals: 2
               thresholds:
                 mode: absolute
                 defaultColor: "#22c55e"
@@ -75,6 +73,9 @@ document:
                     color: "#f59e0b"
                   - value: 5
                     color: "#ef4444"
+              valueFormat:
+                unit: "%"
+                decimals: 2
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -94,8 +95,6 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: "%"
-              decimals: 2
               thresholds:
                 mode: absolute
                 defaultColor: "#22c55e"
@@ -104,6 +103,9 @@ document:
                     color: "#f59e0b"
                   - value: 20
                     color: "#ef4444"
+              valueFormat:
+                unit: "%"
+                decimals: 2
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -123,8 +125,9 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: ms
-              decimals: 1
+              valueFormat:
+                unit: ms
+                decimals: 1
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -197,7 +200,8 @@ document:
             kind: TimeSeriesChart
             spec:
               showLegend: true
-              unit: ms
+              valueFormat:
+                unit: ms
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -330,8 +334,6 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: "%"
-              decimals: 2
               thresholds:
                 mode: absolute
                 defaultColor: "#22c55e"
@@ -340,6 +342,9 @@ document:
                     color: "#f59e0b"
                   - value: 5
                     color: "#ef4444"
+              valueFormat:
+                unit: "%"
+                decimals: 2
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -359,8 +364,9 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: ms
-              decimals: 1
+              valueFormat:
+                unit: ms
+                decimals: 1
           queries:
             - kind: ClickHouseSQL
               spec:

--- a/packages/app/src/data/dashboards/built-in/catalog/application/log-overview.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/application/log-overview.yaml
@@ -62,8 +62,6 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: "%"
-              decimals: 2
               thresholds:
                 mode: absolute
                 defaultColor: "#22c55e"
@@ -72,6 +70,9 @@ document:
                     color: "#f59e0b"
                   - value: 5
                     color: "#ef4444"
+              valueFormat:
+                unit: "%"
+                decimals: 2
           queries:
             - kind: ClickHouseSQL
               spec:

--- a/packages/app/src/data/dashboards/built-in/catalog/application/log-overview.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/application/log-overview.yaml
@@ -12,7 +12,9 @@ document:
   spec:
     display:
       name: Log Overview
-    duration: 6h
+    timeRange:
+      from: now-6h
+      to: now
     refreshInterval: 1m
     variables:
       - kind: ListVariable

--- a/packages/app/src/data/dashboards/built-in/catalog/application/rpc-services.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/application/rpc-services.yaml
@@ -65,8 +65,6 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: "%"
-              decimals: 2
               thresholds:
                 mode: absolute
                 defaultColor: "#22c55e"
@@ -75,6 +73,9 @@ document:
                     color: "#f59e0b"
                   - value: 5
                     color: "#ef4444"
+              valueFormat:
+                unit: "%"
+                decimals: 2
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -94,8 +95,9 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: ms
-              decimals: 1
+              valueFormat:
+                unit: ms
+                decimals: 1
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -115,8 +117,9 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: ms
-              decimals: 1
+              valueFormat:
+                unit: ms
+                decimals: 1
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -194,7 +197,8 @@ document:
             kind: TimeSeriesChart
             spec:
               showLegend: true
-              unit: ms
+              valueFormat:
+                unit: ms
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -356,8 +360,6 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: "%"
-              decimals: 2
               thresholds:
                 mode: absolute
                 defaultColor: "#22c55e"
@@ -366,6 +368,9 @@ document:
                     color: "#f59e0b"
                   - value: 5
                     color: "#ef4444"
+              valueFormat:
+                unit: "%"
+                decimals: 2
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -385,8 +390,9 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: ms
-              decimals: 1
+              valueFormat:
+                unit: ms
+                decimals: 1
           queries:
             - kind: ClickHouseSQL
               spec:

--- a/packages/app/src/data/dashboards/built-in/catalog/application/rpc-services.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/application/rpc-services.yaml
@@ -15,7 +15,9 @@ document:
   spec:
     display:
       name: RPC Services
-    duration: 6h
+    timeRange:
+      from: now-6h
+      to: now
     refreshInterval: 1m
     variables:
       - kind: ListVariable

--- a/packages/app/src/data/dashboards/built-in/catalog/application/server-functions.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/application/server-functions.yaml
@@ -65,8 +65,6 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: "%"
-              decimals: 2
               thresholds:
                 mode: absolute
                 defaultColor: "#22c55e"
@@ -75,6 +73,9 @@ document:
                     color: "#f59e0b"
                   - value: 5
                     color: "#ef4444"
+              valueFormat:
+                unit: "%"
+                decimals: 2
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -94,8 +95,9 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: ms
-              decimals: 1
+              valueFormat:
+                unit: ms
+                decimals: 1
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -115,8 +117,9 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: ms
-              decimals: 1
+              valueFormat:
+                unit: ms
+                decimals: 1
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -190,7 +193,8 @@ document:
             kind: TimeSeriesChart
             spec:
               showLegend: true
-              unit: ms
+              valueFormat:
+                unit: ms
           queries:
             - kind: ClickHouseSQL
               spec:

--- a/packages/app/src/data/dashboards/built-in/catalog/application/server-functions.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/application/server-functions.yaml
@@ -15,7 +15,9 @@ document:
   spec:
     display:
       name: Server Functions
-    duration: 6h
+    timeRange:
+      from: now-6h
+      to: now
     refreshInterval: 1m
     variables:
       - kind: ListVariable

--- a/packages/app/src/data/dashboards/built-in/catalog/application/serverless-functions.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/application/serverless-functions.yaml
@@ -15,7 +15,9 @@ document:
   spec:
     display:
       name: Serverless Functions
-    duration: 6h
+    timeRange:
+      from: now-6h
+      to: now
     refreshInterval: 1m
     variables:
       - kind: ListVariable

--- a/packages/app/src/data/dashboards/built-in/catalog/application/serverless-functions.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/application/serverless-functions.yaml
@@ -65,8 +65,6 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: "%"
-              decimals: 2
               thresholds:
                 mode: absolute
                 defaultColor: "#22c55e"
@@ -75,6 +73,9 @@ document:
                     color: "#f59e0b"
                   - value: 5
                     color: "#ef4444"
+              valueFormat:
+                unit: "%"
+                decimals: 2
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -94,8 +95,9 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: ms
-              decimals: 1
+              valueFormat:
+                unit: ms
+                decimals: 1
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -115,8 +117,6 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: "%"
-              decimals: 1
               thresholds:
                 mode: absolute
                 defaultColor: "#22c55e"
@@ -125,6 +125,9 @@ document:
                     color: "#f59e0b"
                   - value: 20
                     color: "#ef4444"
+              valueFormat:
+                unit: "%"
+                decimals: 1
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -198,7 +201,8 @@ document:
             kind: TimeSeriesChart
             spec:
               showLegend: true
-              unit: ms
+              valueFormat:
+                unit: ms
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -227,7 +231,8 @@ document:
             kind: TimeSeriesChart
             spec:
               showLegend: true
-              unit: ms
+              valueFormat:
+                unit: ms
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -285,7 +290,8 @@ document:
             kind: TimeSeriesChart
             spec:
               showLegend: true
-              unit: ms
+              valueFormat:
+                unit: ms
           queries:
             - kind: ClickHouseSQL
               spec:

--- a/packages/app/src/data/dashboards/built-in/catalog/application/traces-overview.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/application/traces-overview.yaml
@@ -12,7 +12,9 @@ document:
   spec:
     display:
       name: Traces Overview
-    duration: 6h
+    timeRange:
+      from: now-6h
+      to: now
     refreshInterval: 1m
     variables:
       - kind: ListVariable

--- a/packages/app/src/data/dashboards/built-in/catalog/application/traces-overview.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/application/traces-overview.yaml
@@ -78,8 +78,6 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: "%"
-              decimals: 2
               thresholds:
                 mode: absolute
                 defaultColor: "#22c55e"
@@ -88,6 +86,9 @@ document:
                     color: "#f59e0b"
                   - value: 5
                     color: "#ef4444"
+              valueFormat:
+                unit: "%"
+                decimals: 2
           queries:
             - kind: ClickHouseSQL
               spec:

--- a/packages/app/src/data/dashboards/built-in/catalog/browser/product-analytics.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/browser/product-analytics.yaml
@@ -107,8 +107,9 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: s
-              decimals: 1
+              valueFormat:
+                unit: s
+                decimals: 1
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -133,8 +134,6 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: "%"
-              decimals: 1
               thresholds:
                 mode: absolute
                 defaultColor: "#22c55e"
@@ -143,6 +142,9 @@ document:
                     color: "#f59e0b"
                   - value: 70
                     color: "#ef4444"
+              valueFormat:
+                unit: "%"
+                decimals: 1
           queries:
             - kind: ClickHouseSQL
               spec:

--- a/packages/app/src/data/dashboards/built-in/catalog/browser/product-analytics.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/browser/product-analytics.yaml
@@ -15,7 +15,9 @@ document:
   spec:
     display:
       name: Product Analytics
-    duration: 24h
+    timeRange:
+      from: now-24h
+      to: now
     variables:
       - kind: ListVariable
         spec:

--- a/packages/app/src/data/dashboards/built-in/catalog/browser/web-vitals.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/browser/web-vitals.yaml
@@ -15,7 +15,9 @@ document:
   spec:
     display:
       name: Web Vitals
-    duration: 24h
+    timeRange:
+      from: now-24h
+      to: now
     variables:
       - kind: ListVariable
         spec:

--- a/packages/app/src/data/dashboards/built-in/catalog/browser/web-vitals.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/browser/web-vitals.yaml
@@ -57,8 +57,6 @@ document:
           plugin:
             kind: GaugeChart
             spec:
-              unit: ms
-              decimals: 0
               min: 0
               max: 5300
               thresholds:
@@ -75,6 +73,9 @@ document:
               variant: horizontal
               showAxis: false
               showThresholdLabels: true
+              valueFormat:
+                unit: ms
+                decimals: 0
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -94,8 +95,6 @@ document:
           plugin:
             kind: GaugeChart
             spec:
-              unit: ms
-              decimals: 0
               min: 0
               max: 700
               thresholds:
@@ -112,6 +111,9 @@ document:
               variant: horizontal
               showAxis: false
               showThresholdLabels: true
+              valueFormat:
+                unit: ms
+                decimals: 0
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -131,7 +133,6 @@ document:
           plugin:
             kind: GaugeChart
             spec:
-              decimals: 3
               min: 0
               max: 0.35
               thresholds:
@@ -148,6 +149,8 @@ document:
               variant: horizontal
               showAxis: false
               showThresholdLabels: true
+              valueFormat:
+                decimals: 3
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -167,8 +170,6 @@ document:
           plugin:
             kind: GaugeChart
             spec:
-              unit: ms
-              decimals: 0
               min: 0
               max: 2400
               thresholds:
@@ -185,6 +186,9 @@ document:
               variant: horizontal
               showAxis: false
               showThresholdLabels: true
+              valueFormat:
+                unit: ms
+                decimals: 0
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -280,7 +284,8 @@ document:
             kind: TimeSeriesChart
             spec:
               showLegend: true
-              unit: ms
+              valueFormat:
+                unit: ms
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -310,7 +315,8 @@ document:
             kind: TimeSeriesChart
             spec:
               showLegend: true
-              unit: ms
+              valueFormat:
+                unit: ms
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -371,7 +377,8 @@ document:
             spec:
               showLegend: true
               stacked: true
-              unit: ms
+              valueFormat:
+                unit: ms
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -404,7 +411,8 @@ document:
             spec:
               showLegend: true
               stacked: true
-              unit: ms
+              valueFormat:
+                unit: ms
           queries:
             - kind: ClickHouseSQL
               spec:

--- a/packages/app/src/data/dashboards/built-in/catalog/databases/mongodb-overview.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/databases/mongodb-overview.yaml
@@ -30,8 +30,9 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: d
-              decimals: 1
+              valueFormat:
+                unit: d
+                decimals: 1
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -50,7 +51,8 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              decimals: 0
+              valueFormat:
+                decimals: 0
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -69,7 +71,8 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              decimals: 0
+              valueFormat:
+                decimals: 0
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -92,8 +95,9 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              decimals: 0
               sparkline: true
+              valueFormat:
+                decimals: 0
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -115,8 +119,9 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: "%"
-              decimals: 1
+              valueFormat:
+                unit: "%"
+                decimals: 1
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -143,9 +148,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
               stacked: false
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -177,9 +183,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
               stacked: true
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -211,9 +218,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: s
               showLegend: true
               stacked: false
+              valueFormat:
+                unit: s
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -245,8 +253,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -274,9 +283,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
               stacked: false
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -308,9 +318,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: s
               showLegend: false
               stacked: false
+              valueFormat:
+                unit: s
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -337,8 +348,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: MB
               showLegend: true
+              valueFormat:
+                unit: MiBy
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -365,9 +377,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: MB
               showLegend: true
               stacked: false
+              valueFormat:
+                unit: MiBy
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -394,8 +407,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: MB
               showLegend: true
+              valueFormat:
+                unit: MiBy
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -423,8 +437,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: MB
               showLegend: true
+              valueFormat:
+                unit: MiBy
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -452,9 +467,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
               stacked: false
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -486,9 +502,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
               stacked: false
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:

--- a/packages/app/src/data/dashboards/built-in/catalog/databases/mongodb-overview.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/databases/mongodb-overview.yaml
@@ -15,7 +15,9 @@ document:
   spec:
     display:
       name: MongoDB Overview
-    duration: 6h
+    timeRange:
+      from: now-6h
+      to: now
     refreshInterval: 1m
     panels:
       uptime:

--- a/packages/app/src/data/dashboards/built-in/catalog/databases/mysql-overview.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/databases/mysql-overview.yaml
@@ -15,7 +15,9 @@ document:
   spec:
     display:
       name: MySQL Overview
-    duration: 6h
+    timeRange:
+      from: now-6h
+      to: now
     refreshInterval: 1m
     panels:
       uptime:

--- a/packages/app/src/data/dashboards/built-in/catalog/databases/mysql-overview.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/databases/mysql-overview.yaml
@@ -30,8 +30,9 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: d
-              decimals: 1
+              valueFormat:
+                unit: d
+                decimals: 1
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -51,8 +52,9 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: MB
-              decimals: 0
+              valueFormat:
+                unit: MiBy
+                decimals: 0
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -71,8 +73,9 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              decimals: 0
               sparkline: true
+              valueFormat:
+                decimals: 0
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -94,8 +97,9 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              decimals: 1
               sparkline: true
+              valueFormat:
+                decimals: 1
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -122,8 +126,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -151,9 +156,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
               stacked: false
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -185,9 +191,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
               stacked: false
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -219,9 +226,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
               stacked: false
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -252,9 +260,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
               stacked: true
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -286,9 +295,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: MB
               showLegend: true
               stacked: false
+              valueFormat:
+                unit: MiBy
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -319,8 +329,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: MB
               showLegend: true
+              valueFormat:
+                unit: MiBy
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -348,8 +359,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -377,9 +389,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
               stacked: false
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:

--- a/packages/app/src/data/dashboards/built-in/catalog/databases/postgres-overview.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/databases/postgres-overview.yaml
@@ -15,7 +15,9 @@ document:
   spec:
     display:
       name: Postgres Overview
-    duration: 6h
+    timeRange:
+      from: now-6h
+      to: now
     refreshInterval: 1m
     panels:
       connections:

--- a/packages/app/src/data/dashboards/built-in/catalog/databases/postgres-overview.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/databases/postgres-overview.yaml
@@ -29,8 +29,9 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              decimals: 0
               sparkline: true
+              valueFormat:
+                decimals: 0
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -56,7 +57,8 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              decimals: 0
+              valueFormat:
+                decimals: 0
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -75,7 +77,8 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              decimals: 0
+              valueFormat:
+                decimals: 0
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -95,8 +98,9 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: "%"
-              decimals: 1
+              valueFormat:
+                unit: "%"
+                decimals: 1
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -122,8 +126,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -151,9 +156,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
               stacked: false
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -181,9 +187,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
               stacked: true
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -214,8 +221,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: "%"
               showLegend: false
+              valueFormat:
+                unit: "%"
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -243,9 +251,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
               stacked: false
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -276,8 +285,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: MB
               showLegend: true
+              valueFormat:
+                unit: MiBy
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -305,9 +315,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
               stacked: true
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -338,9 +349,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: s
               showLegend: true
               stacked: false
+              valueFormat:
+                unit: s
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -372,9 +384,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: false
               stacked: false
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:

--- a/packages/app/src/data/dashboards/built-in/catalog/databases/redis-overview.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/databases/redis-overview.yaml
@@ -15,7 +15,9 @@ document:
   spec:
     display:
       name: Redis Overview
-    duration: 6h
+    timeRange:
+      from: now-6h
+      to: now
     refreshInterval: 1m
     panels:
       uptime:

--- a/packages/app/src/data/dashboards/built-in/catalog/databases/redis-overview.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/databases/redis-overview.yaml
@@ -30,8 +30,9 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: d
-              decimals: 1
+              valueFormat:
+                unit: d
+                decimals: 1
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -50,9 +51,10 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: MB
-              decimals: 1
               sparkline: true
+              valueFormat:
+                unit: MiBy
+                decimals: 1
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -74,8 +76,9 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: MB
-              decimals: 0
+              valueFormat:
+                unit: MiBy
+                decimals: 0
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -94,8 +97,9 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              decimals: 0
               sparkline: true
+              valueFormat:
+                decimals: 0
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -117,8 +121,9 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: "%"
-              decimals: 1
+              valueFormat:
+                unit: "%"
+                decimals: 1
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -144,8 +149,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: false
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -167,9 +173,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
               stacked: false
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -197,8 +204,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: MB
               showLegend: true
+              valueFormat:
+                unit: MiBy
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -220,9 +228,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: MB
               showLegend: true
               stacked: false
+              valueFormat:
+                unit: MiBy
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -249,8 +258,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -273,9 +283,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
               stacked: false
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -302,8 +313,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -331,8 +343,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -359,9 +372,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
               stacked: false
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -389,9 +403,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
               stacked: false
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:

--- a/packages/app/src/data/dashboards/built-in/catalog/everr/telemetry-usage.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/everr/telemetry-usage.yaml
@@ -29,8 +29,7 @@ document:
             kind: StatChart
             spec:
               calculation: sum
-              unit: By
-              displayUnit: auto
+              valueFormat: { unit: By, scale: binary }
               sparkline: true
               colors:
                 Logs: "hsl(263, 90%, 65%)"
@@ -100,8 +99,7 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: By
-              displayUnit: auto
+              valueFormat: { unit: By, scale: binary }
               showLabel: true
           queries:
             - kind: ClickHouseSQL
@@ -158,8 +156,7 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: By
-              displayUnit: auto
+              valueFormat: { unit: By, scale: binary }
               lineWidth: 2
               curveType: linear
               showLegend: true
@@ -227,8 +224,7 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: By
-              displayUnit: auto
+              valueFormat: { unit: By, scale: binary }
               lineWidth: 2
               curveType: linear
               connectNulls: true

--- a/packages/app/src/data/dashboards/built-in/catalog/everr/telemetry-usage.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/everr/telemetry-usage.yaml
@@ -18,6 +18,9 @@ document:
       from: now/M
       to: now
     refreshInterval: 5m
+    # metrics_sum timestamps have one-second precision. Ordering each monotonic
+    # counter by value resolves distinct same-second samples, while exact retry
+    # duplicates remain adjacent and contribute a zero delta.
     panels:
       signal-totals:
         kind: Panel
@@ -41,7 +44,7 @@ document:
                 plugin:
                   kind: ClickHouseSQL
                   spec:
-                    query: |-
+                    query: &usage_by_signal_query |-
                       WITH parseDateTimeBestEffort({from:String}) AS selected_from,
                            parseDateTimeBestEffort({to:String}) AS selected_to
                       SELECT toStartOfInterval(TimeUnix, INTERVAL {step:UInt32} SECOND) AS ts,
@@ -81,7 +84,7 @@ document:
                                          Attributes['everr.ingestion.signal'],
                                          ResourceAttributes['service.instance.id'],
                                          StartTimeUnix
-                            ORDER BY TimeUnix
+                            ORDER BY TimeUnix, Value
                             ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
                           )
                         )
@@ -142,7 +145,7 @@ document:
                                          Attributes['everr.ingestion.signal'],
                                          ResourceAttributes['service.instance.id'],
                                          StartTimeUnix
-                            ORDER BY TimeUnix
+                            ORDER BY TimeUnix, Value
                             ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
                           )
                         )
@@ -167,54 +170,7 @@ document:
                 plugin:
                   kind: ClickHouseSQL
                   spec:
-                    query: |-
-                      WITH parseDateTimeBestEffort({from:String}) AS selected_from,
-                           parseDateTimeBestEffort({to:String}) AS selected_to
-                      SELECT toStartOfInterval(TimeUnix, INTERVAL {step:UInt32} SECOND) AS ts,
-                             toFloat64(sumIf(delta, signal = 'logs')) AS Logs,
-                             toFloat64(sumIf(delta, signal = 'traces')) AS Traces,
-                             toFloat64(sumIf(delta, signal = 'metrics')) AS Metrics
-                      FROM (
-                        SELECT TimeUnix,
-                               signal,
-                               if(previous_value < 0,
-                                  value_decimal - if(value_decimal > 9007199254740992, 1024, 0),
-                                  greatest(value_decimal - previous_value, 0)) AS delta
-                        FROM (
-                          SELECT TimeUnix,
-                                 Attributes['everr.ingestion.signal'] AS signal,
-                                 toDecimal128(Value, 0) AS value_decimal,
-                                 lagInFrame(toDecimal128(Value, 0), 1, toDecimal128(-1, 0)) OVER counter AS previous_value
-                          FROM metrics_sum
-                          WHERE ServiceName = 'everr-ingestion'
-                            AND MetricName = 'everr.ingestion.volume'
-                            AND Attributes['everr.usage.month'] >= formatDateTime(toStartOfMonth(selected_from), '%Y-%m')
-                            AND Attributes['everr.usage.month'] <= formatDateTime(toStartOfMonth(selected_to), '%Y-%m')
-                            AND TimeUnix >= toStartOfMonth(selected_from)
-                            AND TimeUnix <= selected_to
-                            AND AggregationTemporality = 2
-                            AND IsMonotonic
-                            AND MetricUnit = 'By'
-                            AND ScopeName = 'github.com/everr-labs/everr/collector/usage'
-                            AND ScopeVersion = '1'
-                            AND ResourceAttributes['everr.tenant.id'] = Attributes['everr.usage.tenant.id']
-                            AND notEmpty(ResourceAttributes['service.instance.id'])
-                            AND notEmpty(Attributes['everr.usage.tenant.id'])
-                            AND Attributes['everr.ingestion.signal'] IN ('logs', 'traces', 'metrics')
-                            AND Value >= 0
-                          WINDOW counter AS (
-                            PARTITION BY Attributes['everr.usage.month'],
-                                         Attributes['everr.ingestion.signal'],
-                                         ResourceAttributes['service.instance.id'],
-                                         StartTimeUnix
-                            ORDER BY TimeUnix
-                            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
-                          )
-                        )
-                      )
-                      WHERE TimeUnix >= selected_from AND TimeUnix <= selected_to
-                      GROUP BY ts
-                      ORDER BY ts
+                    query: *usage_by_signal_query
       cumulative:
         kind: Panel
         spec:
@@ -273,7 +229,7 @@ document:
                                            Attributes['everr.ingestion.signal'],
                                            ResourceAttributes['service.instance.id'],
                                            StartTimeUnix
-                              ORDER BY TimeUnix
+                              ORDER BY TimeUnix, Value
                               ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
                             )
                           )

--- a/packages/app/src/data/dashboards/built-in/catalog/everr/telemetry-usage.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/everr/telemetry-usage.yaml
@@ -1,0 +1,316 @@
+id: telemetry-usage
+name: Telemetry Usage
+description: "Telemetry usage and its cumulative trend for the selected time range."
+category: Everr
+requires:
+  - signal: metrics
+    match: everr.ingestion.volume
+    label: no everr.ingestion.volume metric
+document:
+  kind: Dashboard
+  metadata:
+    name: telemetry-usage
+  spec:
+    display:
+      name: Telemetry Usage
+      description: "Ingestion volume and its cumulative trend for the selected time range."
+    timeRange:
+      from: now/M
+      to: now
+    refreshInterval: 5m
+    panels:
+      signal-totals:
+        kind: Panel
+        spec:
+          display:
+            name: Usage by signal
+            description: Total volume by telemetry type, with non-cumulative interval trends.
+          plugin:
+            kind: StatChart
+            spec:
+              calculation: sum
+              unit: By
+              displayUnit: auto
+              sparkline: true
+              colors:
+                Logs: "hsl(263, 90%, 65%)"
+                Traces: "hsl(56, 90%, 65%)"
+                Metrics: "hsl(195, 90%, 65%)"
+          queries:
+            - kind: ClickHouseSQL
+              spec:
+                plugin:
+                  kind: ClickHouseSQL
+                  spec:
+                    query: |-
+                      WITH parseDateTimeBestEffort({from:String}) AS selected_from,
+                           parseDateTimeBestEffort({to:String}) AS selected_to
+                      SELECT toStartOfInterval(TimeUnix, INTERVAL {step:UInt32} SECOND) AS ts,
+                             toFloat64(sumIf(delta, signal = 'logs')) AS Logs,
+                             toFloat64(sumIf(delta, signal = 'traces')) AS Traces,
+                             toFloat64(sumIf(delta, signal = 'metrics')) AS Metrics
+                      FROM (
+                        SELECT TimeUnix,
+                               signal,
+                               if(previous_value < 0,
+                                  value_decimal - if(value_decimal > 9007199254740992, 1024, 0),
+                                  greatest(value_decimal - previous_value, 0)) AS delta
+                        FROM (
+                          SELECT TimeUnix,
+                                 Attributes['everr.ingestion.signal'] AS signal,
+                                 toDecimal128(Value, 0) AS value_decimal,
+                                 lagInFrame(toDecimal128(Value, 0), 1, toDecimal128(-1, 0)) OVER counter AS previous_value
+                          FROM metrics_sum
+                          WHERE ServiceName = 'everr-ingestion'
+                            AND MetricName = 'everr.ingestion.volume'
+                            AND Attributes['everr.usage.month'] >= formatDateTime(toStartOfMonth(selected_from), '%Y-%m')
+                            AND Attributes['everr.usage.month'] <= formatDateTime(toStartOfMonth(selected_to), '%Y-%m')
+                            AND TimeUnix >= toStartOfMonth(selected_from)
+                            AND TimeUnix <= selected_to
+                            AND AggregationTemporality = 2
+                            AND IsMonotonic
+                            AND MetricUnit = 'By'
+                            AND ScopeName = 'github.com/everr-labs/everr/collector/usage'
+                            AND ScopeVersion = '1'
+                            AND ResourceAttributes['everr.tenant.id'] = Attributes['everr.usage.tenant.id']
+                            AND notEmpty(ResourceAttributes['service.instance.id'])
+                            AND notEmpty(Attributes['everr.usage.tenant.id'])
+                            AND Attributes['everr.ingestion.signal'] IN ('logs', 'traces', 'metrics')
+                            AND Value >= 0
+                          WINDOW counter AS (
+                            PARTITION BY Attributes['everr.usage.month'],
+                                         Attributes['everr.ingestion.signal'],
+                                         ResourceAttributes['service.instance.id'],
+                                         StartTimeUnix
+                            ORDER BY TimeUnix
+                            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                          )
+                        )
+                      )
+                      WHERE TimeUnix >= selected_from AND TimeUnix <= selected_to
+                      GROUP BY ts
+                      ORDER BY ts
+      totals:
+        kind: Panel
+        spec:
+          display:
+            name: Usage summary
+            description: Total ingestion volume for the selected time range.
+          plugin:
+            kind: StatChart
+            spec:
+              calculation: last
+              unit: By
+              displayUnit: auto
+              showLabel: true
+          queries:
+            - kind: ClickHouseSQL
+              spec:
+                plugin:
+                  kind: ClickHouseSQL
+                  spec:
+                    query: |-
+                      WITH parseDateTimeBestEffort({from:String}) AS selected_from,
+                           parseDateTimeBestEffort({to:String}) AS selected_to
+                      SELECT toFloat64(sumIf(delta, TimeUnix >= selected_from)) AS `Selected range`
+                      FROM (
+                        SELECT TimeUnix,
+                               if(previous_value < 0,
+                                  value_decimal - if(value_decimal > 9007199254740992, 1024, 0),
+                                  greatest(value_decimal - previous_value, 0)) AS delta
+                        FROM (
+                          SELECT TimeUnix,
+                                 toDecimal128(Value, 0) AS value_decimal,
+                                 lagInFrame(toDecimal128(Value, 0), 1, toDecimal128(-1, 0)) OVER counter AS previous_value
+                          FROM metrics_sum
+                          WHERE ServiceName = 'everr-ingestion'
+                            AND MetricName = 'everr.ingestion.volume'
+                            AND Attributes['everr.usage.month'] >= formatDateTime(toStartOfMonth(selected_from), '%Y-%m')
+                            AND Attributes['everr.usage.month'] <= formatDateTime(toStartOfMonth(selected_to), '%Y-%m')
+                            AND TimeUnix >= toStartOfMonth(selected_from)
+                            AND TimeUnix <= selected_to
+                            AND AggregationTemporality = 2
+                            AND IsMonotonic
+                            AND MetricUnit = 'By'
+                            AND ScopeName = 'github.com/everr-labs/everr/collector/usage'
+                            AND ScopeVersion = '1'
+                            AND ResourceAttributes['everr.tenant.id'] = Attributes['everr.usage.tenant.id']
+                            AND notEmpty(ResourceAttributes['service.instance.id'])
+                            AND notEmpty(Attributes['everr.usage.tenant.id'])
+                            AND Attributes['everr.ingestion.signal'] IN ('logs', 'traces', 'metrics')
+                            AND Value >= 0
+                          WINDOW counter AS (
+                            PARTITION BY Attributes['everr.usage.month'],
+                                         Attributes['everr.ingestion.signal'],
+                                         ResourceAttributes['service.instance.id'],
+                                         StartTimeUnix
+                            ORDER BY TimeUnix
+                            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                          )
+                        )
+                      )
+      interval-volume:
+        kind: Panel
+        spec:
+          display:
+            name: Ingestion volume by signal
+            description: Logs, traces, and metrics ingested in each interval of the selected time range.
+          plugin:
+            kind: TimeSeriesChart
+            spec:
+              unit: By
+              displayUnit: auto
+              lineWidth: 2
+              curveType: linear
+              showLegend: true
+              stacked: true
+          queries:
+            - kind: ClickHouseSQL
+              spec:
+                plugin:
+                  kind: ClickHouseSQL
+                  spec:
+                    query: |-
+                      WITH parseDateTimeBestEffort({from:String}) AS selected_from,
+                           parseDateTimeBestEffort({to:String}) AS selected_to
+                      SELECT toStartOfInterval(TimeUnix, INTERVAL {step:UInt32} SECOND) AS ts,
+                             toFloat64(sumIf(delta, signal = 'logs')) AS Logs,
+                             toFloat64(sumIf(delta, signal = 'traces')) AS Traces,
+                             toFloat64(sumIf(delta, signal = 'metrics')) AS Metrics
+                      FROM (
+                        SELECT TimeUnix,
+                               signal,
+                               if(previous_value < 0,
+                                  value_decimal - if(value_decimal > 9007199254740992, 1024, 0),
+                                  greatest(value_decimal - previous_value, 0)) AS delta
+                        FROM (
+                          SELECT TimeUnix,
+                                 Attributes['everr.ingestion.signal'] AS signal,
+                                 toDecimal128(Value, 0) AS value_decimal,
+                                 lagInFrame(toDecimal128(Value, 0), 1, toDecimal128(-1, 0)) OVER counter AS previous_value
+                          FROM metrics_sum
+                          WHERE ServiceName = 'everr-ingestion'
+                            AND MetricName = 'everr.ingestion.volume'
+                            AND Attributes['everr.usage.month'] >= formatDateTime(toStartOfMonth(selected_from), '%Y-%m')
+                            AND Attributes['everr.usage.month'] <= formatDateTime(toStartOfMonth(selected_to), '%Y-%m')
+                            AND TimeUnix >= toStartOfMonth(selected_from)
+                            AND TimeUnix <= selected_to
+                            AND AggregationTemporality = 2
+                            AND IsMonotonic
+                            AND MetricUnit = 'By'
+                            AND ScopeName = 'github.com/everr-labs/everr/collector/usage'
+                            AND ScopeVersion = '1'
+                            AND ResourceAttributes['everr.tenant.id'] = Attributes['everr.usage.tenant.id']
+                            AND notEmpty(ResourceAttributes['service.instance.id'])
+                            AND notEmpty(Attributes['everr.usage.tenant.id'])
+                            AND Attributes['everr.ingestion.signal'] IN ('logs', 'traces', 'metrics')
+                            AND Value >= 0
+                          WINDOW counter AS (
+                            PARTITION BY Attributes['everr.usage.month'],
+                                         Attributes['everr.ingestion.signal'],
+                                         ResourceAttributes['service.instance.id'],
+                                         StartTimeUnix
+                            ORDER BY TimeUnix
+                            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                          )
+                        )
+                      )
+                      WHERE TimeUnix >= selected_from AND TimeUnix <= selected_to
+                      GROUP BY ts
+                      ORDER BY ts
+      cumulative:
+        kind: Panel
+        spec:
+          display:
+            name: Cumulative volume
+            description: Total telemetry accumulated within the selected time range.
+          plugin:
+            kind: TimeSeriesChart
+            spec:
+              unit: By
+              displayUnit: auto
+              lineWidth: 2
+              curveType: linear
+              connectNulls: true
+          queries:
+            - kind: ClickHouseSQL
+              spec:
+                plugin:
+                  kind: ClickHouseSQL
+                  spec:
+                    query: |-
+                      WITH parseDateTimeBestEffort({from:String}) AS selected_from,
+                           parseDateTimeBestEffort({to:String}) AS selected_to
+                      SELECT ts,
+                             toFloat64(sum(bucket_total) OVER (ORDER BY ts ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)) AS Total
+                      FROM (
+                        SELECT toStartOfInterval(TimeUnix, INTERVAL {step:UInt32} SECOND) AS ts,
+                               sum(delta) AS bucket_total
+                        FROM (
+                          SELECT TimeUnix,
+                                 if(previous_value < 0,
+                                    value_decimal - if(value_decimal > 9007199254740992, 1024, 0),
+                                    greatest(value_decimal - previous_value, 0)) AS delta
+                          FROM (
+                            SELECT TimeUnix,
+                                   toDecimal128(Value, 0) AS value_decimal,
+                                   lagInFrame(toDecimal128(Value, 0), 1, toDecimal128(-1, 0)) OVER counter AS previous_value
+                            FROM metrics_sum
+                            WHERE ServiceName = 'everr-ingestion'
+                              AND MetricName = 'everr.ingestion.volume'
+                              AND Attributes['everr.usage.month'] >= formatDateTime(toStartOfMonth(selected_from), '%Y-%m')
+                              AND Attributes['everr.usage.month'] <= formatDateTime(toStartOfMonth(selected_to), '%Y-%m')
+                              AND TimeUnix >= toStartOfMonth(selected_from)
+                              AND TimeUnix <= selected_to
+                              AND AggregationTemporality = 2
+                              AND IsMonotonic
+                              AND MetricUnit = 'By'
+                              AND ScopeName = 'github.com/everr-labs/everr/collector/usage'
+                              AND ScopeVersion = '1'
+                              AND ResourceAttributes['everr.tenant.id'] = Attributes['everr.usage.tenant.id']
+                              AND notEmpty(ResourceAttributes['service.instance.id'])
+                              AND notEmpty(Attributes['everr.usage.tenant.id'])
+                              AND Attributes['everr.ingestion.signal'] IN ('logs', 'traces', 'metrics')
+                              AND Value >= 0
+                            WINDOW counter AS (
+                              PARTITION BY Attributes['everr.usage.month'],
+                                           Attributes['everr.ingestion.signal'],
+                                           ResourceAttributes['service.instance.id'],
+                                           StartTimeUnix
+                              ORDER BY TimeUnix
+                              ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                            )
+                          )
+                        )
+                        WHERE TimeUnix >= selected_from AND TimeUnix <= selected_to
+                        GROUP BY ts
+                      )
+                      ORDER BY ts
+    layouts:
+      - kind: Grid
+        spec:
+          items:
+            - x: 0
+              y: 0
+              width: 8
+              height: 6
+              content:
+                $ref: "#/spec/panels/totals"
+            - x: 8
+              y: 0
+              width: 16
+              height: 6
+              content:
+                $ref: "#/spec/panels/signal-totals"
+            - x: 0
+              y: 6
+              width: 24
+              height: 8
+              content:
+                $ref: "#/spec/panels/interval-volume"
+            - x: 0
+              y: 14
+              width: 24
+              height: 8
+              content:
+                $ref: "#/spec/panels/cumulative"

--- a/packages/app/src/data/dashboards/built-in/catalog/index.ts
+++ b/packages/app/src/data/dashboards/built-in/catalog/index.ts
@@ -40,6 +40,8 @@ const ORDER = [
   "mongodb-overview",
   // Infrastructure
   "kubernetes-workloads",
+  // Everr
+  "telemetry-usage",
   // Browser
   "web-vitals",
   "product-analytics",

--- a/packages/app/src/data/dashboards/built-in/catalog/infrastructure/kubernetes-workloads.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/infrastructure/kubernetes-workloads.yaml
@@ -15,7 +15,9 @@ document:
   spec:
     display:
       name: Kubernetes Workloads
-    duration: 6h
+    timeRange:
+      from: now-6h
+      to: now
     refreshInterval: 1m
     variables:
       - kind: ListVariable

--- a/packages/app/src/data/dashboards/built-in/catalog/infrastructure/kubernetes-workloads.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/infrastructure/kubernetes-workloads.yaml
@@ -44,7 +44,8 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              decimals: 0
+              valueFormat:
+                decimals: 0
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -64,7 +65,8 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              decimals: 0
+              valueFormat:
+                decimals: 0
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -84,8 +86,6 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: "%"
-              decimals: 1
               thresholds:
                 mode: absolute
                 defaultColor: "#22c55e"
@@ -94,6 +94,9 @@ document:
                     color: "#f59e0b"
                   - value: 90
                     color: "#ef4444"
+              valueFormat:
+                unit: "%"
+                decimals: 1
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -115,8 +118,6 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: "%"
-              decimals: 1
               thresholds:
                 mode: absolute
                 defaultColor: "#22c55e"
@@ -125,6 +126,9 @@ document:
                     color: "#f59e0b"
                   - value: 90
                     color: "#ef4444"
+              valueFormat:
+                unit: "%"
+                decimals: 1
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -145,8 +149,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: " cores"
               showLegend: true
+              valueFormat:
+                unit: '{core}'
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -174,8 +179,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: " GiB"
               showLegend: true
+              valueFormat:
+                unit: GiBy
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -203,9 +209,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: " cores"
               showLegend: true
               stacked: true
+              valueFormat:
+                unit: '{core}'
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -236,9 +243,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: " GiB"
               showLegend: true
               stacked: true
+              valueFormat:
+                unit: GiBy
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -313,9 +321,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: MB
               showLegend: true
               stacked: false
+              valueFormat:
+                unit: MiBy
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -347,9 +356,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: MB
               showLegend: true
               stacked: false
+              valueFormat:
+                unit: MiBy
           queries:
             - kind: ClickHouseSQL
               spec:

--- a/packages/app/src/data/dashboards/built-in/catalog/runtime/jvm-runtime.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/runtime/jvm-runtime.yaml
@@ -15,7 +15,9 @@ document:
   spec:
     display:
       name: JVM Runtime
-    duration: 6h
+    timeRange:
+      from: now-6h
+      to: now
     refreshInterval: 1m
     variables:
       - kind: ListVariable

--- a/packages/app/src/data/dashboards/built-in/catalog/runtime/jvm-runtime.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/runtime/jvm-runtime.yaml
@@ -43,8 +43,9 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: MB
-              decimals: 0
+              valueFormat:
+                unit: MiBy
+                decimals: 0
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -67,8 +68,6 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: "%"
-              decimals: 1
               thresholds:
                 mode: absolute
                 defaultColor: "#22c55e"
@@ -77,6 +76,9 @@ document:
                     color: "#f59e0b"
                   - value: 90
                     color: "#ef4444"
+              valueFormat:
+                unit: "%"
+                decimals: 1
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -103,8 +105,9 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: MB
-              decimals: 0
+              valueFormat:
+                unit: MiBy
+                decimals: 0
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -127,7 +130,8 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              decimals: 0
+              valueFormat:
+                decimals: 0
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -150,8 +154,6 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: "%"
-              decimals: 1
               thresholds:
                 mode: absolute
                 defaultColor: "#22c55e"
@@ -160,6 +162,9 @@ document:
                     color: "#f59e0b"
                   - value: 90
                     color: "#ef4444"
+              valueFormat:
+                unit: "%"
+                decimals: 1
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -178,8 +183,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: MB
               showLegend: true
+              valueFormat:
+                unit: MiBy
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -209,8 +215,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: MB
               showLegend: true
+              valueFormat:
+                unit: MiBy
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -239,8 +246,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: MB
               showLegend: true
+              valueFormat:
+                unit: MiBy
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -268,8 +276,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: MB
               showLegend: true
+              valueFormat:
+                unit: MiBy
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -297,8 +306,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -328,8 +338,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ms
               showLegend: true
+              valueFormat:
+                unit: ms
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -359,8 +370,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: "%"
               showLegend: false
+              valueFormat:
+                unit: "%"
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -390,8 +402,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -419,8 +432,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: "%"
               showLegend: true
+              valueFormat:
+                unit: "%"
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -443,8 +457,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -467,8 +482,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: false
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -490,9 +506,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
               stacked: false
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -520,8 +537,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: MB
               showLegend: true
+              valueFormat:
+                unit: MiBy
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -544,8 +562,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ""
               showLegend: true
+              valueFormat:
+                unit: ""
           queries:
             - kind: ClickHouseSQL
               spec:

--- a/packages/app/src/data/dashboards/built-in/catalog/runtime/metric-overview.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/runtime/metric-overview.yaml
@@ -12,7 +12,9 @@ document:
   spec:
     display:
       name: Metric Overview
-    duration: 6h
+    timeRange:
+      from: now-6h
+      to: now
     refreshInterval: 1m
     variables:
       - kind: ListVariable

--- a/packages/app/src/data/dashboards/built-in/catalog/runtime/nodejs-runtime.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/runtime/nodejs-runtime.yaml
@@ -15,7 +15,9 @@ document:
   spec:
     display:
       name: Node.js Runtime
-    duration: 6h
+    timeRange:
+      from: now-6h
+      to: now
     refreshInterval: 1m
     variables:
       - kind: ListVariable

--- a/packages/app/src/data/dashboards/built-in/catalog/runtime/nodejs-runtime.yaml
+++ b/packages/app/src/data/dashboards/built-in/catalog/runtime/nodejs-runtime.yaml
@@ -44,8 +44,6 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: "%"
-              decimals: 1
               thresholds:
                 mode: absolute
                 defaultColor: "#22c55e"
@@ -54,6 +52,9 @@ document:
                     color: "#f59e0b"
                   - value: 95
                     color: "#ef4444"
+              valueFormat:
+                unit: "%"
+                decimals: 1
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -72,8 +73,9 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: ms
-              decimals: 1
+              valueFormat:
+                unit: ms
+                decimals: 1
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -92,8 +94,9 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: MB
-              decimals: 0
+              valueFormat:
+                unit: MiBy
+                decimals: 0
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -117,8 +120,6 @@ document:
             kind: StatChart
             spec:
               calculation: last
-              unit: "%"
-              decimals: 1
               thresholds:
                 mode: absolute
                 defaultColor: "#22c55e"
@@ -127,6 +128,9 @@ document:
                     color: "#f59e0b"
                   - value: 90
                     color: "#ef4444"
+              valueFormat:
+                unit: "%"
+                decimals: 1
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -152,8 +156,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ms
               showLegend: true
+              valueFormat:
+                unit: ms
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -179,8 +184,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: "%"
               showLegend: false
+              valueFormat:
+                unit: "%"
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -201,8 +207,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: MB
               showLegend: true
+              valueFormat:
+                unit: MiBy
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -231,8 +238,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: ms
               showLegend: false
+              valueFormat:
+                unit: ms
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -254,8 +262,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: MB
               showLegend: true
+              valueFormat:
+                unit: MiBy
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -282,8 +291,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: MB
               showLegend: true
+              valueFormat:
+                unit: MiBy
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -310,8 +320,9 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: MB
               showLegend: true
+              valueFormat:
+                unit: MiBy
           queries:
             - kind: ClickHouseSQL
               spec:
@@ -338,9 +349,10 @@ document:
           plugin:
             kind: TimeSeriesChart
             spec:
-              unit: s
               showLegend: true
               stacked: true
+              valueFormat:
+                unit: s
           queries:
             - kind: ClickHouseSQL
               spec:

--- a/packages/app/src/data/dashboards/built-in/manifest.ts
+++ b/packages/app/src/data/dashboards/built-in/manifest.ts
@@ -28,6 +28,7 @@ export const BUILTIN_MANIFEST: BuiltinManifestEntry[] = [
   { id: "redis-overview", name: "Redis Overview" },
   { id: "mongodb-overview", name: "MongoDB Overview" },
   { id: "kubernetes-workloads", name: "Kubernetes Workloads" },
+  { id: "telemetry-usage", name: "Telemetry Usage" },
   { id: "web-vitals", name: "Web Vitals" },
   { id: "product-analytics", name: "Product Analytics" },
 ];

--- a/packages/app/src/data/dashboards/built-in/types.ts
+++ b/packages/app/src/data/dashboards/built-in/types.ts
@@ -6,6 +6,7 @@ export const BUILTIN_CATEGORIES = [
   "Runtime",
   "Databases",
   "Infrastructure",
+  "Everr",
   "Browser",
 ] as const;
 

--- a/packages/app/src/data/dashboards/normalize.ts
+++ b/packages/app/src/data/dashboards/normalize.ts
@@ -1,4 +1,5 @@
 import { isValid } from "@everr/datemath";
+import { isValidTimeRange } from "@everr/ui/lib/time-range";
 import type {
   Dashboard,
   DashboardResource,
@@ -19,11 +20,7 @@ export function timeRangeFromDuration(
 function dashboardTimeRange(
   spec: Pick<DashboardResourceSpec, "duration" | "timeRange">,
 ): DashboardTimeRange | undefined {
-  if (
-    spec.timeRange &&
-    isValid(spec.timeRange.from) &&
-    isValid(spec.timeRange.to)
-  ) {
+  if (spec.timeRange && isValidTimeRange(spec.timeRange)) {
     return spec.timeRange;
   }
   return timeRangeFromDuration(spec.duration);

--- a/packages/app/src/data/dashboards/normalize.ts
+++ b/packages/app/src/data/dashboards/normalize.ts
@@ -1,25 +1,17 @@
-import { isValid } from "@everr/datemath";
-import { isValidTimeRange } from "@everr/ui/lib/time-range";
+import {
+  isValidTimeRange,
+  type TimeRange,
+  timeRangeFromDuration,
+} from "@everr/ui/lib/time-range";
 import type {
   Dashboard,
   DashboardResource,
   DashboardResourceSpec,
-  DashboardSpec,
 } from "./schema";
-
-type DashboardTimeRange = NonNullable<DashboardSpec["timeRange"]>;
-
-export function timeRangeFromDuration(
-  duration: string | undefined,
-): DashboardTimeRange | undefined {
-  return duration && isValid(`now-${duration}`)
-    ? { from: `now-${duration}`, to: "now" }
-    : undefined;
-}
 
 function dashboardTimeRange(
   spec: Pick<DashboardResourceSpec, "duration" | "timeRange">,
-): DashboardTimeRange | undefined {
+): TimeRange | undefined {
   if (spec.timeRange && isValidTimeRange(spec.timeRange)) {
     return spec.timeRange;
   }

--- a/packages/app/src/data/dashboards/normalize.ts
+++ b/packages/app/src/data/dashboards/normalize.ts
@@ -1,0 +1,47 @@
+import { isValid } from "@everr/datemath";
+import type {
+  Dashboard,
+  DashboardResource,
+  DashboardResourceSpec,
+  DashboardSpec,
+} from "./schema";
+
+type DashboardTimeRange = NonNullable<DashboardSpec["timeRange"]>;
+
+export function timeRangeFromDuration(
+  duration: string | undefined,
+): DashboardTimeRange | undefined {
+  return duration && isValid(`now-${duration}`)
+    ? { from: `now-${duration}`, to: "now" }
+    : undefined;
+}
+
+function dashboardTimeRange(
+  spec: Pick<DashboardResourceSpec, "duration" | "timeRange">,
+): DashboardTimeRange | undefined {
+  if (
+    spec.timeRange &&
+    isValid(spec.timeRange.from) &&
+    isValid(spec.timeRange.to)
+  ) {
+    return spec.timeRange;
+  }
+  return timeRangeFromDuration(spec.duration);
+}
+
+/**
+ * Normalize a stored Perses-compatible resource into Everr's dashboard model.
+ * Unknown fields remain intact, while the compatibility-only `duration` field
+ * becomes the canonical `timeRange` representation used by the renderer.
+ */
+export function dashboardFromResource(document: DashboardResource): Dashboard {
+  const { duration: _duration, timeRange: _timeRange, ...spec } = document.spec;
+  const timeRange = dashboardTimeRange(document.spec);
+  return {
+    ...document,
+    spec: {
+      ...spec,
+      ...(timeRange ? { timeRange } : {}),
+    },
+  };
+}

--- a/packages/app/src/data/dashboards/schema.test.ts
+++ b/packages/app/src/data/dashboards/schema.test.ts
@@ -90,6 +90,23 @@ describe("dashboardSpecSchema time range", () => {
     });
     expect(result.timeRange).toEqual({ from: "now/M", to: "now" });
   });
+
+  it("rejects reversed ranges on the strict write path", () => {
+    const result = dashboardSpecSchemaStrict.safeParse({
+      ...spec("#/spec/panels/cpu"),
+      timeRange: { from: "now", to: "now-6h" },
+    });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(["timeRange"]);
+  });
+
+  it("keeps the read path lenient for stored reversed ranges", () => {
+    const result = dashboardSpecSchema.safeParse({
+      ...spec("#/spec/panels/cpu"),
+      timeRange: { from: "now", to: "now-6h" },
+    });
+    expect(result.success).toBe(true);
+  });
 });
 
 describe("dashboardSpecSchemaStrict plugin specs", () => {

--- a/packages/app/src/data/dashboards/schema.test.ts
+++ b/packages/app/src/data/dashboards/schema.test.ts
@@ -111,8 +111,7 @@ describe("dashboardSpecSchemaStrict plugin specs", () => {
   it("accepts valid options for a known kind", () => {
     const result = dashboardSpecSchemaStrict.safeParse(
       specWithPlugin("TimeSeriesChart", {
-        unit: "ms",
-        displayUnit: "auto",
+        valueFormat: { unit: "ms", scale: "duration" },
         lineWidth: 2,
       }),
     );

--- a/packages/app/src/data/dashboards/schema.test.ts
+++ b/packages/app/src/data/dashboards/schema.test.ts
@@ -82,6 +82,16 @@ describe("dashboardSpecSchema datasources", () => {
   });
 });
 
+describe("dashboardSpecSchema time range", () => {
+  it("preserves an explicit default range", () => {
+    const result = dashboardSpecSchema.parse({
+      ...spec("#/spec/panels/cpu"),
+      timeRange: { from: "now/M", to: "now" },
+    });
+    expect(result.timeRange).toEqual({ from: "now/M", to: "now" });
+  });
+});
+
 describe("dashboardSpecSchemaStrict plugin specs", () => {
   const specWithPlugin = (kind: string, pluginSpec: unknown) => ({
     panels: {
@@ -100,7 +110,11 @@ describe("dashboardSpecSchemaStrict plugin specs", () => {
 
   it("accepts valid options for a known kind", () => {
     const result = dashboardSpecSchemaStrict.safeParse(
-      specWithPlugin("TimeSeriesChart", { unit: "ms", lineWidth: 2 }),
+      specWithPlugin("TimeSeriesChart", {
+        unit: "ms",
+        displayUnit: "auto",
+        lineWidth: 2,
+      }),
     );
     expect(result.success).toBe(true);
   });

--- a/packages/app/src/data/dashboards/schema.test.ts
+++ b/packages/app/src/data/dashboards/schema.test.ts
@@ -107,6 +107,15 @@ describe("dashboardSpecSchema time range", () => {
     });
     expect(result.success).toBe(true);
   });
+
+  it("rejects a zero-length legacy duration on the strict write path", () => {
+    const result = dashboardSpecSchemaStrict.safeParse({
+      ...spec("#/spec/panels/cpu"),
+      duration: "0h",
+    });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(["duration"]);
+  });
 });
 
 describe("dashboardSpecSchemaStrict plugin specs", () => {

--- a/packages/app/src/data/dashboards/schema.ts
+++ b/packages/app/src/data/dashboards/schema.ts
@@ -262,7 +262,11 @@ export type DatasourceSpec = z.infer<typeof datasourceSpec>;
 export type TextVariable = z.infer<typeof textVariable>;
 export type ListVariable = z.infer<typeof listVariable>;
 export type Variable = z.infer<typeof variable>;
-export type DashboardSpec = z.infer<typeof dashboardSpecSchema>;
+/** Dashboard spec accepted at the resource boundary, including Perses input. */
+export type DashboardResourceSpec = z.infer<typeof dashboardSpecSchema>;
+
+/** Canonical dashboard spec used by the renderer. */
+export type DashboardSpec = Omit<DashboardResourceSpec, "duration">;
 
 export interface DashboardMetadata {
   name: string;
@@ -274,6 +278,13 @@ export interface Dashboard {
   kind: "Dashboard";
   metadata: DashboardMetadata;
   spec: DashboardSpec;
+}
+
+/** Losslessly stored dashboard resource before compatibility normalization. */
+export interface DashboardResource {
+  kind: "Dashboard";
+  metadata: DashboardMetadata;
+  spec: DashboardResourceSpec;
 }
 
 /** Validates a dashboard slug: lowercase letters, digits and hyphens only. */

--- a/packages/app/src/data/dashboards/schema.ts
+++ b/packages/app/src/data/dashboards/schema.ts
@@ -1,3 +1,4 @@
+import { isValidTimeRange } from "@everr/ui/lib/time-range";
 import * as z from "zod";
 import { panelPluginSpecs, queryPluginSpecs } from "./plugin-specs";
 
@@ -239,6 +240,13 @@ export function collectPanelStrictIssues(
  */
 export const dashboardSpecSchemaStrict = dashboardSpecSchema.superRefine(
   (spec, ctx) => {
+    if (spec.timeRange && !isValidTimeRange(spec.timeRange)) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Time range must be valid and its start must precede its end",
+        path: ["timeRange"],
+      });
+    }
     for (const [key, p] of Object.entries(spec.panels)) {
       for (const issue of collectPanelStrictIssues(p)) {
         ctx.addIssue({

--- a/packages/app/src/data/dashboards/schema.ts
+++ b/packages/app/src/data/dashboards/schema.ts
@@ -1,4 +1,7 @@
-import { isValidTimeRange } from "@everr/ui/lib/time-range";
+import {
+  isValidTimeRange,
+  timeRangeFromDuration,
+} from "@everr/ui/lib/time-range";
 import * as z from "zod";
 import { panelPluginSpecs, queryPluginSpecs } from "./plugin-specs";
 
@@ -245,6 +248,16 @@ export const dashboardSpecSchemaStrict = dashboardSpecSchema.superRefine(
         code: "custom",
         message: "Time range must be valid and its start must precede its end",
         path: ["timeRange"],
+      });
+    }
+    if (
+      spec.duration !== undefined &&
+      timeRangeFromDuration(spec.duration) === undefined
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Duration must define a positive time range",
+        path: ["duration"],
       });
     }
     for (const [key, p] of Object.entries(spec.panels)) {

--- a/packages/app/src/data/dashboards/schema.ts
+++ b/packages/app/src/data/dashboards/schema.ts
@@ -147,6 +147,12 @@ export const dashboardSpecSchema = z
     variables: z.array(variable).optional(),
     panels: z.record(z.string(), panel),
     layouts: z.array(gridLayout),
+    timeRange: z
+      .object({
+        from: z.string(),
+        to: z.string(),
+      })
+      .optional(),
     duration: z.string().optional(),
     refreshInterval: z.string().optional(),
   })

--- a/packages/app/src/data/dashboards/server.test.ts
+++ b/packages/app/src/data/dashboards/server.test.ts
@@ -304,6 +304,28 @@ describe("getDashboard (project/slug)", () => {
     expect(result).toEqual({ document, previewStatus: undefined });
   });
 
+  it("normalizes a stored Perses duration before returning the dashboard", async () => {
+    selectImpl = () => [
+      {
+        document: {
+          kind: "Dashboard",
+          metadata: { name: "cpu" },
+          spec: { panels: {}, layouts: [], duration: "6h" },
+        },
+      },
+    ];
+
+    const result = await getDashboard({
+      data: { project: "team", slug: "cpu" },
+    });
+
+    expect(result.document.spec.timeRange).toEqual({
+      from: "now-6h",
+      to: "now",
+    });
+    expect(result.document.spec).not.toHaveProperty("duration");
+  });
+
   it("throws a notFound when the dashboard is missing", async () => {
     selectImpl = () => [];
     const error = await getDashboard({

--- a/packages/app/src/data/dashboards/server.ts
+++ b/packages/app/src/data/dashboards/server.ts
@@ -25,7 +25,8 @@ import {
   decodeCapabilityRows,
 } from "./built-in/capabilities";
 import { interpolateVariables } from "./interpolate";
-import type { Dashboard } from "./schema";
+import { dashboardFromResource } from "./normalize";
+import type { DashboardResource } from "./schema";
 import { dashboardSpecSchema } from "./schema";
 import { generateTestData } from "./testdata/generate";
 import { testDataSpec } from "./testdata/spec";
@@ -78,7 +79,10 @@ export const getDashboard = createAuthenticatedServerFn({ method: "GET" })
       // Typed binding (not an assertion) so the live and preview branches share
       // one return shape without widening `undefined` via a cast.
       const previewStatus: PreviewStatus | undefined = undefined;
-      return { document: row.document satisfies Dashboard, previewStatus };
+      return {
+        document: dashboardFromResource(row.document),
+        previewStatus,
+      };
     }
 
     // Live rows (previewId NULL) plus this preview's rows; `previewId` is the
@@ -114,7 +118,7 @@ export const getDashboard = createAuthenticatedServerFn({ method: "GET" })
     if (!row) throw notFound();
     dashboardSpecSchema.parse(row.document.spec);
     return {
-      document: row.document satisfies Dashboard,
+      document: dashboardFromResource(row.document satisfies DashboardResource),
       previewStatus: row.previewStatus,
     };
   });

--- a/packages/app/src/data/dashboards/time-defaults.test.ts
+++ b/packages/app/src/data/dashboards/time-defaults.test.ts
@@ -2,6 +2,30 @@ import { describe, expect, it } from "vitest";
 import { dashboardTimeDefaults } from "./time-defaults";
 
 describe("dashboardTimeDefaults", () => {
+  it("uses an explicit time range", () => {
+    expect(
+      dashboardTimeDefaults({ timeRange: { from: "now/M", to: "now" } }),
+    ).toEqual({ from: "now/M", to: "now" });
+  });
+
+  it("prefers an explicit time range over a duration", () => {
+    expect(
+      dashboardTimeDefaults({
+        timeRange: { from: "now/M", to: "now" },
+        duration: "31d",
+      }),
+    ).toEqual({ from: "now/M", to: "now" });
+  });
+
+  it("falls back to a valid duration when the explicit range is invalid", () => {
+    expect(
+      dashboardTimeDefaults({
+        timeRange: { from: "banana", to: "now" },
+        duration: "7d",
+      }),
+    ).toEqual({ from: "now-7d", to: "now" });
+  });
+
   it("derives from/to from a valid duration", () => {
     expect(dashboardTimeDefaults({ duration: "1h" })).toEqual({
       from: "now-1h",

--- a/packages/app/src/data/dashboards/time-defaults.test.ts
+++ b/packages/app/src/data/dashboards/time-defaults.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { dashboardFromResource } from "./normalize";
+import type { DashboardResource } from "./schema";
 import { dashboardTimeDefaults } from "./time-defaults";
 
 describe("dashboardTimeDefaults", () => {
@@ -8,33 +10,10 @@ describe("dashboardTimeDefaults", () => {
     ).toEqual({ from: "now/M", to: "now" });
   });
 
-  it("prefers an explicit time range over a duration", () => {
+  it("ignores an invalid time range", () => {
     expect(
-      dashboardTimeDefaults({
-        timeRange: { from: "now/M", to: "now" },
-        duration: "31d",
-      }),
-    ).toEqual({ from: "now/M", to: "now" });
-  });
-
-  it("falls back to a valid duration when the explicit range is invalid", () => {
-    expect(
-      dashboardTimeDefaults({
-        timeRange: { from: "banana", to: "now" },
-        duration: "7d",
-      }),
-    ).toEqual({ from: "now-7d", to: "now" });
-  });
-
-  it("derives from/to from a valid duration", () => {
-    expect(dashboardTimeDefaults({ duration: "1h" })).toEqual({
-      from: "now-1h",
-      to: "now",
-    });
-  });
-
-  it("ignores an invalid duration", () => {
-    expect(dashboardTimeDefaults({ duration: "banana" })).toBeUndefined();
+      dashboardTimeDefaults({ timeRange: { from: "banana", to: "now" } }),
+    ).toBeUndefined();
   });
 
   it("derives refresh from a supported refreshInterval", () => {
@@ -49,11 +28,55 @@ describe("dashboardTimeDefaults", () => {
 
   it("derives both together", () => {
     expect(
-      dashboardTimeDefaults({ duration: "6h", refreshInterval: "1m" }),
+      dashboardTimeDefaults({
+        timeRange: { from: "now-6h", to: "now" },
+        refreshInterval: "1m",
+      }),
     ).toEqual({ from: "now-6h", to: "now", refresh: "1m" });
   });
 
   it("returns undefined when the spec declares nothing", () => {
     expect(dashboardTimeDefaults({})).toBeUndefined();
+  });
+});
+
+describe("dashboardFromResource", () => {
+  function resource(
+    time: Pick<DashboardResource["spec"], "duration" | "timeRange">,
+  ): DashboardResource {
+    return {
+      kind: "Dashboard",
+      metadata: { name: "requests" },
+      spec: { panels: {}, layouts: [], ...time },
+    };
+  }
+
+  it("normalizes a Perses duration to an Everr time range", () => {
+    const dashboard = dashboardFromResource(resource({ duration: "1h" }));
+
+    expect(dashboard.spec.timeRange).toEqual({ from: "now-1h", to: "now" });
+    expect(dashboard.spec).not.toHaveProperty("duration");
+  });
+
+  it("prefers an explicit Everr time range over a Perses duration", () => {
+    const dashboard = dashboardFromResource(
+      resource({
+        timeRange: { from: "now/M", to: "now" },
+        duration: "31d",
+      }),
+    );
+
+    expect(dashboard.spec.timeRange).toEqual({ from: "now/M", to: "now" });
+  });
+
+  it("falls back to duration when the explicit range is invalid", () => {
+    const dashboard = dashboardFromResource(
+      resource({
+        timeRange: { from: "banana", to: "now" },
+        duration: "7d",
+      }),
+    );
+
+    expect(dashboard.spec.timeRange).toEqual({ from: "now-7d", to: "now" });
   });
 });

--- a/packages/app/src/data/dashboards/time-defaults.test.ts
+++ b/packages/app/src/data/dashboards/time-defaults.test.ts
@@ -16,6 +16,12 @@ describe("dashboardTimeDefaults", () => {
     ).toBeUndefined();
   });
 
+  it("ignores a reversed time range", () => {
+    expect(
+      dashboardTimeDefaults({ timeRange: { from: "now", to: "now-6h" } }),
+    ).toBeUndefined();
+  });
+
   it("derives refresh from a supported refreshInterval", () => {
     expect(dashboardTimeDefaults({ refreshInterval: "30s" })).toEqual({
       refresh: "30s",
@@ -73,6 +79,17 @@ describe("dashboardFromResource", () => {
     const dashboard = dashboardFromResource(
       resource({
         timeRange: { from: "banana", to: "now" },
+        duration: "7d",
+      }),
+    );
+
+    expect(dashboard.spec.timeRange).toEqual({ from: "now-7d", to: "now" });
+  });
+
+  it("falls back to duration when the explicit range is reversed", () => {
+    const dashboard = dashboardFromResource(
+      resource({
+        timeRange: { from: "now", to: "now-6h" },
         duration: "7d",
       }),
     );

--- a/packages/app/src/data/dashboards/time-defaults.test.ts
+++ b/packages/app/src/data/dashboards/time-defaults.test.ts
@@ -64,6 +64,13 @@ describe("dashboardFromResource", () => {
     expect(dashboard.spec).not.toHaveProperty("duration");
   });
 
+  it("drops a zero-length Perses duration", () => {
+    const dashboard = dashboardFromResource(resource({ duration: "0h" }));
+
+    expect(dashboard.spec).not.toHaveProperty("timeRange");
+    expect(dashboard.spec).not.toHaveProperty("duration");
+  });
+
   it("prefers an explicit Everr time range over a Perses duration", () => {
     const dashboard = dashboardFromResource(
       resource({

--- a/packages/app/src/data/dashboards/time-defaults.ts
+++ b/packages/app/src/data/dashboards/time-defaults.ts
@@ -4,14 +4,14 @@ import type { RouteTimeDefaults } from "@/lib/time-range";
 import type { DashboardSpec } from "./schema";
 
 /**
- * Translate a dashboard's saved time range, duration, and refresh interval into
+ * Translate a dashboard's saved time range and refresh interval into
  * route-level defaults. These are layered under the URL search params by the
  * time-range hooks (explicit URL values always win), so they seed the global
  * picker and the panels without writing anything to the URL. Returns undefined
  * when the dashboard declares nothing usable.
  */
 export function dashboardTimeDefaults(
-  spec: Pick<DashboardSpec, "duration" | "refreshInterval" | "timeRange">,
+  spec: Pick<DashboardSpec, "refreshInterval" | "timeRange">,
 ): RouteTimeDefaults | undefined {
   const defaults: RouteTimeDefaults = {};
 
@@ -22,9 +22,6 @@ export function dashboardTimeDefaults(
   ) {
     defaults.from = spec.timeRange.from;
     defaults.to = spec.timeRange.to;
-  } else if (spec.duration && isValid(`now-${spec.duration}`)) {
-    defaults.from = `now-${spec.duration}`;
-    defaults.to = "now";
   }
 
   if (

--- a/packages/app/src/data/dashboards/time-defaults.ts
+++ b/packages/app/src/data/dashboards/time-defaults.ts
@@ -1,5 +1,5 @@
-import { isValid } from "@everr/datemath";
 import { getRefreshIntervalMs } from "@everr/ui/components/refresh-picker";
+import { isValidTimeRange } from "@everr/ui/lib/time-range";
 import type { RouteTimeDefaults } from "@/lib/time-range";
 import type { DashboardSpec } from "./schema";
 
@@ -15,11 +15,7 @@ export function dashboardTimeDefaults(
 ): RouteTimeDefaults | undefined {
   const defaults: RouteTimeDefaults = {};
 
-  if (
-    spec.timeRange &&
-    isValid(spec.timeRange.from) &&
-    isValid(spec.timeRange.to)
-  ) {
+  if (spec.timeRange && isValidTimeRange(spec.timeRange)) {
     defaults.from = spec.timeRange.from;
     defaults.to = spec.timeRange.to;
   }

--- a/packages/app/src/data/dashboards/time-defaults.ts
+++ b/packages/app/src/data/dashboards/time-defaults.ts
@@ -4,18 +4,25 @@ import type { RouteTimeDefaults } from "@/lib/time-range";
 import type { DashboardSpec } from "./schema";
 
 /**
- * Translate a dashboard's saved `duration`/`refreshInterval` into route-level
- * time defaults. These are layered UNDER the URL search params by the time-range
- * hooks (explicit URL values always win), so they seed the global picker and the
- * panels without writing anything to the URL. Returns undefined when the
- * dashboard declares nothing usable.
+ * Translate a dashboard's saved time range, duration, and refresh interval into
+ * route-level defaults. These are layered under the URL search params by the
+ * time-range hooks (explicit URL values always win), so they seed the global
+ * picker and the panels without writing anything to the URL. Returns undefined
+ * when the dashboard declares nothing usable.
  */
 export function dashboardTimeDefaults(
-  spec: Pick<DashboardSpec, "duration" | "refreshInterval">,
+  spec: Pick<DashboardSpec, "duration" | "refreshInterval" | "timeRange">,
 ): RouteTimeDefaults | undefined {
   const defaults: RouteTimeDefaults = {};
 
-  if (spec.duration && isValid(`now-${spec.duration}`)) {
+  if (
+    spec.timeRange &&
+    isValid(spec.timeRange.from) &&
+    isValid(spec.timeRange.to)
+  ) {
+    defaults.from = spec.timeRange.from;
+    defaults.to = spec.timeRange.to;
+  } else if (spec.duration && isValid(`now-${spec.duration}`)) {
     defaults.from = `now-${spec.duration}`;
     defaults.to = "now";
   }

--- a/packages/app/src/data/runbooks/desired.test.ts
+++ b/packages/app/src/data/runbooks/desired.test.ts
@@ -82,7 +82,7 @@ describe("buildDesiredRunbookSet", () => {
       "```panel",
       "kind: Panel",
       "spec:",
-      "  plugin: { kind: TimeSeriesChart, spec: { unit: 42 } }",
+      "  plugin: { kind: TimeSeriesChart, spec: { valueFormat: { unit: 42 } } }",
       "```",
     ].join("\n");
     const d = doc({ spec: { markdown: { inline: md } } });
@@ -119,7 +119,7 @@ describe("buildDesiredRunbookSet", () => {
       "```panel",
       "kind: Panel",
       "spec:",
-      "  plugin: { kind: TimeSeriesChart, spec: { unit: req } }",
+      "  plugin: { kind: TimeSeriesChart, spec: { valueFormat: { unit: req } } }",
       "```",
       "```panel",
       "ref: shared",

--- a/packages/app/src/data/runbooks/embed.test.ts
+++ b/packages/app/src/data/runbooks/embed.test.ts
@@ -8,7 +8,7 @@ describe("parsePanelEmbed", () => {
         "kind: Panel",
         "height: 420",
         "spec:",
-        "  plugin: { kind: TimeSeriesChart, spec: { unit: req } }",
+        "  plugin: { kind: TimeSeriesChart, spec: { valueFormat: { unit: req } } }",
       ].join("\n"),
     );
     expect(embed).toMatchObject({

--- a/packages/app/src/data/runbooks/pages.test.ts
+++ b/packages/app/src/data/runbooks/pages.test.ts
@@ -227,4 +227,18 @@ describe("toDashboardDocument", () => {
     expect(doc.spec.variables).toHaveLength(1);
     expect(Object.keys(doc.spec.panels)).toEqual(["p"]);
   });
+
+  it("adapts a runbook duration to the dashboard time range", () => {
+    const doc = toDashboardDocument(
+      {
+        kind: "Runbook",
+        metadata: { name: "rb" },
+        spec: { ...spec, duration: "6h" },
+      },
+      "demo",
+      "rb",
+    );
+
+    expect(doc.spec.timeRange).toEqual({ from: "now-6h", to: "now" });
+  });
 });

--- a/packages/app/src/data/runbooks/pages.ts
+++ b/packages/app/src/data/runbooks/pages.ts
@@ -1,4 +1,4 @@
-import { timeRangeFromDuration } from "@/data/dashboards/normalize";
+import { timeRangeFromDuration } from "@everr/ui/lib/time-range";
 import type { Dashboard } from "@/data/dashboards/schema";
 import type { Runbook, RunbookPage, RunbookSpec } from "./schema";
 

--- a/packages/app/src/data/runbooks/pages.ts
+++ b/packages/app/src/data/runbooks/pages.ts
@@ -1,3 +1,4 @@
+import { timeRangeFromDuration } from "@/data/dashboards/normalize";
 import type { Dashboard } from "@/data/dashboards/schema";
 import type { Runbook, RunbookPage, RunbookSpec } from "./schema";
 
@@ -222,7 +223,7 @@ export function toDashboardDocument(
     display: runbook.spec.display,
     panels: runbook.spec.panels ?? {},
     layouts: [],
-    duration: runbook.spec.duration,
+    timeRange: timeRangeFromDuration(runbook.spec.duration),
     refreshInterval: runbook.spec.refreshInterval,
   };
   if (runbook.spec.variables !== undefined) {

--- a/packages/app/src/data/runbooks/schema.test.ts
+++ b/packages/app/src/data/runbooks/schema.test.ts
@@ -107,6 +107,15 @@ describe("runbookSpecSchema", () => {
 });
 
 describe("runbookSpecSchemaStrict", () => {
+  it("rejects a zero-length duration", () => {
+    const r = runbookSpecSchemaStrict.safeParse({
+      markdown: md,
+      duration: "0h",
+    });
+    expect(r.success).toBe(false);
+    expect(r.error?.issues[0]?.path).toEqual(["duration"]);
+  });
+
   it("rejects a bad query plugin spec with path through collectPanelStrictIssues", () => {
     const r = runbookSpecSchemaStrict.safeParse({
       markdown: md,

--- a/packages/app/src/data/runbooks/schema.test.ts
+++ b/packages/app/src/data/runbooks/schema.test.ts
@@ -149,12 +149,19 @@ describe("runbookSpecSchemaStrict", () => {
       panels: {
         bad: {
           kind: "Panel",
-          spec: { plugin: { kind: "TimeSeriesChart", spec: { unit: 42 } } },
+          spec: {
+            plugin: {
+              kind: "TimeSeriesChart",
+              spec: { valueFormat: { unit: 42 } },
+            },
+          },
         },
       },
     });
     expect(r.success).toBe(false);
     const issue = r.error?.issues[0];
-    expect(issue?.path.join(".")).toBe("panels.bad.spec.plugin.spec.unit");
+    expect(issue?.path.join(".")).toBe(
+      "panels.bad.spec.plugin.spec.valueFormat.unit",
+    );
   });
 });

--- a/packages/app/src/data/runbooks/schema.ts
+++ b/packages/app/src/data/runbooks/schema.ts
@@ -1,3 +1,4 @@
+import { timeRangeFromDuration } from "@everr/ui/lib/time-range";
 import * as z from "zod";
 import {
   collectPanelStrictIssues,
@@ -106,6 +107,16 @@ export const runbookSpecSchema = z
  */
 export const runbookSpecSchemaStrict = runbookSpecSchema.superRefine(
   (spec, ctx) => {
+    if (
+      spec.duration !== undefined &&
+      timeRangeFromDuration(spec.duration) === undefined
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Duration must define a positive time range",
+        path: ["duration"],
+      });
+    }
     for (const [key, p] of Object.entries(spec.panels ?? {})) {
       for (const issue of collectPanelStrictIssues(p)) {
         ctx.addIssue({

--- a/packages/app/src/db/schema/app.ts
+++ b/packages/app/src/db/schema/app.ts
@@ -12,7 +12,7 @@ import {
   uniqueIndex,
   uuid,
 } from "drizzle-orm/pg-core";
-import type { Dashboard } from "@/data/dashboards/schema";
+import type { DashboardResource } from "@/data/dashboards/schema";
 import type { Runbook } from "@/data/runbooks/schema";
 
 export const githubInstallationStatusEnum = pgEnum("installation_status", [
@@ -198,7 +198,7 @@ export const dashboards = pgTable(
     // The whole Perses document, stored verbatim so unknown fields survive a
     // read/apply round-trip. Identity/index data (project, slug, folderPath)
     // lives in dedicated columns above.
-    document: jsonb("document").notNull().$type<Dashboard>(),
+    document: jsonb("document").notNull().$type<DashboardResource>(),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/packages/app/src/lib/time-range.test.ts
+++ b/packages/app/src/lib/time-range.test.ts
@@ -2,6 +2,7 @@ import { getRefreshIntervalMs } from "@everr/ui/components/refresh-picker";
 import { formatTimeRangeDisplay } from "@everr/ui/components/time-range-picker";
 import {
   DEFAULT_TIME_RANGE,
+  isValidTimeRange,
   resolveTimeRange,
   TimeRangeSchema,
   withTimeRange,
@@ -133,6 +134,26 @@ describe("resolveTimeRange", () => {
     expect(result.fromDate < result.toDate).toBe(true);
     expect(result.fromISO).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/);
     expect(result.toISO).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/);
+  });
+
+  it("uses one reference time for both bounds", () => {
+    const now = new Date("2026-09-12T12:00:00.000Z");
+    const result = resolveTimeRange({ from: "now-1h", to: "now" }, now);
+    expect(result.fromDate.toISOString()).toBe("2026-09-12T11:00:00.000Z");
+    expect(result.toDate.toISOString()).toBe("2026-09-12T12:00:00.000Z");
+  });
+});
+
+describe("isValidTimeRange", () => {
+  const now = new Date("2026-09-12T12:00:00.000Z");
+
+  it("accepts a chronological range", () => {
+    expect(isValidTimeRange({ from: "now-6h", to: "now" }, now)).toBe(true);
+  });
+
+  it("rejects invalid and reversed ranges", () => {
+    expect(isValidTimeRange({ from: "banana", to: "now" }, now)).toBe(false);
+    expect(isValidTimeRange({ from: "now", to: "now-6h" }, now)).toBe(false);
   });
 });
 

--- a/packages/app/src/lib/time-range.test.ts
+++ b/packages/app/src/lib/time-range.test.ts
@@ -179,6 +179,9 @@ describe("formatTimeRangeDisplay", () => {
     expect(formatTimeRangeDisplay({ from: "now-1h", to: "now" })).toBe(
       "Last 1 hour",
     );
+    expect(formatTimeRangeDisplay({ from: "now/M", to: "now" })).toBe(
+      "This month so far",
+    );
   });
 
   it("returns raw expression for custom ranges", () => {

--- a/packages/app/src/lib/time-range.test.ts
+++ b/packages/app/src/lib/time-range.test.ts
@@ -5,6 +5,7 @@ import {
   isValidTimeRange,
   resolveTimeRange,
   TimeRangeSchema,
+  timeRangeFromDuration,
   withTimeRange,
 } from "@everr/ui/lib/time-range";
 import { describe, expect, it } from "vitest";
@@ -154,6 +155,22 @@ describe("isValidTimeRange", () => {
   it("rejects invalid and reversed ranges", () => {
     expect(isValidTimeRange({ from: "banana", to: "now" }, now)).toBe(false);
     expect(isValidTimeRange({ from: "now", to: "now-6h" }, now)).toBe(false);
+  });
+});
+
+describe("timeRangeFromDuration", () => {
+  const now = new Date("2026-09-12T12:00:00.000Z");
+
+  it("converts a positive duration to a valid range", () => {
+    expect(timeRangeFromDuration("6h", now)).toEqual({
+      from: "now-6h",
+      to: "now",
+    });
+  });
+
+  it("rejects invalid and zero-length durations", () => {
+    expect(timeRangeFromDuration("banana", now)).toBeUndefined();
+    expect(timeRangeFromDuration("0h", now)).toBeUndefined();
   });
 });
 

--- a/packages/app/src/routes/_authenticated/_dashboard/_previewable/runbooks/-runbook-route.ts
+++ b/packages/app/src/routes/_authenticated/_dashboard/_previewable/runbooks/-runbook-route.ts
@@ -1,7 +1,7 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { dashboardTimeDefaults } from "@/data/dashboards/time-defaults";
 import { runbookOptions } from "@/data/runbooks/options";
-import { findPage } from "@/data/runbooks/pages";
+import { findPage, toDashboardDocument } from "@/data/runbooks/pages";
 import type { BreadcrumbSegment } from "@/router-types";
 
 /**
@@ -51,6 +51,7 @@ export async function loadRunbook({
   const { document, previewStatus } = await queryClient.ensureQueryData(
     runbookOptions(project, slug, preview),
   );
+  const dashboard = toDashboardDocument(document, project, slug);
   // Expose the runbook's duration/refreshInterval as route time defaults so
   // the time-range hooks seed the picker and panels from the first render —
   // no post-mount URL write, so panels never query the wrong window first.
@@ -62,6 +63,6 @@ export async function loadRunbook({
     // stops at the runbook rather than naming a page the pane cannot show.
     pageTitle: pagePath ? findPage(document.spec, pagePath)?.title : undefined,
     previewStatus,
-    timeDefaults: dashboardTimeDefaults(document.spec),
+    timeDefaults: dashboardTimeDefaults(dashboard.spec),
   };
 }

--- a/packages/app/src/telemetry/config.test.ts
+++ b/packages/app/src/telemetry/config.test.ts
@@ -59,6 +59,28 @@ describe("telemetry config", () => {
     });
   });
 
+  it("uses an authenticated custom Everr ingest endpoint", () => {
+    expect(
+      resolveTelemetryConfig(
+        {
+          EVERR_INGEST_ENDPOINT: "http://127.0.0.1:4318/",
+          EVERR_INGEST_KEY: "secret",
+          NODE_ENV: "development",
+        },
+        "instance-1",
+      ),
+    ).toEqual({
+      endpoint: "http://127.0.0.1:4318",
+      headers: { Authorization: "Bearer secret" },
+      resourceAttributes: telemetryResourceAttributes(
+        {
+          NODE_ENV: "development",
+        },
+        "instance-1",
+      ),
+    });
+  });
+
   it("derives stable service resource attributes", () => {
     expect(
       telemetryResourceAttributes(

--- a/packages/app/src/telemetry/config.ts
+++ b/packages/app/src/telemetry/config.ts
@@ -7,6 +7,7 @@ export type TelemetrySignal = "traces" | "metrics" | "logs";
 
 export type TelemetryEnv = Partial<{
   DEPLOYMENT_ENVIRONMENT: string;
+  EVERR_INGEST_ENDPOINT: string;
   EVERR_INGEST_KEY: string;
   GITHUB_SHA: string;
   NODE_ENV: string;
@@ -27,18 +28,21 @@ export function resolveTelemetryConfig(
   serviceInstanceId: string,
 ): TelemetryConfig | null {
   const explicitEndpoint = cleanEnvValue(env.OTEL_EXPORTER_OTLP_ENDPOINT);
+  const everrEndpoint = cleanEnvValue(env.EVERR_INGEST_ENDPOINT);
   const ingestKey = cleanEnvValue(env.EVERR_INGEST_KEY);
 
   const endpoint = normalizeBaseEndpoint(
     explicitEndpoint ??
-      (ingestKey ? EVERR_HOSTED_OTLP_ENDPOINT : DEFAULT_LOCAL_OTLP_ENDPOINT),
+      (ingestKey
+        ? (everrEndpoint ?? EVERR_HOSTED_OTLP_ENDPOINT)
+        : DEFAULT_LOCAL_OTLP_ENDPOINT),
   );
-  const usesHostedIngest = !explicitEndpoint && Boolean(ingestKey);
+  const usesEverrIngest = !explicitEndpoint && Boolean(ingestKey);
 
   return {
     endpoint,
     headers:
-      usesHostedIngest && ingestKey
+      usesEverrIngest && ingestKey
         ? { Authorization: `Bearer ${ingestKey}` }
         : undefined,
     resourceAttributes: telemetryResourceAttributes(env, serviceInstanceId),

--- a/packages/docs/content/docs/concepts/observability-as-code.mdx
+++ b/packages/docs/content/docs/concepts/observability-as-code.mdx
@@ -22,7 +22,7 @@ spec:
     p99:
       kind: Panel
       spec:
-        plugin: { kind: TimeSeriesChart, spec: { unit: ms } }
+        plugin: { kind: TimeSeriesChart, spec: { valueFormat: { unit: ms } } }
         queries:
           - kind: ClickHouseSQL
             spec:

--- a/packages/docs/content/docs/guides/link-alerts-to-runbooks.mdx
+++ b/packages/docs/content/docs/guides/link-alerts-to-runbooks.mdx
@@ -43,7 +43,7 @@ The `error-spike` alert is firing. Is it still happening?
 kind: Panel
 spec:
   display: { name: Error rate }
-  plugin: { kind: TimeSeriesChart, spec: { unit: "%", showLegend: true } }
+  plugin: { kind: TimeSeriesChart, spec: { showLegend: true, valueFormat: { unit: "%" } } }
   queries:
     - kind: ClickHouseSQL
       spec:

--- a/packages/docs/content/docs/learn/add-a-runbook.mdx
+++ b/packages/docs/content/docs/learn/add-a-runbook.mdx
@@ -49,7 +49,7 @@ spec:
   display: { name: p99 event loop delay (ms) }
   plugin:
     kind: TimeSeriesChart
-    spec: { unit: ms, showLegend: true }
+    spec: { showLegend: true, valueFormat: { unit: ms } }
   queries:
     - kind: ClickHouseSQL
       spec:

--- a/packages/docs/content/docs/learn/first-dashboard.mdx
+++ b/packages/docs/content/docs/learn/first-dashboard.mdx
@@ -38,7 +38,7 @@ spec:
         display: { name: p99 latency (ms) }
         plugin:
           kind: TimeSeriesChart
-          spec: { unit: ms, showLegend: true }
+          spec: { showLegend: true, valueFormat: { unit: ms } }
         queries:
           - kind: ClickHouseSQL
             spec:

--- a/packages/docs/content/docs/reference/dashboard-spec.mdx
+++ b/packages/docs/content/docs/reference/dashboard-spec.mdx
@@ -29,7 +29,8 @@ spec:
 | `layouts` | [[Grid](#grid-layout)] | yes | Placement of panels on the grid. |
 | `display` | [Display](#display) | no | Dashboard title / description. |
 | `variables` | [[Variable](#variables)] | no | Template variables. |
-| `duration` | string | no | Default time-range window (e.g. `1h`, `24h`). [Seeds the time range.](#time-defaults) |
+| `timeRange` | `{ from: string, to: string }` | no | Default range in Everr date math, for example `{ from: now/M, to: now }`. [Seeds the time range.](#time-defaults) |
+| `duration` | string | no | Perses compatibility input, for example `1h` or `24h`. Everr normalizes it to `timeRange` when `timeRange` is absent. |
 | `refreshInterval` | string | no | Default auto-refresh (e.g. `30s`, `1m`). |
 | `datasources` | map&lt;string, object&gt; | no | Accepted for Perses compatibility; **no runtime effect**. |
 
@@ -148,7 +149,17 @@ A slug must be unique within a project; applying two files that resolve to the s
 
 ## Time defaults
 
-When a dashboard defines `duration` and/or `refreshInterval`, Everr seeds the URL time-range params from them once per visit if they're absent. Explicit URL params always win, so shared links keep their exact range.
+Use `timeRange` for a dashboard's default range:
+
+```yaml
+timeRange:
+  from: now/M
+  to: now
+```
+
+Everr date math supports fixed windows such as `now-24h` and calendar-aligned ranges such as `now/M` (the start of this month). Everr seeds missing URL time-range parameters from `timeRange` and `refreshInterval`. Explicit URL parameters always win, so shared links keep their exact range.
+
+Perses dashboards that declare `duration` are still accepted. At the resource boundary, Everr converts `duration: 24h` to `{ from: now-24h, to: now }`. If both fields are present, `timeRange` wins. Everr-authored dashboards should use `timeRange`.
 
 ## Compatibility boundaries
 

--- a/packages/docs/content/docs/reference/runbook-spec.mdx
+++ b/packages/docs/content/docs/reference/runbook-spec.mdx
@@ -78,7 +78,7 @@ kind: Panel
 height: 280
 spec:
   display: { name: Error rate }
-  plugin: { kind: TimeSeriesChart, spec: { unit: "%", showLegend: true } }
+  plugin: { kind: TimeSeriesChart, spec: { showLegend: true, valueFormat: { unit: "%" } } }
   queries:
     - kind: ClickHouseSQL
       spec:

--- a/packages/docs/content/docs/reference/visualizations.mdx
+++ b/packages/docs/content/docs/reference/visualizations.mdx
@@ -9,6 +9,52 @@ They infer their structure from the columns your query returns. See [Shaping dat
 
 Options are validated: `everr apply` rejects a dashboard whose option values don't match the tables below, naming the file and the offending option. Unknown option keys are accepted and preserved. If an already-stored dashboard contains an invalid value, the panel still renders with the default and shows a warning icon in its header listing the ignored options.
 
+## Value formatting
+
+Numeric visualizations accept `valueFormat` in `plugin.spec`. Omitting it uses an empty unit, no scaling, and at most two decimal places (trailing zeros dropped).
+
+Use the case-sensitive UCUM codes prescribed by [OpenTelemetry instrument units](https://opentelemetry.io/docs/specs/semconv/general/metrics/#instrument-units): prefer non-prefixed units such as `By`, seconds (`s`) for durations, `1` for dimensionless utilization, and singular annotations such as `{request}` for counts. The panel must declare the unit actually returned by the query, even when that query returns a prefixed unit such as `ms`. Quote `"1"` and annotations in YAML.
+
+Common codes receive readable display labels: `By` becomes `B`, `Cel` becomes `°C`, `us` becomes `µs`, `1` has no suffix, and `{request}` becomes `request`. These labels also work in rates with a supported time denominator, such as `By/s` and `{request}/s`. Codes remain unchanged in the configuration. Unknown expressions remain literal: this is a presentation subset, not a full UCUM validator or conversion engine. In particular, `B` is not a byte alias (UCUM defines it as bel), and `1` does not implicitly turn a fraction into a percentage.
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `unit` | `""` | UCUM/OTel code of the query result; unknown custom units remain literal labels. |
+| `scale` | `none` | `none`, `decimal`, `binary`, or `duration`. |
+| `decimals` | omitted | Fixed fraction digits (0 to 10); omitted uses up to 2 without trailing zeros. |
+| `display` | `value` | `value` preserves ordinary unit formatting; `percent` displays a dimensionless ratio as a percentage. |
+
+```yaml
+valueFormat: { unit: "{request}/s", scale: decimal, decimals: 1 }
+```
+
+- `none`: preserve the input magnitude, e.g. `8200 connections` displays as `8,200 connections`.
+- `decimal`: abbreviate in powers of 1000 (`k`, `M`, `G`, etc.). `12500 widgets/s` displays as `12.5k widgets/s`.
+- With `Hz`, `W`, `J`, `V`, or `A`, decimal prefixes attach to the unit: `3200000000 Hz` displays as `3.2 GHz`, and `1500 W` as `1.5 kW`. This changes prefix placement only; values below 1000 retain their input unit, and already-prefixed inputs are not reinterpreted.
+- `binary`: abbreviate in powers of 1024 (`Ki`, `Mi`, `Gi`, etc.). `2621440 By/s` displays as `2.5 MiB/s`.
+- `duration`: choose a time unit from nanoseconds through days. Declare the query's actual unit: `ns`, `us`, `ms`, `s`, `min`, `h`, or `d`. With `unit: s`, `0.025` displays as `25 ms` and `90` as `1.5 min`. Other input units are rejected for duration scaling. Use the ASCII code `us`; its display label is `µs`.
+- With a time unit, `decimal` selects seconds or decimal subdivisions, so `90000 ms` displays as `90 s` without advancing to minutes.
+- Custom labels and rates need no registration. The query calculates the rate or percentage: `2.3` with `unit: "%"` means `2.3%`, not a fraction.
+- For decimal/binary scaling, the number is in the declared unit; existing prefixes are not interpreted. Use `By` or `By/s` for bytes, and `bit` or `bit/s` for bits. These attach the display prefix to the symbol; other units keep it with the number.
+- A missing label gives `12.5k`. Other labels are space-separated, except `%`.
+- Time-series, bar, and gauge axes share one display scale across their ticks. Individual values and tooltips choose their own scale. Formatting never changes geometry, aggregation, or threshold comparisons; thresholds remain in input units.
+
+Top-level `unit`, `decimals`, and `displayUnit` have been removed. Move them into `valueFormat`. For example, `unit: ms` with `decimals: 1` becomes `valueFormat: { unit: ms, decimals: 1 }`. Replace `unit: By, displayUnit: auto` with `valueFormat: { unit: By, scale: binary }`. Choose `scale: decimal` explicitly for abbreviated counts; the old implicit million/billion abbreviations no longer apply.
+
+Table supports a panel default and `columns.<column-name>.valueFormat` overrides. An override replaces the entire default format. Only numeric cells are formatted; text and null cells retain their existing behavior.
+
+To show an OTel utilization ratio as a percentage, use `valueFormat: { unit: "1", display: percent }`: `0.75` displays as `75%`. This requires `unit: "1"` and `scale: none` (the default). Precision applies to the displayed percentage; negative values and values above 1 are not clamped. Ordinary `unit: "1"` still displays `0.75`, while `unit: "%"` means the query already returns percentages and is not multiplied again. Gauge bounds and absolute thresholds remain raw ratios: use `max: 1` and a threshold of `0.8` for 80%. This is independent of bar stacking normalization and percent-mode thresholds.
+
+```yaml
+columns:
+  throughput:
+    valueFormat: { unit: "{request}/s", scale: decimal }
+  bandwidth:
+    valueFormat: { unit: By/s, scale: binary }
+  latency:
+    valueFormat: { unit: s, scale: duration }
+```
+
 ## TimeSeriesChart
 
 Line chart over time. Supports drag-to-zoom (writes the new range to the URL). Data shape: see [Time series](#time-series).
@@ -17,18 +63,18 @@ Line chart over time. Supports drag-to-zoom (writes the new range to the URL). D
 plugin:
   kind: TimeSeriesChart
   spec:
-    unit: ms
     showLegend: true
     lineWidth: 1.5
     curveType: monotone
     connectNulls: false
     stacked: false
+    valueFormat:
+      unit: ms
 ```
 
 | Option | Type | Default | Notes |
 | --- | --- | --- | --- |
-| `unit` | string | `""` | Unit of the numeric query result. It remains a literal suffix unless `displayUnit` is set. |
-| `displayUnit` | enum | none | Set to `auto` to scale recognized byte or duration units. Prefixed input units such as `GiBy`, the common `GiB` alias, and `ms` are supported. |
+| `valueFormat` | object | none | Shared [value formatting](#value-formatting). |
 | `showLegend` | boolean | `false` | Show the series legend. |
 | `lineWidth` | number | `1.5` | Stroke width. |
 | `curveType` | enum | `monotone` | One of `monotone`, `linear`, `natural`, `stepBefore`, `stepAfter`. |
@@ -43,17 +89,17 @@ Bar chart over time or over categories. Data shape: see [Bar](#bar).
 plugin:
   kind: BarChart
   spec:
-    unit: req
     showLegend: true
     stacking: stacked
     orientation: vertical
     showValues: false
+    valueFormat:
+      unit: '{request}'
 ```
 
 | Option | Type | Default | Notes |
 | --- | --- | --- | --- |
-| `unit` | string | `""` | Unit of the numeric query result. It remains a literal suffix unless `displayUnit` is set. |
-| `displayUnit` | enum | none | Set to `auto` to scale recognized byte or duration units. Prefixed input units such as `GiBy`, the common `GiB` alias, and `ms` are supported. |
+| `valueFormat` | object | none | Shared [value formatting](#value-formatting). |
 | `showLegend` | boolean | `false` | Show the series legend. |
 | `stacking` | enum | `none` | `none` draws series side by side; `stacked` piles them into one bar per x value; `percent` additionally normalizes each stack to 100% (the value axis becomes percentages, tooltips keep raw values). |
 | `orientation` | enum | `vertical` | `vertical` draws bars bottom-up; `horizontal` draws them left-to-right with categories on the y-axis (best for categorical data with long labels). |
@@ -73,20 +119,20 @@ plugin:
 | Option | Type | Default | Notes |
 | --- | --- | --- | --- |
 | `stickyHeader` | boolean | `false` | Keep the header visible while scrolling. |
+| `valueFormat` | object | none | Default [value formatting](#value-formatting) for numeric columns. |
+| `columns` | map | `{}` | Column name to `{ valueFormat: { ... } }`; overrides the panel default for that column. |
 
 ## StatChart
 
 Reduces a numeric column to a single big value via a calculation, with an optional sparkline and threshold coloring. Data shape: see [Stat and gauge](#stat-and-gauge).
 
-Values at or above one million abbreviate (`1234567` → `1.23M`); smaller values keep thousands grouping. The tile label is shown automatically with multiple tiles and hidden for a single tile unless `showLabel` is set.
+Values use at most two decimal places by default. Set `valueFormat.scale: decimal` for abbreviated counts. The tile label is shown automatically with multiple tiles and hidden for a single tile unless `showLabel` is set.
 
 ```yaml
 plugin:
   kind: StatChart
   spec:
     calculation: last
-    unit: ms
-    decimals: 1
     sparkline: true
     thresholds:
       mode: percent
@@ -95,14 +141,15 @@ plugin:
       steps:
         - { value: 40, color: "#f59e0b" }
         - { value: 80, color: "#ef4444" }
+    valueFormat:
+      unit: ms
+      decimals: 1
 ```
 
 | Option | Type | Default | Notes |
 | --- | --- | --- | --- |
 | `calculation` | enum | `last` | One of `last`, `first`, `mean`, `min`, `max`, `sum`, `count`, `range`, `diff`. |
-| `unit` | string | `""` | Unit of the numeric query result. It remains a literal suffix unless `displayUnit` is set. |
-| `displayUnit` | enum | none | Set to `auto` to scale recognized byte or duration units. Prefixed input units such as `GiBy`, the common `GiB` alias, and `ms` are supported. |
-| `decimals` | number | none | Fixed fraction digits (0 to 10). Omitted: up to 2, trailing zeros dropped. |
+| `valueFormat` | object | none | Shared [value formatting](#value-formatting). |
 | `sparkline` | boolean | `false` | Draw a sparkline (in time order, or row order without a time column). |
 | `colors` | map | `{}` | Pin sparkline colors by series label. Unmapped series keep the default accent color. Threshold colors take precedence. |
 | `colorMode` | enum | `value` | `value` tints the number; `background` fills the whole tile with the threshold color. |
@@ -125,7 +172,6 @@ plugin:
   kind: GaugeChart
   spec:
     calculation: last
-    unit: "%"
     min: 0
     max: 100
     thresholds:
@@ -133,13 +179,14 @@ plugin:
       steps:
         - { value: 70, color: "#f59e0b" }
         - { value: 90, color: "#ef4444" }
+    valueFormat:
+      unit: "%"
 ```
 
 | Option | Type | Default | Notes |
 | --- | --- | --- | --- |
 | `calculation` | enum | `last` | One of `last`, `first`, `mean`, `min`, `max`, `sum`, `count`, `range`, `diff`. |
-| `unit` | string | `""` | Suffix appended to the value. |
-| `decimals` | number | none | Fixed fraction digits (0 to 10). Omitted: up to 2, trailing zeros dropped. |
+| `valueFormat` | object | none | Shared [value formatting](#value-formatting). |
 | `min` | number | `0` | Gauge axis lower bound. |
 | `max` | number | `100` | Gauge axis upper bound. Set it to the metric's real ceiling: the arc reads as value ÷ range. |
 | `showLabel` | boolean | `false` | Show the series label on a single-gauge panel too. |
@@ -162,9 +209,10 @@ plugin:
     latColumn: lat
     lonColumn: lon
     valueColumn: value
-    unit: req
     showLegend: true
     colorScheme: blue
+    valueFormat:
+      unit: '{request}'
 ```
 
 | Option | Type | Default | Notes |
@@ -176,7 +224,7 @@ plugin:
 | `valueColumn` | string | `value` | Sizes markers / shades regions. |
 | `labelColumn` | string | none | Tooltip title; falls back to the region or coordinates. |
 | `aggregation` | enum | `sum` | Choropleth mode: how rows that map to the same region combine: `sum`, `avg`, `min`, `max`, or `last`. Use `avg`/`max` for non-additive metrics like latency percentiles or error rates; `sum` is only correct for additive metrics like request counts. |
-| `unit` | string | `""` | Value formatting in the tooltip and legend. |
+| `valueFormat` | object | none | Shared [value formatting](#value-formatting). |
 | `showLegend` | boolean | `true` | Points: the value→marker-size mapping, plus per-query swatches when the panel has multiple queries. Choropleth: the color ramp. |
 | `colorScheme` | enum | `blue` | One of `blue`, `green`, `orange`, `red`, setting the marker base / choropleth ramp. |
 | `projection` | enum | `naturalEarth1` | Map projection: `naturalEarth1`, `mercator`, or `equalEarth`. |
@@ -199,9 +247,10 @@ plugin:
     nameColumn: route
     valueColumn: requests
     groupColumn: service
-    unit: req
     showValues: true
     showLegend: true
+    valueFormat:
+      unit: '{request}'
 ```
 
 | Option | Type | Default | Notes |
@@ -210,7 +259,7 @@ plugin:
 | `valueColumn` | string | `value` | Tile size column; must be positive: rows at or below 0 are dropped. |
 | `groupColumn` | string | none | Group tiles by this column: one color per group, legend lists the groups. Rows with a null group are dropped. |
 | `maxTiles` | number | none | Cap the tile count (≥ 2): the largest `maxTiles - 1` tiles stay, the rest merge into a single muted "Other (n)" tile so long tails don't render as slivers. Unset renders every row. |
-| `unit` | string | `""` | Value formatting in tiles and the tooltip. |
+| `valueFormat` | object | none | Shared [value formatting](#value-formatting). |
 | `showValues` | boolean | `true` | Render the value inside tiles that are large enough to fit it. |
 | `showLegend` | boolean | `true` | Group color legend, only shown when there are groups (from `groupColumn` or multiple queries). |
 
@@ -283,16 +332,17 @@ plugin:
   spec:
     yColumn: duration_bucket
     valueColumn: requests
-    unit: req
     colorScheme: spectral
     scaleType: log
+    valueFormat:
+      unit: '{request}'
 ```
 
 | Option | Type | Default | Notes |
 | --- | --- | --- | --- |
 | `yColumn` | string | first non-time column | Y-bucket column. |
 | `valueColumn` | string | first remaining numeric column | Cell intensity column. |
-| `unit` | string | `""` | Value formatting in cells, tooltip and legend. |
+| `valueFormat` | object | none | Shared [value formatting](#value-formatting). |
 | `showLegend` | boolean | `true` | Color ramp legend (min → max) below the grid. |
 | `showValues` | boolean | `false` | Render the value inside cells wide enough to fit it. |
 | `colorScheme` | enum | `spectral` | Cell color ramp. Multi-hue: `spectral` (cool blue → yellow → hot red), `greenYellowRed`. Single-hue light→dark: `blues`, `greens`, `oranges`, `reds`. |
@@ -312,8 +362,9 @@ plugin:
     sourceColumn: client
     targetColumn: server
     valueColumn: calls
-    unit: req
     directed: true
+    valueFormat:
+      unit: '{request}'
 ```
 
 | Option | Type | Default | Notes |
@@ -321,7 +372,7 @@ plugin:
 | `sourceColumn` | string | `source` | Edge source column; falls back to the first column when absent. |
 | `targetColumn` | string | `target` | Edge target column; falls back to the second column when absent. |
 | `valueColumn` | string | `value` | Edge weight column, driving edge thickness and node size. Falls back to the first remaining numeric column; without one every edge weighs 1. |
-| `unit` | string | `""` | Value formatting in tooltips and edge labels. |
+| `valueFormat` | object | none | Shared [value formatting](#value-formatting). |
 | `directed` | boolean | `true` | Draw arrowheads pointing at each edge's target. |
 | `showValues` | boolean | `false` | Render the edge's value at its midpoint. |
 | `maxNodes` | number | none | Cap the node count (≥ 2): the highest-value nodes stay, the rest (and their edges) are hidden behind the "not shown" badge. The layout also has a built-in 250-node limit. |
@@ -373,7 +424,7 @@ This produces one bar per service, in the query's order. Multiple queries merge 
 
 ### Table [#shaping-table]
 
-Renders every column as-is, in query order. No special column naming is required, so return whatever you want to display:
+Renders every column in query order, with optional numeric value formatting. No special column naming is required, so return whatever you want to display:
 
 ```sql
 SELECT ServiceName, count() AS spans, round(avg(Duration) / 1e6, 1) AS avg_ms

--- a/packages/docs/content/docs/reference/visualizations.mdx
+++ b/packages/docs/content/docs/reference/visualizations.mdx
@@ -27,7 +27,8 @@ plugin:
 
 | Option | Type | Default | Notes |
 | --- | --- | --- | --- |
-| `unit` | string | `""` | Suffix appended to axis/values. |
+| `unit` | string | `""` | Unit of the numeric query result. It remains a literal suffix unless `displayUnit` is set. |
+| `displayUnit` | enum | none | Set to `auto` to scale recognized byte or duration units. Prefixed input units such as `GiBy`, the common `GiB` alias, and `ms` are supported. |
 | `showLegend` | boolean | `false` | Show the series legend. |
 | `lineWidth` | number | `1.5` | Stroke width. |
 | `curveType` | enum | `monotone` | One of `monotone`, `linear`, `natural`, `stepBefore`, `stepAfter`. |
@@ -51,7 +52,8 @@ plugin:
 
 | Option | Type | Default | Notes |
 | --- | --- | --- | --- |
-| `unit` | string | `""` | Suffix appended to axis/values. |
+| `unit` | string | `""` | Unit of the numeric query result. It remains a literal suffix unless `displayUnit` is set. |
+| `displayUnit` | enum | none | Set to `auto` to scale recognized byte or duration units. Prefixed input units such as `GiBy`, the common `GiB` alias, and `ms` are supported. |
 | `showLegend` | boolean | `false` | Show the series legend. |
 | `stacking` | enum | `none` | `none` draws series side by side; `stacked` piles them into one bar per x value; `percent` additionally normalizes each stack to 100% (the value axis becomes percentages, tooltips keep raw values). |
 | `orientation` | enum | `vertical` | `vertical` draws bars bottom-up; `horizontal` draws them left-to-right with categories on the y-axis (best for categorical data with long labels). |
@@ -98,9 +100,11 @@ plugin:
 | Option | Type | Default | Notes |
 | --- | --- | --- | --- |
 | `calculation` | enum | `last` | One of `last`, `first`, `mean`, `min`, `max`, `sum`, `count`, `range`, `diff`. |
-| `unit` | string | `""` | Suffix appended to the value. |
+| `unit` | string | `""` | Unit of the numeric query result. It remains a literal suffix unless `displayUnit` is set. |
+| `displayUnit` | enum | none | Set to `auto` to scale recognized byte or duration units. Prefixed input units such as `GiBy`, the common `GiB` alias, and `ms` are supported. |
 | `decimals` | number | none | Fixed fraction digits (0 to 10). Omitted: up to 2, trailing zeros dropped. |
 | `sparkline` | boolean | `false` | Draw a sparkline (in time order, or row order without a time column). |
+| `colors` | map | `{}` | Pin sparkline colors by series label. Unmapped series keep the default accent color. Threshold colors take precedence. |
 | `colorMode` | enum | `value` | `value` tints the number; `background` fills the whole tile with the threshold color. |
 | `showLabel` | boolean | `false` | Show the series label on a single-tile panel too. |
 | `noValue` | string | en dash | Text shown for a query that produced no value. |

--- a/packages/ui/src/components/time-range-picker.tsx
+++ b/packages/ui/src/components/time-range-picker.tsx
@@ -46,7 +46,7 @@ export const QUICK_RANGE_GROUPS: QuickRangeGroup[] = [
       { label: "Today", from: "now/d", to: "now/d" },
       { label: "Yesterday", from: "now-1d/d", to: "now-1d/d" },
       { label: "This week", from: "now/w", to: "now/w" },
-      { label: "This month", from: "now/M", to: "now/M" },
+      { label: "This month so far", from: "now/M", to: "now" },
     ],
   },
 ];

--- a/packages/ui/src/lib/time-range.ts
+++ b/packages/ui/src/lib/time-range.ts
@@ -43,13 +43,22 @@ export function withTimeRange<T extends { from?: string; to?: string }>(
   return { ...search, from, to, timeRange: { from, to } };
 }
 
-export function resolveTimeRange(range: TimeRange) {
-  const fromDate = resolve(range.from, { roundUp: false });
-  const toDate = resolve(range.to, { roundUp: true });
+export function resolveTimeRange(range: TimeRange, now = new Date()) {
+  const fromDate = resolve(range.from, { now, roundUp: false });
+  const toDate = resolve(range.to, { now, roundUp: true });
   return {
     fromDate,
     toDate,
     fromISO: toClickHouseDateTime(fromDate),
     toISO: toClickHouseDateTime(toDate),
   };
+}
+
+export function isValidTimeRange(range: TimeRange, now = new Date()): boolean {
+  try {
+    const { fromDate, toDate } = resolveTimeRange(range, now);
+    return fromDate < toDate;
+  } catch {
+    return false;
+  }
 }

--- a/packages/ui/src/lib/time-range.ts
+++ b/packages/ui/src/lib/time-range.ts
@@ -62,3 +62,12 @@ export function isValidTimeRange(range: TimeRange, now = new Date()): boolean {
     return false;
   }
 }
+
+export function timeRangeFromDuration(
+  duration: string | undefined,
+  now = new Date(),
+): TimeRange | undefined {
+  if (!duration) return undefined;
+  const range = { from: `now-${duration}`, to: "now" };
+  return isValidTimeRange(range, now) ? range : undefined;
+}


### PR DESCRIPTION
## Summary

- add a built-in Telemetry Usage dashboard with selected-range totals, per-signal interval trends, and a cumulative trend
- add semantic byte and duration formatting plus optional stat sparkline color overrides
- support explicit dashboard time ranges and authenticated custom Everr ingest endpoints for local development
- simplify local collector configuration by using the authenticated public ingest path
- share repeated usage SQL and chart axis sizing logic
- attach percent suffixes consistently in stat and gauge values while preserving spacing for other units

## Query correctness

- order cumulative samples by timestamp and value so distinct same-second publications follow monotonic counter order and exact retry duplicates add zero
- keep the existing DateTime column type and schema unchanged
- reject reversed and zero-length explicit dashboard ranges through one shared validator
- keep collector timestamp round-trip fixtures within the default retention window

## Verification

- pnpm --filter @everr/app test:ci (1,909 tests)
- pnpm --filter @everr/app typecheck
- targeted Biome checks for changed TypeScript files
- make test in collector/exporter/chdbexporter
- collector formatting, module tidy, and lint checks through the pre-commit hook
- docker compose config --quiet
- isolated ClickHouse 26.2 fixture with distinct same-second cumulative publications and exact retry duplicates; all three usage query shapes returned the expected total of 200
- manual dashboard verification for Telemetry Usage, Web Vitals, and the value-format gallery
- browser DOM verification that percent gauge units have no margin or SVG offset while ordinary units retain spacing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared `valueFormat` controls across dashboard visualizations, including units, scaling, precision, percentages, durations, and custom labels.
  * Added numeric formatting for tables, including per-column overrides.
  * Added the built-in **Telemetry Usage** dashboard.
  * Added configurable authenticated Everr ingest endpoints.
  * Added explicit dashboard time ranges with compatibility support for duration-based configurations.

* **Improvements**
  * Improved chart axis sizing and value-label spacing.
  * Renamed “This month” to “This month so far” to clarify its current-month range.

* **Bug Fixes**
  * Removed development-only unauthenticated telemetry ports and self-telemetry pipelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->